### PR TITLE
fix scale command

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -3,4 +3,4 @@ set -e
 deployment="${1:-primer-components.now.sh}"
 now
 now alias $deployment
-now scale $deployment 1
+now scale $deployment sfo 1


### PR DESCRIPTION
This PR fixes the scale command in our deploy script to use the SFO servers, previously this command was failing because it was trying to scale in `bru` which is not allowed. I think this is the cause of the slowness the past week because we might have ran script/deploy without manually running the scale command set to `sfo` 🤚 