### PR TITLE
Remove build instructions from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,7 @@ Description of changes
 
 #### Merge checklist
 - [ ] Changed base branch to release branch
-- [ ] Tested in Chrome [(BrowserStack)][BrowserStack]
-- [ ] Tested in Firefox [(BrowserStack)][BrowserStack]
-- [ ] Tested in Safari [(BrowserStack)][BrowserStack]
-- [ ] Tested in Edge [(BrowserStack)][BrowserStack]
-
-[BrowserStack]: https://www.browserstack.com/
+- [ ] Tested in Chrome
+- [ ] Tested in Firefox
+- [ ] Tested in Safari
+- [ ] Tested in Edge


### PR DESCRIPTION
This updates the pull request template:
1. Removes the Kit update and GitHub Pages build instructions
1. Adds a hint for the `Closes #` line
1. Removes the BrowserStack links (I think they're distracting, and if we're serious about browser testing we should be automating it)
1. Tidies up some other markup

#### Merge checklist
- [x] Changed base branch to release branch