### PR TITLE
Fix item color to not depend on inherit

### DIFF
--- a/.changeset/sixty-jokes-compete.md
+++ b/.changeset/sixty-jokes-compete.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Fix ActionList.Item color

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -146,7 +146,7 @@ const getItemVariant = (variant = 'default', disabled?: boolean) => {
       }
     default:
       return {
-        color: 'inherit',
+        color: get('colors.fg.default'),
         iconColor: get('colors.fg.muted'),
         annotationColor: get('colors.fg.muted'),
         hoverCursor: 'pointer'


### PR DESCRIPTION
In https://github.com/primer/react/pull/1466, we ran into an issue with dropdown menu items inheriting colors wrongly instead of picking up the theme colors.
I could not reproduce it in the storybooks, but look at original issue [here](https://github.com/primer/react/pull/1466#issuecomment-928673630)

You can look at the reproduction here too
https://codesandbox.io/s/upbeat-moore-8mot8?file=/src/App.tsx

![Screenshot (16)](https://user-images.githubusercontent.com/417268/135042313-52f9f8b4-7995-4c83-9f36-3c16c08fb38a.png)


- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Questions

1. Need help to bump primer/react version.
2. Not sure why I can't reproduce this in storybooks.

