### PR TITLE
Avatar: add alt and src

### DIFF
--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -8,6 +8,10 @@ type StyledAvatarProps = {
   size?: number
   /** Sets the shape of the avatar to a square if true. If false, the avatar will be circular. */
   square?: boolean
+  /** URL of the avatar image. */
+  src: string
+  /** Provide an alt text in case the Avatar is used without the user's name next to it. */
+  alt?: string
 } & SystemCommonProps &
   SxProp
 

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -10,7 +10,7 @@ type StyledAvatarProps = {
   square?: boolean
   /** URL of the avatar image. */
   src: string
-  /** Provide an alt text in case the Avatar is used without the user's name next to it. */
+  /** Provide alt text when the Avatar is used without the user's name next to it. */
   alt?: string
 } & SystemCommonProps &
   SxProp

--- a/src/__tests__/Avatar.tsx
+++ b/src/__tests__/Avatar.tsx
@@ -16,7 +16,7 @@ describe('Avatar', () => {
   })
 
   it('should have no axe violations', async () => {
-    const {container} = HTMLRender(<Avatar />)
+    const {container} = HTMLRender(<Avatar src="primer.png" />)
     const results = await axe(container)
     expect(results).toHaveNoViolations()
     cleanup()
@@ -24,13 +24,13 @@ describe('Avatar', () => {
 
   it('renders small by default', () => {
     const size = 20
-    const result = render(<Avatar alt="" />)
+    const result = render(<Avatar src="primer.png" />)
     expect(result.props.width).toEqual(size)
     expect(result.props.height).toEqual(size)
   })
 
   it('respects the size prop', () => {
-    const result = render(<Avatar size={40} alt="github" />)
+    const result = render(<Avatar size={40} src="primer.png" alt="github" />)
     expect(result.props.width).toEqual(40)
     expect(result.props.height).toEqual(40)
   })
@@ -40,6 +40,6 @@ describe('Avatar', () => {
   })
 
   it('respects margin props', () => {
-    expect(render(<Avatar m={2} alt="" />)).toHaveStyleRule('margin', px(theme.space[2]))
+    expect(render(<Avatar m={2} src="primer.png" alt="" />)).toHaveStyleRule('margin', px(theme.space[2]))
   })
 })


### PR DESCRIPTION
Describe your changes here.

Closes #1405

### Screenshots

before:
![image](https://user-images.githubusercontent.com/1863771/132737236-cc66b4cc-f08b-43f2-b613-63fef0afceb6.png)
after:
![image](https://user-images.githubusercontent.com/1863771/132737181-59ae5f4f-6ba4-4ecc-820f-d748818c6bff.png)

### Worth mentioning

I've made `alt` text optional based on [@alliethu's comment](https://github.com/primer/react/issues/1405#issuecomment-915608230). We set the default value to `""` (empty string) so that screen readers ignore it.

### Room for improvement

1. The default value for `alt` shows up as `-` even though the value is an empty string. This is because we set [`savePropValueAsString`](https://github.com/primer/react/blob/main/docs/gatsby-node.js#L47) which treats `undefined` and `""` the same. It would be interesting to show an explicit empty string as `null` and empty string have different meaning for `alt` ([reference](https://webaim.org/techniques/alttext/#basics) via @alliethu, thx! 👋 )
2. Right now, we don't indicate a prop is required, it would be really nice to have that.
3. The order of props in the documentation is not the same as the order they are defined. It would be nice to control the order

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.