### PR TITLE
Update og:image for primer components

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -42,7 +42,7 @@ export default class MyDocument extends Document {
           <meta name="description" content="Primer components built with React.js." />
           <meta
             name="og:image"
-            content="https://user-images.githubusercontent.com/586552/46673190-3856f500-cba7-11e8-9752-b0c8fe5d4968.png"
+            content="https://user-images.githubusercontent.com/586552/46702062-ca82eb80-cbef-11e8-8c0b-4a9252dc04c6.png"
           />
           {styles}
         </Head>


### PR DESCRIPTION
Issue: #304 

- [x] Added an og:image
- [x] Updated the title to "Primer Components"
- [ ] Update url to "primer.style/components"

More options for the og:image illustration [in this figma file](https://www.figma.com/file/eAQrsDWP2StsAfhPPXX9ucHy/Primer-Components-og-image?node-id=0%3A1). Happy to play around with that more.

I'm not entirely sure how to test the displayed url. 
![frame](https://user-images.githubusercontent.com/586552/46677928-807b1500-cbb1-11e8-8e62-647f2ec869f2.png)

Testing locally or through the stage URL doesn't reflect the prod URL – would love to chat this through with someone more familiar with testing og tags 


