### PR TITLE
Build site on Travis as a test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 
 node_js:
   - 8
+
+script:
+  - npm test
+  - npm run build


### PR DESCRIPTION
This adds `npm run build` as a step in the test script run on Travis. We had to add the `script` block because Travis's default is to run `npm test` if none exists. This will confirm that our build isn't failing on Travis, and is a step towards #38.