### PR TITLE
Button visual design updates

### DIFF
--- a/src/BaseStyles.tsx
+++ b/src/BaseStyles.tsx
@@ -8,11 +8,7 @@ const GlobalStyle = createGlobalStyle`
   body { margin: 0; }
   table { border-collapse: collapse; }
   
-  [role="button"]:focus:not(:focus-visible):not(.focus-visible),
-  [role="tabpanel"][tabindex="0"]:focus:not(:focus-visible):not(.focus-visible),
-  button:focus:not(:focus-visible):not(.focus-visible),
-  summary:focus:not(:focus-visible):not(.focus-visible),
-  a:focus:not(:focus-visible):not(.focus-visible) {
+  [role="tabpanel"][tabindex="0"]:focus:not(:focus-visible):not(.focus-visible) {
     outline: none;
     box-shadow: none;
   }

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -18,13 +18,9 @@ const Button = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
   // focus must come before :active so that the active box shadow overrides
   &:focus {
     border-color: ${get('colors.btn.focusBorder')};
-    box-shadow: ${get('shadows.btn.focusShadow')};
   }
 
-  // additional selector with high specificity is needed to beat
-  // the specificity of the :focus-visible styles in BaseStyles
-  &:active,
-  &:active:focus:not(:focus-visible):not(.focus-visible) {
+  &:active {
     background-color: ${get('colors.btn.selectedBg')};
     box-shadow: ${get('shadows.btn.shadowActive')};
   }

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -21,7 +21,10 @@ const Button = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
     box-shadow: ${get('shadows.btn.focusShadow')};
   }
 
-  &:active {
+  // additional selector with high specificity is needed to beat
+  // the specificity of the :focus-visible styles in BaseStyles
+  &:active,
+  &:active:focus:not(:focus-visible):not(.focus-visible) {
     background-color: ${get('colors.btn.selectedBg')};
     box-shadow: ${get('shadows.btn.shadowActive')};
   }

--- a/src/Button/ButtonBase.tsx
+++ b/src/Button/ButtonBase.tsx
@@ -10,7 +10,7 @@ export type ButtonSystemProps = FontSizeProps & SystemCommonProps & SystemLayout
 const variants = variant({
   variants: {
     small: {
-      p: '4px 8px',
+      p: '4px 12px',
       fontSize: 0
     },
     medium: {

--- a/src/Button/ButtonBase.tsx
+++ b/src/Button/ButtonBase.tsx
@@ -10,7 +10,7 @@ export type ButtonSystemProps = FontSizeProps & SystemCommonProps & SystemLayout
 const variants = variant({
   variants: {
     small: {
-      p: '4px 12px',
+      p: '4px 8px',
       fontSize: 0
     },
     medium: {

--- a/src/Button/ButtonClose.tsx
+++ b/src/Button/ButtonClose.tsx
@@ -16,10 +16,6 @@ const StyledButton = styled.button<StyledButtonProps>`
   border-radius: ${get('radii.2')};
   color: ${get('colors.text.secondary')};
 
-  &:focus {
-    box-shadow: ${get('shadows.btn.focusShadow')};
-  }
-
   &:hover {
     color: ${get('colors.text.link')};
   }

--- a/src/Button/ButtonDanger.tsx
+++ b/src/Button/ButtonDanger.tsx
@@ -19,7 +19,6 @@ const ButtonDanger = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & Sx
   // focus must come before :active so that the active box shadow overrides
   &:focus {
     border-color: ${get('colors.btn.danger.focusBorder')};
-    box-shadow: ${get('shadows.btn.danger.focusShadow')};
   }
 
   &:active {

--- a/src/Button/ButtonInvisible.tsx
+++ b/src/Button/ButtonInvisible.tsx
@@ -5,18 +5,27 @@ import {ComponentProps} from '../utils/types'
 import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 
 const ButtonInvisible = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
-  color: ${get('colors.text.link')};
+  color: ${get('colors.btn.text')};
   background-color: transparent;
   border: 0;
   border-radius: ${get('radii.2')};
   box-shadow: none;
 
-  &:disabled {
-    color: ${get('colors.text.disabled')};
+  &:hover {
+    background-color: ${get('colors.btn.hoverBg')};
   }
 
   &:focus {
     box-shadow: ${get('shadows.btn.focusShadow')};
+  }
+
+  &:active {
+    background-color: ${get('colors.btn.selectedBg')};
+  }
+
+  &:disabled {
+    background-color: transparent;
+    color: ${get('colors.text.disabled')};
   }
 
   ${buttonSystemProps};

--- a/src/Button/ButtonInvisible.tsx
+++ b/src/Button/ButtonInvisible.tsx
@@ -5,7 +5,7 @@ import {ComponentProps} from '../utils/types'
 import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 
 const ButtonInvisible = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
-  color: ${get('colors.btn.text')};
+  color: ${get('colors.text.link')};
   background-color: transparent;
   border: 0;
   border-radius: ${get('radii.2')};

--- a/src/Button/ButtonInvisible.tsx
+++ b/src/Button/ButtonInvisible.tsx
@@ -15,10 +15,6 @@ const ButtonInvisible = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps &
     background-color: ${get('colors.btn.hoverBg')};
   }
 
-  &:focus {
-    box-shadow: ${get('shadows.btn.focusShadow')};
-  }
-
   &:active {
     background-color: ${get('colors.btn.selectedBg')};
   }

--- a/src/Button/ButtonOutline.tsx
+++ b/src/Button/ButtonOutline.tsx
@@ -4,34 +4,52 @@ import sx, {SxProp} from '../sx'
 import {ComponentProps} from '../utils/types'
 import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 
+// TODO:
+//
+// - Instead of _just_ setting :hover background-color to `colors.btn.hoverBg`,
+// change `colors.btn.outline.hoverBg` in primitives
+// - Remove `colors.btn.outline.hoverText` from primitives
+// - Remove `colors.btn.outline.hoverShadow` from primitives
+// - Remove `colors.btn.outline.hoverBorder` from primitives, or change it if we don't just use the default (`colors.btn.hoverBorder`)
+// - Remove `colors.btn.outline.selectedText` from primitives
+// - Remove `colors.btn.outline.selectedBg` from primitives
+// - Instead of _just_ setting :focus box-shadow to `shadows.btn.focusShadow`,
+// change `shadows.btn.outline.focusShadow` in primitives
+// - Remove `colors.btn.outline.focusBorder`
+// - Remove `colors.btn.outline.selectedBg` from primitives, or change it if we don't just use the default (`colors.btn.selectedBg`)
+// - Remove `colors.btn.outline.selectedBorder` from primitives
+// - Remove `colors.btn.outline.disabledBg` from primitives, or change it if we don't just use the default (`colors.btn.bg`)
+// - Remove `colors.btn.outline.text` from primitives, or change it if we don't just use the default (`colors.btn.text`)
+// - Remove `colors.btn.outline.disabledText` from primitives, or change it if we don't just use the default (`colors.text.disabled`)
+//
+
 const ButtonOutline = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
-  color: ${get('colors.btn.outline.text')};
+  color: ${get('colors.btn.text')};
   border: 1px solid ${get('colors.btn.border')};
-  background-color: ${get('colors.btn.bg')};
-  box-shadow: ${get('shadows.btn.shadow')};
+  background-color: transparent;
 
   &:hover {
-    color: ${get('colors.btn.outline.hoverText')};
-    background-color: ${get('colors.btn.outline.hoverBg')};
-    border-color: ${get('colors.btn.outline.hoverBorder')};
-    box-shadow: ${get('shadows.btn.outline.hoverShadow')};
+    background-color: ${get('colors.btn.hoverBg')};
+    border-color: ${get('colors.btn.hoverBorder')};
   }
   // focus must come before :active so that the active box shadow overrides
   &:focus {
-    border-color: ${get('colors.btn.outline.focusBorder')};
-    box-shadow: ${get('shadows.btn.outline.focusShadow')};
+    border-color: ${get('colors.btn.focusBorder')};
+    box-shadow: ${get('shadows.btn.focusShadow')};
   }
 
-  &:active {
-    color: ${get('colors.btn.outline.selectedText')};
-    background-color: ${get('colors.btn.outline.selectedBg')};
-    box-shadow: ${get('shadows.btn.outline.selectedShadow')};
+  // additional selector with high specificity is needed to beat
+  // the specificity of the :focus-visible styles in BaseStyles
+  &:active,
+  &:active:focus:not(:focus-visible):not(.focus-visible) {
+    background-color: ${get('colors.btn.selectedBg')};
+    box-shadow: ${get('shadows.btn.shadowActive')};
     border-color: ${get('colors.btn.outline.selectedBorder')};
   }
 
   &:disabled {
-    color: ${get('colors.btn.outline.disabledText')};
-    background-color: ${get('colors.btn.outline.disabledBg')};
+    color: ${get('colors.text.disabled')};
+    background-color: transparent;
     border-color: ${get('colors.btn.border')};
   }
 

--- a/src/Button/ButtonOutline.tsx
+++ b/src/Button/ButtonOutline.tsx
@@ -35,13 +35,9 @@ const ButtonOutline = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & S
   // focus must come before :active so that the active box shadow overrides
   &:focus {
     border-color: ${get('colors.btn.focusBorder')};
-    box-shadow: ${get('shadows.btn.focusShadow')};
   }
 
-  // additional selector with high specificity is needed to beat
-  // the specificity of the :focus-visible styles in BaseStyles
-  &:active,
-  &:active:focus:not(:focus-visible):not(.focus-visible) {
+  &:active {
     background-color: ${get('colors.btn.selectedBg')};
     box-shadow: ${get('shadows.btn.shadowActive')};
     border-color: ${get('colors.btn.outline.selectedBorder')};

--- a/src/Button/ButtonOutline.tsx
+++ b/src/Button/ButtonOutline.tsx
@@ -4,48 +4,34 @@ import sx, {SxProp} from '../sx'
 import {ComponentProps} from '../utils/types'
 import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 
-// TODO:
-//
-// - Instead of _just_ setting :hover background-color to `colors.btn.hoverBg`,
-// change `colors.btn.outline.hoverBg` in primitives
-// - Remove `colors.btn.outline.hoverText` from primitives
-// - Remove `colors.btn.outline.hoverShadow` from primitives
-// - Remove `colors.btn.outline.hoverBorder` from primitives, or change it if we don't just use the default (`colors.btn.hoverBorder`)
-// - Remove `colors.btn.outline.selectedText` from primitives
-// - Remove `colors.btn.outline.selectedBg` from primitives
-// - Instead of _just_ setting :focus box-shadow to `shadows.btn.focusShadow`,
-// change `shadows.btn.outline.focusShadow` in primitives
-// - Remove `colors.btn.outline.focusBorder`
-// - Remove `colors.btn.outline.selectedBg` from primitives, or change it if we don't just use the default (`colors.btn.selectedBg`)
-// - Remove `colors.btn.outline.selectedBorder` from primitives
-// - Remove `colors.btn.outline.disabledBg` from primitives, or change it if we don't just use the default (`colors.btn.bg`)
-// - Remove `colors.btn.outline.text` from primitives, or change it if we don't just use the default (`colors.btn.text`)
-// - Remove `colors.btn.outline.disabledText` from primitives, or change it if we don't just use the default (`colors.text.disabled`)
-//
-
 const ButtonOutline = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
-  color: ${get('colors.btn.text')};
+  color: ${get('colors.btn.outline.text')};
   border: 1px solid ${get('colors.btn.border')};
-  background-color: transparent;
+  background-color: ${get('colors.btn.outline.bg')};
+  box-shadow: ${get('shadows.btn.shadow')};
 
   &:hover {
-    background-color: ${get('colors.btn.hoverBg')};
-    border-color: ${get('colors.btn.hoverBorder')};
+    color: ${get('colors.btn.outline.hoverText')};
+    background-color: ${get('colors.btn.outline.hoverBg')};
+    border-color: ${get('colors.btn.outline.hoverBorder')};
+    box-shadow: ${get('shadows.btn.outline.hoverShadow')};
   }
   // focus must come before :active so that the active box shadow overrides
   &:focus {
-    border-color: ${get('colors.btn.focusBorder')};
+    border-color: ${get('colors.btn.outline.focusBorder')};
+    box-shadow: ${get('shadows.btn.outline.focusShadow')};
   }
 
   &:active {
-    background-color: ${get('colors.btn.selectedBg')};
-    box-shadow: ${get('shadows.btn.shadowActive')};
+    color: ${get('colors.btn.outline.selectedText')};
+    background-color: ${get('colors.btn.outline.selectedBg')};
+    box-shadow: ${get('shadows.btn.outline.selectedShadow')};
     border-color: ${get('colors.btn.outline.selectedBorder')};
   }
 
   &:disabled {
-    color: ${get('colors.text.disabled')};
-    background-color: transparent;
+    color: ${get('colors.btn.outline.disabledText')};
+    background-color: ${get('colors.btn.outline.disabledBg')};
     border-color: ${get('colors.btn.border')};
   }
 

--- a/src/Button/ButtonPrimary.tsx
+++ b/src/Button/ButtonPrimary.tsx
@@ -4,6 +4,11 @@ import sx, {SxProp} from '../sx'
 import {ComponentProps} from '../utils/types'
 import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 
+// TODO:
+//
+// - Instead of `colors.btn.primary.hoverBg`, add `colors.btn.primary.focusBg`
+//   OR use an outline-offset on all focus states instead of darkening the bg color
+//
 export const ButtonPrimary = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
   color: ${get('colors.btn.primary.text')};
   border: 1px solid ${get('colors.btn.primary.border')};
@@ -18,8 +23,8 @@ export const ButtonPrimary = styled(ButtonBase)<ButtonBaseProps & ButtonSystemPr
   }
   // focus must come before :active so that the active box shadow overrides
   &:focus {
+    background-color: ${get('colors.btn.primary.hoverBg')};
     border-color: ${get('colors.btn.primary.focusBorder')};
-    box-shadow: ${get('shadows.btn.primary.focusShadow')};
   }
 
   &:active {

--- a/src/Button/ButtonStyles.tsx
+++ b/src/Button/ButtonStyles.tsx
@@ -16,6 +16,7 @@ export default css`
   appearance: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
 
   &:hover {
     // needed to override link styles

--- a/src/Button/ButtonStyles.tsx
+++ b/src/Button/ButtonStyles.tsx
@@ -4,7 +4,7 @@ import {get} from '../constants'
 export default css`
   position: relative;
   display: inline-block;
-  padding: 6px 12px;
+  padding: 6px 16px;
   font-family: inherit;
   font-weight: ${get('fontWeights.bold')};
   line-height: 20px;

--- a/src/Button/ButtonStyles.tsx
+++ b/src/Button/ButtonStyles.tsx
@@ -4,7 +4,7 @@ import {get} from '../constants'
 export default css`
   position: relative;
   display: inline-block;
-  padding: 6px 16px;
+  padding: 6px 12px;
   font-family: inherit;
   font-weight: ${get('fontWeights.bold')};
   line-height: 20px;

--- a/src/Button/ButtonStyles.tsx
+++ b/src/Button/ButtonStyles.tsx
@@ -22,10 +22,6 @@ export default css`
     text-decoration: none;
   }
 
-  &:focus {
-    outline: none;
-  }
-
   &:disabled {
     cursor: default;
   }

--- a/src/__tests__/__snapshots__/ActionMenu.tsx.snap
+++ b/src/__tests__/__snapshots__/ActionMenu.tsx.snap
@@ -22,6 +22,7 @@ exports[`ActionMenu renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #24292e;
   background-color: #fafbfc;
@@ -32,10 +33,6 @@ exports[`ActionMenu renders consistently 1`] = `
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -53,7 +50,6 @@ exports[`ActionMenu renders consistently 1`] = `
 
 .c0:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 
 .c0:active {

--- a/src/__tests__/__snapshots__/AnchoredOverlay.tsx.snap
+++ b/src/__tests__/__snapshots__/AnchoredOverlay.tsx.snap
@@ -28,6 +28,7 @@ exports[`AnchoredOverlay renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #24292e;
   background-color: #fafbfc;
@@ -38,10 +39,6 @@ exports[`AnchoredOverlay renders consistently 1`] = `
 .c1:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c1:focus {
-  outline: none;
 }
 
 .c1:disabled {
@@ -59,7 +56,6 @@ exports[`AnchoredOverlay renders consistently 1`] = `
 
 .c1:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 
 .c1:active {
@@ -123,6 +119,7 @@ Object {
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #24292e;
   background-color: #fafbfc;
@@ -133,10 +130,6 @@ Object {
 .c1:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c1:focus {
-  outline: none;
 }
 
 .c1:disabled {
@@ -154,7 +147,6 @@ Object {
 
 .c1:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 
 .c1:active {
@@ -242,7 +234,7 @@ Object {
       <button
         aria-haspopup="true"
         aria-labelledby="__primer_id_10007"
-        class="ButtonBase-sc-181ps9o-0 Button-xjtz72-0 jhgDtb"
+        class="ButtonBase-sc-181ps9o-0 Button-xjtz72-0 gpFBsa"
         id="__primer_id_10007"
         tabindex="0"
       >

--- a/src/__tests__/__snapshots__/Button.tsx.snap
+++ b/src/__tests__/__snapshots__/Button.tsx.snap
@@ -22,6 +22,7 @@ exports[`Button renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #24292e;
   background-color: #fafbfc;
@@ -32,10 +33,6 @@ exports[`Button renders consistently 1`] = `
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -53,7 +50,6 @@ exports[`Button renders consistently 1`] = `
 
 .c0:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 
 .c0:active {
@@ -94,6 +90,7 @@ exports[`Button respects the "disabled" prop 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #24292e;
   background-color: #fafbfc;
@@ -104,10 +101,6 @@ exports[`Button respects the "disabled" prop 1`] = `
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -125,7 +118,6 @@ exports[`Button respects the "disabled" prop 1`] = `
 
 .c0:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 
 .c0:active {
@@ -167,6 +159,7 @@ exports[`ButtonDanger renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #d73a49;
   border: 1px solid rgba(27,31,35,0.15);
@@ -177,10 +170,6 @@ exports[`ButtonDanger renders consistently 1`] = `
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -200,13 +189,12 @@ exports[`ButtonDanger renders consistently 1`] = `
 
 .c0:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(203,36,49,0.4);
 }
 
 .c0:active {
   color: #ffffff;
   background-color: hsla(354,66%,51%,1);
-  box-shadow: inset 0 1px 0 rgba(134,24,29,0.2);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.25);
   border-color: rgba(27,31,35,0.15);
 }
 
@@ -242,6 +230,7 @@ exports[`ButtonDanger renders correct disabled styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #d73a49;
   border: 1px solid rgba(27,31,35,0.15);
@@ -252,10 +241,6 @@ exports[`ButtonDanger renders correct disabled styles 1`] = `
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -275,13 +260,12 @@ exports[`ButtonDanger renders correct disabled styles 1`] = `
 
 .c0:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(203,36,49,0.4);
 }
 
 .c0:active {
   color: #ffffff;
   background-color: hsla(354,66%,51%,1);
-  box-shadow: inset 0 1px 0 rgba(134,24,29,0.2);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.25);
   border-color: rgba(27,31,35,0.15);
 }
 
@@ -370,20 +354,17 @@ exports[`ButtonInvisible renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #0366d6;
   border: 1px solid rgba(27,31,35,0.15);
-  background-color: #fafbfc;
+  background-color: rgba(0,0,0,0);
   box-shadow: 0 1px 0 rgba(27,31,35,0.04);
 }
 
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -403,7 +384,6 @@ exports[`ButtonInvisible renders consistently 1`] = `
 
 .c0:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(0,92,197,0.4);
 }
 
 .c0:active {
@@ -446,6 +426,7 @@ exports[`ButtonInvisible renders correct disabled styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #0366d6;
   background-color: transparent;
@@ -459,10 +440,6 @@ exports[`ButtonInvisible renders correct disabled styles 1`] = `
   text-decoration: none;
 }
 
-.c0:focus {
-  outline: none;
-}
-
 .c0:disabled {
   cursor: default;
 }
@@ -471,12 +448,17 @@ exports[`ButtonInvisible renders correct disabled styles 1`] = `
   opacity: 0.6;
 }
 
-.c0:disabled {
-  color: #959da5;
+.c0:hover {
+  background-color: #f3f4f6;
 }
 
-.c0:focus {
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+.c0:active {
+  background-color: hsla(220,14%,94%,1);
+}
+
+.c0:disabled {
+  background-color: transparent;
+  color: #959da5;
 }
 
 <button
@@ -507,20 +489,17 @@ exports[`ButtonOutline renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #0366d6;
   border: 1px solid rgba(27,31,35,0.15);
-  background-color: #fafbfc;
+  background-color: rgba(0,0,0,0);
   box-shadow: 0 1px 0 rgba(27,31,35,0.04);
 }
 
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -540,7 +519,6 @@ exports[`ButtonOutline renders consistently 1`] = `
 
 .c0:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(0,92,197,0.4);
 }
 
 .c0:active {
@@ -583,20 +561,17 @@ exports[`ButtonOutline renders correct disabled styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #0366d6;
   border: 1px solid rgba(27,31,35,0.15);
-  background-color: #fafbfc;
+  background-color: rgba(0,0,0,0);
   box-shadow: 0 1px 0 rgba(27,31,35,0.04);
 }
 
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -616,7 +591,6 @@ exports[`ButtonOutline renders correct disabled styles 1`] = `
 
 .c0:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(0,92,197,0.4);
 }
 
 .c0:active {
@@ -660,6 +634,7 @@ exports[`ButtonPrimary renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #ffffff;
   border: 1px solid rgba(27,31,35,0.15);
@@ -670,10 +645,6 @@ exports[`ButtonPrimary renders consistently 1`] = `
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -690,13 +661,13 @@ exports[`ButtonPrimary renders consistently 1`] = `
 }
 
 .c0:focus {
+  background-color: #2c974b;
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(46,164,79,0.4);
 }
 
 .c0:active {
   background-color: hsla(137,55%,36%,1);
-  box-shadow: inset 0 1px 0 rgba(20,70,32,0.2);
+  box-shadow: inset 0px 0.2em 0.3em rgba(27,31,35,0.3);
 }
 
 .c0:disabled {
@@ -732,6 +703,7 @@ exports[`ButtonPrimary renders correct disabled styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #ffffff;
   border: 1px solid rgba(27,31,35,0.15);
@@ -742,10 +714,6 @@ exports[`ButtonPrimary renders correct disabled styles 1`] = `
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -762,13 +730,13 @@ exports[`ButtonPrimary renders correct disabled styles 1`] = `
 }
 
 .c0:focus {
+  background-color: #2c974b;
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(46,164,79,0.4);
 }
 
 .c0:active {
   background-color: hsla(137,55%,36%,1);
-  box-shadow: inset 0 1px 0 rgba(20,70,32,0.2);
+  box-shadow: inset 0px 0.2em 0.3em rgba(27,31,35,0.3);
 }
 
 .c0:disabled {

--- a/src/__tests__/__snapshots__/Dialog.tsx.snap
+++ b/src/__tests__/__snapshots__/Dialog.tsx.snap
@@ -74,10 +74,6 @@ Array [
   right: 16px;
 }
 
-.c1:focus {
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
-}
-
 .c1:hover {
   color: #0366d6;
 }

--- a/src/__tests__/__snapshots__/Dropdown.tsx.snap
+++ b/src/__tests__/__snapshots__/Dropdown.tsx.snap
@@ -44,6 +44,7 @@ exports[`Dropdown.Button renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #24292e;
   background-color: #fafbfc;
@@ -54,10 +55,6 @@ exports[`Dropdown.Button renders consistently 1`] = `
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -75,7 +72,6 @@ exports[`Dropdown.Button renders consistently 1`] = `
 
 .c0:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 
 .c0:active {

--- a/src/__tests__/__snapshots__/DropdownMenu.tsx.snap
+++ b/src/__tests__/__snapshots__/DropdownMenu.tsx.snap
@@ -22,6 +22,7 @@ exports[`DropdownMenu renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #24292e;
   background-color: #fafbfc;
@@ -32,10 +33,6 @@ exports[`DropdownMenu renders consistently 1`] = `
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c0:focus {
-  outline: none;
 }
 
 .c0:disabled {
@@ -53,7 +50,6 @@ exports[`DropdownMenu renders consistently 1`] = `
 
 .c0:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 
 .c0:active {

--- a/src/__tests__/__snapshots__/SelectMenu.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectMenu.tsx.snap
@@ -22,6 +22,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #24292e;
   background-color: #fafbfc;
@@ -32,10 +33,6 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
 .c1:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c1:focus {
-  outline: none;
 }
 
 .c1:disabled {
@@ -53,7 +50,6 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
 
 .c1:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 
 .c1:active {

--- a/src/__tests__/__snapshots__/SelectPanel.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectPanel.tsx.snap
@@ -28,6 +28,7 @@ exports[`SelectPanel renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
+  outline-offset: 3px;
   font-size: 14px;
   color: #24292e;
   background-color: #fafbfc;
@@ -38,10 +39,6 @@ exports[`SelectPanel renders consistently 1`] = `
 .c1:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-}
-
-.c1:focus {
-  outline: none;
 }
 
 .c1:disabled {
@@ -59,7 +56,6 @@ exports[`SelectPanel renders consistently 1`] = `
 
 .c1:focus {
   border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 
 .c1:active {

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -56,7 +56,28 @@ export default {
   }
 } as Meta
 
+const buttonTestGroupStyles = {display: 'flex', gap: '1rem', paddingBottom: '2rem'}
+
 export const defaultButton = (args: StrictButtonStyleProps) => <Button {...args}>Default Button</Button>
+export const buttonCorrectionTest = (args: StrictButtonStyleProps) => (
+  <>
+    <div>Default</div>
+    <div style={buttonTestGroupStyles}>
+      <div><Button {...args}>Button</Button></div>
+      <div><Button {...args} disabled>Disabled</Button></div>
+    </div>
+    <div>Outline</div>
+    <div style={buttonTestGroupStyles}>
+      <div><ButtonOutline {...args}>Button</ButtonOutline></div>
+      <div><ButtonOutline {...args} disabled>Disabled</ButtonOutline></div>
+    </div>
+    <div>Invisible</div>
+    <div style={buttonTestGroupStyles}>
+      <div><ButtonInvisible {...args}>Button</ButtonInvisible></div>
+      <div><ButtonInvisible {...args} disabled>Disabled</ButtonInvisible></div>
+    </div>
+  </>
+)
 export const dangerButton = (args: StrictButtonStyleProps) => <ButtonDanger {...args}>Danger Button</ButtonDanger>
 export const outlineButton = (args: StrictButtonStyleProps) => <ButtonOutline {...args}>Outline Button</ButtonOutline>
 export const primaryButton = (args: StrictButtonStyleProps) => <ButtonPrimary {...args}>Primary Button</ButtonPrimary>
@@ -78,6 +99,7 @@ export const buttonTableList = (args: ButtonStyleProps) => (
   <ButtonTableList {...args}>Button Table List</ButtonTableList>
 )
 
+buttonCorrectionTest.args = {variant: 'medium'}
 defaultButton.args = {variant: 'medium'}
 dangerButton.args = {variant: 'medium'}
 outlineButton.args = {variant: 'medium'}


### PR DESCRIPTION
Issue: https://github.com/github/primer/issues/263

Related PRs:
https://github.com/primer/primitives/pull/219
https://github.com/primer/css/pull/1553

Summary of changes:
* Focus style update
    * Uses native focus outline style to improve visibility. The custom styles had a very subtle focus ring
    * The focus ring has a small offset to improve contrast against the green background of the Primary button
* Show inner shadow for button `:active` states
    * Gives a sense of depth
* Add background color changes for the Invisible button
    * Makes it more obvious when an Invisible button is being hovered or pressed

### Screenshots

#### Native focus ring style for all buttons

##### Before
https://user-images.githubusercontent.com/2313998/131442571-a3f92bbf-93e9-44c4-bd42-9c733e53e168.mp4

##### After
https://user-images.githubusercontent.com/2313998/131442656-3b72f3c1-06fe-420b-9ce0-ef40623e9948.mp4

#### Show inner shadow for button `:active` states
##### Before
https://user-images.githubusercontent.com/2313998/131442693-e02199bb-4a62-4ac5-9fb7-c0215ec0b377.mp4

##### After
https://user-images.githubusercontent.com/2313998/131442746-7db89472-7893-40ea-85d9-a03137cb08a4.mp4


#### Add background color changes for the Invisible button

##### Before
https://user-images.githubusercontent.com/2313998/131442795-0b4d9020-bedd-44d3-992d-47705d049b88.mp4

##### After
https://user-images.githubusercontent.com/2313998/131442809-f9332fca-9115-47f4-a813-a0d46cbb19f0.mp4

### Merge checklist

- [x] ~Added~/updated tests
- [n/a] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
