### PR TITLE
Only add a media query event listener where supported

### DIFF
--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -108,11 +108,11 @@ function useSystemColorMode() {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    media?.addEventListener('change', handleChange)
+    media?.addEventListener?.('change', handleChange)
 
     return function cleanup() {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      media?.removeEventListener('change', handleChange)
+      media?.removeEventListener?.('change', handleChange)
     }
   }, [])
 


### PR DESCRIPTION
This change fixes an issue in safari 13 where an unhandled error from ThemeProvider [would cause blank pages](https://github.com/primer/react/issues/1366). This approach has limitations:

- In Safari 13 we aren't updating the system color mode
- This PR doesn't attempt to fix error handling or lint for calls to APIs unsupported in Safari 13

Closes #1366

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
