### PR TITLE
Use Link components for <a> in MDX docs

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,18 +5,6 @@ import Octicon, {iconsByName} from '@githubprimer/octicons-react'
 import * as primerComponents from '../src'
 import * as docComponents from './doc-components'
 
-/**
- * See: https://github.com/zeit/next-plugins/tree/master/packages/next-sass#usage
- * Apparently this needs to live in _app because _document is rendered server-side,
- * so the code it generates isn't included in the client-side bundle.
- *
- * Unfortunately, the Next app's assetPrefix isn't available in this file
- * (except via window.__NEXT_DATA__), so we can't  generate the correct base
- * URL for it here. So the <link> lives in _document but the import has to live
- * here, because ¯\_(ツ)_/¯
- */
-import '../src/primer-react.scss'
-
 const {SideNav, Header, customTheme} = docComponents
 const {Box, FlexContainer, Link} = primerComponents
 
@@ -25,13 +13,15 @@ const iconComponents = Object.keys(iconsByName).reduce((map, key) => {
   return map
 }, {})
 
+const DocLink = props => <Link nounderline {...props} />
+
 const components = {
   ...primerComponents,
   ...docComponents,
   ...iconComponents,
   Octicon,
   // render links with our component
-  a: Link
+  a: DocLink
 }
 
 export default class MyApp extends App {


### PR DESCRIPTION
This maps all `a` elements rendered in our MDX docs to `<Link nounderline>`. It was super easy!

| Before | After |
| :--- | :--- |
| ![image](https://user-images.githubusercontent.com/113896/45781754-ca598680-bc15-11e8-9bee-5a65271d20d9.png) | ![image](https://user-images.githubusercontent.com/113896/45786241-69857a80-bc24-11e8-8996-e67e8ed17617.png) |


