### PR TITLE
Pass displayName to wrapped system components

### DIFF
--- a/src/system-props.js
+++ b/src/system-props.js
@@ -101,6 +101,7 @@ export function withSystemProps(Component, props = COMMON) {
   }
 
   const Wrapped = system(component, ...props)
+  Wrapped.displayName = Component.displayName
   Object.assign(Wrapped.propTypes, Component.propTypes)
 
   // Copy over non-system keys from components


### PR DESCRIPTION
This gives us a better debugging experience by setting `displayName` on the wrapped component in `withSystemProps()`, so that instead of every component being identified as `Styled(render)` (`render` comes from the function introduce in ed96d16), it gets the display name added automatically by our babel plugin.

I think the reason we have to do this explicitly is because emotion adds `displayName = Styled(...)`, which causes our for loop below to skip over it because it already exists.