### PR TITLE
Guard against null value

### DIFF
--- a/src/polyfills/eventListenerSignal.ts
+++ b/src/polyfills/eventListenerSignal.ts
@@ -40,6 +40,7 @@ function monkeyPatch() {
   const originalAddEventListener = EventTarget.prototype.addEventListener
   EventTarget.prototype.addEventListener = function (name, originalCallback, optionsOrCapture) {
     if (
+      optionsOrCapture &&
       typeof optionsOrCapture === 'object' &&
       'signal' in optionsOrCapture &&
       optionsOrCapture.signal instanceof AbortSignal


### PR DESCRIPTION
This PR fixes an issue in case a `null` value is passed as `optionsOrCapture`.

Fixes: #1274

### Screenshots
N/A

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
