### PR TITLE
Add flex to timeline item

### DIFF
--- a/.changeset/great-countries-yawn.md
+++ b/.changeset/great-countries-yawn.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': patch
+---
+
+Fix the Timeline.Item layout

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -29,6 +29,7 @@ type StyledTimelineItemProps = {condensed?: boolean}
 const TimelineItem = styled(Box).attrs<StyledTimelineItemProps>(props => ({
   className: classnames('Timeline-Item', props.className)
 }))<StyledTimelineItemProps>`
+  display: flex;
   position: relative;
   padding: ${get('space.3')} 0;
   margin-left: ${get('space.3')};

--- a/src/__tests__/__snapshots__/Timeline.tsx.snap
+++ b/src/__tests__/__snapshots__/Timeline.tsx.snap
@@ -89,6 +89,10 @@ exports[`Timeline.Badge renders consistently 1`] = `
 
 exports[`Timeline.Item renders consistently 1`] = `
 .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   position: relative;
   padding: 16px 0;
   margin-left: 16px;
@@ -112,6 +116,10 @@ exports[`Timeline.Item renders consistently 1`] = `
 
 exports[`Timeline.Item renders with condensed prop 1`] = `
 .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   position: relative;
   padding: 16px 0;
   margin-left: 16px;


### PR DESCRIPTION
Added `display:flex;` to the `Timeline.Item` component. 

Closes #1402

### Merge checklist
- [X] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge