### PR TITLE
feat(SelectPanel): allow external anchor ref

### DIFF
--- a/.changeset/swift-books-wave.md
+++ b/.changeset/swift-books-wave.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Allow `anchorRef` to be passed into `SelectPanel` if you want to use an external anchor

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -7,36 +7,8 @@ import {AnchoredOverlay} from './AnchoredOverlay'
 import {useProvidedStateOrCreate} from './hooks/useProvidedStateOrCreate'
 import {OverlayProps} from './Overlay'
 import {useProvidedRefOrCreate} from './hooks'
+import {AnchoredOverlayWrapperAnchorProps} from './AnchoredOverlay/AnchoredOverlay'
 
-interface ActionMenuPropsWithAnchor {
-  /**
-   * A custom function component used to render the anchor element.
-   * Will receive the `anchoredContent` prop as `children` prop.
-   * Uses a `Button` by default.
-   */
-  renderAnchor?: <T extends React.HTMLAttributes<HTMLElement>>(props: T) => JSX.Element
-
-  /**
-   * An override to the internal renderAnchor ref that will be spread on to the renderAnchor,
-   * When renderAnchor is defined, this prop will be spread on to the rendAnchor
-   * component that is passed in.
-   */
-  anchorRef?: React.RefObject<HTMLElement>
-}
-
-interface ActionMenuPropsWithoutAnchor {
-  /**
-   * A custom function component used to render the anchor element.
-   * When renderAnchor is null, an anchorRef is required.
-   */
-  renderAnchor: null
-
-  /**
-   * An override to the internal renderAnchor ref. When renderAnchor is null this can be
-   * used to make an anchor that is detached from ActionMenu.
-   */
-  anchorRef: React.RefObject<HTMLElement>
-}
 interface ActionMenuBaseProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
   /**
    * Content that is passed into the renderAnchor component, which is a button by default.
@@ -64,7 +36,7 @@ interface ActionMenuBaseProps extends Partial<Omit<GroupedListProps, keyof ListP
   overlayProps?: Partial<OverlayProps>
 }
 
-export type ActionMenuProps = ActionMenuBaseProps & (ActionMenuPropsWithAnchor | ActionMenuPropsWithoutAnchor)
+export type ActionMenuProps = ActionMenuBaseProps & AnchoredOverlayWrapperAnchorProps
 
 const ActionMenuItem = (props: ItemProps) => <Item role="menuitem" {...props} />
 

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -32,6 +32,10 @@ interface AnchoredOverlayPropsWithoutAnchor {
   anchorRef: React.RefObject<HTMLElement>
 }
 
+export type AnchoredOverlayWrapperAnchorProps =
+  | Partial<AnchoredOverlayPropsWithAnchor>
+  | AnchoredOverlayPropsWithoutAnchor
+
 interface AnchoredOverlayBaseProps extends Pick<OverlayProps, 'height' | 'width'> {
   /**
    * Determines whether the overlay portion of the component should be shown or not

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -1,6 +1,6 @@
 import type {OverlayProps} from '../Overlay'
 import {Meta} from '@storybook/react'
-import React, {useState} from 'react'
+import React, {useRef, useState} from 'react'
 import {theme, ThemeProvider} from '..'
 import {ItemInput} from '../ActionList/List'
 import BaseStyles from '../BaseStyles'
@@ -118,6 +118,37 @@ export function SingleSelectStory(): JSX.Element {
   )
 }
 SingleSelectStory.storyName = 'Single Select'
+
+export function ExternalAnchorStory(): JSX.Element {
+  const [selected, setSelected] = React.useState<ItemInput | undefined>(items[0])
+  const [filter, setFilter] = React.useState('')
+  const filteredItems = items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
+  const [open, setOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  return (
+    <>
+      <h1>Select Panel With External Anchor</h1>
+      <DropdownButton ref={buttonRef} onClick={() => setOpen(!open)}>
+        Custom: {selected?.text || 'Click Me'}
+      </DropdownButton>
+      <SelectPanel
+        renderAnchor={null}
+        anchorRef={buttonRef}
+        placeholderText="Filter Labels"
+        open={open}
+        onOpenChange={setOpen}
+        items={filteredItems}
+        selected={selected}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
+        showItemDividers={true}
+        overlayProps={{width: 'small', height: 'xsmall'}}
+      />
+    </>
+  )
+}
+ExternalAnchorStory.storyName = 'With External Anchor'
 
 export function SelectPanelHeightInitialWithOverflowingItemsStory(): JSX.Element {
   const [selected, setSelected] = React.useState<ItemInput | undefined>(items[0])


### PR DESCRIPTION
`SelectPanel` currently creates an anchor internally, but has no option to anchor next to an outside ref.  We added this "external anchor" feature to `ActionMenu` in #1199, but never added it to the other AnchoredOverlay wrappers.  This is needed for some new menu behaviors being built by another team.

### Screenshots

![image](https://user-images.githubusercontent.com/3026298/128265789-f1785e80-c038-4ed5-8a14-ccd671a96c62.png)

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
