### PR TITLE
remove semibold from theme

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -50,7 +50,6 @@ const theme = {
   fontWeights: {
     light: 300,
     normal: 400,
-    semibold: 500,
     bold: 600
   },
   colors,


### PR DESCRIPTION
Removes `semibold` from the theme

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
