### PR TITLE
Updates avatar stack to remove soft 10 limit

### DIFF
--- a/src/AvatarStack.tsx
+++ b/src/AvatarStack.tsx
@@ -129,11 +129,12 @@ const AvatarStackWrapper = styled.span<StyledAvatarStackWrapperProps>`
   ${sx};
 `
 const transformChildren = (children: React.ReactNode) => {
+  const countOfChildren = React.Children.count(children)
   return React.Children.map(children, (child, index) => {
     if (!React.isValidElement(child)) return child
     return React.cloneElement(child, {
       className: classnames(child.props.className, 'pc-AvatarItem'),
-      sx: {zIndex: 10 - index, ...child.props.sx}
+      sx: {zIndex: countOfChildren - index, ...child.props.sx}
     })
   })
 }


### PR DESCRIPTION
An avatar stack had a limit of 10 avatars, based on a zIndex styling choice. 

This PR updates this component to set the z-indices on avatars in a stack based on the total number of elements it intends to display, and not a hard cap of 10

Closes #1438 

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
