### PR TITLE
Single confirm dialog

### DIFF
--- a/.changeset/neat-coins-mix.md
+++ b/.changeset/neat-coins-mix.md
@@ -1,5 +1,5 @@
 ---
-'@primer/components': patch
+'@primer/components': minor
 ---
 
-ConfirmationDialog can now render with one button, by passing a falsy value to `cancelButtonContent`.
+adding `AlertDialog` to account for cases where only one button is needed.

--- a/.changeset/neat-coins-mix.md
+++ b/.changeset/neat-coins-mix.md
@@ -2,4 +2,4 @@
 '@primer/components': minor
 ---
 
-adding `AlertDialog` to account for cases where only one button is needed in a dialog.
+add `AlertDialog` component for cases where only one button is needed in a dialog.

--- a/.changeset/neat-coins-mix.md
+++ b/.changeset/neat-coins-mix.md
@@ -2,4 +2,4 @@
 '@primer/components': minor
 ---
 
-adding `AlertDialog` to account for cases where only one button is needed.
+adding `AlertDialog` to account for cases where only one button is needed in a dialog.

--- a/.changeset/neat-coins-mix.md
+++ b/.changeset/neat-coins-mix.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': patch
+---
+
+ConfirmationDialog can now render with one button, by passing a falsy value to `cancelButtonContent`.

--- a/docs/content/Dialog2.mdx
+++ b/docs/content/Dialog2.mdx
@@ -158,6 +158,27 @@ render(<ShorthandExample2 />)
 </State>
 ```
 
+### Example (using `ConfirmationDialog` component with one confirm option)
+
+```jsx live
+<State default={false}>
+  {([isOpen, setIsOpen]) => {
+    const openDialog = React.useCallback(() => setIsOpen(true), [setIsOpen])
+    const closeDialog = React.useCallback(() => setIsOpen(false), [setIsOpen])
+    return (
+      <>
+        <Button onClick={openDialog}>Open</Button>
+        {isOpen && (
+          <ConfirmationDialog title="Confirm action?" onClose={closeDialog} cancelButtonContent={null}>
+            Are you sure you want to confirm this action?
+          </ConfirmationDialog>
+        )}
+      </>
+    )
+  }}
+</State>
+```
+
 ### ConfirmationDialogProps
 
 | Prop name            | Type                                                                  | Default    | Description                                                                                                                   |

--- a/docs/content/Dialog2.mdx
+++ b/docs/content/Dialog2.mdx
@@ -180,38 +180,39 @@ render(<ShorthandExample2 />)
 
 ## AlertDialog
 
-An `AlertDialog` is a special kind of dialog with more rigid behavior. It is used to alert or confirm a single user action. AlertDialogs can only have at most one button: no buttons or one to confirm the alert dialog. No custom rendering capabilities are provided for AlertDialog.
+AlertDialog is a special kind of dialog with an urgent interruption, and informs the user about a situation.
+They summarize a **single** decision that requires acknowledgement and can only be dismissed by the alert close button or `escape` key.
+Use a clear question or statement for the alert title with an explanation in the content area, such as "Erase Disk storage?".
+Avoid apologies, ambiguity, or questions, such as “Warning!” or “Are you sure?”
+No custom rendering capabilities are provided for AlertDialog.
 
 ### useAlert hook
 
-An alternate way to use `AlertDialog` is with the `useAlert()` hook. It takes no parameters and returns an `async` function, `alert`. When `alert` is called (see AlertOptions below for its argument), it shows the alert dialog. When the dialog is dismissed, a promise is resolved with `true` or `false` depending on whether or not the confirm button was used.
+An alternate way to use `AlertDialog` is with the `useAlert()` hook. It takes no parameters and returns an `async` function, `alert`. When `alert` is called (see AlertOptions below for its argument), it shows the alert dialog. When the dialog is dismissed, a promise is resolved with `true` or `false` depending on whether or not the acknowledgement button was used.
 
 ### Example (with `useAlert` hook)
 
 ```javascript live noinline
-function ShorthandExample2() {
+function ShorthandExample() {
   const alert = useAlert()
   const buttonClick = React.useCallback(
     async function (e) {
       if (
         await alert({
-          title: 'Are you sure?',
-          content: 'You must confirm this action to continue.',
-          confirmButtonContent: 'OK'
+          title: 'Erase USB Storage?',
+          content: 'By pressing "OK" you acknowledge All files will be deleted and cannot be recovered',
+          buttonContent: 'OK'
+          buttonType: 'danger'
         })
       ) {
-        e.target.textContent = 'Confirmed!'
+        e.target.textContent = 'Acknowledged!'
       }
     },
     [confirm]
   )
-  return (
-    <>
-      <Button onClick={buttonClick}>Confirmable action</Button>
-    </>
-  )
+  return <Button onClick={buttonClick}>Confirmable action</Button>
 }
-render(<ShorthandExample2 />)
+render(<ShorthandExample />)
 ```
 
 ### Example (using `AlertDialog` component)
@@ -225,8 +226,8 @@ render(<ShorthandExample2 />)
       <>
         <Button onClick={openDialog}>Open</Button>
         {isOpen && (
-          <AlertDialog title="Confirm action?" onClose={closeDialog}>
-            Are you sure you want to confirm this action?
+          <AlertDialog title="Invalid or Expired credit card" onClose={closeDialog}>
+            Please enter a valid form of payment.
           </AlertDialog>
         )}
       </>
@@ -237,18 +238,18 @@ render(<ShorthandExample2 />)
 
 ### AlertDialogProps
 
-| Prop name            | Type                                                       | Default  | Description                                                                                                                   |
-| :------------------- | :--------------------------------------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------- |
-| title                | `React.ReactNode`                                          |          | Required. Sets the title of the dialog, which by default is also used as the `aria-labelledby` attribute.                     |
-| onClose              | `(gesture: 'confirm' │ 'close-button' │ 'escape') => void` |          | Required. This callback is invoked when a gesture to close the dialog is performed. The first argument indicates the gesture. |
-| confirmButtonContent | `React.ReactNode`                                          |          | The content to use for the confirm button.                                                                                    |
-| confirmButtonType    | `"normal" │ "primary" │ "danger"`                          | `Button` | The type of button to use for the confirm button.                                                                             |
+| Prop name     | Type                                                           | Default  | Description                                                                                                                   |
+| :------------ | :------------------------------------------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| title         | `React.ReactNode`                                              |          | Required. Sets the title of the dialog, which by default is also used as the `aria-labelledby` attribute.                     |
+| onClose       | `(gesture: 'acknowledge' │ 'close-button' │ 'escape') => void` |          | Required. This callback is invoked when a gesture to close the dialog is performed. The first argument indicates the gesture. |
+| buttonContent | `React.ReactNode`                                              |          | The content to use for the button.                                                                                            |
+| buttonType    | `"normal" │ "primary" │ "danger"`                              | `Button` | The type of button to use for the button.                                                                                     |
 
 ### AlertOptions
 
-| Prop name            | Type                              | Default  | Description                                                                                               |
-| :------------------- | :-------------------------------- | :------- | :-------------------------------------------------------------------------------------------------------- |
-| title                | `React.ReactNode`                 |          | Required. Sets the title of the dialog, which by default is also used as the `aria-labelledby` attribute. |
-| content              | `React.ReactNode`                 |          | Required. Used as the body of the ConfirmationDialog that is displayed.                                   |
-| confirmButtonContent | `React.ReactNode`                 |          | The content to use for the confirm button.                                                                |
-| confirmButtonType    | `"normal" │ "primary" │ "danger"` | `Button` | The type of button to use for the confirm button.                                                         |
+| Prop name     | Type                              | Default  | Description                                                                                               |
+| :------------ | :-------------------------------- | :------- | :-------------------------------------------------------------------------------------------------------- |
+| title         | `React.ReactNode`                 |          | Required. Sets the title of the dialog, which by default is also used as the `aria-labelledby` attribute. |
+| content       | `React.ReactNode`                 |          | Required. Used as the body of the ConfirmationDialog that is displayed.                                   |
+| buttonContent | `React.ReactNode`                 |          | The content to use for the alert button.                                                                  |
+| buttonType    | `"normal" │ "primary" │ "danger"` | `Button` | The type of button to use for the button.                                                                 |

--- a/docs/content/Dialog2.mdx
+++ b/docs/content/Dialog2.mdx
@@ -158,7 +158,7 @@ render(<ShorthandExample2 />)
 </State>
 ```
 
-### Example (using `ConfirmationDialog` component with one confirm option)
+### Example (using `ConfirmationDialog` component with no cancel option)
 
 ```jsx live
 <State default={false}>

--- a/docs/content/Dialog2.mdx
+++ b/docs/content/Dialog2.mdx
@@ -158,27 +158,6 @@ render(<ShorthandExample2 />)
 </State>
 ```
 
-### Example (using `ConfirmationDialog` component with no cancel option)
-
-```jsx live
-<State default={false}>
-  {([isOpen, setIsOpen]) => {
-    const openDialog = React.useCallback(() => setIsOpen(true), [setIsOpen])
-    const closeDialog = React.useCallback(() => setIsOpen(false), [setIsOpen])
-    return (
-      <>
-        <Button onClick={openDialog}>Open</Button>
-        {isOpen && (
-          <ConfirmationDialog title="Confirm action?" onClose={closeDialog} cancelButtonContent={null}>
-            Are you sure you want to confirm this action?
-          </ConfirmationDialog>
-        )}
-      </>
-    )
-  }}
-</State>
-```
-
 ### ConfirmationDialogProps
 
 | Prop name            | Type                                                                  | Default    | Description                                                                                                                   |
@@ -198,3 +177,78 @@ render(<ShorthandExample2 />)
 | cancelButtonContent  | `React.ReactNode`                 | `"Cancel"` | The content to use for the cancel button.                                                                 |
 | confirmButtonContent | `React.ReactNode`                 | `"OK"`     | The content to use for the confirm button.                                                                |
 | confirmButtonType    | `"normal" │ "primary" │ "danger"` | `Button`   | The type of button to use for the confirm button.                                                         |
+
+## AlertDialog
+
+An `AlertDialog` is a special kind of dialog with more rigid behavior. It is used to alert or confirm a single user action. AlertDialogs can only have at most one button: no buttons or one to confirm the alert dialog. No custom rendering capabilities are provided for AlertDialog.
+
+### useAlert hook
+
+An alternate way to use `AlertDialog` is with the `useAlert()` hook. It takes no parameters and returns an `async` function, `alert`. When `alert` is called (see AlertOptions below for its argument), it shows the alert dialog. When the dialog is dismissed, a promise is resolved with `true` or `false` depending on whether or not the confirm button was used.
+
+### Example (with `useAlert` hook)
+
+```javascript live noinline
+function ShorthandExample2() {
+  const alert = useAlert()
+  const buttonClick = React.useCallback(
+    async function (e) {
+      if (
+        await alert({
+          title: 'Are you sure?',
+          content: 'You must confirm this action to continue.',
+          confirmButtonContent: 'OK'
+        })
+      ) {
+        e.target.textContent = 'Confirmed!'
+      }
+    },
+    [confirm]
+  )
+  return (
+    <>
+      <Button onClick={buttonClick}>Confirmable action</Button>
+    </>
+  )
+}
+render(<ShorthandExample2 />)
+```
+
+### Example (using `AlertDialog` component)
+
+```jsx live
+<State default={false}>
+  {([isOpen, setIsOpen]) => {
+    const openDialog = React.useCallback(() => setIsOpen(true), [setIsOpen])
+    const closeDialog = React.useCallback(() => setIsOpen(false), [setIsOpen])
+    return (
+      <>
+        <Button onClick={openDialog}>Open</Button>
+        {isOpen && (
+          <AlertDialog title="Confirm action?" onClose={closeDialog}>
+            Are you sure you want to confirm this action?
+          </AlertDialog>
+        )}
+      </>
+    )
+  }}
+</State>
+```
+
+### AlertDialogProps
+
+| Prop name            | Type                                                       | Default  | Description                                                                                                                   |
+| :------------------- | :--------------------------------------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| title                | `React.ReactNode`                                          |          | Required. Sets the title of the dialog, which by default is also used as the `aria-labelledby` attribute.                     |
+| onClose              | `(gesture: 'confirm' │ 'close-button' │ 'escape') => void` |          | Required. This callback is invoked when a gesture to close the dialog is performed. The first argument indicates the gesture. |
+| confirmButtonContent | `React.ReactNode`                                          |          | The content to use for the confirm button.                                                                                    |
+| confirmButtonType    | `"normal" │ "primary" │ "danger"`                          | `Button` | The type of button to use for the confirm button.                                                                             |
+
+### AlertOptions
+
+| Prop name            | Type                              | Default  | Description                                                                                               |
+| :------------------- | :-------------------------------- | :------- | :-------------------------------------------------------------------------------------------------------- |
+| title                | `React.ReactNode`                 |          | Required. Sets the title of the dialog, which by default is also used as the `aria-labelledby` attribute. |
+| content              | `React.ReactNode`                 |          | Required. Used as the body of the ConfirmationDialog that is displayed.                                   |
+| confirmButtonContent | `React.ReactNode`                 |          | The content to use for the confirm button.                                                                |
+| confirmButtonType    | `"normal" │ "primary" │ "danger"` | `Button` | The type of button to use for the confirm button.                                                         |

--- a/src/Dialog/AlertDialog.tsx
+++ b/src/Dialog/AlertDialog.tsx
@@ -9,30 +9,30 @@ import ReactDOM from 'react-dom'
 import {ThemeProvider, useTheme, ThemeProviderProps} from '../ThemeProvider'
 
 /**
- * Props to customize the ConfirmationDialog.
+ * Props to customize the AlertDialog.
  */
 export interface AlertDialogProps {
   /**
    * Required. This callback is invoked when a gesture to close the dialog
    * is performed. The first argument indicates the gesture.
    */
-  onClose(gesture: 'confirm' | 'close-button' | 'escape'): void
+  onClose(gesture: 'acknowledge' | 'close-button' | 'escape'): void
 
   /**
-   * Required. The title of the ConfirmationDialog. This is usually a brief
-   * question.
+   * Required. The title of the AlertDialog. This is usually a clear
+   * question or statement.
    */
   title: React.ReactNode
 
   /**
-   * The text to use for the confirm button. Default: "OK".
+   * The text to use to acknowledge the alert. Default: "Got it!".
    */
-  confirmButtonContent?: React.ReactNode
+  buttonContent?: React.ReactNode
 
   /**
-   * The type of button to use for the confirm button. Default: Button.
+   * The type of button to use for the acknowledgement gesture. Default: normal.
    */
-  confirmButtonType?: 'normal' | 'primary' | 'danger'
+  buttonType?: 'normal' | 'primary' | 'danger'
 }
 
 const StyledAlertHeader = styled.header`
@@ -94,27 +94,30 @@ const AlertFooter: React.FC<DialogProps> = ({footerButtons}) => {
 }
 
 /**
- * An AlertDialog is a special kind of dialog with more rigid behavior. It
- * is used to alert or confirm a single user action. AlertDialogs can only have at most
- * one button: no buttons or one to confirm the alert dialog.
+ * AlertDialog is a special kind of dialog with an urgent interruption, and informs the user about a situation.
+ * They summarize a __single__ decision that requires acknowledgement and can only be dismissed by the alert close button or `escape` key.
+ * Use a clear question or statement for the alert title with an explanation in the content area, such as "Erase USB storage?".
+ * Avoid apologies, ambiguity, or questions, such as “Warning!” or “Are you sure?”
  * No custom rendering capabilities are provided for AlertDialog.
  */
 export const AlertDialog: React.FC<AlertDialogProps> = props => {
-  const {onClose, title, confirmButtonContent, confirmButtonType = 'normal', children} = props
+  const {onClose, title, buttonContent = 'Got it!', buttonType = 'normal', children} = props
 
   const onConfirmButtonClick = useCallback(() => {
-    onClose('confirm')
+    onClose('acknowledge')
   }, [onClose])
 
-  const confirmButton: DialogButtonProps = {
-    content: confirmButtonContent,
-    buttonType: confirmButtonType,
+  const acknowledgeButton: DialogButtonProps = {
+    content: buttonContent,
+    buttonType,
     variant: 'large',
     onClick: onConfirmButtonClick
   }
 
-  const hasConfirm = !!confirmButtonContent
-  const footerButtons = hasConfirm ? [confirmButton] : undefined
+  const hasAcknowledgeContent = !!buttonContent
+  const footerButtons = hasAcknowledgeContent ? [acknowledgeButton] : undefined
+  const footer = hasAcknowledgeContent ? AlertFooter : undefined
+
   return (
     <Dialog
       onClose={onClose}
@@ -124,7 +127,7 @@ export const AlertDialog: React.FC<AlertDialogProps> = props => {
       width="medium"
       renderHeader={AlertHeader}
       renderBody={AlertBody}
-      renderFooter={hasConfirm ? AlertFooter : undefined}
+      renderFooter={footer}
     >
       {children}
     </Dialog>
@@ -139,7 +142,7 @@ async function alert(themeProps: ThemeProviderProps, options: AlertOptions): Pro
     const hostElement = document.createElement('div')
     const onClose: AlertDialogProps['onClose'] = gesture => {
       ReactDOM.unmountComponentAtNode(hostElement)
-      resolve(gesture === 'confirm')
+      resolve(gesture === 'acknowledge')
     }
 
     ReactDOM.render(
@@ -155,8 +158,8 @@ async function alert(themeProps: ThemeProviderProps, options: AlertOptions): Pro
 
 /**
  * This hook takes no parameters and returns an `async` function, `alert`. When `alert`
- * is called, it shows the confirmation dialog. When the dialog is dismissed, a promise is
- * resolved with `true` or `false` depending on whether or not the confirm button was used.
+ * is called, it shows the AlertDialog. When the dialog is dismissed, a promise is
+ * resolved with `true` or `false` depending on whether or not the acknowledgement button was used.
  */
 export function useAlert() {
   const {theme, colorMode, dayScheme, nightScheme} = useTheme()

--- a/src/Dialog/AlertDialog.tsx
+++ b/src/Dialog/AlertDialog.tsx
@@ -1,0 +1,171 @@
+import React, {useCallback} from 'react'
+import {Dialog, DialogButtonProps, DialogHeaderProps, DialogProps} from '../Dialog/Dialog'
+import styled from 'styled-components'
+import {get} from '../constants'
+import Box from '../Box'
+import {useFocusZone} from '../hooks/useFocusZone'
+import {FocusKeys} from '../behaviors/focusZone'
+import ReactDOM from 'react-dom'
+import {ThemeProvider, useTheme, ThemeProviderProps} from '../ThemeProvider'
+
+/**
+ * Props to customize the ConfirmationDialog.
+ */
+export interface AlertDialogProps {
+  /**
+   * Required. This callback is invoked when a gesture to close the dialog
+   * is performed. The first argument indicates the gesture.
+   */
+  onClose(gesture: 'confirm' | 'close-button' | 'escape'): void
+
+  /**
+   * Required. The title of the ConfirmationDialog. This is usually a brief
+   * question.
+   */
+  title: React.ReactNode
+
+  /**
+   * The text to use for the confirm button. Default: "OK".
+   */
+  confirmButtonContent?: React.ReactNode
+
+  /**
+   * The type of button to use for the confirm button. Default: Button.
+   */
+  confirmButtonType?: 'normal' | 'primary' | 'danger'
+}
+
+const StyledAlertHeader = styled.header`
+  padding: ${get('space.2')};
+  display: flex;
+  flex-direction: row;
+`
+
+const StyledTitle = styled(Box)`
+  font-size: ${get('fontSizes.3')};
+  font-weight: ${get('fontWeights.bold')};
+  padding: 6px ${get('space.2')};
+  flex-grow: 1;
+`
+
+const StyledAlertBody = styled(Box)`
+  font-size: ${get('fontSizes.1')};
+  padding: 0 ${get('space.3')} ${get('space.3')} ${get('space.3')};
+  color: ${get('colors.text.tertiary')};
+  flex-grow: 1;
+`
+
+const StyledAlertFooter = styled(Box)`
+  display: flex;
+  margin: 0 ${get('space.3')} ${get('space.3')} ${get('space.3')};
+
+  button {
+    font-size: ${get('fontSizes.1')};
+    flex: 1 1 0;
+    padding: 5px ${get('space.3')};
+  }
+`
+
+const AlertHeader: React.FC<DialogHeaderProps> = ({title, onClose, dialogLabelId}) => {
+  const onCloseClick = useCallback(() => {
+    onClose('close-button')
+  }, [onClose])
+  return (
+    <StyledAlertHeader>
+      <StyledTitle id={dialogLabelId}>{title}</StyledTitle>
+      <Dialog.CloseButton onClose={onCloseClick} />
+    </StyledAlertHeader>
+  )
+}
+
+const AlertBody: React.FC<DialogProps> = ({children}) => <StyledAlertBody>{children}</StyledAlertBody>
+
+const AlertFooter: React.FC<DialogProps> = ({footerButtons}) => {
+  const {containerRef: footerRef} = useFocusZone({
+    bindKeys: FocusKeys.ArrowHorizontal | FocusKeys.Tab,
+    focusInStrategy: 'closest'
+  })
+
+  return (
+    <StyledAlertFooter ref={footerRef as React.RefObject<HTMLDivElement>}>
+      <Dialog.Buttons buttons={footerButtons ?? []} />
+    </StyledAlertFooter>
+  )
+}
+
+/**
+ * An AlertDialog is a special kind of dialog with more rigid behavior. It
+ * is used to alert or confirm a single user action. AlertDialogs can only have at most
+ * one button: no buttons or one to confirm the alert dialog.
+ * No custom rendering capabilities are provided for AlertDialog.
+ */
+export const AlertDialog: React.FC<AlertDialogProps> = props => {
+  const {onClose, title, confirmButtonContent, confirmButtonType = 'normal', children} = props
+
+  const onConfirmButtonClick = useCallback(() => {
+    onClose('confirm')
+  }, [onClose])
+
+  const confirmButton: DialogButtonProps = {
+    content: confirmButtonContent,
+    buttonType: confirmButtonType,
+    variant: 'large',
+    onClick: onConfirmButtonClick
+  }
+
+  const hasConfirm = !!confirmButtonContent
+  const footerButtons = hasConfirm ? [confirmButton] : undefined
+  return (
+    <Dialog
+      onClose={onClose}
+      title={title}
+      footerButtons={footerButtons}
+      role="alertdialog"
+      width="medium"
+      renderHeader={AlertHeader}
+      renderBody={AlertBody}
+      renderFooter={hasConfirm ? AlertFooter : undefined}
+    >
+      {children}
+    </Dialog>
+  )
+}
+
+type AlertOptions = Omit<AlertDialogProps, 'onClose'> & {content: React.ReactNode}
+async function alert(themeProps: ThemeProviderProps, options: AlertOptions): Promise<boolean> {
+  const {content, ...alertDialogProps} = options
+
+  return new Promise(resolve => {
+    const hostElement = document.createElement('div')
+    const onClose: AlertDialogProps['onClose'] = gesture => {
+      ReactDOM.unmountComponentAtNode(hostElement)
+      resolve(gesture === 'confirm')
+    }
+
+    ReactDOM.render(
+      <ThemeProvider {...themeProps}>
+        <AlertDialog {...alertDialogProps} onClose={onClose}>
+          {content}
+        </AlertDialog>
+      </ThemeProvider>,
+      hostElement
+    )
+  })
+}
+
+/**
+ * This hook takes no parameters and returns an `async` function, `alert`. When `alert`
+ * is called, it shows the confirmation dialog. When the dialog is dismissed, a promise is
+ * resolved with `true` or `false` depending on whether or not the confirm button was used.
+ */
+export function useAlert() {
+  const {theme, colorMode, dayScheme, nightScheme} = useTheme()
+
+  return useCallback(
+    (options: AlertOptions) => {
+      const themeProps: ThemeProviderProps = {theme, colorMode, dayScheme, nightScheme}
+      return alert(themeProps, options)
+    },
+    [theme, colorMode, dayScheme, nightScheme]
+  )
+}

--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -113,12 +113,12 @@ const StyledConfirmationFooter = styled(Box)`
 
 const StyledSingleConfirmationFooter = styled(Box)`
   display: flex;
-  margin: 0 16px 16px 16px;
+  margin: 0 ${get('space.3')} ${get('space.3')} ${get('space.3')};
 
   button {
     font-size: ${get('fontSizes.1')};
     flex: 1 1 0;
-    padding: 5px 16px;
+    padding: 5px ${get('space.3')};
   }
 `
 

--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -110,16 +110,31 @@ const StyledConfirmationFooter = styled(Box)`
     border-radius: 0;
   }
 `
+
+const StyledSingleConfirmationFooter = styled(Box)`
+  display: flex;
+  margin: 0 16px 16px 16px;
+
+  button {
+    font-size: ${get('fontSizes.1')};
+    flex: 1 1 0;
+    padding: 5px 16px;
+  }
+`
+
 const ConfirmationFooter: React.FC<DialogProps> = ({footerButtons}) => {
   const {containerRef: footerRef} = useFocusZone({
     bindKeys: FocusKeys.ArrowHorizontal | FocusKeys.Tab,
     focusInStrategy: 'closest'
   })
-  // Must have exactly 2 buttons!
+
+  const Footer = footerButtons?.length === 1 ? StyledSingleConfirmationFooter : StyledConfirmationFooter
+
+  // Must have at most 2 buttons!
   return (
-    <StyledConfirmationFooter ref={footerRef as React.RefObject<HTMLDivElement>}>
+    <Footer ref={footerRef as React.RefObject<HTMLDivElement>}>
       <Dialog.Buttons buttons={footerButtons ?? []} />
-    </StyledConfirmationFooter>
+    </Footer>
   )
 }
 

--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -16,7 +16,7 @@ export interface ConfirmationDialogProps {
    * Required. This callback is invoked when a gesture to close the dialog
    * is performed. The first argument indicates the gesture.
    */
-  onClose: (gesture: 'confirm' | 'cancel' | 'close-button' | 'cancel' | 'escape') => void
+  onClose: (gesture: 'confirm' | 'cancel' | 'close-button' | 'escape') => void
 
   /**
    * Required. The title of the ConfirmationDialog. This is usually a brief
@@ -110,31 +110,16 @@ const StyledConfirmationFooter = styled(Box)`
     border-radius: 0;
   }
 `
-
-const StyledSingleConfirmationFooter = styled(Box)`
-  display: flex;
-  margin: 0 ${get('space.3')} ${get('space.3')} ${get('space.3')};
-
-  button {
-    font-size: ${get('fontSizes.1')};
-    flex: 1 1 0;
-    padding: 5px ${get('space.3')};
-  }
-`
-
 const ConfirmationFooter: React.FC<DialogProps> = ({footerButtons}) => {
   const {containerRef: footerRef} = useFocusZone({
     bindKeys: FocusKeys.ArrowHorizontal | FocusKeys.Tab,
     focusInStrategy: 'closest'
   })
-
-  const Footer = footerButtons?.length === 1 ? StyledSingleConfirmationFooter : StyledConfirmationFooter
-
-  // Must have at most 2 buttons!
+  // Must have exactly 2 buttons!
   return (
-    <Footer ref={footerRef as React.RefObject<HTMLDivElement>}>
+    <StyledConfirmationFooter ref={footerRef as React.RefObject<HTMLDivElement>}>
       <Dialog.Buttons buttons={footerButtons ?? []} />
-    </Footer>
+    </StyledConfirmationFooter>
   )
 }
 
@@ -172,7 +157,7 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = props => {
     variant: 'large',
     onClick: onConfirmButtonClick
   }
-  const footerButtons = [cancelButton, confirmButton].filter(btn => !!btn.content)
+  const footerButtons = [cancelButton, confirmButton]
   return (
     <Dialog
       onClose={onClose}

--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -157,7 +157,7 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = props => {
     variant: 'large',
     onClick: onConfirmButtonClick
   }
-  const footerButtons = [cancelButton, confirmButton]
+  const footerButtons = [cancelButton, confirmButton].filter(btn => !!btn.content)
   return (
     <Dialog
       onClose={onClose}

--- a/src/__tests__/AlertDialog.tsx
+++ b/src/__tests__/AlertDialog.tsx
@@ -5,8 +5,8 @@ import {render, RenderResult} from '@testing-library/react'
 
 describe('AlertDialog', () => {
   const handleClose = jest.fn()
-  const title = 'Are you sure?'
-  const content = 'Do you really want to do a trick?'
+  const title = 'Drop table xyz'
+  const content = 'By pressing "OK" you confirm to drop the table'
 
   const renderElement = (props: Omit<AlertDialogProps, 'onClose' | 'title'> = {}): RenderResult =>
     render(
@@ -38,17 +38,14 @@ describe('AlertDialog', () => {
   })
 
   it('renders without buttons', () => {
-    const {container} = renderElement()
-
-    expect(container.querySelector('button')).toBeNull()
+    renderElement({buttonContent: null})
+    expect(screen.queryByText('Got it!')).toBeNull()
   })
 
   it('renders with custom button', () => {
     const confirm = 'Got it!'
 
-    renderElement({
-      confirmButtonContent: confirm
-    })
+    renderElement()
 
     expect(screen.queryByText(confirm)).toBeDefined()
   })

--- a/src/__tests__/AlertDialog.tsx
+++ b/src/__tests__/AlertDialog.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
 import {fireEvent, screen} from '@testing-library/dom'
-import {ConfirmationDialog, ConfirmationDialogProps} from '../Dialog/ConfirmationDialog'
+import {AlertDialog, AlertDialogProps} from '../Dialog/AlertDialog'
 import {render, RenderResult} from '@testing-library/react'
 
-describe('ConfirmationDialog', () => {
+describe('AlertDialog', () => {
   const handleClose = jest.fn()
   const title = 'Are you sure?'
   const content = 'Do you really want to do a trick?'
 
-  const renderElement = (props: Omit<ConfirmationDialogProps, 'onClose' | 'title'> = {}): RenderResult =>
+  const renderElement = (props: Omit<AlertDialogProps, 'onClose' | 'title'> = {}): RenderResult =>
     render(
-      <ConfirmationDialog title={title} onClose={handleClose} {...props}>
+      <AlertDialog title={title} onClose={handleClose} {...props}>
         {content}
-      </ConfirmationDialog>
+      </AlertDialog>
     )
 
   beforeEach(() => {
@@ -37,30 +37,19 @@ describe('ConfirmationDialog', () => {
     expect(handleClose).toHaveBeenCalledTimes(1)
   })
 
-  it('renders with default buttons', () => {
-    const expectedButtons = ['Cancel', 'OK']
+  it('renders without buttons', () => {
+    const {container} = renderElement()
 
-    renderElement()
-
-    for (const btnText of expectedButtons) {
-      expect(screen.getByText(btnText)).toBeTruthy()
-    }
-
-    fireEvent.click(screen.getByText(expectedButtons[0]))
-    expect(handleClose).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('button')).toBeNull()
   })
 
-  it('renders with custom buttons', () => {
-    const cancel = 'Dismiss'
+  it('renders with custom button', () => {
     const confirm = 'Got it!'
 
     renderElement({
-      cancelButtonContent: cancel,
       confirmButtonContent: confirm
     })
 
-    for (const expected of [cancel, confirm]) {
-      expect(screen.queryByText(expected)).toBeDefined()
-    }
+    expect(screen.queryByText(confirm)).toBeDefined()
   })
 })

--- a/src/__tests__/ConfirmationDialog.tsx
+++ b/src/__tests__/ConfirmationDialog.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import {fireEvent, screen} from '@testing-library/dom'
+import {ConfirmationDialog, ConfirmationDialogProps} from '../Dialog/ConfirmationDialog'
+import {render, RenderResult} from '@testing-library/react'
+
+describe('ConfirmationDialog', () => {
+  const handleClose = jest.fn()
+  const title = 'Are you sure?'
+  const content = 'Do you really want to do a trick?'
+
+  const renderElement = (props: Omit<ConfirmationDialogProps, 'onClose' | 'title'> = {}): RenderResult =>
+    render(
+      <ConfirmationDialog title={title} onClose={handleClose} {...props}>
+        {content}
+      </ConfirmationDialog>
+    )
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders a title and content', () => {
+    renderElement()
+
+    expect(screen.getByText(title)).toBeTruthy()
+    expect(screen.getByText(content)).toBeTruthy()
+  })
+
+  it('renders a close button in dialog header', () => {
+    renderElement()
+
+    const closeButton = screen.getByLabelText('Close')
+
+    expect(closeButton).toBeDefined()
+
+    fireEvent.click(closeButton)
+    expect(handleClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders with default buttons', () => {
+    const expectedButtons = ['Cancel', 'OK']
+
+    renderElement()
+
+    for (const btnText of expectedButtons) {
+      expect(screen.getByText(btnText)).toBeTruthy()
+    }
+
+    fireEvent.click(screen.getByText(expectedButtons[0]))
+    expect(handleClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders with custom buttons', () => {
+    const cancel = 'Dismiss'
+    const confirm = 'Got it!'
+
+    renderElement({
+      cancelButtonContent: cancel,
+      confirmButtonContent: confirm
+    })
+
+    for (const expected of [cancel, confirm]) {
+      expect(screen.queryByText(expected)).toBeDefined()
+    }
+  })
+
+  it.each([
+    {prop: 'cancelButtonContent', visible: 'OK', notVisible: 'Cancel'},
+    {prop: 'confirmButtonContent', visible: 'Cancel', notVisible: 'OK'}
+  ])('renders "$visible" but not "$notVisible" when $prop is set to falsy value', ({prop, visible, notVisible}) => {
+    renderElement({
+      [prop]: null
+    })
+
+    expect(screen.getByText(visible)).toBeTruthy()
+    expect(screen.queryByText(notVisible)).toBeFalsy()
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {useOpenAndCloseFocus} from './hooks/useOpenAndCloseFocus'
 export {useOnEscapePress} from './hooks/useOnEscapePress'
 export {useOverlay} from './hooks/useOverlay'
 export {useConfirm} from './Dialog/ConfirmationDialog'
+export {useAlert} from './Dialog/AlertDialog'
 
 // Components
 export {ActionList} from './ActionList'

--- a/src/stories/AlertDialog.stories.tsx
+++ b/src/stories/AlertDialog.stories.tsx
@@ -1,13 +1,13 @@
-import React, {useState, useRef, useCallback} from 'react'
+import React, {useState, useCallback, useRef} from 'react'
 import {Meta} from '@storybook/react'
 
 import {BaseStyles, Button, Box, ThemeProvider, useTheme} from '..'
-import {ConfirmationDialog, useConfirm} from '../Dialog/ConfirmationDialog'
+import {AlertDialog, useAlert} from '../Dialog/AlertDialog'
 import {ActionMenu} from '../ActionMenu'
 
 export default {
-  title: 'Internal components/ConfirmationDialog',
-  component: ConfirmationDialog,
+  title: 'Internal components/AlertDialog',
+  component: AlertDialog,
   decorators: [
     Story => {
       // Since portal roots are registered globally, we need this line so that each storybook
@@ -23,7 +23,7 @@ export default {
   ]
 } as Meta
 
-export const BasicConfirmationDialog = () => {
+export const BasicAlertDialog = () => {
   const [isOpen, setIsOpen] = useState(false)
   const buttonRef = useRef<HTMLButtonElement>(null)
   const onDialogClose = useCallback(() => setIsOpen(false), [])
@@ -33,34 +33,29 @@ export const BasicConfirmationDialog = () => {
         Show dialog
       </Button>
       {isOpen && (
-        <ConfirmationDialog
-          title="Delete universe?"
-          onClose={onDialogClose}
-          confirmButtonContent="Delete it!"
-          confirmButtonType="danger"
-        >
+        <AlertDialog title="Delete universe?" onClose={onDialogClose} confirmButtonContent="OK">
           Deleting the universe could have disastrous effects, including but not limited to destroying all life on
           Earth.
-        </ConfirmationDialog>
+        </AlertDialog>
       )}
     </>
   )
 }
 
 export const ShorthandHook = () => {
-  const confirm = useConfirm()
+  const alert = useAlert()
   const {theme} = useTheme()
   const onButtonClick = useCallback(
     async (event: React.MouseEvent) => {
       if (
-        (await confirm({title: 'Are you sure?', content: 'Do you really want to turn this button green?'})) &&
+        (await alert({title: 'Are you sure?', content: 'Do you really want to turn this button green?'})) &&
         event.target instanceof HTMLElement
       ) {
         event.target.style.backgroundColor = theme?.colors.auto.green[3] ?? 'green'
         event.target.textContent = "I'm green!"
       }
     },
-    [confirm, theme]
+    [alert, theme]
   )
   return (
     <Box display="flex" flexDirection="column" alignItems="flex-start">
@@ -81,13 +76,15 @@ export const ShorthandHook = () => {
 }
 
 export const ShorthandHookFromActionMenu = () => {
-  const confirm = useConfirm()
+  const alert = useAlert()
   const [text, setText] = useState('open me')
   const onButtonClick = useCallback(async () => {
-    if (await confirm({title: 'Are you sure?', content: 'Do you really want to do a trick?'})) {
+    if (
+      await alert({title: 'Are you sure?', content: 'Do you really want to do a trick?', confirmButtonContent: 'OK'})
+    ) {
       setText('tada!')
     }
-  }, [confirm])
+  }, [alert])
 
   return (
     <Box display="flex" flexDirection="column" alignItems="flex-start">

--- a/src/stories/AlertDialog.stories.tsx
+++ b/src/stories/AlertDialog.stories.tsx
@@ -33,7 +33,7 @@ export const BasicAlertDialog = () => {
         Show dialog
       </Button>
       {isOpen && (
-        <AlertDialog title="Delete universe?" onClose={onDialogClose} confirmButtonContent="OK">
+        <AlertDialog title="Delete universe?" onClose={onDialogClose} buttonContent="OK">
           Deleting the universe could have disastrous effects, including but not limited to destroying all life on
           Earth.
         </AlertDialog>
@@ -48,7 +48,10 @@ export const ShorthandHook = () => {
   const onButtonClick = useCallback(
     async (event: React.MouseEvent) => {
       if (
-        (await alert({title: 'Are you sure?', content: 'Do you really want to turn this button green?'})) &&
+        (await alert({
+          title: 'Button color change',
+          content: 'This button will turn green!'
+        })) &&
         event.target instanceof HTMLElement
       ) {
         event.target.style.backgroundColor = theme?.colors.auto.green[3] ?? 'green'
@@ -80,9 +83,14 @@ export const ShorthandHookFromActionMenu = () => {
   const [text, setText] = useState('open me')
   const onButtonClick = useCallback(async () => {
     if (
-      await alert({title: 'Are you sure?', content: 'Do you really want to do a trick?', confirmButtonContent: 'OK'})
+      await alert({
+        title: 'Erase USB Storage?',
+        content: 'By pressing "OK" you acknowledge All files will be deleted and cannot be recovered',
+        buttonContent: 'OK',
+        buttonType: 'danger'
+      })
     ) {
-      setText('tada!')
+      setText('Erasing storage...')
     }
   }, [alert])
 
@@ -92,7 +100,7 @@ export const ShorthandHookFromActionMenu = () => {
         renderAnchor={props => <Button {...props}>{text}</Button>}
         items={[
           {
-            text: 'Do a trick!',
+            text: 'Erase',
             onAction: onButtonClick
           }
         ]}

--- a/src/stories/ConfirmationDialog.stories.tsx
+++ b/src/stories/ConfirmationDialog.stories.tsx
@@ -84,8 +84,36 @@ export const ShorthandHookFromActionMenu = () => {
   const confirm = useConfirm()
   const [text, setText] = useState('open me')
   const onButtonClick = useCallback(async () => {
+    if (await confirm({title: 'Are you sure?', content: 'Do you really want to do a trick?'})) {
+      setText('tada!')
+    }
+  }, [confirm])
+
+  return (
+    <Box display="flex" flexDirection="column" alignItems="flex-start">
+      <ActionMenu
+        renderAnchor={props => <Button {...props}>{text}</Button>}
+        items={[
+          {
+            text: 'Do a trick!',
+            onAction: onButtonClick
+          }
+        ]}
+      />
+    </Box>
+  )
+}
+
+export const SingleConfirmFromActionMenu = () => {
+  const confirm = useConfirm()
+  const [text, setText] = useState('open me')
+  const onButtonClick = useCallback(async () => {
     if (
-      await confirm({title: 'Are you sure?', content: 'Do you really want to do a trick?', cancelButtonContent: null})
+      await confirm({
+        title: 'Are you sure?',
+        content: 'Do you really want to do a trick?',
+        cancelButtonContent: null
+      })
     ) {
       setText('tada!')
     }

--- a/src/stories/ConfirmationDialog.stories.tsx
+++ b/src/stories/ConfirmationDialog.stories.tsx
@@ -84,7 +84,9 @@ export const ShorthandHookFromActionMenu = () => {
   const confirm = useConfirm()
   const [text, setText] = useState('open me')
   const onButtonClick = useCallback(async () => {
-    if (await confirm({title: 'Are you sure?', content: 'Do you really want to do a trick?'})) {
+    if (
+      await confirm({title: 'Are you sure?', content: 'Do you really want to do a trick?', cancelButtonContent: null})
+    ) {
       setText('tada!')
     }
   }, [confirm])


### PR DESCRIPTION
Adds an alert dialog component to account for cases where 1 or no buttons in a dialog are needed

### Screenshots

**Before:**
light | dark
------------ | -------------
|![Screen Shot 2021-08-12 at 5 54 46 PM](https://user-images.githubusercontent.com/6519974/129288215-ec9ff257-c04f-4f58-bacc-45f0e50401dc.png)|![Screen Shot 2021-08-12 at 5 50 44 PM](https://user-images.githubusercontent.com/6519974/129288225-87bac4d1-d52c-429b-8cf6-49adddab257a.png)|

**After:**
light | dark
------------ | -------------
|![Screen Shot 2021-08-11 at 7 16 41 PM](https://user-images.githubusercontent.com/6519974/129128329-09ed61cf-b5f8-45c6-9616-2a921b7a16db.png)|![Screen Shot 2021-08-12 at 4 59 09 PM](https://user-images.githubusercontent.com/6519974/129288253-5f0c9d0c-4345-4dd7-94d1-42fd97056d96.png)|



Please note ☝🏽   is the desired design.

CC/@cmwinters 

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
