### PR TITLE
details reset prop and caret prop

### DIFF
--- a/docs/content/Details.md
+++ b/docs/content/Details.md
@@ -85,14 +85,13 @@ Use the `reset` prop to remove the left caret when using the html tag. Use the `
 ```jsx live
 <State>
   {([]) => {
-    const {getDetailsProps} = useDetails({closeOnOutsideClick: true})
     return (
       <Grid gridAutoFlow="row" gridGap="2vmin">
-        <details>
+        <Details>
           <summary>default</summary>
-          this is some content
-        </details>
-        <Details {...getDetailsProps()} reset>
+          <p> this is some content</p>
+        </Details>
+        <Details reset>
           <summary>reset</summary>
           <p> This is some content </p>
         </Details>

--- a/docs/content/Details.md
+++ b/docs/content/Details.md
@@ -6,7 +6,6 @@ title: Details & useDetails hook
 
 The `useDetails` hook also takes a few configuration options as parameters which are noted in the table below.
 
-
 You must use a `summary` element as your `Details` trigger button. To style your summary element like a [Button](./Button), you can use the `as` prop (see example below).
 
 It's also possible to use the `useDetails` hook with components other than the Primer `Details`, such as a custom `Details` or `Modal` wrapper in your consuming application. All that matters is that the outer element is a `details` and it contains a `summary` for the button that opens and closes the component, and that `getDetailsProps` is properly spread onto the component rendering your `details` element.
@@ -23,10 +22,10 @@ It's also possible to use the `useDetails` hook with components other than the P
     )
   }}
 </State>
-
 ```
 
 You can use the `open` state returned from the hook to conditionally render content:
+
 ```jsx live
 <State>
   {([]) => {
@@ -39,7 +38,6 @@ You can use the `open` state returned from the hook to conditionally render cont
     )
   }}
 </State>
-
 ```
 
 You can also manually show/hide the content using the `setOpen` function returned from the hook. This can be useful if you have action items in the content of the component such as confirmation buttons:
@@ -57,18 +55,16 @@ You can also manually show/hide the content using the `setOpen` function returne
     )
   }}
 </State>
-
 ```
 
-In previous versions of Primer React Components, we allowed users to pass in a custom `onToggle` function. You can do this now by overriding the `onToggle` function returned in `getDetailsProps`. Please note that in most cases, you'll want the hook's handling of  `onToggle` to be run as well, so that the internal state is properly updated. To do this, manually call the `onToggle` handler returned from `useDetails` before executing your custom `onToggle` code.
-
+In previous versions of Primer React Components, we allowed users to pass in a custom `onToggle` function. You can do this now by overriding the `onToggle` function returned in `getDetailsProps`. Please note that in most cases, you'll want the hook's handling of `onToggle` to be run as well, so that the internal state is properly updated. To do this, manually call the `onToggle` handler returned from `useDetails` before executing your custom `onToggle` code.
 
 ```jsx live
 <State>
   {([]) => {
     const {getDetailsProps, open, setOpen} = useDetails({closeOnOutsideClick: true})
     const {onToggle, ...detailsProps} = getDetailsProps()
-    const customToggle = (e) => {
+    const customToggle = e => {
       onToggle(e)
       window.alert('hi')
     }
@@ -82,6 +78,29 @@ In previous versions of Primer React Components, we allowed users to pass in a c
 </State>
 ```
 
+## Custom Caret
+
+Use the `reset` prop to remove the left caret when using the html tag. Use the `Caret` component to add a default github styled caret to your summary
+
+```jsx live
+<State>
+  {([]) => {
+    const {getDetailsProps} = useDetails({closeOnOutsideClick: true})
+    return (
+      <Grid gridAutoFlow="row" gridGap="2vmin">
+        <details>
+          <summary>default</summary>
+          this is some content
+        </details>
+        <Details {...getDetailsProps()} reset>
+          <summary>reset</summary>
+          <p> This is some content </p>
+        </Details>
+      </Grid>
+    )
+  }}
+</State>
+```
 
 ## `Details` System props
 
@@ -89,16 +108,16 @@ Details components get `COMMON` system props. Read our [System Props](/system-pr
 
 ## `useDetails` hook configuration options
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| defaultOpen | Boolean | | Sets the initial open/closed state |
-| closeOnOutsideClick | Boolean | false | Sets whether or not element will close when the user clicks outside of it |
-| ref | React ref | | optional ref to pass down to Details component |
-
+| Name                | Type      | Default | Description                                                               |
+| :------------------ | :-------- | :-----: | :------------------------------------------------------------------------ |
+| defaultOpen         | Boolean   |         | Sets the initial open/closed state                                        |
+| closeOnOutsideClick | Boolean   |  false  | Sets whether or not element will close when the user clicks outside of it |
+| ref                 | React ref |         | optional ref to pass down to Details component                            |
 
 ### Values returned by the `useDetails` hook
-| Name | Type | Description |
-| :- | :- | :- |
-| open | string | Whether or not Details is currently open |
-| setOpen | function | Used to manually change the open state of the Details component |
-| getDetailsProps | Object | Contains an `onToggle` function, the `ref` to pass down to `Details` and the `open` attribute. In most cases, you won't need to interact with any of these values directly, but if you'd like to override any of these yourself you may.
+
+| Name            | Type     | Description                                                                                                                                                                                                                              |
+| :-------------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| open            | string   | Whether or not Details is currently open                                                                                                                                                                                                 |
+| setOpen         | function | Used to manually change the open state of the Details component                                                                                                                                                                          |
+| getDetailsProps | Object   | Contains an `onToggle` function, the `ref` to pass down to `Details` and the `open` attribute. In most cases, you won't need to interact with any of these values directly, but if you'd like to override any of these yourself you may. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "28.1.1",
+  "version": "28.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Details.tsx
+++ b/src/Details.tsx
@@ -3,18 +3,21 @@ import {COMMON, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
 import {ComponentProps} from './utils/types'
 
-type StyledDetailsProps = SystemCommonProps & SxProp
+type StyledDetailsProps = SystemCommonProps & SxProp & {reset?: boolean}
 
 const Details = styled.details<StyledDetailsProps>`
-  & > summary {
-    list-style: none;
-  }
-  & > summary::-webkit-details-marker {
-    display: none;
-  }
+  ${props =>
+    props.reset &&
+    `
+& > summary {
+  list-style: none;
+}
+& > summary::-webkit-details-marker {
+  display: none;
+}`}
 
   ${COMMON}
-  ${sx};
+${sx};
 `
 
 Details.displayName = 'Details'

--- a/src/__tests__/Details.tsx
+++ b/src/__tests__/Details.tsx
@@ -113,4 +113,20 @@ describe('Details', () => {
 
     wrapper.unmount()
   })
+
+  it('Removes default caret with the reset prop', () => {
+    const Component = () => {
+      const {getDetailsProps, open} = useDetails({closeOnOutsideClick: true, defaultOpen: true})
+      return (
+        <Details {...getDetailsProps()} reset>
+          <summary>Here is one</summary>
+        </Details>
+      )
+    }
+    const wrapper = mount(<Component />)
+
+    expect(wrapper.find('summary')).toHaveStyleRule('list-style', 'none')
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
Describe your changes here.
reset prop and caret prop for Details Component 
Closes #994  (type the issue number after # if applicable; otherwise remove this line)

### Screenshots
Please provide before/after screenshots for any visual changes
![Screenshot from 2021-05-30 16-42-50](https://user-images.githubusercontent.com/20450775/120123847-24040400-c166-11eb-9322-f322a99ef701.png)


### Merge checklist
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
