### PR TITLE
Adding active style to side nav links

### DIFF
--- a/pages/doc-components/Header.js
+++ b/pages/doc-components/Header.js
@@ -30,7 +30,7 @@ const Header = ({router}) => (
           </NextLink>
           <NextLink href="/components/sandbox">
             <Link
-              color="white" 
+              color="white"
               href="/components/sandbox"
               mr={0}
               px={4}

--- a/pages/doc-components/SideNav.js
+++ b/pages/doc-components/SideNav.js
@@ -30,7 +30,6 @@ const SideNav = ({router}) => (
     <Box width={256} height="100%" bg="gray.0" display="inline-block" borderRight={1} borderColor="gray.2">
       <FlexContainer flexDirection="column" alignItems="start" p={5} borderBottom={1} borderColor="gray.2">
         <NextLink href="/components/docs/system-props">
-
           <Link
             color="gray.9"
             href="/components/docs/system-props"


### PR DESCRIPTION
Gives the side nav active links a different color/style so that when they're active you can tell what page they're on.

<img width="301" alt="image" src="https://user-images.githubusercontent.com/54012/46043303-87435b80-c0cc-11e8-9e87-4f1baa234444.png">

*Note there's typography properties that I'm using that need to be added to the `Link.js` component.

#### Merge checklist
- [x] Changed base branch to release branch
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
