### PR TITLE
Exclude storybook stories from TypeScript compilation for builds

### DIFF
--- a/.changeset/brave-rats-sneeze.md
+++ b/.changeset/brave-rats-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': patch
+---
+
+Exclude storybook stories from TypeScript compilation for builds

--- a/script/build
+++ b/script/build
@@ -13,7 +13,7 @@ npx cross-env BABEL_MODULE=commonjs babel src --out-dir lib --extensions ".js,.t
 npx babel src --out-dir lib-esm --extensions ".js,.ts,.jsx,.tsx"
 
 # Type check
-npx tsc
+npx tsc --project tsconfig.build.json
 
 # Copy type declarations
 npx copyfiles -u 1 "./lib/**/*.d.ts" ./lib-esm

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  // NOTE: We exclude Storybook stories — in part because we don't want their type definitions
+  // included in our build, but also because _something_ in Storybook mucks with the type definitions
+  // of Primer components. See also https://github.com/primer/react/issues/1163.
+  "exclude": ["**/*.stories.tsx"]
+}


### PR DESCRIPTION
In the course of investigating TypeScript type questions with @colebemis, we noticed that building our typedefs with _any_ Storybook story included would lead to some components gaining a css prop in their typedef. E.g., lib/Button/Button.d.ts would include the line:

```
      css?: import("@emotion/core").InterpolationWithTheme<any>;
```

And excluding all stories would give us a build without any `css` props attached to components. This solution should give us clean type defs in our builds while still allowing typechecking of stories. Some caveats:

- There is a possibility that some errors will not be caught until running the build script, which isn't part of most people's workflow, from what I can tell. I suspect these will be rare.
- We still don't know _why_ the optional property became required as it did in the linked bug.
- This bug might only have surfaced with the intersection of multiple factors, and we're removing only one. There might be some other patterns we should still clean up (wild speculation: incorrect typing around PRC components spreading "rest" props on subcomponents)

Closes https://github.com/primer/react/issues/1163

### Screenshots

![image](https://user-images.githubusercontent.com/21195/134082952-736b823f-9221-4fa7-b4de-eac1fe5c62de.png)
😅 

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
