### PR TITLE
Migrate to new functional color system

### DIFF
--- a/.changeset/rotten-dodos-complain.md
+++ b/.changeset/rotten-dodos-complain.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": minor
+---
+
+Add `dark_high_contrast` color scheme

--- a/.changeset/wise-apes-brake.md
+++ b/.changeset/wise-apes-brake.md
@@ -1,5 +1,5 @@
 ---
-"@primer/components": patch
+"@primer/components": minor
 ---
 
 Add new [functional color variables](https://primer.style/primitives/colors) to the theme object.

--- a/.changeset/wise-apes-brake.md
+++ b/.changeset/wise-apes-brake.md
@@ -1,0 +1,7 @@
+---
+"@primer/components": patch
+---
+
+Add new [functional color variables](https://primer.style/primitives/colors) to the theme object.
+ 
+ **Tip:** Install [`eslint-plugin-primer-react`](https://primer.style/react/linting) to ensure that you're not using any deprecated color variables.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,8 @@
     "plugin:react-hooks/recommended",
     "plugin:prettier/recommended",
     "plugin:github/recommended",
-    "plugin:github/browser"
+    "plugin:github/browser",
+    "plugin:primer-react/recommended"
   ],
   "ignorePatterns": [
     "node_modules",

--- a/docs/content/theme-reference.md
+++ b/docs/content/theme-reference.md
@@ -5,4 +5,12 @@ description: The default theme object for Primer React components
 
 import {theme} from '@primer/components'
 
+<Note>
+
+See [Theming](/theming) to learn how theming works in Primer React.
+
+</Note>
+
+Colors in this theme object are imported from [Primer Primitives](https://primer.style/primitives/colors).
+
 <pre><code class="language-json">{JSON.stringify(theme, null, 2)}</code></pre>

--- a/docs/content/theming.md
+++ b/docs/content/theming.md
@@ -3,8 +3,6 @@ title: Theming
 description: Theming in Primer React is made possible by a theme object that defines your application's colors, spacing, fonts, and more.
 ---
 
-
-
 ## ThemeProvider
 
 To give components access to the theme object, you must add `ThemeProvider` to the root of your application:

--- a/docs/content/theming.md
+++ b/docs/content/theming.md
@@ -1,8 +1,9 @@
 ---
 title: Theming
+description: Theming in Primer React is made possible by a theme object that defines your application's colors, spacing, fonts, and more.
 ---
 
-Theming in Primer React is made possible by a theme object that defines your application's colors, spacing, fonts, and more.
+
 
 ## ThemeProvider
 

--- a/docs/src/@primer/gatsby-theme-doctocat/components/live-code.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/live-code.js
@@ -49,7 +49,7 @@ function LiveCode({code, language, noinline}) {
         <Box
           sx={{
             border: '1px solid',
-            borderColor: 'border.primary',
+            borderColor: 'border.default',
             borderTopRightRadius: 2,
             borderTopLeftRadius: 2
           }}

--- a/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
@@ -29,7 +29,7 @@ function ThemeSwitcher({children}) {
 function LivePreviewWrapper({children}) {
   return (
     <ThemeSwitcher>
-      <Box width="100%" p={3} bg="bg.canvas" sx={{borderTopLeftRadius: 2, borderTopRightRadius: 2}}>
+      <Box width="100%" p={3} bg="canvas.default" sx={{borderTopLeftRadius: 2, borderTopRightRadius: 2}}>
         <BaseStyles>{children}</BaseStyles>
       </Box>
     </ThemeSwitcher>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4042,9 +4042,9 @@
       "integrity": "sha512-j5XppNRCvgaMZLPsVvvmp6GSh7P5pq6PUbsfLNBWi2Kz3KYDeoGDWbPr5MjoxFOGUn6Hjnt6qjHPRxahd11vLQ=="
     },
     "@primer/primitives": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.6.4.tgz",
-      "integrity": "sha512-KKlP7m+94pbuFl3BYycQrmtNhX5+0gK3ftAh5L4a73Ov4FHbgMyVto3Cr0C5tlpvg0760Nisu+e/4T+/uvx8tA=="
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.7.1.tgz",
+      "integrity": "sha512-kttAUcP3QgT5UbYLeMTKDxPvnAVzywX0xnKPcLkmEVQyhmEBlTO4LSlYIzL5YcKyklHcFRf1426UcGOY9wdWDQ=="
     },
     "@reach/router": {
       "version": "1.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "28.5.0",
+  "version": "29.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14749,6 +14749,11 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-primer-react": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-primer-react/-/eslint-plugin-primer-react-0.4.1.tgz",
+      "integrity": "sha512-FMYe8ZQvyApHIXOhGUMhfiWTVlanWxuW75WBCnWjlr4hvtOz77GTUo0U/1IStk02zXMUzC37FLbNClbnip3fxw=="
+    },
     "eslint-plugin-react": {
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.24.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@primer/octicons-react": "^13.0.0",
-    "@primer/primitives": "4.6.4",
+    "@primer/primitives": "4.7.1",
     "@styled-system/css": "5.1.5",
     "@styled-system/props": "5.1.5",
     "@styled-system/theme-get": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/styled-system__theme-get": "5.0.1",
     "classnames": "2.3.1",
     "deepmerge": "4.2.2",
+    "eslint-plugin-primer-react": "0.4.1",
     "focus-visible": "5.2.0",
     "styled-system": "5.1.5"
   },

--- a/src/ActionList/Divider.tsx
+++ b/src/ActionList/Divider.tsx
@@ -4,7 +4,7 @@ import {get} from '../constants'
 
 export const StyledDivider = styled.div`
   height: 1px;
-  background: ${get('colors.selectMenu.borderSecondary')};
+  background: ${get('colors.border.muted')};
   margin-top: calc(${get('space.2')} - 1px);
   margin-bottom: ${get('space.2')};
 `

--- a/src/ActionList/Header.tsx
+++ b/src/ActionList/Header.tsx
@@ -37,15 +37,15 @@ export const StyledHeader = styled.div<{variant: HeaderProps['variant']} & SxPro
   padding: 6px ${get('space.3')};
   font-size: ${get('fontSizes.0')};
   font-weight: ${get('fontWeights.bold')};
-  color: ${get('colors.text.secondary')};
+  color: ${get('colors.fg.muted')};
 
   ${({variant}) =>
     variant === 'filled' &&
     css`
-      background: ${get('colors.bg.tertiary')};
+      background: ${get('colors.canvas.subtle')};
       margin: ${get('space.2')} 0;
-      border-top: 1px solid ${get('colors.border.tertiary')};
-      border-bottom: 1px solid ${get('colors.border.tertiary')};
+      border-top: 1px solid ${get('colors.neutral.muted')};
+      border-bottom: 1px solid ${get('colors.neutral.muted')};
 
       &:first-child {
         margin-top: 0;

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -129,9 +129,9 @@ export interface ItemProps extends Omit<React.ComponentPropsWithoutRef<'div'>, '
 const getItemVariant = (variant = 'default', disabled?: boolean) => {
   if (disabled) {
     return {
-      color: get('colors.text.disabled'),
-      iconColor: get('colors.text.disabled'),
-      annotationColor: get('colors.text.disabled'),
+      color: get('colors.fg.muted'),
+      iconColor: get('colors.fg.muted'),
+      annotationColor: get('colors.fg.muted'),
       hoverCursor: 'default'
     }
   }
@@ -139,16 +139,16 @@ const getItemVariant = (variant = 'default', disabled?: boolean) => {
   switch (variant) {
     case 'danger':
       return {
-        color: get('colors.text.danger'),
-        iconColor: get('colors.icon.danger'),
-        annotationColor: get('colors.text.disabled'),
+        color: get('colors.danger.fg'),
+        iconColor: get('colors.danger.fg'),
+        annotationColor: get('colors.fg.muted'),
         hoverCursor: 'pointer'
       }
     default:
       return {
         color: 'inherit',
-        iconColor: get('colors.text.secondary'),
-        annotationColor: get('colors.text.secondary'),
+        iconColor: get('colors.fg.muted'),
+        annotationColor: get('colors.fg.muted'),
         hoverCursor: 'pointer'
       }
   }
@@ -211,7 +211,7 @@ const StyledItem = styled.div<
       width: 100%;
       top: -7px;
       // NB: This 'get' won’t execute if it’s moved into the arrow function below.
-      border: 0 solid ${get('colors.selectMenu.borderSecondary')};
+      border: 0 solid ${get('colors.border.muted')};
       border-top-width: ${({showDivider}) => (showDivider ? `1px` : '0')};
     }
   }
@@ -297,7 +297,7 @@ const TrailingContent = styled(ColoredVisualContainer)`
 `
 
 const DescriptionContainer = styled.span`
-  color: ${get('colors.text.secondary')};
+  color: ${get('colors.fg.muted')};
   font-size: ${get('fontSizes.0')};
   // TODO: When rem-based spacing on a 4px scale lands, replace
   // hardcoded '16px' with '${get('lh-12')}'.

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -106,7 +106,7 @@ const StyledList = styled.div`
 
   &[${hasActiveDescendantAttribute}], &:focus-within {
     --item-hover-bg-override: none;
-    --item-hover-divider-border-color-override: ${get('colors.selectMenu.borderSecondary')};
+    --item-hover-divider-border-color-override: ${get('colors.border.muted')};
   }
 `
 

--- a/src/AvatarPair.tsx
+++ b/src/AvatarPair.tsx
@@ -16,7 +16,11 @@ export type AvatarPairProps = BoxProps
 const AvatarPair = ({children, ...rest}: AvatarPairProps) => {
   const avatars = React.Children.map(children, (child, i) => {
     if (!React.isValidElement(child)) return child
-    return i === 0 ? React.cloneElement(child, {size: 40}) : <ChildAvatar bg="bg.canvas" {...child.props} size={20} />
+    return i === 0 ? (
+      React.cloneElement(child, {size: 40})
+    ) : (
+      <ChildAvatar bg="canvas.default" {...child.props} size={20} />
+    )
   })
   return (
     <Box position="relative" display="inline-flex" {...rest}>

--- a/src/AvatarStack.tsx
+++ b/src/AvatarStack.tsx
@@ -21,7 +21,7 @@ const AvatarStackWrapper = styled.span<StyledAvatarStackWrapperProps>`
     flex-shrink: 0;
     height: 20px;
     width: 20px;
-    box-shadow: 0 0 0 1px ${get('colors.bg.canvas')};
+    box-shadow: 0 0 0 1px ${get('colors.canvas.default')};
     margin-left: -11px;
     position: relative;
     overflow: hidden;
@@ -118,7 +118,7 @@ const AvatarStackWrapper = styled.span<StyledAvatarStackWrapperProps>`
       margin-left: ${get('space.1')};
       opacity: 100%;
       visibility: visible;
-      box-shadow: 0 0 0 4px ${get('colors.bg.canvas')};
+      box-shadow: 0 0 0 4px ${get('colors.canvas.default')};
       &:first-child {
         margin-left: 0;
       }

--- a/src/BranchName.tsx
+++ b/src/BranchName.tsx
@@ -8,8 +8,8 @@ const BranchName = styled.a<SystemCommonProps & SxProp>`
   padding: 2px 6px;
   font-size: ${get('fontSizes.0')};
   font-family: ${get('fonts.mono')};
-  color: ${get('colors.branchName.text')};
-  background-color: ${get('colors.branchName.bg')};
+  color: ${get('colors.fg.muted')};
+  background-color: ${get('colors.accent.subtle')};
   border-radius: ${get('radii.2')};
   ${COMMON};
   ${sx};

--- a/src/Breadcrumb.tsx
+++ b/src/Breadcrumb.tsx
@@ -17,7 +17,7 @@ const Wrapper = styled.li`
   &::after {
     padding-right: 0.5em;
     padding-left: 0.5em;
-    color: ${get('colors.text.disabled')};
+    color: ${get('colors.fg.muted')};
     font-size: ${get('fontSizes.1')};
     content: '/';
   }
@@ -64,7 +64,7 @@ const BreadcrumbItem = styled.a.attrs<StyledBreadcrumbItemProps>(props => ({
   className: classnames(props.selected && SELECTED_CLASS, props.className),
   'aria-current': props.selected ? 'page' : null
 }))<StyledBreadcrumbItemProps>`
-  color: ${get('colors.text.link')};
+  color: ${get('colors.accent.fg')};
   display: inline-block;
   font-size: ${get('fontSizes.1')};
   text-decoration: none;
@@ -72,7 +72,7 @@ const BreadcrumbItem = styled.a.attrs<StyledBreadcrumbItemProps>(props => ({
     text-decoration: underline;
   }
   &.selected {
-    color: ${get('colors.text.primary')};
+    color: ${get('colors.fg.default')};
     pointer-events: none;
   }
   ${COMMON}

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -27,7 +27,7 @@ const Button = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
   }
 
   &:disabled {
-    color: ${get('colors.text.disabled')};
+    color: ${get('colors.fg.muted')};
     background-color: ${get('colors.btn.bg')};
     border-color: ${get('colors.btn.border')};
   }

--- a/src/Button/ButtonClose.tsx
+++ b/src/Button/ButtonClose.tsx
@@ -14,14 +14,14 @@ const StyledButton = styled.button<StyledButtonProps>`
   outline: none;
   cursor: pointer;
   border-radius: ${get('radii.2')};
-  color: ${get('colors.text.secondary')};
+  color: ${get('colors.fg.muted')};
 
   &:focus {
     box-shadow: ${get('shadows.btn.focusShadow')};
   }
 
   &:hover {
-    color: ${get('colors.text.link')};
+    color: ${get('colors.accent.fg')};
   }
   ${COMMON};
   ${LAYOUT};

--- a/src/Button/ButtonInvisible.tsx
+++ b/src/Button/ButtonInvisible.tsx
@@ -5,14 +5,14 @@ import {ComponentProps} from '../utils/types'
 import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 
 const ButtonInvisible = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
-  color: ${get('colors.text.link')};
+  color: ${get('colors.accent.fg')};
   background-color: transparent;
   border: 0;
   border-radius: ${get('radii.2')};
   box-shadow: none;
 
   &:disabled {
-    color: ${get('colors.text.disabled')};
+    color: ${get('colors.fg.muted')};
   }
 
   &:focus {

--- a/src/Button/ButtonTableList.tsx
+++ b/src/Button/ButtonTableList.tsx
@@ -17,7 +17,7 @@ const ButtonTableList = styled.summary<StyledButtonTableListProps>`
   display: inline-block;
   padding: 0;
   font-size: ${get('fontSizes.1')};
-  color: ${get('colors.text.secondary')};
+  color: ${get('colors.fg.muted')};
   text-decoration: none;
   white-space: nowrap;
   cursor: pointer;
@@ -33,7 +33,7 @@ const ButtonTableList = styled.summary<StyledButtonTableListProps>`
   &:disabled {
     &,
     &:hover {
-      color: rgba(${get('colors.text.secondary')}, 0.5);
+      color: rgba(${get('colors.fg.muted')}, 0.5);
       cursor: default;
     }
   }

--- a/src/CircleBadge.tsx
+++ b/src/CircleBadge.tsx
@@ -30,7 +30,7 @@ const CircleBadge = styled.div<StyledCircleBadgeProps>`
   display: ${props => (props.inline ? 'inline-flex' : 'flex')};
   align-items: center;
   justify-content: center;
-  background-color: ${get('colors.bg.canvas')};
+  background-color: ${get('colors.canvas.default')};
   border-radius: 50%;
   box-shadow: ${get('shadows.shadow.medium')};
   ${COMMON};

--- a/src/CircleOcticon.tsx
+++ b/src/CircleOcticon.tsx
@@ -20,7 +20,7 @@ function CircleOcticon(props: CircleOcticonProps) {
       size={size}
       borderRadius="50%"
       borderStyle="solid"
-      borderColor="border.primary"
+      borderColor="border.default"
     >
       <Box display="flex" {...rest} alignItems="center" justifyContent="center">
         <IconComponent size={size} />

--- a/src/CounterLabel.tsx
+++ b/src/CounterLabel.tsx
@@ -12,10 +12,10 @@ const colorStyles = ({scheme, ...props}: StyledCounterLabelProps) => {
   return {
     color:
       scheme === 'secondary'
-        ? get('colors.counter.text')(props)
+        ? get('colors.fg.default')(props)
         : scheme === 'primary'
-        ? get('colors.counter.primary.text')(props)
-        : get('colors.counter.text')(props)
+        ? get('colors.fg.onEmphasis')(props)
+        : get('colors.fg.default')(props)
   }
 }
 
@@ -23,10 +23,10 @@ const bgStyles = ({scheme, ...props}: StyledCounterLabelProps) => {
   return {
     backgroundColor:
       scheme === 'secondary'
-        ? get('colors.counter.bg')(props)
+        ? get('colors.neutral.muted')(props)
         : scheme === 'primary'
-        ? get('colors.counter.primary.bg')(props)
-        : get('colors.counter.bg')(props)
+        ? get('colors.neutral.emphasis')(props)
+        : get('colors.neutral.muted')(props)
   }
 }
 

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -28,7 +28,7 @@ const DialogBase = styled.div<StyledDialogBaseProps>`
   max-height: 80vh;
   z-index: 999;
   margin: 10vh auto;
-  background-color: ${get('colors.bg.primary')};
+  background-color: ${get('colors.canvas.default')};
   width: ${props => (props.narrow ? '320px' : props.wide ? '640px' : '440px')};
   outline: none;
 
@@ -46,7 +46,7 @@ const DialogBase = styled.div<StyledDialogBaseProps>`
 
 const DialogHeaderBase = styled(Box)<SxProp>`
   border-radius: ${get('radii.2')} ${get('radii.2')} 0px 0px;
-  border-bottom: 1px solid ${get('colors.border.primary')};
+  border-bottom: 1px solid ${get('colors.border.default')};
   display: flex;
 
   @media screen and (max-width: 750px) {
@@ -60,7 +60,7 @@ export type DialogHeaderProps = ComponentProps<typeof DialogHeaderBase>
 function DialogHeader({theme, children, backgroundColor = 'gray.1', ...rest}: DialogHeaderProps) {
   if (React.Children.toArray(children).every(ch => typeof ch === 'string')) {
     children = (
-      <Text theme={theme} color="text.primary" fontSize={1} fontWeight="bold" fontFamily="sans-serif">
+      <Text theme={theme} color="fg.default" fontSize={1} fontWeight="bold" fontFamily="sans-serif">
         {children}
       </Text>
     )

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -85,7 +85,7 @@ const Overlay = styled.span`
     content: ' ';
     background: transparent;
     z-index: 99;
-    background: ${get('colors.fade.black50')};
+    background: ${get('colors.primer.canvas.backdrop')};
   }
 `
 

--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -65,7 +65,7 @@ const ConfirmationHeader: React.FC<DialogHeaderProps> = ({title, onClose, dialog
 const StyledConfirmationBody = styled(Box)`
   font-size: ${get('fontSizes.1')};
   padding: 0 ${get('space.3')} ${get('space.3')} ${get('space.3')};
-  color: ${get('colors.text.tertiary')};
+  color: ${get('colors.fg.muted')};
   flex-grow: 1;
 `
 const ConfirmationBody: React.FC<DialogProps> = ({children}) => {

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -182,7 +182,7 @@ interface StyledDialogProps {
 const StyledDialog = styled.div<StyledDialogProps & SystemCommonProps & SystemPositionProps & SxProp>`
   display: flex;
   flex-direction: column;
-  background-color: ${get('colors.bg.overlay')};
+  background-color: ${get('colors.canvas.overlay')};
   box-shadow: ${get('shadows.overlay.shadow')};
   min-width: 296px;
   max-width: calc(100vw - 64px);
@@ -297,7 +297,7 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
 _Dialog.displayName = 'Dialog'
 
 const Header = styled(Box).attrs({as: 'header'})`
-  box-shadow: 0 1px 0 ${get('colors.border.overlay')};
+  box-shadow: 0 1px 0 ${get('colors.border.default')};
   padding: ${get('space.2')};
   z-index: 1;
   flex-shrink: 0;
@@ -309,7 +309,7 @@ const Title = styled(Box)`
 const Subtitle = styled(Box)`
   font-size: ${get('fontSizes.0')};
   margin-top: ${get('space.1')};
-  color: ${get('colors.text.tertiary')};
+  color: ${get('colors.fg.muted')};
 `
 const Body = styled(Box)`
   flex-grow: 1;
@@ -317,7 +317,7 @@ const Body = styled(Box)`
   padding: ${get('space.3')};
 `
 const Footer = styled(Box).attrs({as: 'footer'})`
-  box-shadow: 0 -1px 0 ${get('colors.border.overlay')};
+  box-shadow: 0 -1px 0 ${get('colors.border.default')};
   padding: ${get('space.3')};
   display: flex;
   flex-flow: wrap;
@@ -373,7 +373,7 @@ const DialogCloseButton = styled(Button)`
   background: transparent;
   border: 0;
   vertical-align: middle;
-  color: ${get('colors.text.secondary')};
+  color: ${get('colors.fg.muted')};
   padding: ${get('space.2')};
   align-self: flex-start;
   line-height: normal;

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -56,10 +56,10 @@ type StyledDropdownMenuProps = {
 
 const DropdownMenu = styled.ul<StyledDropdownMenuProps>`
   background-clip: padding-box;
-  background-color: ${get('colors.bg.overlay')};
-  border: 1px solid ${get('colors.border.overlay')};
+  background-color: ${get('colors.canvas.overlay')};
+  border: 1px solid ${get('colors.border.default')};
   border-radius: ${get('radii.2')};
-  box-shadow: ${get('shadows.dropdown.shadow')};
+  box-shadow: ${get('shadows.shadow.large')};
   left: 0;
   list-style: none;
   margin-top: 2px;
@@ -83,12 +83,12 @@ const DropdownMenu = styled.ul<StyledDropdownMenuProps>`
 
   &::before {
     border: 8px solid transparent;
-    border-bottom-color: ${get('colors.bg.overlay')};
+    border-bottom-color: ${get('colors.canvas.overlay')};
   }
 
   &::after {
     border: 7px solid transparent;
-    border-bottom-color: ${get('colors.bg.overlay')};
+    border-bottom-color: ${get('colors.canvas.overlay')};
   }
 
   // stylelint-disable-next-line selector-max-type
@@ -104,31 +104,31 @@ const DropdownItem = styled.li`
   display: block;
   padding: ${get('space.1')} 10px ${get('space.1')} 15px;
   overflow: hidden;
-  color: ${get('colors.text.primary')};
+  color: ${get('colors.fg.default')};
   text-overflow: ellipsis;
   white-space: nowrap;
   a {
-    color: ${get('colors.text.primary')};
+    color: ${get('colors.fg.default')};
     text-decoration: none;
     display: block;
     overflow: hidden;
-    color: ${get('colors.text.primary')};
+    color: ${get('colors.fg.default')};
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   &:focus,
   a:focus {
-    color: ${get('colors.state.hover.primaryText')};
+    color: ${get('colors.fg.onEmphasis')};
     text-decoration: none;
-    background-color: ${get('colors.state.hover.primaryBg')};
+    background-color: ${get('colors.accent.emphasis')};
   }
 
   &:hover,
   &:hover a {
-    color: ${get('colors.state.hover.primaryText')};
+    color: ${get('colors.fg.onEmphasis')};
     text-decoration: none;
-    background-color: ${get('colors.state.hover.primaryBg')};
+    background-color: ${get('colors.accent.emphasis')};
     outline: none;
   }
   ${COMMON};

--- a/src/DropdownStyles.ts
+++ b/src/DropdownStyles.ts
@@ -16,7 +16,7 @@ const getDirectionStyles = (theme: Theme, direction: 'ne' | 'e' | 'se' | 's' | '
         right: -16px;
         left: auto;
         border-color: transparent;
-        border-left-color: ${get('colors.border.overlay')(theme)};
+        border-left-color: ${get('colors.border.default')(theme)};
       }
 
       &::after {
@@ -24,7 +24,7 @@ const getDirectionStyles = (theme: Theme, direction: 'ne' | 'e' | 'se' | 's' | '
         right: -14px;
         left: auto;
         border-color: transparent;
-        border-left-color: ${get('colors.border.overlay')(theme)};
+        border-left-color: ${get('colors.border.default')(theme)};
       }
     `,
     e: `
@@ -38,14 +38,14 @@ const getDirectionStyles = (theme: Theme, direction: 'ne' | 'e' | 'se' | 's' | '
         top: 10px;
         left: -16px;
         border-color: transparent;
-        border-right-color: ${get('colors.border.overlay')(theme)};
+        border-right-color: ${get('colors.border.default')(theme)};
       }
 
       &::after {
         top: 11px;
         left: -14px;
         border-color: transparent;
-        border-right-color: ${get('colors.border.overlay')(theme)};
+        border-right-color: ${get('colors.border.default')(theme)};
       }
     `,
     ne: `
@@ -63,7 +63,7 @@ const getDirectionStyles = (theme: Theme, direction: 'ne' | 'e' | 'se' | 's' | '
       &::before {
         bottom: -8px;
         left: 9px;
-        border-top: 8px solid ${get('colors.border.overlay')(theme)};
+        border-top: 8px solid ${get('colors.border.default')(theme)};
         border-bottom: 0;
         border-left: 8px solid transparent;
       }
@@ -71,7 +71,7 @@ const getDirectionStyles = (theme: Theme, direction: 'ne' | 'e' | 'se' | 's' | '
       &::after {
         bottom: -7px;
         left: 10px;
-        border-top: 7px solid ${get('colors.border.overlay')(theme)};
+        border-top: 7px solid ${get('colors.border.default')(theme)};
         border-right: 7px solid transparent;
         border-bottom: 0;
         border-left: 7px solid transparent;

--- a/src/FilterList.tsx
+++ b/src/FilterList.tsx
@@ -33,8 +33,8 @@ const FilterListItemBase = styled.a<StyledFilterListItemBaseProps>`
   margin: ${props => (props.small ? '0 0 2px' : '0 0 5px 0')};
   overflow: hidden;
   font-size: ${get('fontSizes.1')};
-  color: ${props => (props.selected ? get('colors.state.selected.primaryText') : get('colors.text.secondary'))};
-  background-color: ${props => (props.selected ? get('colors.state.selected.primaryBg') : '')}!important;
+  color: ${props => (props.selected ? get('colors.fg.onEmphasis') : get('colors.fg.muted'))};
+  background-color: ${props => (props.selected ? get('colors.accent.emphasis') : '')}!important;
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -42,11 +42,11 @@ const FilterListItemBase = styled.a<StyledFilterListItemBaseProps>`
   border-radius: ${get('radii.1')};
   &:hover {
     text-decoration: none;
-    background-color: ${get('colors.bg.tertiary')};
+    background-color: ${get('colors.canvas.subtle')};
   }
   &:active {
-    color: ${get('colors.state.selected.primaryText')};
-    background-color: ${get('colors.state.selected.primaryBg')};
+    color: ${get('colors.fg.onEmphasis')};
+    background-color: ${get('colors.accent.emphasis')};
   }
   .count {
     float: right;

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -45,7 +45,7 @@ function scrollIntoViewingArea(
 }
 
 const StyledHeader = styled.div`
-  box-shadow: 0 1px 0 ${get('colors.border.primary')};
+  box-shadow: 0 1px 0 ${get('colors.border.default')};
   z-index: 1;
 `
 
@@ -126,7 +126,7 @@ export function FilteredActionList({
           ref={inputRef}
           block
           width="auto"
-          color="text.primary"
+          color="fg.default"
           value={filterValue}
           onChange={onInputChange}
           onKeyPress={onInputKeyPress}

--- a/src/Flash.tsx
+++ b/src/Flash.tsx
@@ -49,7 +49,7 @@ const Flash = styled.div<
     SxProp
 >`
   position: relative;
-  color: ${get('colors.text.primary')};
+  color: ${get('colors.fg.default')};
   padding: ${get('space.3')};
   border-style: solid;
   border-width: ${props => (props.full ? '1px 0px' : '1px')};

--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -7,8 +7,8 @@ import {ComponentProps} from './utils/types'
 const outlineStyles = css`
   margin-top: -1px; // offsets the 1px border
   margin-bottom: -1px; // offsets the 1px border
-  color: ${get('colors.label.secondary.text')};
-  border: ${get('borderWidths.1')} solid ${get('colors.label.border')};
+  color: ${get('colors.fg.muted')};
+  border: ${get('borderWidths.1')} solid ${get('colors.border.default')};
   box-shadow: none;
   ${borderColor};
   ${COMMON};
@@ -52,7 +52,7 @@ const Label = styled.span<
 >`
   display: inline-block;
   font-weight: ${get('fontWeights.semibold')};
-  color: ${get('colors.text.inverse')};
+  color: ${get('colors.fg.onEmphasis')};
   border-radius: ${get('radii.3')};
 
   &:hover {

--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -20,11 +20,11 @@ const hoverColor = system({
 })
 
 const Link = styled.a<StyledLinkProps>`
-  color: ${props => (props.muted ? get('colors.text.secondary')(props) : get('colors.text.link')(props))};
+  color: ${props => (props.muted ? get('colors.fg.muted')(props) : get('colors.accent.fg')(props))};
   text-decoration: ${props => (props.underline ? 'underline' : 'none')};
   &:hover {
     text-decoration: ${props => (props.muted ? 'none' : 'underline')};
-    ${props => (props.hoverColor ? hoverColor : props.muted ? `color: ${get('colors.text.link')(props)}` : '')};
+    ${props => (props.hoverColor ? hoverColor : props.muted ? `color: ${get('colors.accent.fg')(props)}` : '')};
   }
   &:is(button) {
     display: inline-block;

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -52,7 +52,7 @@ function getSlideAnimationStartingVector(anchorSide?: AnchorSide): {x: number; y
 }
 
 const StyledOverlay = styled.div<StyledOverlayProps & SystemCommonProps & SxProp>`
-  background-color: ${get('colors.bg.overlay')};
+  background-color: ${get('colors.canvas.overlay')};
   box-shadow: ${get('shadows.overlay.shadow')};
   position: absolute;
   min-width: 192px;

--- a/src/Pagehead.tsx
+++ b/src/Pagehead.tsx
@@ -8,7 +8,7 @@ const Pagehead = styled.div<SystemCommonProps & SxProp>`
   padding-top: ${get('space.4')};
   padding-bottom: ${get('space.4')};
   margin-bottom: ${get('space.4')};
-  border-bottom: 1px solid ${get('colors.border.primary')};
+  border-bottom: 1px solid ${get('colors.border.default')};
   ${COMMON};
   ${sx};
 `

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -11,7 +11,7 @@ const Page = styled.a`
   padding: 5px 10px;
   font-style: normal;
   line-height: 20px;
-  color: ${get('colors.text.primary')};
+  color: ${get('colors.fg.default')};
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
@@ -32,30 +32,30 @@ const Page = styled.a`
   &:hover,
   &:focus {
     text-decoration: none;
-    border-color: ${get('colors.border.primary')};
+    border-color: ${get('colors.border.default')};
     outline: 0;
     transition-duration: 0.1s;
   }
 
   &:active {
-    border-color: ${get('colors.border.secondary')};
+    border-color: ${get('colors.border.muted')};
   }
 
   &[rel='prev'],
   &[rel='next'] {
-    color: ${get('colors.text.link')};
+    color: ${get('colors.accent.fg')};
   }
 
   &[aria-current],
   &[aria-current]:hover {
-    color: ${get('colors.state.selected.primaryText')};
-    background-color: ${get('colors.state.selected.primaryBg')};
+    color: ${get('colors.fg.onEmphasis')};
+    background-color: ${get('colors.accent.emphasis')};
     border-color: transparent;
   }
 
   &[aria-disabled],
   &[aria-disabled]:hover {
-    color: ${get('colors.text.disabled')}; // check
+    color: ${get('colors.fg.muted')}; // check
     cursor: default;
     border-color: transparent;
   }

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -44,14 +44,14 @@ const Popover = styled.div.attrs<StyledPopoverProps>(({className, caret}) => {
 `
 
 const PopoverContent = styled(Box)`
-  border: 1px solid ${get('colors.border.primary')};
+  border: 1px solid ${get('colors.border.default')};
   border-radius: ${get('radii.2')};
   position: relative;
   width: 232px;
   margin-right: auto;
   margin-left: auto;
   padding: ${get('space.4')};
-  background-color: ${get('colors.bg.overlay')};
+  background-color: ${get('colors.canvas.overlay')};
 
   ${COMMON};
   ${LAYOUT};
@@ -69,14 +69,14 @@ const PopoverContent = styled(Box)`
     top: -${get('space.3')};
     margin-left: -9px;
     border: ${get('space.2')} solid transparent; // TODO: solid?
-    border-bottom-color: ${get('colors.border.overlay')};
+    border-bottom-color: ${get('colors.border.default')};
   }
 
   &::after {
     top: -14px;
     margin-left: -${get('space.2')};
     border: 7px solid transparent; // todo: solid
-    border-bottom-color: ${get('colors.bg.overlay')};
+    border-bottom-color: ${get('colors.canvas.overlay')};
   }
 
   // Bottom-oriented carets
@@ -91,13 +91,13 @@ const PopoverContent = styled(Box)`
 
     &::before {
       bottom: -${get('space.3')};
-      border-top-color: ${get('colors.border.overlay')};
+      border-top-color: ${get('colors.border.default')};
     }
 
     &::after {
       bottom: -14px;
       // stylelint-disable-next-line primer/borders
-      border-top-color: ${get('colors.bg.overlay')};
+      border-top-color: ${get('colors.canvas.overlay')};
     }
   }
 
@@ -170,13 +170,13 @@ const PopoverContent = styled(Box)`
   ${Popover}.caret-pos--right-bottom & {
     &::before {
       right: -${get('space.3')};
-      border-left-color: ${get('colors.border.overlay')};
+      border-left-color: ${get('colors.border.default')};
     }
 
     &::after {
       right: -14px;
       // stylelint-disable-next-line primer/borders
-      border-left-color: ${get('colors.bg.overlay')};
+      border-left-color: ${get('colors.canvas.overlay')};
     }
   }
 
@@ -186,13 +186,13 @@ const PopoverContent = styled(Box)`
   ${Popover}.caret-pos--left-bottom & {
     &::before {
       left: -${get('space.3')};
-      border-right-color: ${get('colors.border.overlay')};
+      border-right-color: ${get('colors.border.default')};
     }
 
     &::after {
       left: -14px;
       // stylelint-disable-next-line primer/borders
-      border-right-color: ${get('colors.bg.overlay')};
+      border-right-color: ${get('colors.canvas.overlay')};
     }
   }
 

--- a/src/ProgressBar.tsx
+++ b/src/ProgressBar.tsx
@@ -26,7 +26,7 @@ type StyledProgressContainerProps = {
 const ProgressContainer = styled.span<StyledProgressContainerProps>`
   display: ${props => (props.inline ? 'inline-flex' : 'flex')};
   overflow: hidden;
-  background-color: ${get('colors.border.primary')};
+  background-color: ${get('colors.border.default')};
   border-radius: ${get('radii.1')};
   height: ${props => sizeMap[props.barSize || 'default']};
   ${COMMON}

--- a/src/SelectMenu/SelectMenuDivider.tsx
+++ b/src/SelectMenu/SelectMenuDivider.tsx
@@ -8,9 +8,9 @@ const dividerStyles = css`
   margin: 0;
   font-size: ${get('fontSizes.0')};
   font-weight: ${get('fontWeights.bold')};
-  color: ${get('colors.text.tertiary')};
-  background-color: ${get('colors.bg.tertiary')};
-  border-bottom: ${get('borderWidths.1')} solid ${get('colors.selectMenu.borderSecondary')};
+  color: ${get('colors.fg.muted')};
+  background-color: ${get('colors.canvas.subtle')};
+  border-bottom: ${get('borderWidths.1')} solid ${get('colors.border.muted')};
 `
 
 const SelectMenuDivider = styled.div<SystemCommonProps & SxProp>`

--- a/src/SelectMenu/SelectMenuFilter.tsx
+++ b/src/SelectMenu/SelectMenuFilter.tsx
@@ -9,8 +9,8 @@ import {MenuContext} from './SelectMenuContext'
 const StyledForm = styled.form<SystemCommonProps & SxProp>`
   padding: ${get('space.3')};
   margin: 0;
-  border-bottom: ${get('borderWidths.1')} solid ${get('colors.selectMenu.borderSecondary')};
-  background-color: ${get('colors.bg.overlay')};
+  border-bottom: ${get('borderWidths.1')} solid ${get('colors.border.muted')};
+  background-color: ${get('colors.canvas.overlay')};
   ${COMMON};
 
   @media (min-width: ${get('breakpoints.0')}) {

--- a/src/SelectMenu/SelectMenuFooter.tsx
+++ b/src/SelectMenu/SelectMenuFooter.tsx
@@ -7,9 +7,9 @@ const footerStyles = css`
   margin-top: -1px;
   padding: ${get('space.2')} ${get('space.3')};
   font-size: ${get('fontSizes.0')};
-  color: ${get('colors.text.tertiary')};
+  color: ${get('colors.fg.muted')};
   text-align: center;
-  border-top: ${get('borderWidths.1')} solid ${get('colors.selectMenu.borderSecondary')};
+  border-top: ${get('borderWidths.1')} solid ${get('colors.border.muted')};
 
   @media (min-width: ${get('breakpoints.0')}) {
     padding: ${get('space.1')} ${get('space.2')};

--- a/src/SelectMenu/SelectMenuHeader.tsx
+++ b/src/SelectMenu/SelectMenuHeader.tsx
@@ -8,7 +8,7 @@ import {ComponentProps} from '../utils/types'
 // SelectMenu.Modal
 
 const SelectMenuTitle = styled.h3`
-  color: ${get('colors.text.primary')};
+  color: ${get('colors.fg.default')};
   flex: auto;
   font-size: ${get('fontSizes.1')};
   font-weight: ${get('fontWeights.bold')};
@@ -23,7 +23,7 @@ const StyledHeader = styled.header<SystemTypographyProps & SystemCommonProps & S
   display: flex;
   flex: none; // fixes header from getting squeezed in Safari iOS
   padding: ${get('space.3')};
-  border-bottom: ${get('borderWidths')} solid ${get('colors.selectMenu.borderSecondary')};
+  border-bottom: ${get('borderWidths')} solid ${get('colors.border.muted')};
   ${COMMON}
   ${TYPOGRAPHY}
 

--- a/src/SelectMenu/SelectMenuItem.tsx
+++ b/src/SelectMenu/SelectMenuItem.tsx
@@ -14,10 +14,10 @@ export const listItemStyles = css`
   overflow: hidden;
   text-align: left;
   cursor: pointer;
-  background-color: ${get('colors.bg.overlay')};
+  background-color: ${get('colors.canvas.overlay')};
   border: 0;
-  border-bottom: ${get('borderWidths.1')} solid ${get('colors.selectMenu.borderSecondary')};
-  color: ${get('colors.text.secondary')};
+  border-bottom: ${get('borderWidths.1')} solid ${get('colors.border.muted')};
+  color: ${get('colors.fg.muted')};
   text-decoration: none;
   font-size: ${get('fontSizes.0')};
   font-family: inherit; // needed if user uses a "button" tag
@@ -54,7 +54,7 @@ export const listItemStyles = css`
   // selected items
   &[aria-checked='true'] {
     font-weight: 500;
-    color: ${get('colors.text.primary')};
+    color: ${get('colors.fg.default')};
 
     .SelectMenu-selected-icon {
       visibility: visible;
@@ -68,7 +68,7 @@ export const listItemStyles = css`
     &:hover,
     &:active,
     &:focus {
-      background-color: ${get('colors.state.hover.secondaryBg')};
+      background-color: ${get('colors.neutral.subtle')};
     }
   }
 
@@ -80,7 +80,7 @@ export const listItemStyles = css`
     // Android
     &:focus,
     &:active {
-      background-color: ${get('colors.bg.secondary')};
+      background-color: ${get('colors.canvas.subtle')};
     }
 
     // iOS Safari

--- a/src/SelectMenu/SelectMenuList.tsx
+++ b/src/SelectMenu/SelectMenuList.tsx
@@ -10,7 +10,7 @@ const listStyles = css`
   flex: auto;
   overflow-x: hidden;
   overflow-y: auto;
-  background-color: ${get('colors.bg.overlay')};
+  background-color: ${get('colors.canvas.overlay')};
   -webkit-overflow-scrolling: touch; // Adds momentum + bouncy scrolling
 
   @media (hover: hover) {
@@ -19,13 +19,13 @@ const listStyles = css`
     }
 
     .SelectMenuTab:not([aria-checked='true']):hover {
-      color: ${get('colors.text.primary')};
-      background-color: ${get('colors.bg.tertiary')};
+      color: ${get('colors.fg.default')};
+      background-color: ${get('colors.canvas.subtle')};
     }
 
     .SelectMenuTab:not([aria-checked='true']):active {
-      color: ${get('colors.text.primary')};
-      background-color: ${get('colors.bg.tertiary')};
+      color: ${get('colors.fg.default')};
+      background-color: ${get('colors.canvas.subtle')};
     }
   }
 `

--- a/src/SelectMenu/SelectMenuLoadingAnimation.tsx
+++ b/src/SelectMenu/SelectMenuLoadingAnimation.tsx
@@ -7,7 +7,7 @@ import {ComponentProps} from '../utils/types'
 const Animation = styled.div<SystemCommonProps>`
   padding: ${get('space.6')} ${get('space.4')};
   text-align: center;
-  background-color: ${get('colors.bg.overlay')};
+  background-color: ${get('colors.canvas.overlay')};
   ${COMMON}
 `
 

--- a/src/SelectMenu/SelectMenuModal.tsx
+++ b/src/SelectMenu/SelectMenuModal.tsx
@@ -32,7 +32,7 @@ const modalStyles = css<StyledModalProps>`
   overflow: hidden; // Enables border radius on scrollable child elements
   pointer-events: auto;
   flex-direction: column;
-  background-color: ${get('colors.bg.overlay')};
+  background-color: ${get('colors.canvas.overlay')};
   border-radius: ${get('radii.2')};
   box-shadow: ${get('shadows.shadow.small')};
   animation: ${animateModal} 0.12s cubic-bezier(0, 0.1, 0.1, 1) backwards;
@@ -42,7 +42,7 @@ const modalStyles = css<StyledModalProps>`
     max-height: 350px;
     margin: ${get('space.1')} 0 ${get('space.3')} 0;
     font-size: ${get('fontSizes.0')};
-    border: ${get('borderWidths.1')} solid ${get('colors.border.overlay')};
+    border: ${get('borderWidths.1')} solid ${get('colors.border.default')};
     border-radius: ${get('radii.2')};
     box-shadow: ${get('shadows.shadow.small')};
   }
@@ -68,7 +68,7 @@ const modalWrapperStyles = css<StyledModalWrapperProps>`
     left: 0;
     pointer-events: none;
     content: '';
-    background-color: ${get('colors.selectMenu.backdropBg')};
+    background-color: ${get('colors.primer.canvas.backdrop')};
 
     @media (min-width: ${get('breakpoints.0')}) {
       display: none;

--- a/src/SelectMenu/SelectMenuTab.tsx
+++ b/src/SelectMenu/SelectMenuTab.tsx
@@ -11,11 +11,11 @@ const tabStyles = css`
   padding: ${get('space.2')} ${get('space.3')};
   font-size: ${get('fontSizes.0')};
   font-weight: 500;
-  color: ${get('colors.text.tertiary')};
+  color: ${get('colors.fg.muted')};
   text-align: center;
   background-color: transparent;
   border: 0;
-  box-shadow: inset 0 -1px 0 ${get('colors.selectMenu.borderSecondary')};
+  box-shadow: inset 0 -1px 0 ${get('colors.border.muted')};
 
   @media (min-width: ${get('breakpoints.0')}) {
     flex: none;
@@ -29,17 +29,17 @@ const tabStyles = css`
   &[aria-selected='true'] {
     z-index: 1; // Keeps box-shadow visible when hovering
     color: ${get('colors.text-primary')};
-    background-color: ${get('colors.bg.overlay')};
-    box-shadow: 0 0 0 1px ${get('colors.selectMenu.borderSecondary')};
+    background-color: ${get('colors.canvas.overlay')};
+    box-shadow: 0 0 0 1px ${get('colors.border.muted')};
 
     @media (min-width: ${get('breakpoints.0')}) {
-      border-color: ${get('colors.selectMenu.borderSecondary')};
+      border-color: ${get('colors.border.muted')};
       box-shadow: none;
     }
   }
 
   &:focus {
-    background-color: ${get('colors.state.hover.secondaryBg')};
+    background-color: ${get('colors.neutral.subtle')};
   }
 `
 

--- a/src/SelectMenu/SelectMenuTabPanel.tsx
+++ b/src/SelectMenu/SelectMenuTabPanel.tsx
@@ -7,7 +7,7 @@ import {MenuContext} from './SelectMenuContext'
 import SelectMenuList from './SelectMenuList'
 
 const TabPanelBase = styled.div<SystemCommonProps & SxProp>`
-  border-top: ${get('borderWidths.1')} solid ${get('colors.selectMenu.borderSecondary')};
+  border-top: ${get('borderWidths.1')} solid ${get('colors.border.muted')};
   ${COMMON}
   ${sx};
 `

--- a/src/SideNav.tsx
+++ b/src/SideNav.tsx
@@ -28,7 +28,7 @@ function SideNavBase({variant, className, bordered, children, ...props}: SideNav
     <Box
       borderWidth="1px"
       borderStyle="solid"
-      borderColor="border.primary"
+      borderColor="border.default"
       borderRadius={2}
       as="nav"
       className={newClassName}
@@ -40,7 +40,7 @@ function SideNavBase({variant, className, bordered, children, ...props}: SideNav
 }
 
 const SideNav = styled(SideNavBase)`
-  background-color: ${get('colors.bg.secondary')};
+  background-color: ${get('colors.canvas.subtle')};
 
   ${props =>
     props.bordered &&
@@ -64,14 +64,14 @@ type StyledSideNavLinkProps = {
 
 // used for variant normal hover, focus pseudo selectors
 const CommonAccessibilityVariantNormalStyles = css`
-  background-color: ${get('colors.state.hover.secondaryBg')};
+  background-color: ${get('colors.neutral.subtle')};
   outline: none;
   text-decoration: none;
 `
 
 // used for light weight hover, focus pseudo selectors
 const CommonAccessibilityVariantLightWeightStyles = css`
-  color: ${get('colors.text.primary')};
+  color: ${get('colors.fg.default')};
   text-decoration: none;
   outline: none;
 `
@@ -104,10 +104,10 @@ const SideNavLink = styled(Link).attrs<StyledSideNavLinkProps>(props => {
   }
 
   ${SideNav}.variant-normal > & {
-    color: ${get('colors.text.primary')};
+    color: ${get('colors.fg.default')};
     padding: ${get('space.3')};
     border: 0;
-    border-top: ${get('borderWidths.1')} solid ${get('colors.border.secondary')};
+    border-top: ${get('borderWidths.1')} solid ${get('colors.border.muted')};
 
     &:first-child {
       border-top: 0;
@@ -138,7 +138,7 @@ const SideNavLink = styled(Link).attrs<StyledSideNavLinkProps>(props => {
 
     &:focus {
       ${CommonAccessibilityVariantNormalStyles}
-      box-shadow: ${get('shadows.state.focus.shadow')};
+      box-shadow: ${get('shadows.primer.shadow.focus')};
       z-index: 1;
     }
 
@@ -148,14 +148,14 @@ const SideNavLink = styled(Link).attrs<StyledSideNavLinkProps>(props => {
 
       // Bar on the left
       &::before {
-        background-color: ${get('colors.sidenav.borderActive')};
+        background-color: ${get('colors.primer.border.active')};
       }
     }
   }
 
   ${SideNav}.variant-lightweight > & {
     padding: ${get('space.1')} 0;
-    color: ${get('colors.text.link')};
+    color: ${get('colors.accent.fg')};
 
     &:hover {
       ${CommonAccessibilityVariantLightWeightStyles}
@@ -163,13 +163,13 @@ const SideNavLink = styled(Link).attrs<StyledSideNavLinkProps>(props => {
 
     &:focus {
       ${CommonAccessibilityVariantLightWeightStyles}
-      box-shadow: ${get('shadows.state.focus.shadow')};
+      box-shadow: ${get('shadows.primer.shadow.focus')};
       z-index: 1;
     }
 
     &[aria-current='page'],
     &[aria-selected='true'] {
-      color: ${get('colors.text.primary')};
+      color: ${get('colors.fg.default')};
       font-weight: ${get('fontWeights.semibold')};
     }
   }

--- a/src/StateLabel.tsx
+++ b/src/StateLabel.tsx
@@ -79,7 +79,7 @@ const StateLabelBase = styled.span<StyledStateLabelBaseProps>`
   align-items: center;
   font-weight: ${get('fontWeights.bold')};
   line-height: 16px;
-  color: ${get('colors.bg.primary')};
+  color: ${get('colors.canvas.default')};
   text-align: center;
   border-radius: ${get('radii.3')};
   border-width: 1px;

--- a/src/SubNav.tsx
+++ b/src/SubNav.tsx
@@ -77,19 +77,19 @@ const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
   font-size: ${get('fontSizes.1')};
   line-height: 20px; //custom value for SubNav
   min-height: 34px; //custom value for SubNav
-  color: ${get('colors.text.primary')};
+  color: ${get('colors.fg.default')};
   text-align: center;
   text-decoration: none;
-  border-top: 1px solid ${get('colors.border.primary')};
-  border-bottom: 1px solid ${get('colors.border.primary')};
-  border-right: 1px solid ${get('colors.border.primary')};
+  border-top: 1px solid ${get('colors.border.default')};
+  border-bottom: 1px solid ${get('colors.border.default')};
+  border-right: 1px solid ${get('colors.border.default')};
   display: flex;
   align-items: center;
 
   &:first-of-type {
     border-top-left-radius: ${get('radii.2')};
     border-bottom-left-radius: ${get('radii.2')};
-    border-left: 1px solid ${get('colors.border.primary')};
+    border-left: 1px solid ${get('colors.border.default')};
   }
 
   &:last-of-type {
@@ -100,20 +100,20 @@ const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
   &:hover,
   &:focus {
     text-decoration: none;
-    background-color: ${get('colors.bg.tertiary')};
+    background-color: ${get('colors.canvas.subtle')};
     transition: 0.2s ease;
 
     .SubNav-octicon {
-      color: ${get('colors.icon.secondary')};
+      color: ${get('colors.fg.muted')};
     }
   }
 
   &.selected {
-    color: ${get('colors.state.selected.primaryText')};
-    background-color: ${get('colors.state.selected.primaryBg')};
-    border-color: ${get('colors.state.selected.primaryBorder')};
+    color: ${get('colors.fg.onEmphasis')};
+    background-color: ${get('colors.accent.emphasis')};
+    border-color: ${get('colors.accent.emphasis')};
     .SubNav-octicon {
-      color: ${get('colors.state.selected.primaryText')};
+      color: ${get('colors.fg.onEmphasis')};
     }
   }
 

--- a/src/TabNav.tsx
+++ b/src/TabNav.tsx
@@ -12,7 +12,7 @@ const SELECTED_CLASS = 'selected'
 
 const TabNavBase = styled.div<SystemCommonProps & SxProp>`
   margin-top: 0;
-  border-bottom: 1px solid ${get('colors.border.primary')};
+  border-bottom: 1px solid ${get('colors.border.default')};
   ${COMMON}
   ${sx}
 `
@@ -47,7 +47,7 @@ const TabNavLink = styled.a.attrs<StyledTabNavLinkProps>(props => ({
   padding: 8px 12px;
   font-size: ${get('fontSizes.1')};
   line-height: 20px;
-  color: ${get('colors.text.primary')};
+  color: ${get('colors.fg.default')};
   text-decoration: none;
   background-color: transparent;
   border: 1px solid transparent;
@@ -55,16 +55,16 @@ const TabNavLink = styled.a.attrs<StyledTabNavLinkProps>(props => ({
 
   &:hover,
   &:focus {
-    color: ${get('colors.text.primary')};
+    color: ${get('colors.fg.default')};
     text-decoration: none;
   }
 
   &.selected {
-    color: ${get('colors.text.primary')};
-    border-color: ${get('colors.border.primary')};
+    color: ${get('colors.fg.default')};
+    border-color: ${get('colors.border.default')};
     border-top-right-radius: ${get('radii.2')};
     border-top-left-radius: ${get('radii.2')};
-    background-color: ${get('colors.bg.canvas')};
+    background-color: ${get('colors.canvas.default')};
   }
 
   ${COMMON};

--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -55,14 +55,14 @@ const Wrapper = styled.span<StyledWrapperProps>`
   min-height: 34px;
   font-size: ${get('fontSizes.1')};
   line-height: 20px;
-  color: ${get('colors.text.primary')};
+  color: ${get('colors.fg.default')};
   vertical-align: middle;
   background-repeat: no-repeat; // Repeat and position set for form states (success, error, etc)
   background-position: right 8px center; // For form validation. This keeps images 8px from right and centered vertically.
-  border: 1px solid ${get('colors.border.primary')};
+  border: 1px solid ${get('colors.border.default')};
   border-radius: ${get('radii.2')};
   outline: none;
-  box-shadow: ${get('shadows.shadow.inset')};
+  box-shadow: ${get('shadows.primer.shadow.inset')};
 
   ${props => {
     if (props.hasIcon) {
@@ -78,28 +78,28 @@ const Wrapper = styled.span<StyledWrapperProps>`
 
   .TextInput-icon {
     align-self: center;
-    color: ${get('colors.icon.tertiary')};
+    color: ${get('colors.fg.muted')};
     margin: 0 ${get('space.2')};
     flex-shrink: 0;
   }
 
   &:focus-within {
-    border-color: ${get('colors.state.focus.border')};
-    box-shadow: ${get('shadows.state.focus.shadow')};
+    border-color: ${get('colors.accent.emphasis')};
+    box-shadow: ${get('shadows.primer.shadow.focus')};
   }
 
   ${props =>
     props.contrast &&
     css`
-      background-color: ${get('colors.input.contrastBg')};
+      background-color: ${get('colors.canvas.inset')};
     `}
 
   ${props =>
     props.disabled &&
     css`
-      color: ${get('colors.text.secondary')};
+      color: ${get('colors.fg.muted')};
       background-color: ${get('colors.input.disabledBg')};
-      border-color: ${get('colors.input.disabledBorder')};
+      border-color: ${get('colors.border.default')};
     `}
 
   ${props =>

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -42,7 +42,7 @@ const TimelineItem = styled(Box).attrs<StyledTimelineItemProps>(props => ({
     display: block;
     width: 2px;
     content: '';
-    background-color: ${get('colors.border.secondary')};
+    background-color: ${get('colors.border.muted')};
   }
 
   ${props =>
@@ -58,8 +58,8 @@ const TimelineItem = styled(Box).attrs<StyledTimelineItemProps>(props => ({
         height: 16px;
         margin-top: ${get('space.2')};
         margin-bottom: ${get('space.2')};
-        color: ${get('colors.icon.tertiary')};
-        background-color: ${get('colors.bg.canvas')};
+        color: ${get('colors.fg.muted')};
+        background-color: ${get('colors.canvas.default')};
         border: 0;
       }
     `}
@@ -79,10 +79,10 @@ const TimelineBadge = (props: TimelineBadgeProps) => {
         flexShrink={0}
         css={`
           border-radius: 50%;
-          border: 2px solid ${get('colors.bg.canvas')};
+          border: 2px solid ${get('colors.canvas.default')};
         `}
         overflow="hidden"
-        color="icon.secondary"
+        color="fg.muted"
         bg="timeline.badgeBg"
         width="32px"
         height="32px"
@@ -102,7 +102,7 @@ const TimelineBody = styled(Box)`
   min-width: 0;
   max-width: 100%;
   margin-top: ${get('space.1')};
-  color: ${get('colors.timeline.text')};
+  color: ${get('colors.fg.muted')};
   flex: auto;
   font-size: ${get('fontSizes.1')};
   ${sx};
@@ -115,9 +115,9 @@ const TimelineBreak = styled(Box)`
   margin: 0;
   margin-bottom: -${get('space.3')};
   margin-left: 0;
-  background-color: ${get('colors.bg.canvas')};
+  background-color: ${get('colors.canvas.default')};
   border: 0;
-  border-top: ${get('space.1')} solid ${get('colors.border.primary')};
+  border-top: ${get('space.1')} solid ${get('colors.border.default')};
   ${sx};
 `
 

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -14,7 +14,7 @@ const TooltipBase = styled.span<SystemCommonProps & SxProp>`
     display: none;
     width: 0px;
     height: 0px;
-    color: ${get('colors.tooltip.bg')};
+    color: ${get('colors.neutral.emphasisPlus')};
     pointer-events: none;
     content: '';
     border: 6px solid transparent;
@@ -28,7 +28,7 @@ const TooltipBase = styled.span<SystemCommonProps & SxProp>`
     padding: 0.5em 0.75em;
     font: normal normal 11px/1.5 ${get('fonts.normal')};
     -webkit-font-smoothing: subpixel-antialiased;
-    color: ${get('colors.tooltip.text')};
+    color: ${get('colors.fg.onEmphasis')};
     text-align: center;
     text-decoration: none;
     text-shadow: none;
@@ -38,7 +38,7 @@ const TooltipBase = styled.span<SystemCommonProps & SxProp>`
     white-space: pre;
     pointer-events: none;
     content: attr(aria-label);
-    background: ${get('colors.tooltip.bg')};
+    background: ${get('colors.neutral.emphasisPlus')};
     border-radius: ${get('radii.1')};
     opacity: 0;
   }
@@ -101,7 +101,7 @@ const TooltipBase = styled.span<SystemCommonProps & SxProp>`
       right: 50%;
       bottom: -7px;
       margin-right: -6px;
-      border-bottom-color: ${get('colors.tooltip.bg')};
+      border-bottom-color: ${get('colors.neutral.emphasisPlus')};
     }
   }
 
@@ -132,7 +132,7 @@ const TooltipBase = styled.span<SystemCommonProps & SxProp>`
       right: 50%;
       bottom: auto;
       margin-right: -6px;
-      border-top-color: ${get('colors.tooltip.bg')};
+      border-top-color: ${get('colors.neutral.emphasisPlus')};
     }
   }
 
@@ -168,7 +168,7 @@ const TooltipBase = styled.span<SystemCommonProps & SxProp>`
       bottom: 50%;
       left: -7px;
       margin-top: -6px;
-      border-left-color: ${get('colors.tooltip.bg')};
+      border-left-color: ${get('colors.neutral.emphasisPlus')};
     }
   }
 
@@ -186,7 +186,7 @@ const TooltipBase = styled.span<SystemCommonProps & SxProp>`
       right: -7px;
       bottom: 50%;
       margin-top: -6px;
-      border-right-color: ${get('colors.tooltip.bg')};
+      border-right-color: ${get('colors.neutral.emphasisPlus')};
     }
   }
 

--- a/src/UnderlineNav.tsx
+++ b/src/UnderlineNav.tsx
@@ -13,7 +13,7 @@ const SELECTED_CLASS = 'selected'
 const UnderlineNavBase = styled.nav`
   display: flex;
   justify-content: space-between;
-  border-bottom: 1px solid ${get('colors.border.secondary')};
+  border-bottom: 1px solid ${get('colors.border.muted')};
   &.UnderlineNav--right {
     justify-content: flex-end;
 
@@ -74,29 +74,29 @@ const UnderlineNavLink = styled.a.attrs<StyledUnderlineNavLinkProps>(props => ({
   margin-right: ${get('space.3')};
   font-size: ${get('fontSizes.1')};
   line-height: ${get('lineHeights.default')};
-  color: ${get('colors.underlinenav.text')};
+  color: ${get('colors.fg.default')};
   text-align: center;
   border-bottom: 2px solid transparent;
   text-decoration: none;
 
   &:hover,
   &:focus {
-    color: ${get('colors.underlinenav.textHover')};
+    color: ${get('colors.fg.default')};
     text-decoration: none;
-    border-bottom-color: ${get('colors.border.tertiary')};
+    border-bottom-color: ${get('colors.neutral.muted')};
     transition: 0.2s ease;
 
     .UnderlineNav-octicon {
-      color: ${get('colors.text.tertiary')};
+      color: ${get('colors.fg.muted')};
     }
   }
 
   &.selected {
-    color: ${get('colors.underlinenav.textActive')};
-    border-bottom-color: ${get('colors.underlinenav.borderActive')};
+    color: ${get('colors.fg.default')};
+    border-bottom-color: ${get('colors.primer.border.active')};
 
     .UnderlineNav-octicon {
-      color: ${get('colors.underlinenav.iconActive')};
+      color: ${get('colors.fg.default')};
     }
   }
 

--- a/src/__tests__/BorderBox.tsx
+++ b/src/__tests__/BorderBox.tsx
@@ -23,7 +23,7 @@ describe('BorderBox', () => {
   })
 
   it('renders borders', () => {
-    expect(render(<BorderBox borderColor="border.success" />)).toHaveStyleRule(
+    expect(render(<BorderBox borderColor="success.emphasis" />)).toHaveStyleRule(
       'border-color',
       theme.colorSchemes.light.colors.border?.success
     )

--- a/src/__tests__/CircleOcticon.tsx
+++ b/src/__tests__/CircleOcticon.tsx
@@ -38,7 +38,7 @@ describe('CircleOcticon', () => {
   })
 
   it('respects the bg prop', () => {
-    expect(render(<CircleOcticon icon={CheckIcon} bg="bg.danger" />)).toHaveStyleRule(
+    expect(render(<CircleOcticon icon={CheckIcon} bg="danger.subtle" />)).toHaveStyleRule(
       'background-color',
       theme.colorSchemes.light.colors.bg?.danger
     )

--- a/src/__tests__/Link.tsx
+++ b/src/__tests__/Link.tsx
@@ -43,6 +43,6 @@ describe('Link', () => {
   })
 
   it('respectes the "color" prop when "muted" prop is also passed', () => {
-    expect(render(<Link muted color="text.inverse" />)).toMatchSnapshot()
+    expect(render(<Link muted color="fg.onEmphasis" />)).toMatchSnapshot()
   })
 })

--- a/src/__tests__/Pagination/__snapshots__/Pagination.tsx.snap
+++ b/src/__tests__/Pagination/__snapshots__/Pagination.tsx.snap
@@ -11,7 +11,7 @@ exports[`Pagination renders consistently 1`] = `
   padding: 5px 10px;
   font-style: normal;
   line-height: 20px;
-  color: #24292e;
+  color: #24292f;
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
@@ -37,31 +37,31 @@ exports[`Pagination renders consistently 1`] = `
 .c2:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
-  border-color: #e1e4e8;
+  border-color: #d0d7de;
   outline: 0;
   -webkit-transition-duration: 0.1s;
   transition-duration: 0.1s;
 }
 
 .c2:active {
-  border-color: hsla(214,13%,93%,1);
+  border-color: hsla(210,18%,87%,1);
 }
 
 .c2[rel='prev'],
 .c2[rel='next'] {
-  color: #0366d6;
+  color: #0969da;
 }
 
 .c2[aria-current],
 .c2[aria-current]:hover {
   color: #ffffff;
-  background-color: #0366d6;
+  background-color: #0969da;
   border-color: transparent;
 }
 
 .c2[aria-disabled],
 .c2[aria-disabled]:hover {
-  color: #959da5;
+  color: #57606a;
   cursor: default;
   border-color: transparent;
 }

--- a/src/__tests__/PointerBox.tsx
+++ b/src/__tests__/PointerBox.tsx
@@ -26,10 +26,10 @@ describe('PointerBox', () => {
   })
 
   it('passes the "borderColor" prop to both <BorderBox> and <Caret>', () => {
-    expect(render(<PointerBox borderColor="border.danger" />)).toMatchSnapshot()
+    expect(render(<PointerBox borderColor="danger.emphasis" />)).toMatchSnapshot()
   })
 
   it('passes the "bg" prop to both <BorderBox> and <Caret>', () => {
-    expect(render(<PointerBox bg="bg.danger" />)).toMatchSnapshot()
+    expect(render(<PointerBox bg="danger.subtle" />)).toMatchSnapshot()
   })
 })

--- a/src/__tests__/Position.tsx
+++ b/src/__tests__/Position.tsx
@@ -32,7 +32,7 @@ describe('position components', () => {
 
     it('can render other components with the as prop', () => {
       const result = render(
-        <Absolute as={Box} borderWidth="1px" borderStyle="solid" borderColor="border.primary" borderRadius={2} />
+        <Absolute as={Box} borderWidth="1px" borderStyle="solid" borderColor="border.default" borderRadius={2} />
       )
       expect(result).toHaveStyleRule('position', 'absolute')
       expect(result).toHaveStyleRule('border-width', '1px')
@@ -60,7 +60,7 @@ describe('position components', () => {
 
     it('can render other components with the as prop', () => {
       const result = render(
-        <Fixed as={Box} borderWidth="1px" borderStyle="solid" borderColor="border.primary" borderRadius={2} />
+        <Fixed as={Box} borderWidth="1px" borderStyle="solid" borderColor="border.default" borderRadius={2} />
       )
       expect(result).toHaveStyleRule('position', 'fixed')
       expect(result).toHaveStyleRule('border-width', '1px')
@@ -84,7 +84,7 @@ describe('position components', () => {
 
     it('can render other components with the as prop', () => {
       const result = render(
-        <Relative as={Box} borderWidth="1px" borderStyle="solid" borderColor="border.primary" borderRadius={2} />
+        <Relative as={Box} borderWidth="1px" borderStyle="solid" borderColor="border.default" borderRadius={2} />
       )
       expect(result).toHaveStyleRule('position', 'relative')
       expect(result).toHaveStyleRule('border-width', '1px')
@@ -108,7 +108,7 @@ describe('position components', () => {
 
     it('can render other components with the as prop', () => {
       const result = render(
-        <Sticky as={Box} borderWidth="1px" borderStyle="solid" borderColor="border.primary" borderRadius={2} />
+        <Sticky as={Box} borderWidth="1px" borderStyle="solid" borderColor="border.default" borderRadius={2} />
       )
       expect(result).toHaveStyleRule('position', 'sticky')
       expect(result).toHaveStyleRule('border-width', '1px')

--- a/src/__tests__/ThemeProvider.tsx
+++ b/src/__tests__/ThemeProvider.tsx
@@ -65,7 +65,7 @@ it('respects theme prop', () => {
 it('has default theme', () => {
   render(
     <ThemeProvider>
-      <Text color="text.primary" mb={1}>
+      <Text color="fg.default" mb={1}>
         Hello
       </Text>
     </ThemeProvider>

--- a/src/__tests__/__snapshots__/ActionList.tsx.snap
+++ b/src/__tests__/__snapshots__/ActionList.tsx.snap
@@ -14,7 +14,7 @@ exports[`ActionList renders consistently 1`] = `
 .c0[data-has-active-descendant],
 .c0:focus-within {
   --item-hover-bg-override: none;
-  --item-hover-divider-border-color-override: hsla(214,13%,93%,1);
+  --item-hover-divider-border-color-override: hsla(210,18%,87%,1);
 }
 
 <div

--- a/src/__tests__/__snapshots__/ActionMenu.tsx.snap
+++ b/src/__tests__/__snapshots__/ActionMenu.tsx.snap
@@ -23,10 +23,10 @@ exports[`ActionMenu renders consistently 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #24292e;
-  background-color: #fafbfc;
-  border: 1px solid rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
+  color: #24292f;
+  background-color: #f6f8fa;
+  border: 1px solid rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
 }
 
 .c0:hover {
@@ -48,23 +48,23 @@ exports[`ActionMenu renders consistently 1`] = `
 
 .c0:hover {
   background-color: #f3f4f6;
-  border-color: rgba(27,31,35,0.15);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 .c0:active {
   background-color: hsla(220,14%,94%,1);
-  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
 }
 
 .c0:disabled {
-  color: #959da5;
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: #57606a;
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 <button

--- a/src/__tests__/__snapshots__/AnchoredOverlay.tsx.snap
+++ b/src/__tests__/__snapshots__/AnchoredOverlay.tsx.snap
@@ -4,7 +4,7 @@ exports[`AnchoredOverlay renders consistently 1`] = `
 .c0 {
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   line-height: 1.5;
-  color: #24292e;
+  color: #24292f;
 }
 
 .c1 {
@@ -29,10 +29,10 @@ exports[`AnchoredOverlay renders consistently 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #24292e;
-  background-color: #fafbfc;
-  border: 1px solid rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
+  color: #24292f;
+  background-color: #f6f8fa;
+  border: 1px solid rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
 }
 
 .c1:hover {
@@ -54,23 +54,23 @@ exports[`AnchoredOverlay renders consistently 1`] = `
 
 .c1:hover {
   background-color: #f3f4f6;
-  border-color: rgba(27,31,35,0.15);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c1:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 .c1:active {
   background-color: hsla(220,14%,94%,1);
-  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
 }
 
 .c1:disabled {
-  color: #959da5;
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: #57606a;
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 <div
@@ -99,7 +99,7 @@ Object {
   "baseElement": .c0 {
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   line-height: 1.5;
-  color: #24292e;
+  color: #24292f;
 }
 
 .c1 {
@@ -124,10 +124,10 @@ Object {
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #24292e;
-  background-color: #fafbfc;
-  border: 1px solid rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
+  color: #24292f;
+  background-color: #f6f8fa;
+  border: 1px solid rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
 }
 
 .c1:hover {
@@ -149,28 +149,28 @@ Object {
 
 .c1:hover {
   background-color: #f3f4f6;
-  border-color: rgba(27,31,35,0.15);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c1:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 .c1:active {
   background-color: hsla(220,14%,94%,1);
-  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
 }
 
 .c1:disabled {
-  color: #959da5;
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: #57606a;
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c2 {
   background-color: #ffffff;
-  box-shadow: 0 1px 3px rgba(27,31,35,0.12),0 8px 24px rgba(68,77,86,0.12);
+  box-shadow: 0 1px 3px rgba(27,31,36,0.12),0 8px 24px rgba(66,74,83,0.12);
   position: absolute;
   min-width: 192px;
   max-width: 640px;
@@ -235,7 +235,7 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="BaseStyles__Base-qvuaww-0 dhupSQ"
+      class="BaseStyles__Base-qvuaww-0 ihFkAM"
       color="text.primary"
       data-portal-root="true"
       font-family="normal"
@@ -243,7 +243,7 @@ Object {
       <button
         aria-haspopup="true"
         aria-labelledby="__primer_id_10007"
-        class="ButtonBase-sc-181ps9o-0 Button-xjtz72-0 jhgDtb"
+        class="ButtonBase-sc-181ps9o-0 Button-xjtz72-0 jPURef"
         id="__primer_id_10007"
         tabindex="0"
       >
@@ -257,7 +257,7 @@ Object {
           style="position: relative; z-index: 1;"
         >
           <div
-            class="Overlay__StyledOverlay-jhwkzw-0 cWgXnb"
+            class="Overlay__StyledOverlay-jhwkzw-0 jFTKwM"
             data-focus-trap="active"
             height="auto"
             role="none"

--- a/src/__tests__/__snapshots__/AnchoredOverlay.tsx.snap
+++ b/src/__tests__/__snapshots__/AnchoredOverlay.tsx.snap
@@ -243,7 +243,7 @@ Object {
       <button
         aria-haspopup="true"
         aria-labelledby="react-aria-1"
-        class="ButtonBase-sc-181ps9o-0 Button-xjtz72-0 jhgDtb"
+        class="ButtonBase-sc-181ps9o-0 Button-xjtz72-0 jPURef"
         id="react-aria-1"
         tabindex="0"
       >

--- a/src/__tests__/__snapshots__/BorderBox.tsx.snap
+++ b/src/__tests__/__snapshots__/BorderBox.tsx.snap
@@ -4,7 +4,7 @@ exports[`BorderBox renders consistently 1`] = `
 .c0 {
   border-width: 1px;
   border-style: solid;
-  border-color: #e1e4e8;
+  border-color: #d0d7de;
   border-radius: 6px;
 }
 

--- a/src/__tests__/__snapshots__/BranchName.tsx.snap
+++ b/src/__tests__/__snapshots__/BranchName.tsx.snap
@@ -6,8 +6,8 @@ exports[`BranchName renders consistently 1`] = `
   padding: 2px 6px;
   font-size: 12px;
   font-family: SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
-  color: #586069;
-  background-color: hsla(210,100%,96%,1);
+  color: #57606a;
+  background-color: #ddf4ff;
   border-radius: 6px;
 }
 

--- a/src/__tests__/__snapshots__/BreadcrumbItem.tsx.snap
+++ b/src/__tests__/__snapshots__/BreadcrumbItem.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Breadcrumb.Item adds activeClassName={SELECTED_CLASS} when it gets a "to" prop 1`] = `
 .c0 {
-  color: #0366d6;
+  color: #0969da;
   display: inline-block;
   font-size: 14px;
   -webkit-text-decoration: none;
@@ -15,7 +15,7 @@ exports[`Breadcrumb.Item adds activeClassName={SELECTED_CLASS} when it gets a "t
 }
 
 .c0.selected {
-  color: #24292e;
+  color: #24292f;
   pointer-events: none;
 }
 
@@ -29,7 +29,7 @@ exports[`Breadcrumb.Item adds activeClassName={SELECTED_CLASS} when it gets a "t
 
 exports[`Breadcrumb.Item renders consistently 1`] = `
 .c0 {
-  color: #0366d6;
+  color: #0969da;
   display: inline-block;
   font-size: 14px;
   -webkit-text-decoration: none;
@@ -42,7 +42,7 @@ exports[`Breadcrumb.Item renders consistently 1`] = `
 }
 
 .c0.selected {
-  color: #24292e;
+  color: #24292f;
   pointer-events: none;
 }
 
@@ -54,7 +54,7 @@ exports[`Breadcrumb.Item renders consistently 1`] = `
 
 exports[`Breadcrumb.Item respects the "selected" prop 1`] = `
 .c0 {
-  color: #0366d6;
+  color: #0969da;
   display: inline-block;
   font-size: 14px;
   -webkit-text-decoration: none;
@@ -67,7 +67,7 @@ exports[`Breadcrumb.Item respects the "selected" prop 1`] = `
 }
 
 .c0.selected {
-  color: #24292e;
+  color: #24292f;
   pointer-events: none;
 }
 

--- a/src/__tests__/__snapshots__/Button.tsx.snap
+++ b/src/__tests__/__snapshots__/Button.tsx.snap
@@ -23,10 +23,10 @@ exports[`Button renders consistently 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #24292e;
-  background-color: #fafbfc;
-  border: 1px solid rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
+  color: #24292f;
+  background-color: #f6f8fa;
+  border: 1px solid rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
 }
 
 .c0:hover {
@@ -48,23 +48,23 @@ exports[`Button renders consistently 1`] = `
 
 .c0:hover {
   background-color: #f3f4f6;
-  border-color: rgba(27,31,35,0.15);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 .c0:active {
   background-color: hsla(220,14%,94%,1);
-  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
 }
 
 .c0:disabled {
-  color: #959da5;
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: #57606a;
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 <button
@@ -95,10 +95,10 @@ exports[`Button respects the "disabled" prop 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #24292e;
-  background-color: #fafbfc;
-  border: 1px solid rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
+  color: #24292f;
+  background-color: #f6f8fa;
+  border: 1px solid rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
 }
 
 .c0:hover {
@@ -120,23 +120,23 @@ exports[`Button respects the "disabled" prop 1`] = `
 
 .c0:hover {
   background-color: #f3f4f6;
-  border-color: rgba(27,31,35,0.15);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 .c0:active {
   background-color: hsla(220,14%,94%,1);
-  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
 }
 
 .c0:disabled {
-  color: #959da5;
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: #57606a;
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 <button
@@ -168,10 +168,10 @@ exports[`ButtonDanger renders consistently 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #d73a49;
-  border: 1px solid rgba(27,31,35,0.15);
-  background-color: #fafbfc;
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04);
+  color: #cf222e;
+  border: 1px solid rgba(27,31,36,0.15);
+  background-color: #f6f8fa;
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04);
 }
 
 .c0:hover {
@@ -193,26 +193,26 @@ exports[`ButtonDanger renders consistently 1`] = `
 
 .c0:hover {
   color: #ffffff;
-  background-color: #cb2431;
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.1);
+  background-color: #a40e26;
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.1);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(203,36,49,0.4);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(164,14,38,0.4);
 }
 
 .c0:active {
   color: #ffffff;
-  background-color: hsla(354,66%,51%,1);
-  box-shadow: inset 0 1px 0 rgba(134,24,29,0.2);
-  border-color: rgba(27,31,35,0.15);
+  background-color: hsla(356,72%,44%,1);
+  box-shadow: inset 0 1px 0 rgba(76,0,20,0.2);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:disabled {
-  color: rgba(215,58,73,0.5);
-  background-color: #fafbfc;
+  color: rgba(207,34,46,0.5);
+  background-color: #f6f8fa;
 }
 
 <button
@@ -243,10 +243,10 @@ exports[`ButtonDanger renders correct disabled styles 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #d73a49;
-  border: 1px solid rgba(27,31,35,0.15);
-  background-color: #fafbfc;
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04);
+  color: #cf222e;
+  border: 1px solid rgba(27,31,36,0.15);
+  background-color: #f6f8fa;
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04);
 }
 
 .c0:hover {
@@ -268,26 +268,26 @@ exports[`ButtonDanger renders correct disabled styles 1`] = `
 
 .c0:hover {
   color: #ffffff;
-  background-color: #cb2431;
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.1);
+  background-color: #a40e26;
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.1);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(203,36,49,0.4);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(164,14,38,0.4);
 }
 
 .c0:active {
   color: #ffffff;
-  background-color: hsla(354,66%,51%,1);
-  box-shadow: inset 0 1px 0 rgba(134,24,29,0.2);
-  border-color: rgba(27,31,35,0.15);
+  background-color: hsla(356,72%,44%,1);
+  box-shadow: inset 0 1px 0 rgba(76,0,20,0.2);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:disabled {
-  color: rgba(215,58,73,0.5);
-  background-color: #fafbfc;
+  color: rgba(207,34,46,0.5);
+  background-color: #f6f8fa;
 }
 
 <button
@@ -371,10 +371,10 @@ exports[`ButtonInvisible renders consistently 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #0366d6;
-  border: 1px solid rgba(27,31,35,0.15);
-  background-color: #fafbfc;
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04);
+  color: #0969da;
+  border: 1px solid rgba(27,31,36,0.15);
+  background-color: #f6f8fa;
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04);
 }
 
 .c0:hover {
@@ -396,27 +396,27 @@ exports[`ButtonInvisible renders consistently 1`] = `
 
 .c0:hover {
   color: #ffffff;
-  background-color: #0366d6;
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.1);
+  background-color: #0969da;
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.1);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(0,92,197,0.4);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(5,80,174,0.4);
 }
 
 .c0:active {
   color: #ffffff;
-  background-color: hsla(212,97%,40%,1);
-  box-shadow: inset 0 1px 0 rgba(5,38,76,0.2);
-  border-color: rgba(27,31,35,0.15);
+  background-color: hsla(212,92%,42%,1);
+  box-shadow: inset 0 1px 0 rgba(0,33,85,0.2);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:disabled {
-  color: rgba(3,102,214,0.5);
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: rgba(9,105,218,0.5);
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 <button
@@ -447,7 +447,7 @@ exports[`ButtonInvisible renders correct disabled styles 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #0366d6;
+  color: #0969da;
   background-color: transparent;
   border: 0;
   border-radius: 6px;
@@ -472,11 +472,11 @@ exports[`ButtonInvisible renders correct disabled styles 1`] = `
 }
 
 .c0:disabled {
-  color: #959da5;
+  color: #57606a;
 }
 
 .c0:focus {
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 <button
@@ -508,10 +508,10 @@ exports[`ButtonOutline renders consistently 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #0366d6;
-  border: 1px solid rgba(27,31,35,0.15);
-  background-color: #fafbfc;
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04);
+  color: #0969da;
+  border: 1px solid rgba(27,31,36,0.15);
+  background-color: #f6f8fa;
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04);
 }
 
 .c0:hover {
@@ -533,27 +533,27 @@ exports[`ButtonOutline renders consistently 1`] = `
 
 .c0:hover {
   color: #ffffff;
-  background-color: #0366d6;
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.1);
+  background-color: #0969da;
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.1);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(0,92,197,0.4);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(5,80,174,0.4);
 }
 
 .c0:active {
   color: #ffffff;
-  background-color: hsla(212,97%,40%,1);
-  box-shadow: inset 0 1px 0 rgba(5,38,76,0.2);
-  border-color: rgba(27,31,35,0.15);
+  background-color: hsla(212,92%,42%,1);
+  box-shadow: inset 0 1px 0 rgba(0,33,85,0.2);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:disabled {
-  color: rgba(3,102,214,0.5);
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: rgba(9,105,218,0.5);
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 <button
@@ -584,10 +584,10 @@ exports[`ButtonOutline renders correct disabled styles 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #0366d6;
-  border: 1px solid rgba(27,31,35,0.15);
-  background-color: #fafbfc;
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04);
+  color: #0969da;
+  border: 1px solid rgba(27,31,36,0.15);
+  background-color: #f6f8fa;
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04);
 }
 
 .c0:hover {
@@ -609,27 +609,27 @@ exports[`ButtonOutline renders correct disabled styles 1`] = `
 
 .c0:hover {
   color: #ffffff;
-  background-color: #0366d6;
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.1);
+  background-color: #0969da;
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.1);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(0,92,197,0.4);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(5,80,174,0.4);
 }
 
 .c0:active {
   color: #ffffff;
-  background-color: hsla(212,97%,40%,1);
-  box-shadow: inset 0 1px 0 rgba(5,38,76,0.2);
-  border-color: rgba(27,31,35,0.15);
+  background-color: hsla(212,92%,42%,1);
+  box-shadow: inset 0 1px 0 rgba(0,33,85,0.2);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:disabled {
-  color: rgba(3,102,214,0.5);
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: rgba(9,105,218,0.5);
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 <button
@@ -662,9 +662,9 @@ exports[`ButtonPrimary renders consistently 1`] = `
   text-align: center;
   font-size: 14px;
   color: #ffffff;
-  border: 1px solid rgba(27,31,35,0.15);
-  background-color: #2ea44f;
-  box-shadow: 0 1px 0 rgba(27,31,35,0.1);
+  border: 1px solid rgba(27,31,36,0.15);
+  background-color: #2da44e;
+  box-shadow: 0 1px 0 rgba(27,31,36,0.1);
 }
 
 .c0:hover {
@@ -686,23 +686,23 @@ exports[`ButtonPrimary renders consistently 1`] = `
 
 .c0:hover {
   background-color: #2c974b;
-  border-color: rgba(27,31,35,0.15);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(46,164,79,0.4);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(45,164,78,0.4);
 }
 
 .c0:active {
   background-color: hsla(137,55%,36%,1);
-  box-shadow: inset 0 1px 0 rgba(20,70,32,0.2);
+  box-shadow: inset 0 1px 0 rgba(0,45,17,0.2);
 }
 
 .c0:disabled {
   color: rgba(255,255,255,0.8);
   background-color: #94d3a2;
-  border-color: rgba(27,31,35,0.1);
+  border-color: rgba(27,31,36,0.15);
 }
 
 <button
@@ -734,9 +734,9 @@ exports[`ButtonPrimary renders correct disabled styles 1`] = `
   text-align: center;
   font-size: 14px;
   color: #ffffff;
-  border: 1px solid rgba(27,31,35,0.15);
-  background-color: #2ea44f;
-  box-shadow: 0 1px 0 rgba(27,31,35,0.1);
+  border: 1px solid rgba(27,31,36,0.15);
+  background-color: #2da44e;
+  box-shadow: 0 1px 0 rgba(27,31,36,0.1);
 }
 
 .c0:hover {
@@ -758,23 +758,23 @@ exports[`ButtonPrimary renders correct disabled styles 1`] = `
 
 .c0:hover {
   background-color: #2c974b;
-  border-color: rgba(27,31,35,0.15);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(46,164,79,0.4);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(45,164,78,0.4);
 }
 
 .c0:active {
   background-color: hsla(137,55%,36%,1);
-  box-shadow: inset 0 1px 0 rgba(20,70,32,0.2);
+  box-shadow: inset 0 1px 0 rgba(0,45,17,0.2);
 }
 
 .c0:disabled {
   color: rgba(255,255,255,0.8);
   background-color: #94d3a2;
-  border-color: rgba(27,31,35,0.1);
+  border-color: rgba(27,31,36,0.15);
 }
 
 <button
@@ -788,7 +788,7 @@ exports[`ButtonTableList renders consistently 1`] = `
   display: inline-block;
   padding: 0;
   font-size: 14px;
-  color: #586069;
+  color: #57606a;
   -webkit-text-decoration: none;
   text-decoration: none;
   white-space: nowrap;
@@ -811,7 +811,7 @@ exports[`ButtonTableList renders consistently 1`] = `
 
 .c0:disabled,
 .c0:disabled:hover {
-  color: rgba(#586069,0.5);
+  color: rgba(#57606a,0.5);
   cursor: default;
 }
 

--- a/src/__tests__/__snapshots__/Caret.tsx.snap
+++ b/src/__tests__/__snapshots__/Caret.tsx.snap
@@ -24,7 +24,7 @@ exports[`Caret renders cardinal directions 1`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>
@@ -55,7 +55,7 @@ exports[`Caret renders cardinal directions 2`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>
@@ -86,7 +86,7 @@ exports[`Caret renders cardinal directions 3`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>
@@ -117,7 +117,7 @@ exports[`Caret renders cardinal directions 4`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>
@@ -148,7 +148,7 @@ exports[`Caret renders cardinal directions 5`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>
@@ -179,7 +179,7 @@ exports[`Caret renders cardinal directions 6`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>
@@ -210,7 +210,7 @@ exports[`Caret renders cardinal directions 7`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>
@@ -241,7 +241,7 @@ exports[`Caret renders cardinal directions 8`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>
@@ -272,7 +272,7 @@ exports[`Caret renders cardinal directions 9`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>
@@ -303,7 +303,7 @@ exports[`Caret renders cardinal directions 10`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>
@@ -334,7 +334,7 @@ exports[`Caret renders cardinal directions 11`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>
@@ -365,7 +365,7 @@ exports[`Caret renders cardinal directions 12`] = `
     <path
       d="M-8,0L0,8L8,0"
       fill="none"
-      stroke="#e1e4e8"
+      stroke="#d0d7de"
       strokeWidth="1px"
     />
   </g>

--- a/src/__tests__/__snapshots__/CircleBadge.tsx.snap
+++ b/src/__tests__/__snapshots__/CircleBadge.tsx.snap
@@ -46,7 +46,7 @@ exports[`CircleBadge renders consistently 1`] = `
   justify-content: center;
   background-color: #ffffff;
   border-radius: 50%;
-  box-shadow: 0 3px 6px rgba(149,157,165,0.15);
+  box-shadow: 0 3px 6px rgba(140,149,159,0.15);
   width: 96px;
   height: 96px;
 }
@@ -77,7 +77,7 @@ exports[`CircleBadge respects the inline prop 1`] = `
   justify-content: center;
   background-color: #ffffff;
   border-radius: 50%;
-  box-shadow: 0 3px 6px rgba(149,157,165,0.15);
+  box-shadow: 0 3px 6px rgba(140,149,159,0.15);
   width: 96px;
   height: 96px;
 }
@@ -103,7 +103,7 @@ exports[`CircleBadge respects the variant prop 1`] = `
   justify-content: center;
   background-color: #ffffff;
   border-radius: 50%;
-  box-shadow: 0 3px 6px rgba(149,157,165,0.15);
+  box-shadow: 0 3px 6px rgba(140,149,159,0.15);
   width: 128px;
   height: 128px;
 }
@@ -129,7 +129,7 @@ exports[`CircleBadge uses the size prop to override the variant prop 1`] = `
   justify-content: center;
   background-color: #ffffff;
   border-radius: 50%;
-  box-shadow: 0 3px 6px rgba(149,157,165,0.15);
+  box-shadow: 0 3px 6px rgba(140,149,159,0.15);
   width: 20px;
   height: 20px;
 }

--- a/src/__tests__/__snapshots__/CircleOcticon.tsx.snap
+++ b/src/__tests__/__snapshots__/CircleOcticon.tsx.snap
@@ -8,7 +8,7 @@ exports[`CircleOcticon renders consistently 1`] = `
   border-width: 0;
   border-radius: 50%;
   border-style: solid;
-  border-color: #e1e4e8;
+  border-color: #d0d7de;
 }
 
 .c1 {

--- a/src/__tests__/__snapshots__/CounterLabel.tsx.snap
+++ b/src/__tests__/__snapshots__/CounterLabel.tsx.snap
@@ -8,8 +8,8 @@ exports[`CounterLabel renders consistently 1`] = `
   font-weight: 600;
   line-height: 1;
   border-radius: 20px;
-  color: #24292e;
-  background-color: rgba(209,213,218,0.5);
+  color: #24292f;
+  background-color: rgba(175,184,193,0.2);
 }
 
 .c0:empty {

--- a/src/__tests__/__snapshots__/Dialog.tsx.snap
+++ b/src/__tests__/__snapshots__/Dialog.tsx.snap
@@ -5,14 +5,14 @@ exports[`Dialog Dialog.Header renders consistently 1`] = `
   font-size: 14px;
   font-weight: 600;
   font-family: sans-serif;
-  color: #24292e;
+  color: #24292f;
 }
 
 .c0 {
   padding: 16px;
   background-color: #f6f8fa;
   border-radius: 6px 6px 0px 0px;
-  border-bottom: 1px solid #e1e4e8;
+  border-bottom: 1px solid #d0d7de;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -30,7 +30,7 @@ exports[`Dialog Dialog.Header renders consistently 1`] = `
 >
   <span
     className="c1"
-    color="text.primary"
+    color="fg.default"
     fontFamily="sans-serif"
     fontSize={1}
     fontWeight="bold"
@@ -51,7 +51,7 @@ Array [
   content: ' ';
   background: transparent;
   z-index: 99;
-  background: rgba(27,31,35,0.5);
+  background: rgba(27,31,36,0.5);
 }
 
 <span
@@ -68,25 +68,25 @@ Array [
   outline: none;
   cursor: pointer;
   border-radius: 6px;
-  color: #586069;
+  color: #57606a;
   position: absolute;
   top: 16px;
   right: 16px;
 }
 
 .c1:focus {
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 .c1:hover {
-  color: #0366d6;
+  color: #0969da;
 }
 
 .c3 {
   font-size: 14px;
   font-weight: 600;
   font-family: sans-serif;
-  color: #24292e;
+  color: #24292f;
 }
 
 .c5 {
@@ -94,7 +94,7 @@ Array [
 }
 
 .c0 {
-  box-shadow: 0 8px 24px rgba(149,157,165,0.2);
+  box-shadow: 0 8px 24px rgba(140,149,159,0.2);
   border-radius: 6px;
   position: fixed;
   top: 0;
@@ -114,7 +114,7 @@ Array [
   padding: 16px;
   background-color: #f6f8fa;
   border-radius: 6px 6px 0px 0px;
-  border-bottom: 1px solid #e1e4e8;
+  border-bottom: 1px solid #d0d7de;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -177,7 +177,7 @@ Array [
     >
       <span
         className="c3"
-        color="text.primary"
+        color="fg.default"
         fontFamily="sans-serif"
         fontSize={1}
         fontWeight="bold"

--- a/src/__tests__/__snapshots__/Dropdown.tsx.snap
+++ b/src/__tests__/__snapshots__/Dropdown.tsx.snap
@@ -45,10 +45,10 @@ exports[`Dropdown.Button renders consistently 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #24292e;
-  background-color: #fafbfc;
-  border: 1px solid rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
+  color: #24292f;
+  background-color: #f6f8fa;
+  border: 1px solid rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
 }
 
 .c0:hover {
@@ -70,23 +70,23 @@ exports[`Dropdown.Button renders consistently 1`] = `
 
 .c0:hover {
   background-color: #f3f4f6;
-  border-color: rgba(27,31,35,0.15);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 .c0:active {
   background-color: hsla(220,14%,94%,1);
-  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
 }
 
 .c0:disabled {
-  color: #959da5;
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: #57606a;
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c1 {
@@ -135,18 +135,18 @@ exports[`Dropdown.Item renders consistently 1`] = `
   display: block;
   padding: 4px 10px 4px 15px;
   overflow: hidden;
-  color: #24292e;
+  color: #24292f;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .c0 a {
-  color: #24292e;
+  color: #24292f;
   -webkit-text-decoration: none;
   text-decoration: none;
   display: block;
   overflow: hidden;
-  color: #24292e;
+  color: #24292f;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -156,7 +156,7 @@ exports[`Dropdown.Item renders consistently 1`] = `
   color: #ffffff;
   -webkit-text-decoration: none;
   text-decoration: none;
-  background-color: #0366d6;
+  background-color: #0969da;
 }
 
 .c0:hover,
@@ -164,7 +164,7 @@ exports[`Dropdown.Item renders consistently 1`] = `
   color: #ffffff;
   -webkit-text-decoration: none;
   text-decoration: none;
-  background-color: #0366d6;
+  background-color: #0969da;
   outline: none;
 }
 
@@ -179,9 +179,9 @@ exports[`Dropdown.Menu renders consistently 1`] = `
 .c0 {
   background-clip: padding-box;
   background-color: #ffffff;
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
-  box-shadow: 0 8px 24px rgba(149,157,165,0.2);
+  box-shadow: 0 8px 24px rgba(140,149,159,0.2);
   left: 0;
   list-style: none;
   margin-top: 2px;

--- a/src/__tests__/__snapshots__/DropdownMenu.tsx.snap
+++ b/src/__tests__/__snapshots__/DropdownMenu.tsx.snap
@@ -23,10 +23,10 @@ exports[`DropdownMenu renders consistently 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #24292e;
-  background-color: #fafbfc;
-  border: 1px solid rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
+  color: #24292f;
+  background-color: #f6f8fa;
+  border: 1px solid rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
 }
 
 .c0:hover {
@@ -48,23 +48,23 @@ exports[`DropdownMenu renders consistently 1`] = `
 
 .c0:hover {
   background-color: #f3f4f6;
-  border-color: rgba(27,31,35,0.15);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 .c0:active {
   background-color: hsla(220,14%,94%,1);
-  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
 }
 
 .c0:disabled {
-  color: #959da5;
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: #57606a;
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c1 {

--- a/src/__tests__/__snapshots__/FilterListItem.tsx.snap
+++ b/src/__tests__/__snapshots__/FilterListItem.tsx.snap
@@ -8,7 +8,7 @@ exports[`FilterList.Item renders consistently 1`] = `
   margin: 0 0 5px 0;
   overflow: hidden;
   font-size: 14px;
-  color: #586069;
+  color: #57606a;
   background-color: !important;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -26,7 +26,7 @@ exports[`FilterList.Item renders consistently 1`] = `
 
 .c0:active {
   color: #ffffff;
-  background-color: #0366d6;
+  background-color: #0969da;
 }
 
 .c0 .count {
@@ -48,7 +48,7 @@ exports[`FilterList.Item respects the "selected" prop 1`] = `
   overflow: hidden;
   font-size: 14px;
   color: #ffffff;
-  background-color: #0366d6!important;
+  background-color: #0969da!important;
   -webkit-text-decoration: none;
   text-decoration: none;
   text-overflow: ellipsis;
@@ -65,7 +65,7 @@ exports[`FilterList.Item respects the "selected" prop 1`] = `
 
 .c0:active {
   color: #ffffff;
-  background-color: #0366d6;
+  background-color: #0969da;
 }
 
 .c0 .count {

--- a/src/__tests__/__snapshots__/Flash.tsx.snap
+++ b/src/__tests__/__snapshots__/Flash.tsx.snap
@@ -3,15 +3,15 @@
 exports[`Flash renders consistently 1`] = `
 .c0 {
   position: relative;
-  color: #24292e;
+  color: #24292f;
   padding: 16px;
   border-style: solid;
   border-width: 1px;
   border-radius: 6px;
   margin-top: 0;
-  color: #24292e;
-  background-color: #dbedff;
-  border-color: rgba(4,66,137,0.2);
+  color: #24292f;
+  background-color: #ddf4ff;
+  border-color: rgba(84,174,255,0.4);
 }
 
 .c0 p:last-child {
@@ -23,7 +23,7 @@ exports[`Flash renders consistently 1`] = `
 }
 
 .c0 svg {
-  color: rgba(4,66,137,0.6);
+  color: #0969da;
 }
 
 <div

--- a/src/__tests__/__snapshots__/Header.tsx.snap
+++ b/src/__tests__/__snapshots__/Header.tsx.snap
@@ -63,7 +63,7 @@ exports[`Header renders consistently 1`] = `
   font-size: 14px;
   line-height: 1.5;
   color: rgba(255,255,255,0.7);
-  background-color: #24292e;
+  background-color: #24292f;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/__tests__/__snapshots__/Label.tsx.snap
+++ b/src/__tests__/__snapshots__/Label.tsx.snap
@@ -9,7 +9,7 @@ exports[`Label renders consistently 1`] = `
   font-size: 12px;
   line-height: 20px;
   padding: 0 8px;
-  background-color: #6a737d;
+  background-color: #6e7781;
 }
 
 .c0:hover {
@@ -31,13 +31,13 @@ exports[`Label respects the "outline" prop 1`] = `
   font-size: 12px;
   line-height: 20px;
   padding: 0 8px;
-  background-color: #6a737d;
+  background-color: #6e7781;
   margin-top: -1px;
   margin-bottom: -1px;
-  color: #586069;
-  border: 1px solid #e1e4e8;
+  color: #57606a;
+  border: 1px solid #d0d7de;
   box-shadow: none;
-  background-color: #6a737d;
+  background-color: #6e7781;
   background-color: transparent;
 }
 
@@ -60,7 +60,7 @@ exports[`Label respects the "variant" prop 1`] = `
   font-size: 14px;
   line-height: 16px;
   padding: 8px 12px;
-  background-color: #6a737d;
+  background-color: #6e7781;
 }
 
 .c0:hover {

--- a/src/__tests__/__snapshots__/Link.tsx.snap
+++ b/src/__tests__/__snapshots__/Link.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Link applies button styles when rendering a button element 1`] = `
 .c0 {
-  color: #0366d6;
+  color: #0969da;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -36,7 +36,7 @@ exports[`Link applies button styles when rendering a button element 1`] = `
 
 exports[`Link passes href down to link element 1`] = `
 .c0 {
-  color: #0366d6;
+  color: #0969da;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -71,7 +71,7 @@ exports[`Link passes href down to link element 1`] = `
 
 exports[`Link renders consistently 1`] = `
 .c0 {
-  color: #0366d6;
+  color: #0969da;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -105,7 +105,7 @@ exports[`Link renders consistently 1`] = `
 
 exports[`Link respectes the "color" prop when "muted" prop is also passed 1`] = `
 .c0 {
-  color: #586069;
+  color: #57606a;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -114,7 +114,7 @@ exports[`Link respectes the "color" prop when "muted" prop is also passed 1`] = 
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-  color: #0366d6;
+  color: #0969da;
 }
 
 .c0:is(button) {
@@ -136,14 +136,14 @@ exports[`Link respectes the "color" prop when "muted" prop is also passed 1`] = 
 
 <a
   className="c0"
-  color="text.inverse"
+  color="fg.onEmphasis"
   muted={true}
 />
 `;
 
 exports[`Link respectes the "muted" prop 1`] = `
 .c0 {
-  color: #586069;
+  color: #57606a;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -151,7 +151,7 @@ exports[`Link respectes the "muted" prop 1`] = `
 .c0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
-  color: #0366d6;
+  color: #0969da;
 }
 
 .c0:is(button) {
@@ -179,7 +179,7 @@ exports[`Link respectes the "muted" prop 1`] = `
 
 exports[`Link respects hoverColor prop 1`] = `
 .c0 {
-  color: #0366d6;
+  color: #0969da;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -187,7 +187,7 @@ exports[`Link respects hoverColor prop 1`] = `
 .c0:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
-  color: #0366d6;
+  color: #0969da;
 }
 
 .c0:is(button) {

--- a/src/__tests__/__snapshots__/Pagehead.tsx.snap
+++ b/src/__tests__/__snapshots__/Pagehead.tsx.snap
@@ -6,7 +6,7 @@ exports[`Pagehead renders consistently 1`] = `
   padding-top: 24px;
   padding-bottom: 24px;
   margin-bottom: 24px;
-  border-bottom: 1px solid #e1e4e8;
+  border-bottom: 1px solid #d0d7de;
 }
 
 <div

--- a/src/__tests__/__snapshots__/PointerBox.tsx.snap
+++ b/src/__tests__/__snapshots__/PointerBox.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`PointerBox passes the "bg" prop to both <BorderBox> and <Caret> 1`] = `
 .c0 {
-  background-color: #ffeef0;
+  background-color: #FFEBE9;
   border-width: 1px;
   border-style: solid;
-  border-color: #e1e4e8;
+  border-color: #d0d7de;
   border-radius: 6px;
   position: relative;
 }
@@ -31,12 +31,12 @@ exports[`PointerBox passes the "bg" prop to both <BorderBox> and <Caret> 1`] = `
     >
       <path
         d="M-8,0L0,8L8,0L-8,0Z"
-        fill="#ffeef0"
+        fill="#FFEBE9"
       />
       <path
         d="M-8,0L0,8L8,0"
         fill="none"
-        stroke="#e1e4e8"
+        stroke="#d0d7de"
         strokeWidth="1px"
       />
     </g>
@@ -46,7 +46,7 @@ exports[`PointerBox passes the "bg" prop to both <BorderBox> and <Caret> 1`] = `
 
 exports[`PointerBox passes the "borderColor" prop to both <BorderBox> and <Caret> 1`] = `
 .c0 {
-  border-color: #d73a49;
+  border-color: #cf222e;
   border-width: 1px;
   border-style: solid;
   border-radius: 6px;
@@ -79,7 +79,7 @@ exports[`PointerBox passes the "borderColor" prop to both <BorderBox> and <Caret
       <path
         d="M-8,0L0,8L8,0"
         fill="none"
-        stroke="#d73a49"
+        stroke="#cf222e"
         strokeWidth="1px"
       />
     </g>
@@ -91,7 +91,7 @@ exports[`PointerBox renders a <Caret> in <BorderBox> with relative positioning 1
 .c0 {
   border-width: 1px;
   border-style: solid;
-  border-color: #e1e4e8;
+  border-color: #d0d7de;
   border-radius: 6px;
   position: relative;
 }
@@ -122,7 +122,7 @@ exports[`PointerBox renders a <Caret> in <BorderBox> with relative positioning 1
       <path
         d="M-8,0L0,8L8,0"
         fill="none"
-        stroke="#e1e4e8"
+        stroke="#d0d7de"
         strokeWidth="1px"
       />
     </g>
@@ -134,7 +134,7 @@ exports[`PointerBox renders consistently 1`] = `
 .c0 {
   border-width: 1px;
   border-style: solid;
-  border-color: #e1e4e8;
+  border-color: #d0d7de;
   border-radius: 6px;
   position: relative;
 }
@@ -165,7 +165,7 @@ exports[`PointerBox renders consistently 1`] = `
       <path
         d="M-8,0L0,8L8,0"
         fill="none"
-        stroke="#e1e4e8"
+        stroke="#d0d7de"
         strokeWidth="1px"
       />
     </g>

--- a/src/__tests__/__snapshots__/Popover.tsx.snap
+++ b/src/__tests__/__snapshots__/Popover.tsx.snap
@@ -8,7 +8,7 @@ exports[`Popover Popover.Content renders consistently 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -30,7 +30,7 @@ exports[`Popover Popover.Content renders consistently 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -54,7 +54,7 @@ exports[`Popover Popover.Content renders consistently 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -147,7 +147,7 @@ exports[`Popover Popover.Content renders consistently 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -161,7 +161,7 @@ exports[`Popover Popover.Content renders consistently 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -215,7 +215,7 @@ exports[`Popover renders consistently 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -237,7 +237,7 @@ exports[`Popover renders consistently 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -261,7 +261,7 @@ exports[`Popover renders consistently 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -354,7 +354,7 @@ exports[`Popover renders consistently 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -368,7 +368,7 @@ exports[`Popover renders consistently 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -422,7 +422,7 @@ exports[`Popover renders correctly for a caret position of bottom 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -444,7 +444,7 @@ exports[`Popover renders correctly for a caret position of bottom 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -468,7 +468,7 @@ exports[`Popover renders correctly for a caret position of bottom 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -561,7 +561,7 @@ exports[`Popover renders correctly for a caret position of bottom 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -575,7 +575,7 @@ exports[`Popover renders correctly for a caret position of bottom 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -778,7 +778,7 @@ exports[`Popover renders correctly for a caret position of bottom-left 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -800,7 +800,7 @@ exports[`Popover renders correctly for a caret position of bottom-left 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -824,7 +824,7 @@ exports[`Popover renders correctly for a caret position of bottom-left 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -917,7 +917,7 @@ exports[`Popover renders correctly for a caret position of bottom-left 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -931,7 +931,7 @@ exports[`Popover renders correctly for a caret position of bottom-left 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -1134,7 +1134,7 @@ exports[`Popover renders correctly for a caret position of bottom-right 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -1156,7 +1156,7 @@ exports[`Popover renders correctly for a caret position of bottom-right 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -1180,7 +1180,7 @@ exports[`Popover renders correctly for a caret position of bottom-right 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -1273,7 +1273,7 @@ exports[`Popover renders correctly for a caret position of bottom-right 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -1287,7 +1287,7 @@ exports[`Popover renders correctly for a caret position of bottom-right 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -1490,7 +1490,7 @@ exports[`Popover renders correctly for a caret position of left 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -1512,7 +1512,7 @@ exports[`Popover renders correctly for a caret position of left 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -1536,7 +1536,7 @@ exports[`Popover renders correctly for a caret position of left 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -1629,7 +1629,7 @@ exports[`Popover renders correctly for a caret position of left 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -1643,7 +1643,7 @@ exports[`Popover renders correctly for a caret position of left 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -1846,7 +1846,7 @@ exports[`Popover renders correctly for a caret position of left-bottom 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -1868,7 +1868,7 @@ exports[`Popover renders correctly for a caret position of left-bottom 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -1892,7 +1892,7 @@ exports[`Popover renders correctly for a caret position of left-bottom 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -1985,7 +1985,7 @@ exports[`Popover renders correctly for a caret position of left-bottom 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -1999,7 +1999,7 @@ exports[`Popover renders correctly for a caret position of left-bottom 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -2202,7 +2202,7 @@ exports[`Popover renders correctly for a caret position of left-top 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -2224,7 +2224,7 @@ exports[`Popover renders correctly for a caret position of left-top 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -2248,7 +2248,7 @@ exports[`Popover renders correctly for a caret position of left-top 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -2341,7 +2341,7 @@ exports[`Popover renders correctly for a caret position of left-top 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -2355,7 +2355,7 @@ exports[`Popover renders correctly for a caret position of left-top 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -2558,7 +2558,7 @@ exports[`Popover renders correctly for a caret position of right 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -2580,7 +2580,7 @@ exports[`Popover renders correctly for a caret position of right 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -2604,7 +2604,7 @@ exports[`Popover renders correctly for a caret position of right 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -2697,7 +2697,7 @@ exports[`Popover renders correctly for a caret position of right 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -2711,7 +2711,7 @@ exports[`Popover renders correctly for a caret position of right 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -2914,7 +2914,7 @@ exports[`Popover renders correctly for a caret position of right-bottom 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -2936,7 +2936,7 @@ exports[`Popover renders correctly for a caret position of right-bottom 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -2960,7 +2960,7 @@ exports[`Popover renders correctly for a caret position of right-bottom 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -3053,7 +3053,7 @@ exports[`Popover renders correctly for a caret position of right-bottom 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -3067,7 +3067,7 @@ exports[`Popover renders correctly for a caret position of right-bottom 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -3270,7 +3270,7 @@ exports[`Popover renders correctly for a caret position of right-top 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -3292,7 +3292,7 @@ exports[`Popover renders correctly for a caret position of right-top 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -3316,7 +3316,7 @@ exports[`Popover renders correctly for a caret position of right-top 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -3409,7 +3409,7 @@ exports[`Popover renders correctly for a caret position of right-top 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -3423,7 +3423,7 @@ exports[`Popover renders correctly for a caret position of right-top 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -3626,7 +3626,7 @@ exports[`Popover renders correctly for a caret position of top 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -3648,7 +3648,7 @@ exports[`Popover renders correctly for a caret position of top 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -3672,7 +3672,7 @@ exports[`Popover renders correctly for a caret position of top 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -3765,7 +3765,7 @@ exports[`Popover renders correctly for a caret position of top 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -3779,7 +3779,7 @@ exports[`Popover renders correctly for a caret position of top 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -3982,7 +3982,7 @@ exports[`Popover renders correctly for a caret position of top-left 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -4004,7 +4004,7 @@ exports[`Popover renders correctly for a caret position of top-left 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -4028,7 +4028,7 @@ exports[`Popover renders correctly for a caret position of top-left 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -4121,7 +4121,7 @@ exports[`Popover renders correctly for a caret position of top-left 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -4135,7 +4135,7 @@ exports[`Popover renders correctly for a caret position of top-left 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,
@@ -4338,7 +4338,7 @@ exports[`Popover renders correctly for a caret position of top-right 1`] = `
 }
 
 .c2 {
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   position: relative;
   width: 232px;
@@ -4360,7 +4360,7 @@ exports[`Popover renders correctly for a caret position of top-right 1`] = `
   top: -16px;
   margin-left: -9px;
   border: 8px solid transparent;
-  border-bottom-color: #e1e4e8;
+  border-bottom-color: #d0d7de;
 }
 
 .c2::after {
@@ -4384,7 +4384,7 @@ exports[`Popover renders correctly for a caret position of top-right 1`] = `
 .c0.caret-pos--bottom-right .c2::before,
 .c0.caret-pos--bottom-left .c2::before {
   bottom: -16px;
-  border-top-color: #e1e4e8;
+  border-top-color: #d0d7de;
 }
 
 .c0.caret-pos--bottom .c2::after,
@@ -4477,7 +4477,7 @@ exports[`Popover renders correctly for a caret position of top-right 1`] = `
 .c0.caret-pos--right-top .c2::before,
 .c0.caret-pos--right-bottom .c2::before {
   right: -16px;
-  border-left-color: #e1e4e8;
+  border-left-color: #d0d7de;
 }
 
 .c0.caret-pos--right .c2::after,
@@ -4491,7 +4491,7 @@ exports[`Popover renders correctly for a caret position of top-right 1`] = `
 .c0.caret-pos--left-top .c2::before,
 .c0.caret-pos--left-bottom .c2::before {
   left: -16px;
-  border-right-color: #e1e4e8;
+  border-right-color: #d0d7de;
 }
 
 .c0.caret-pos--left .c2::after,

--- a/src/__tests__/__snapshots__/ProgressBar.tsx.snap
+++ b/src/__tests__/__snapshots__/ProgressBar.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ProgressBar renders consistently 1`] = `
 .c1 {
   width: 0;
-  background-color: #28a745;
+  background-color: #2da44e;
 }
 
 .c0 {
@@ -12,7 +12,7 @@ exports[`ProgressBar renders consistently 1`] = `
   display: -ms-flexbox;
   display: flex;
   overflow: hidden;
-  background-color: #e1e4e8;
+  background-color: #d0d7de;
   border-radius: 3px;
   height: 8px;
 }
@@ -29,7 +29,7 @@ exports[`ProgressBar renders consistently 1`] = `
 exports[`ProgressBar respects the "progress" prop 1`] = `
 .c1 {
   width: 80%;
-  background-color: #28a745;
+  background-color: #2da44e;
 }
 
 .c0 {
@@ -38,7 +38,7 @@ exports[`ProgressBar respects the "progress" prop 1`] = `
   display: -ms-flexbox;
   display: flex;
   overflow: hidden;
-  background-color: #e1e4e8;
+  background-color: #d0d7de;
   border-radius: 3px;
   height: 8px;
 }

--- a/src/__tests__/__snapshots__/SelectMenu.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectMenu.tsx.snap
@@ -23,10 +23,10 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #24292e;
-  background-color: #fafbfc;
-  border: 1px solid rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
+  color: #24292f;
+  background-color: #f6f8fa;
+  border: 1px solid rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
 }
 
 .c1:hover {
@@ -48,23 +48,23 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
 
 .c1:hover {
   background-color: #f3f4f6;
-  border-color: rgba(27,31,35,0.15);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c1:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 .c1:active {
   background-color: hsla(220,14%,94%,1);
-  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
 }
 
 .c1:disabled {
-  color: #959da5;
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: #57606a;
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c6 {
@@ -72,18 +72,18 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   margin: 0;
   font-size: 12px;
   font-weight: 600;
-  color: #6a737d;
+  color: #57606a;
   background-color: #f6f8fa;
-  border-bottom: 1px solid hsla(214,13%,93%,1);
+  border-bottom: 1px solid hsla(210,18%,87%,1);
 }
 
 .c7 {
   margin-top: -1px;
   padding: 8px 16px;
   font-size: 12px;
-  color: #6a737d;
+  color: #57606a;
   text-align: center;
-  border-top: 1px solid hsla(214,13%,93%,1);
+  border-top: 1px solid hsla(210,18%,87%,1);
 }
 
 .c5 {
@@ -101,8 +101,8 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   cursor: pointer;
   background-color: #ffffff;
   border: 0;
-  border-bottom: 1px solid hsla(214,13%,93%,1);
-  color: #586069;
+  border-bottom: 1px solid hsla(210,18%,87%,1);
+  color: #57606a;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 12px;
@@ -143,7 +143,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
 
 .c5[aria-checked='true'] {
   font-weight: 500;
-  color: #24292e;
+  color: #24292f;
 }
 
 .c5[aria-checked='true'] .SelectMenu-selected-icon {
@@ -185,7 +185,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   flex-direction: column;
   background-color: #ffffff;
   border-radius: 6px;
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04);
   -webkit-animation: lejQAW 0.12s cubic-bezier(0,0.1,0.1,1) backwards;
   animation: lejQAW 0.12s cubic-bezier(0,0.1,0.1,1) backwards;
   width: 300px;
@@ -217,7 +217,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   left: 0;
   pointer-events: none;
   content: '';
-  background-color: rgba(27,31,35,0.5);
+  background-color: rgba(27,31,36,0.5);
 }
 
 .c0 > summary {
@@ -249,33 +249,33 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   .c5:hover,
   .c5:active,
   .c5:focus {
-    background-color: #f6f8fa;
+    background-color: rgba(234,238,242,0.5);
   }
 }
 
 @media (hover:none) {
   .c5 {
-    -webkit-tap-highlight-color: rgba(209,213,218,0.5);
+    -webkit-tap-highlight-color: rgba(175,184,193,0.5);
   }
 
   .c5:focus,
   .c5:active {
-    background-color: #fafbfc;
+    background-color: #f6f8fa;
   }
 }
 
 @media (hover:hover) {
   .c4 .SelectMenuTab:focus {
-    background-color: #dbedff;
+    background-color: #b6e3ff;
   }
 
   .c4 .SelectMenuTab:not([aria-checked='true']):hover {
-    color: #24292e;
+    color: #24292f;
     background-color: #f6f8fa;
   }
 
   .c4 .SelectMenuTab:not([aria-checked='true']):active {
-    color: #24292e;
+    color: #24292f;
     background-color: #f6f8fa;
   }
 }
@@ -286,9 +286,9 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
     max-height: 350px;
     margin: 4px 0 16px 0;
     font-size: 12px;
-    border: 1px solid #e1e4e8;
+    border: 1px solid #d0d7de;
     border-radius: 6px;
-    box-shadow: 0 1px 0 rgba(27,31,35,0.04);
+    box-shadow: 0 1px 0 rgba(27,31,36,0.04);
   }
 }
 

--- a/src/__tests__/__snapshots__/SelectPanel.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectPanel.tsx.snap
@@ -4,7 +4,7 @@ exports[`SelectPanel renders consistently 1`] = `
 .c0 {
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   line-height: 1.5;
-  color: #24292e;
+  color: #24292f;
 }
 
 .c1 {
@@ -29,10 +29,10 @@ exports[`SelectPanel renders consistently 1`] = `
   text-decoration: none;
   text-align: center;
   font-size: 14px;
-  color: #24292e;
-  background-color: #fafbfc;
-  border: 1px solid rgba(27,31,35,0.15);
-  box-shadow: 0 1px 0 rgba(27,31,35,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
+  color: #24292f;
+  background-color: #f6f8fa;
+  border: 1px solid rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
 }
 
 .c1:hover {
@@ -54,23 +54,23 @@ exports[`SelectPanel renders consistently 1`] = `
 
 .c1:hover {
   background-color: #f3f4f6;
-  border-color: rgba(27,31,35,0.15);
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c1:focus {
-  border-color: rgba(27,31,35,0.15);
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 .c1:active {
   background-color: hsla(220,14%,94%,1);
-  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
 }
 
 .c1:disabled {
-  color: #959da5;
-  background-color: #fafbfc;
-  border-color: rgba(27,31,35,0.15);
+  color: #57606a;
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
 }
 
 .c2 {

--- a/src/__tests__/__snapshots__/SideNav.tsx.snap
+++ b/src/__tests__/__snapshots__/SideNav.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SideNav SideNav.Link renders consistently 1`] = `
 .c0 {
-  color: #0366d6;
+  color: #0969da;
   -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
@@ -39,10 +39,10 @@ exports[`SideNav SideNav.Link renders consistently 1`] = `
 }
 
 .c1.variant-normal > .c0 {
-  color: #24292e;
+  color: #24292f;
   padding: 16px;
   border: 0;
-  border-top: 1px solid hsla(214,13%,93%,1);
+  border-top: 1px solid hsla(210,18%,87%,1);
 }
 
 .c1.variant-normal > .c0:first-child {
@@ -68,18 +68,18 @@ exports[`SideNav SideNav.Link renders consistently 1`] = `
 }
 
 .c1.variant-normal > .c0:hover {
-  background-color: #f6f8fa;
+  background-color: rgba(234,238,242,0.5);
   outline: none;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .c1.variant-normal > .c0:focus {
-  background-color: #f6f8fa;
+  background-color: rgba(234,238,242,0.5);
   outline: none;
   -webkit-text-decoration: none;
   text-decoration: none;
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
   z-index: 1;
 }
 
@@ -90,33 +90,33 @@ exports[`SideNav SideNav.Link renders consistently 1`] = `
 
 .c1.variant-normal > .c0[aria-current='page']::before,
 .c1.variant-normal > .c0[aria-selected='true']::before {
-  background-color: #f9826c;
+  background-color: #FD8C73;
 }
 
 .c1.variant-lightweight > .c0 {
   padding: 4px 0;
-  color: #0366d6;
+  color: #0969da;
 }
 
 .c1.variant-lightweight > .c0:hover {
-  color: #24292e;
+  color: #24292f;
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
 .c1.variant-lightweight > .c0:focus {
-  color: #24292e;
+  color: #24292f;
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
   z-index: 1;
 }
 
 .c1.variant-lightweight > .c0[aria-current='page'],
 .c1.variant-lightweight > .c0[aria-selected='true'] {
-  color: #24292e;
+  color: #24292f;
   font-weight: 500;
 }
 
@@ -129,12 +129,12 @@ exports[`SideNav renders consistently 1`] = `
 .c0 {
   border-width: 0;
   border-style: solid;
-  border-color: #e1e4e8;
+  border-color: #d0d7de;
   border-radius: 6px;
 }
 
 .c1 {
-  background-color: #fafbfc;
+  background-color: #f6f8fa;
 }
 
 <nav

--- a/src/__tests__/__snapshots__/StateLabel.tsx.snap
+++ b/src/__tests__/__snapshots__/StateLabel.tsx.snap
@@ -21,7 +21,7 @@ exports[`StateLabel renders children 1`] = `
   border-radius: 100px;
   border-width: 1px;
   border-style: solid;
-  background-color: #28a745;
+  background-color: #2da44e;
   color: #ffffff;
   border-color: rgba(0,0,0,0);
   padding-left: 12px;
@@ -80,7 +80,7 @@ exports[`StateLabel renders consistently 1`] = `
   border-radius: 100px;
   border-width: 1px;
   border-style: solid;
-  background-color: #28a745;
+  background-color: #2da44e;
   color: #ffffff;
   border-color: rgba(0,0,0,0);
   padding-left: 12px;
@@ -139,7 +139,7 @@ exports[`StateLabel respects the status prop 1`] = `
   border-radius: 100px;
   border-width: 1px;
   border-style: solid;
-  background-color: #28a745;
+  background-color: #2da44e;
   color: #ffffff;
   border-color: rgba(0,0,0,0);
   padding-left: 12px;
@@ -197,7 +197,7 @@ exports[`StateLabel respects the status prop 2`] = `
   border-radius: 100px;
   border-width: 1px;
   border-style: solid;
-  background-color: #d73a49;
+  background-color: #cf222e;
   color: #ffffff;
   border-color: rgba(0,0,0,0);
   padding-left: 12px;
@@ -255,7 +255,7 @@ exports[`StateLabel respects the status prop 3`] = `
   border-radius: 100px;
   border-width: 1px;
   border-style: solid;
-  background-color: #6f42c1;
+  background-color: #8250df;
   color: #ffffff;
   border-color: rgba(0,0,0,0);
   padding-left: 12px;
@@ -313,7 +313,7 @@ exports[`StateLabel respects the variant prop 1`] = `
   border-radius: 100px;
   border-width: 1px;
   border-style: solid;
-  background-color: #28a745;
+  background-color: #2da44e;
   color: #ffffff;
   border-color: rgba(0,0,0,0);
   padding-left: 8px;
@@ -371,7 +371,7 @@ exports[`StateLabel respects the variant prop 2`] = `
   border-radius: 100px;
   border-width: 1px;
   border-style: solid;
-  background-color: #28a745;
+  background-color: #2da44e;
   color: #ffffff;
   border-color: rgba(0,0,0,0);
   padding-left: 12px;

--- a/src/__tests__/__snapshots__/SubNavLink.tsx.snap
+++ b/src/__tests__/__snapshots__/SubNavLink.tsx.snap
@@ -8,13 +8,13 @@ exports[`SubNav.Link adds activeClassName={SELECTED_CLASS} when it gets a "to" p
   font-size: 14px;
   line-height: 20px;
   min-height: 34px;
-  color: #24292e;
+  color: #24292f;
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  border-top: 1px solid #e1e4e8;
-  border-bottom: 1px solid #e1e4e8;
-  border-right: 1px solid #e1e4e8;
+  border-top: 1px solid #d0d7de;
+  border-bottom: 1px solid #d0d7de;
+  border-right: 1px solid #d0d7de;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -28,7 +28,7 @@ exports[`SubNav.Link adds activeClassName={SELECTED_CLASS} when it gets a "to" p
 .c0:first-of-type {
   border-top-left-radius: 6px;
   border-bottom-left-radius: 6px;
-  border-left: 1px solid #e1e4e8;
+  border-left: 1px solid #d0d7de;
 }
 
 .c0:last-of-type {
@@ -47,13 +47,13 @@ exports[`SubNav.Link adds activeClassName={SELECTED_CLASS} when it gets a "to" p
 
 .c0:hover .SubNav-octicon,
 .c0:focus .SubNav-octicon {
-  color: #586069;
+  color: #57606a;
 }
 
 .c0.selected {
   color: #ffffff;
-  background-color: #0366d6;
-  border-color: #0366d6;
+  background-color: #0969da;
+  border-color: #0969da;
 }
 
 .c0.selected .SubNav-octicon {
@@ -75,13 +75,13 @@ exports[`SubNav.Link renders consistently 1`] = `
   font-size: 14px;
   line-height: 20px;
   min-height: 34px;
-  color: #24292e;
+  color: #24292f;
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  border-top: 1px solid #e1e4e8;
-  border-bottom: 1px solid #e1e4e8;
-  border-right: 1px solid #e1e4e8;
+  border-top: 1px solid #d0d7de;
+  border-bottom: 1px solid #d0d7de;
+  border-right: 1px solid #d0d7de;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -95,7 +95,7 @@ exports[`SubNav.Link renders consistently 1`] = `
 .c0:first-of-type {
   border-top-left-radius: 6px;
   border-bottom-left-radius: 6px;
-  border-left: 1px solid #e1e4e8;
+  border-left: 1px solid #d0d7de;
 }
 
 .c0:last-of-type {
@@ -114,13 +114,13 @@ exports[`SubNav.Link renders consistently 1`] = `
 
 .c0:hover .SubNav-octicon,
 .c0:focus .SubNav-octicon {
-  color: #586069;
+  color: #57606a;
 }
 
 .c0.selected {
   color: #ffffff;
-  background-color: #0366d6;
-  border-color: #0366d6;
+  background-color: #0969da;
+  border-color: #0969da;
 }
 
 .c0.selected .SubNav-octicon {
@@ -140,13 +140,13 @@ exports[`SubNav.Link respects the "selected" prop 1`] = `
   font-size: 14px;
   line-height: 20px;
   min-height: 34px;
-  color: #24292e;
+  color: #24292f;
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  border-top: 1px solid #e1e4e8;
-  border-bottom: 1px solid #e1e4e8;
-  border-right: 1px solid #e1e4e8;
+  border-top: 1px solid #d0d7de;
+  border-bottom: 1px solid #d0d7de;
+  border-right: 1px solid #d0d7de;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -160,7 +160,7 @@ exports[`SubNav.Link respects the "selected" prop 1`] = `
 .c0:first-of-type {
   border-top-left-radius: 6px;
   border-bottom-left-radius: 6px;
-  border-left: 1px solid #e1e4e8;
+  border-left: 1px solid #d0d7de;
 }
 
 .c0:last-of-type {
@@ -179,13 +179,13 @@ exports[`SubNav.Link respects the "selected" prop 1`] = `
 
 .c0:hover .SubNav-octicon,
 .c0:focus .SubNav-octicon {
-  color: #586069;
+  color: #57606a;
 }
 
 .c0.selected {
   color: #ffffff;
-  background-color: #0366d6;
-  border-color: #0366d6;
+  background-color: #0969da;
+  border-color: #0969da;
 }
 
 .c0.selected .SubNav-octicon {

--- a/src/__tests__/__snapshots__/TabNav.tsx.snap
+++ b/src/__tests__/__snapshots__/TabNav.tsx.snap
@@ -5,7 +5,7 @@ exports[`TabNav TabNav.Link renders consistently 1`] = `
   padding: 8px 12px;
   font-size: 14px;
   line-height: 20px;
-  color: #24292e;
+  color: #24292f;
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: transparent;
@@ -15,14 +15,14 @@ exports[`TabNav TabNav.Link renders consistently 1`] = `
 
 .c0:hover,
 .c0:focus {
-  color: #24292e;
+  color: #24292f;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .c0.selected {
-  color: #24292e;
-  border-color: #e1e4e8;
+  color: #24292f;
+  border-color: #d0d7de;
   border-top-right-radius: 6px;
   border-top-left-radius: 6px;
   background-color: #ffffff;
@@ -36,7 +36,7 @@ exports[`TabNav TabNav.Link renders consistently 1`] = `
 exports[`TabNav renders consistently 1`] = `
 .c0 {
   margin-top: 0;
-  border-bottom: 1px solid #e1e4e8;
+  border-bottom: 1px solid #d0d7de;
 }
 
 .c1 {

--- a/src/__tests__/__snapshots__/TextInput.tsx.snap
+++ b/src/__tests__/__snapshots__/TextInput.tsx.snap
@@ -27,14 +27,14 @@ exports[`TextInput renders 1`] = `
   min-height: 34px;
   font-size: 14px;
   line-height: 20px;
-  color: #24292e;
+  color: #24292f;
   vertical-align: middle;
   background-repeat: no-repeat;
   background-position: right 8px center;
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   outline: none;
-  box-shadow: inset 0 1px 0 rgba(225,228,232,0.2);
+  box-shadow: inset 0 1px 0 rgba(208,215,222,0.2);
   padding: 6px 12px;
 }
 
@@ -42,7 +42,7 @@ exports[`TextInput renders 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  color: #959da5;
+  color: #57606a;
   margin: 0 8px;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -50,8 +50,8 @@ exports[`TextInput renders 1`] = `
 }
 
 .c0:focus-within {
-  border-color: #0366d6;
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: #0969da;
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 @media (min-width:768px) {
@@ -98,14 +98,14 @@ exports[`TextInput renders block 1`] = `
   min-height: 34px;
   font-size: 14px;
   line-height: 20px;
-  color: #24292e;
+  color: #24292f;
   vertical-align: middle;
   background-repeat: no-repeat;
   background-position: right 8px center;
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   outline: none;
-  box-shadow: inset 0 1px 0 rgba(225,228,232,0.2);
+  box-shadow: inset 0 1px 0 rgba(208,215,222,0.2);
   padding: 6px 12px;
   display: block;
   width: 100%;
@@ -115,7 +115,7 @@ exports[`TextInput renders block 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  color: #959da5;
+  color: #57606a;
   margin: 0 8px;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -123,8 +123,8 @@ exports[`TextInput renders block 1`] = `
 }
 
 .c0:focus-within {
-  border-color: #0366d6;
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: #0969da;
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 @media (min-width:768px) {
@@ -171,14 +171,14 @@ exports[`TextInput renders consistently 1`] = `
   min-height: 34px;
   font-size: 14px;
   line-height: 20px;
-  color: #24292e;
+  color: #24292f;
   vertical-align: middle;
   background-repeat: no-repeat;
   background-position: right 8px center;
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   outline: none;
-  box-shadow: inset 0 1px 0 rgba(225,228,232,0.2);
+  box-shadow: inset 0 1px 0 rgba(208,215,222,0.2);
   padding: 6px 12px;
 }
 
@@ -186,7 +186,7 @@ exports[`TextInput renders consistently 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  color: #959da5;
+  color: #57606a;
   margin: 0 8px;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -194,8 +194,8 @@ exports[`TextInput renders consistently 1`] = `
 }
 
 .c0:focus-within {
-  border-color: #0366d6;
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: #0969da;
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 @media (min-width:768px) {
@@ -241,14 +241,14 @@ exports[`TextInput renders large 1`] = `
   min-height: 34px;
   font-size: 14px;
   line-height: 20px;
-  color: #24292e;
+  color: #24292f;
   vertical-align: middle;
   background-repeat: no-repeat;
   background-position: right 8px center;
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   outline: none;
-  box-shadow: inset 0 1px 0 rgba(225,228,232,0.2);
+  box-shadow: inset 0 1px 0 rgba(208,215,222,0.2);
   padding: 6px 12px;
   padding-left: 8px;
   padding-right: 8px;
@@ -261,7 +261,7 @@ exports[`TextInput renders large 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  color: #959da5;
+  color: #57606a;
   margin: 0 8px;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -269,8 +269,8 @@ exports[`TextInput renders large 1`] = `
 }
 
 .c0:focus-within {
-  border-color: #0366d6;
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: #0969da;
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 @media (min-width:768px) {
@@ -317,14 +317,14 @@ exports[`TextInput renders small 1`] = `
   min-height: 34px;
   font-size: 14px;
   line-height: 20px;
-  color: #24292e;
+  color: #24292f;
   vertical-align: middle;
   background-repeat: no-repeat;
   background-position: right 8px center;
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   outline: none;
-  box-shadow: inset 0 1px 0 rgba(225,228,232,0.2);
+  box-shadow: inset 0 1px 0 rgba(208,215,222,0.2);
   padding: 6px 12px;
   min-height: 28px;
   padding-left: 8px;
@@ -339,7 +339,7 @@ exports[`TextInput renders small 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  color: #959da5;
+  color: #57606a;
   margin: 0 8px;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -347,8 +347,8 @@ exports[`TextInput renders small 1`] = `
 }
 
 .c0:focus-within {
-  border-color: #0366d6;
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: #0969da;
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 @media (min-width:768px) {
@@ -395,14 +395,14 @@ exports[`TextInput should render a password input 1`] = `
   min-height: 34px;
   font-size: 14px;
   line-height: 20px;
-  color: #24292e;
+  color: #24292f;
   vertical-align: middle;
   background-repeat: no-repeat;
   background-position: right 8px center;
-  border: 1px solid #e1e4e8;
+  border: 1px solid #d0d7de;
   border-radius: 6px;
   outline: none;
-  box-shadow: inset 0 1px 0 rgba(225,228,232,0.2);
+  box-shadow: inset 0 1px 0 rgba(208,215,222,0.2);
   padding: 6px 12px;
 }
 
@@ -410,7 +410,7 @@ exports[`TextInput should render a password input 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  color: #959da5;
+  color: #57606a;
   margin: 0 8px;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -418,8 +418,8 @@ exports[`TextInput should render a password input 1`] = `
 }
 
 .c0:focus-within {
-  border-color: #0366d6;
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  border-color: #0969da;
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
 }
 
 @media (min-width:768px) {

--- a/src/__tests__/__snapshots__/ThemeProvider.tsx.snap
+++ b/src/__tests__/__snapshots__/ThemeProvider.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`has default theme 1`] = `
 .c0 {
-  color: #24292e;
+  color: #24292f;
   margin-bottom: 4px;
 }
 
 <span
   class="c0"
-  color="text.primary"
+  color="fg.default"
 >
   Hello
 </span>

--- a/src/__tests__/__snapshots__/Timeline.tsx.snap
+++ b/src/__tests__/__snapshots__/Timeline.tsx.snap
@@ -49,8 +49,8 @@ exports[`Timeline.Badge renders consistently 1`] = `
 .c1 {
   margin-right: 8px;
   margin-left: -15px;
-  color: #586069;
-  background-color: #e1e4e8;
+  color: #57606a;
+  background-color: #eaeef2;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -78,7 +78,7 @@ exports[`Timeline.Badge renders consistently 1`] = `
 >
   <div
     className="c1 TimelineItem-Badge"
-    color="icon.secondary"
+    color="fg.muted"
     display="flex"
     height="32px"
     overflow="hidden"
@@ -106,7 +106,7 @@ exports[`Timeline.Item renders consistently 1`] = `
   display: block;
   width: 2px;
   content: '';
-  background-color: hsla(214,13%,93%,1);
+  background-color: hsla(210,18%,87%,1);
 }
 
 <div
@@ -135,7 +135,7 @@ exports[`Timeline.Item renders with condensed prop 1`] = `
   display: block;
   width: 2px;
   content: '';
-  background-color: hsla(214,13%,93%,1);
+  background-color: hsla(210,18%,87%,1);
 }
 
 .c0:last-child {
@@ -146,7 +146,7 @@ exports[`Timeline.Item renders with condensed prop 1`] = `
   height: 16px;
   margin-top: 8px;
   margin-bottom: 8px;
-  color: #959da5;
+  color: #57606a;
   background-color: #ffffff;
   border: 0;
 }

--- a/src/__tests__/__snapshots__/Tooltip.tsx.snap
+++ b/src/__tests__/__snapshots__/Tooltip.tsx.snap
@@ -11,7 +11,7 @@ exports[`Tooltip renders consistently 1`] = `
   display: none;
   width: 0px;
   height: 0px;
-  color: #24292e;
+  color: #24292f;
   pointer-events: none;
   content: '';
   border: 6px solid transparent;
@@ -39,7 +39,7 @@ exports[`Tooltip renders consistently 1`] = `
   white-space: pre;
   pointer-events: none;
   content: attr(aria-label);
-  background: #24292e;
+  background: #24292f;
   border-radius: 3px;
   opacity: 0;
 }
@@ -96,7 +96,7 @@ exports[`Tooltip renders consistently 1`] = `
   right: 50%;
   bottom: -7px;
   margin-right: -6px;
-  border-bottom-color: #24292e;
+  border-bottom-color: #24292f;
 }
 
 .c0.tooltipped-se::after {
@@ -124,7 +124,7 @@ exports[`Tooltip renders consistently 1`] = `
   right: 50%;
   bottom: auto;
   margin-right: -6px;
-  border-top-color: #24292e;
+  border-top-color: #24292f;
 }
 
 .c0.tooltipped-ne::after {
@@ -158,7 +158,7 @@ exports[`Tooltip renders consistently 1`] = `
   bottom: 50%;
   left: -7px;
   margin-top: -6px;
-  border-left-color: #24292e;
+  border-left-color: #24292f;
 }
 
 .c0.tooltipped-e::after {
@@ -175,7 +175,7 @@ exports[`Tooltip renders consistently 1`] = `
   right: -7px;
   bottom: 50%;
   margin-top: -6px;
-  border-right-color: #24292e;
+  border-right-color: #24292f;
 }
 
 .c0.tooltipped-multiline::after {

--- a/src/__tests__/__snapshots__/UnderlineNav.tsx.snap
+++ b/src/__tests__/__snapshots__/UnderlineNav.tsx.snap
@@ -10,7 +10,7 @@ exports[`UnderlineNav renders consistently 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  border-bottom: 1px solid hsla(214,13%,93%,1);
+  border-bottom: 1px solid hsla(210,18%,87%,1);
 }
 
 .c0.UnderlineNav--right {

--- a/src/__tests__/__snapshots__/UnderlineNavLink.tsx.snap
+++ b/src/__tests__/__snapshots__/UnderlineNavLink.tsx.snap
@@ -6,7 +6,7 @@ exports[`UnderlineNav.Link adds activeClassName={SELECTED_CLASS} when it gets a 
   margin-right: 16px;
   font-size: 14px;
   line-height: 1.5;
-  color: #24292e;
+  color: #24292f;
   text-align: center;
   border-bottom: 2px solid transparent;
   -webkit-text-decoration: none;
@@ -15,26 +15,26 @@ exports[`UnderlineNav.Link adds activeClassName={SELECTED_CLASS} when it gets a 
 
 .c0:hover,
 .c0:focus {
-  color: #24292e;
+  color: #24292f;
   -webkit-text-decoration: none;
   text-decoration: none;
-  border-bottom-color: #d1d5da;
+  border-bottom-color: rgba(175,184,193,0.2);
   -webkit-transition: 0.2s ease;
   transition: 0.2s ease;
 }
 
 .c0:hover .UnderlineNav-octicon,
 .c0:focus .UnderlineNav-octicon {
-  color: #6a737d;
+  color: #57606a;
 }
 
 .c0.selected {
-  color: #24292e;
-  border-bottom-color: #f9826c;
+  color: #24292f;
+  border-bottom-color: #FD8C73;
 }
 
 .c0.selected .UnderlineNav-octicon {
-  color: #24292e;
+  color: #24292f;
 }
 
 <div
@@ -50,7 +50,7 @@ exports[`UnderlineNav.Link renders consistently 1`] = `
   margin-right: 16px;
   font-size: 14px;
   line-height: 1.5;
-  color: #24292e;
+  color: #24292f;
   text-align: center;
   border-bottom: 2px solid transparent;
   -webkit-text-decoration: none;
@@ -59,26 +59,26 @@ exports[`UnderlineNav.Link renders consistently 1`] = `
 
 .c0:hover,
 .c0:focus {
-  color: #24292e;
+  color: #24292f;
   -webkit-text-decoration: none;
   text-decoration: none;
-  border-bottom-color: #d1d5da;
+  border-bottom-color: rgba(175,184,193,0.2);
   -webkit-transition: 0.2s ease;
   transition: 0.2s ease;
 }
 
 .c0:hover .UnderlineNav-octicon,
 .c0:focus .UnderlineNav-octicon {
-  color: #6a737d;
+  color: #57606a;
 }
 
 .c0.selected {
-  color: #24292e;
-  border-bottom-color: #f9826c;
+  color: #24292f;
+  border-bottom-color: #FD8C73;
 }
 
 .c0.selected .UnderlineNav-octicon {
-  color: #24292e;
+  color: #24292f;
 }
 
 <a
@@ -92,7 +92,7 @@ exports[`UnderlineNav.Link respects the "selected" prop 1`] = `
   margin-right: 16px;
   font-size: 14px;
   line-height: 1.5;
-  color: #24292e;
+  color: #24292f;
   text-align: center;
   border-bottom: 2px solid transparent;
   -webkit-text-decoration: none;
@@ -101,26 +101,26 @@ exports[`UnderlineNav.Link respects the "selected" prop 1`] = `
 
 .c0:hover,
 .c0:focus {
-  color: #24292e;
+  color: #24292f;
   -webkit-text-decoration: none;
   text-decoration: none;
-  border-bottom-color: #d1d5da;
+  border-bottom-color: rgba(175,184,193,0.2);
   -webkit-transition: 0.2s ease;
   transition: 0.2s ease;
 }
 
 .c0:hover .UnderlineNav-octicon,
 .c0:focus .UnderlineNav-octicon {
-  color: #6a737d;
+  color: #57606a;
 }
 
 .c0.selected {
-  color: #24292e;
-  border-bottom-color: #f9826c;
+  color: #24292f;
+  border-bottom-color: #FD8C73;
 }
 
 .c0.selected .UnderlineNav-octicon {
-  color: #24292e;
+  color: #24292f;
 }
 
 <a

--- a/src/stories/ActionList.stories.tsx
+++ b/src/stories/ActionList.stories.tsx
@@ -312,7 +312,7 @@ export function CustomItemChildren(): JSX.Element {
             {
               leadingVisual: ArrowRightIcon,
               children: (
-                <Label outline borderColor="border.success">
+                <Label outline borderColor="success.emphasis">
                   Choose this one
                 </Label>
               ),

--- a/src/stories/ThemeProvider.stories.tsx
+++ b/src/stories/ThemeProvider.stories.tsx
@@ -51,11 +51,11 @@ function NightMode() {
       <Box
         my={3}
         p={3}
-        color="text.primary"
-        bg="bg.canvas"
+        color="fg.default"
+        bg="canvas.default"
         borderWidth="1px"
         borderStyle="solid"
-        borderColor="border.primary"
+        borderColor="border.default"
         borderRadius={2}
       >
         Always night mode (<ActiveColorScheme />)
@@ -71,11 +71,11 @@ function InverseMode() {
       <Box
         my={3}
         p={3}
-        color="text.primary"
-        bg="bg.canvas"
+        color="fg.default"
+        bg="canvas.default"
         borderWidth="1px"
         borderStyle="solid"
-        borderColor="border.primary"
+        borderColor="border.default"
         borderRadius={2}
       >
         Always inverse of parent mode (<ActiveColorScheme />)

--- a/src/stories/useFocusTrap.stories.tsx
+++ b/src/stories/useFocusTrap.stories.tsx
@@ -308,7 +308,7 @@ export const MultipleFocusTraps = () => {
           the most recently-suspended trap will reactivate. Suspended focus traps can be disabled, causing them to be
           removed from the stack of suspended traps.
         </Flash>
-        <Box p={2} mb={3} borderWidth="1px" borderStyle="solid" borderColor="border.primary" borderRadius={2}>
+        <Box p={2} mb={3} borderWidth="1px" borderStyle="solid" borderColor="border.default" borderRadius={2}>
           Legend
           <Box display="flex" flexDirection="row">
             <Box

--- a/src/theme-preval.js
+++ b/src/theme-preval.js
@@ -123,6 +123,7 @@ const theme = {
       colors: darkDimmedColors,
       shadows: darkDimmedShadows
     },
+    // eslint-disable-next-line camelcase
     dark_high_contrast: {
       colors: darkHighContrastColors,
       shadows: darkHighContrastShadows

--- a/src/theme-preval.js
+++ b/src/theme-preval.js
@@ -51,6 +51,7 @@ const space = ['0', '4px', '8px', '16px', '24px', '32px', '40px', '48px', '64px'
 const light = partitionColors(primitives.colors.light)
 const dark = partitionColors(primitives.colors.dark)
 const darkDimmed = partitionColors(primitives.colors['dark_dimmed'])
+const darkHighContrast = partitionColors(primitives.colors['dark_high_contrast'])
 
 // This file must be in vanilla JS to work with preval
 // but our temporary filter utils make it impossible for
@@ -87,6 +88,16 @@ const darkDimmedColors = omitScale(darkDimmed.colors)
  */
 const darkDimmedShadows = omitScale(darkDimmed.shadows)
 
+/**
+ * @type Partial<typeof primitives.colors.dark_dimmed>
+ */
+const darkHighContrastColors = omitScale(darkHighContrast.colors)
+
+/**
+ * @type Partial<typeof primitives.colors.dark_high_contrast>
+ */
+const darkHighContrastShadows = omitScale(darkHighContrast.shadows)
+
 const theme = {
   // General
   animation,
@@ -111,6 +122,10 @@ const theme = {
     dark_dimmed: {
       colors: darkDimmedColors,
       shadows: darkDimmedShadows
+    },
+    dark_high_contrast: {
+      colors: darkHighContrastColors,
+      shadows: darkHighContrastShadows
     }
   }
 }


### PR DESCRIPTION
## Background

An recent release of [Primer Primitives](https://primer.style/primitives) [deprecated many existing color variables](https://primer.style/primitives/colors#deprecated-variables) and introduced new [functional color variables](https://primer.style/primitives/colors#functional-variables).

## Problem

Primer React components is using deprecated functional color variables.

## Solution

1. Update `@primer/primitives` version so we can use the new functional color variables
2. Install `eslint-plugin-primer-react` to lint for usages of deprecated color variables
3. Autofix all usages of deprecated variables

---
Part of https://github.com/github/design-infrastructure/issues/1388