### PR TITLE
feat: Focus the primary action in 'ConfirmationDialog', without hacks

### DIFF
--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -117,13 +117,13 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = props => {
   }, [onClose])
   const cancelButton: DialogButtonProps = {
     content: cancelButtonContent,
-    onClick: onCancelButtonClick,
-    autoFocus: true
+    onClick: onCancelButtonClick
   }
   const confirmButton: DialogButtonProps = {
     content: confirmButtonContent,
     buttonType: confirmButtonType,
-    onClick: onConfirmButtonClick
+    onClick: onConfirmButtonClick,
+    autoFocus: true
   }
   const footerButtons = [cancelButton, confirmButton]
   return (

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -1,9 +1,9 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react'
+import React, {useCallback, useRef} from 'react'
 import styled from 'styled-components'
 import Button, {ButtonPrimary, ButtonDanger, ButtonProps} from '../Button'
 import Box from '../Box'
 import {get, SystemCommonProps, SystemPositionProps, COMMON, POSITION} from '../constants'
-import {useOnEscapePress, useProvidedRefOrCreate} from '../hooks'
+import {useOnEscapePress} from '../hooks'
 import {useFocusTrap} from '../hooks/useFocusTrap'
 import sx, {SxProp} from '../sx'
 import StyledOcticon from '../StyledOcticon'
@@ -36,12 +36,6 @@ export type DialogButtonProps = ButtonProps & {
    * focus this button automatically when the dialog appears.
    */
   autoFocus?: boolean
-
-  /**
-   * A reference to the rendered Button’s DOM node, used together with
-   * `autoFocus` for `focusTrap`’s `initialFocus`.
-   */
-  ref?: React.RefObject<HTMLButtonElement>
 }
 
 /**
@@ -351,29 +345,13 @@ const buttonTypes = {
   danger: ButtonDanger
 }
 const Buttons: React.FC<{buttons: DialogButtonProps[]}> = ({buttons}) => {
-  const autoFocusRef = useProvidedRefOrCreate<HTMLButtonElement>(buttons.find(button => button.autoFocus)?.ref)
-  let autoFocusCount = 0
-  const [hasRendered, setHasRendered] = useState(0)
-  useEffect(() => {
-    // hack to work around dialogs originating from other focus traps.
-    if (hasRendered === 1) {
-      autoFocusRef.current?.focus()
-    } else {
-      setHasRendered(hasRendered + 1)
-    }
-  }, [autoFocusRef, hasRendered])
-
   return (
     <>
       {buttons.map((dialogButtonProps, index) => {
-        const {content, buttonType = 'normal', autoFocus = false, ...buttonProps} = dialogButtonProps
+        const {content, buttonType = 'normal', ...buttonProps} = dialogButtonProps
         const ButtonElement = buttonTypes[buttonType]
         return (
-          <ButtonElement
-            key={index}
-            {...buttonProps}
-            ref={autoFocus && autoFocusCount === 0 ? (autoFocusCount++, autoFocusRef) : null}
-          >
+          <ButtonElement key={index} {...buttonProps}>
             {content}
           </ButtonElement>
         )

--- a/src/__tests__/ConfirmationDialog.tsx
+++ b/src/__tests__/ConfirmationDialog.tsx
@@ -1,0 +1,122 @@
+import 'babel-polyfill'
+import {render as HTMLRender, cleanup, act, fireEvent} from '@testing-library/react'
+import {axe, toHaveNoViolations} from 'jest-axe'
+import React, {useCallback, useRef, useState} from 'react'
+
+import {ActionMenu} from '../ActionMenu'
+import BaseStyles from '../BaseStyles'
+import Box from '../Box'
+import Button from '../Button/Button'
+import {ConfirmationDialog, useConfirm} from '../Dialog/ConfirmationDialog'
+import {COMMON, LAYOUT} from '../constants'
+import theme from '../theme'
+import {ThemeProvider} from '../ThemeProvider'
+import {SSRProvider} from '../utils/ssr'
+import {behavesAsComponent, checkExports} from '../utils/testing'
+
+expect.extend(toHaveNoViolations)
+
+const Basic = () => {
+  const [isOpen, setIsOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const onDialogClose = useCallback(() => setIsOpen(false), [])
+  return (
+    <ThemeProvider theme={theme}>
+      <SSRProvider>
+        <BaseStyles>
+          <Button ref={buttonRef} onClick={() => setIsOpen(!isOpen)}>
+            Show dialog
+          </Button>
+          {isOpen && (
+            <ConfirmationDialog
+              title="Confirm"
+              onClose={onDialogClose}
+              cancelButtonContent="Secondary"
+              confirmButtonContent="Primary"
+            >
+              Lorem ipsum dolor sit Pippin good dog.
+            </ConfirmationDialog>
+          )}
+        </BaseStyles>
+      </SSRProvider>
+    </ThemeProvider>
+  )
+}
+
+const ShorthandHookFromActionMenu = () => {
+  const confirm = useConfirm()
+  const [text, setText] = useState('Show menu')
+  const onButtonClick = useCallback(async () => {
+    if (
+      await confirm({
+        title: 'Confirm',
+        content: 'Confirm',
+        cancelButtonContent: 'Secondary',
+        confirmButtonContent: 'Primary'
+      })
+    ) {
+      setText('Confirmed')
+    }
+  }, [confirm])
+  return (
+    <ThemeProvider theme={theme}>
+      <SSRProvider>
+        <BaseStyles>
+          <Box display="flex" flexDirection="column" alignItems="flex-start">
+            <ActionMenu
+              renderAnchor={props => <Button {...props}>{text}</Button>}
+              items={[{text: 'Show dialog', onAction: onButtonClick}]}
+            />
+          </Box>
+        </BaseStyles>
+      </SSRProvider>
+    </ThemeProvider>
+  )
+}
+
+describe('ConfirmationDialog', () => {
+  behavesAsComponent({
+    Component: ConfirmationDialog,
+    systemPropArray: [COMMON, LAYOUT],
+    toRender: () => <Basic />,
+    options: {skipAs: true, skipSx: true}
+  })
+
+  checkExports('Dialog/ConfirmationDialog', {
+    default: undefined,
+    useConfirm,
+    ConfirmationDialog
+  })
+
+  it('should have no axe violations', async () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation()
+    const {container} = HTMLRender(<Basic />)
+    spy.mockRestore()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+    cleanup()
+  })
+
+  it('focuses the primary action when opened', async () => {
+    const {getByText} = HTMLRender(<Basic />)
+    act(() => {
+      fireEvent.click(getByText('Show dialog'))
+    })
+    expect(getByText('Primary')).toEqual(document.activeElement)
+    expect(getByText('Secondary')).not.toEqual(document.activeElement)
+    cleanup()
+  })
+
+  it('supports nested `focusTrap`s', async () => {
+    const {getByText} = HTMLRender(<ShorthandHookFromActionMenu />)
+    act(() => {
+      fireEvent.click(getByText('Show menu'))
+    })
+    act(() => {
+      fireEvent.click(getByText('Show dialog'))
+    })
+    expect(getByText('Primary')).toEqual(document.activeElement)
+    expect(getByText('Secondary')).not.toEqual(document.activeElement)
+    cleanup()
+  })
+})

--- a/src/__tests__/__snapshots__/ConfirmationDialog.tsx.snap
+++ b/src/__tests__/__snapshots__/ConfirmationDialog.tsx.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfirmationDialog renders consistently 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  line-height: 1.5;
+  color: #24292f;
+}
+
+.c1 {
+  position: relative;
+  display: inline-block;
+  padding: 6px 16px;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 20px;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  border-radius: 6px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-align: center;
+  font-size: 14px;
+  color: #24292f;
+  background-color: #f6f8fa;
+  border: 1px solid rgba(27,31,36,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,36,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
+}
+
+.c1:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:disabled {
+  cursor: default;
+}
+
+.c1:disabled svg {
+  opacity: 0.6;
+}
+
+.c1:hover {
+  background-color: #f3f4f6;
+  border-color: rgba(27,31,36,0.15);
+}
+
+.c1:focus {
+  border-color: rgba(27,31,36,0.15);
+  box-shadow: 0 0 0 3px rgba(9,105,218,0.3);
+}
+
+.c1:active {
+  background-color: hsla(220,14%,94%,1);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
+}
+
+.c1:disabled {
+  color: #57606a;
+  background-color: #f6f8fa;
+  border-color: rgba(27,31,36,0.15);
+}
+
+<div
+  className="c0"
+  color="text.primary"
+  data-portal-root={true}
+  fontFamily="normal"
+>
+  <button
+    className="c1"
+    onClick={[Function]}
+  >
+    Show dialog
+  </button>
+</div>
+`;


### PR DESCRIPTION
Alternative to #1471. This PR makes [`focusTrap`’s `initialFocus`](https://github.com/primer/react/blob/ad0d5c6fee8ba31035f5ea1ebf75ba4c9baa52bd/src/behaviors/focusTrap.ts#L82-L84) handle action focus and subsequently removes the (now redundant) [hack in `Dialog.Buttons`](https://github.com/primer/react/blob/ad0d5c6fee8ba31035f5ea1ebf75ba4c9baa52bd/src/Dialog/Dialog.tsx#L345) which previously handled focus.

⚠️ **Warning:** That hack may still be necessary to support cases I did not consider—additional review is appreciated. If we determine the hack is still necessary, please close this PR in favor of #1471.

Fixes https://github.com/github/primer/issues/313

ℹ️ You might wonder–“Why wasn’t moving [the `autoFocus` attribute](https://github.com/primer/react/blob/ad0d5c6fee8ba31035f5ea1ebf75ba4c9baa52bd/src/Dialog/ConfirmationDialog.tsx#L121) from `cancelButton` to `confirmButton` in `ConfirmationDialog.tsx` sufficient?” Great question! I wondered the same thing at first. It turns out that [this special case in `focusTrap`](https://github.com/primer/react/blob/ad0d5c6fee8ba31035f5ea1ebf75ba4c9baa52bd/src/behaviors/focusTrap.ts#L91) causes the primary-action button (`confirmButton`) to receive `tabIndex: -1`, so the secondary-action button (`cancelButton`) still receives focus, even if `autoFocus: true` is moved to `confirmButton`.

### Screenshots

Screen recording demonstrating the primary action is focused when a 'ConfirmationDialog' opens:
![Screen recording demonstrating the primary action is focused when 'ConfirmationDialog' opens](https://user-images.githubusercontent.com/3104489/135106347-771e5baf-3d85-4e85-9d67-7bf54f12eec0.gif)

We generally follow platform conventions, and primary-action-focus is the default in macOS confirmation dialogs (screen recording of Pages below):
![Confirmation dialog in Pages, with the primary action focused by default](https://user-images.githubusercontent.com/3104489/135106959-3248ef4a-1e51-4fe6-9ad9-840ce569fd39.gif)

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
