### PR TITLE
Add textAlign to TYPOGRAPHY, overflow to LAYOUT, justifyItems to FLEX_CONTAINER

### DIFF
--- a/src/system-props.js
+++ b/src/system-props.js
@@ -12,7 +12,8 @@ export const TYPOGRAPHY = COMMON.concat(
   'fontFamily',
   'fontSize',
   'fontWeight',
-  'lineHeight'
+  'lineHeight',
+  'textAlign'
 )
 
 export const LAYOUT = COMMON.concat(
@@ -30,7 +31,6 @@ export const LAYOUT = COMMON.concat(
   'maxWidth',
   'maxHeight',
   'overflow',
-  'textAlign',
   'verticalAlign'
 )
 


### PR DESCRIPTION
This adds the `textAlign` prop to the typography system props list, `overflow` to layout, and `justifyItems` to flex container. I discovered that we left off `textAlign` in [this PR](https://github.com/primer/primer.style/pull/62/commits/95c9b5130b716fd16f95a3cd78ed62760ed32556), and figured that having ways to responsively set it and `overflow` would be handy.

While I was in there I was looking at the props for `<FlexContainer>` and noticed that we had `justifyContent` but not `justifyItems`, so I added that.