### PR TITLE
Hush console errors for tests with invalid props

### DIFF
--- a/src/__tests__/Button.js
+++ b/src/__tests__/Button.js
@@ -3,7 +3,7 @@ import Button from '../Button'
 import ButtonDanger from '../ButtonDanger'
 import ButtonLink from '../ButtonLink'
 import ButtonOutline from '../ButtonOutline'
-import {render, silenceConsoleError} from '../utils/testing'
+import {render} from '../utils/testing'
 
 function noop() {}
 
@@ -45,7 +45,7 @@ describe('Button', () => {
     expect(render(<Button scheme="primary" />).props.className).toEqual('btn btn-primary')
     // non-truthy values should not result in any new classes
     expect(render(<Button scheme={null} />).props.className).toEqual('btn')
-    const hush = silenceConsoleError(jest)
+    const hush = jest.spyOn(console, 'error').mockImplementation(jest.fn())
     expect(render(<Button scheme={false} />).props.className).toEqual('btn')
     hush.mockRestore()
   })

--- a/src/__tests__/Text.js
+++ b/src/__tests__/Text.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Text from '../Text'
-import {render, silenceConsoleError} from '../utils/testing'
+import {render} from '../utils/testing'
 
 describe('Text', () => {
   it('renders margin', () => {
@@ -50,8 +50,8 @@ describe('Text', () => {
 
   it('respects other values for fontSize', () => {
     expect(render(<Text fontSize="00" />)).toEqual(render(<span className="f00" />))
-    const mock = silenceConsoleError(jest)
+    const hush = jest.spyOn(console, 'error').mockImplementation(jest.fn())
     expect(render(<Text fontSize={false} />)).toEqual(render(<span className="" />))
-    mock.mockRestore()
+    hush.mockRestore()
   })
 })

--- a/src/utils/testing.js
+++ b/src/utils/testing.js
@@ -35,25 +35,6 @@ export function renderClasses(component) {
   return className ? className.trim().split(' ') : []
 }
 
-/**
- * console.error() is ugly af in jest; mock it with a noop,
- * and return the mock so that you can restore it:
- *
- * ```js
- * const mock = silenceConsoleError(jest)
- * // do stuff that calls console.error()
- * mock.mockRestore() // restore console.error()
- * ```
- *
- * Note: we need to pass `jest` as a reference here because
- * jest's mocking functions are bound to a module at runtime, and
- * need to be called as methods rather than pure functions
- * exported from the jest-mock module.
- */
-export function silenceConsoleError(jest) {
-  return jest.spyOn(console, 'error').mockImplementation(jest.fn())
-}
-
 export function mount(component) {
   return enzyme.mount(component)
 }


### PR DESCRIPTION
This deploys a couple of strategically placed Jest [mocks](https://jestjs.io/docs/en/mock-functions.html) to silence `console.error()` for tests that render invalid props. Here's the pattern:

```js
import {render} from '../utils/testing'

it('ignores invalid "foo" prop', () => {
  const hush = jest.spyOn(console, 'error').mockImplementation(jest.fn())
  expect(render(<MyComponent foo="bar" />).props.foo).toEqual(undefined)
  hush.mockRestore()
})
```
