### PR TITLE
Position AnchoredOverlay directly on style property

### DIFF
--- a/.changeset/yellow-rice-compete.md
+++ b/.changeset/yellow-rice-compete.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': minor
+---
+
+AnchoredOverlay positions are set directly on style property

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -128,7 +128,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
     [overlayRef.current]
   )
   const overlayPosition = useMemo(() => {
-    return position && {top: `${position.top}px`, left: `${position.left}px`, anchorSide: position.anchorSide}
+    return position && {style: {top: `${position.top}px`, left: `${position.left}px`}, anchorSide: position.anchorSide}
   }, [position])
 
   useEffect(() => {

--- a/src/__tests__/__snapshots__/AnchoredOverlay.tsx.snap
+++ b/src/__tests__/__snapshots__/AnchoredOverlay.tsx.snap
@@ -181,8 +181,6 @@ Object {
   -webkit-animation: overlay-appear 200ms cubic-bezier(0.33,1,0.68,1);
   animation: overlay-appear 200ms cubic-bezier(0.33,1,0.68,1);
   visibility: var(--styled-overlay-visibility);
-  top: 4px;
-  left: 0px;
 }
 
 .c2:focus {
@@ -217,7 +215,7 @@ Object {
               data-focus-trap="active"
               height="auto"
               role="none"
-              style="--styled-overlay-visibility: visible;"
+              style="--styled-overlay-visibility: visible; top: 4px; left: 0px;"
               width="auto"
             >
               <button
@@ -257,11 +255,11 @@ Object {
           style="position: relative; z-index: 1;"
         >
           <div
-            class="Overlay__StyledOverlay-jhwkzw-0 leFwDU"
+            class="Overlay__StyledOverlay-jhwkzw-0 kVoHwu"
             data-focus-trap="active"
             height="auto"
             role="none"
-            style="--styled-overlay-visibility: visible;"
+            style="--styled-overlay-visibility: visible; top: 4px; left: 0px;"
             width="auto"
           >
             <button

--- a/src/stories/useAnchoredPosition.stories.tsx
+++ b/src/stories/useAnchoredPosition.stories.tsx
@@ -298,8 +298,7 @@ export const WithPortal = () => {
             <Portal>
               <Float
                 ref={floatingElementRef as React.RefObject<HTMLDivElement>}
-                top={position?.top ?? 0}
-                left={position?.left ?? 0}
+                style={{top: `${position?.top ?? 0}px`, left: `${position?.left ?? 0}px`}}
                 width={250}
                 height={400}
                 sx={{visibility: position ? 'visible' : 'hidden'}}


### PR DESCRIPTION
This is in support of future work where we will reposition `AnchoredOverlay` with resize. When that happens, we don't want to create an excess of style classes on every ResizeObserver callback.

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
