### PR TITLE
Removes unused `systemPropArray` argument to `behavesAsComponent`

### DIFF
--- a/src/__tests__/ActionList.tsx
+++ b/src/__tests__/ActionList.tsx
@@ -4,7 +4,6 @@ import {axe, toHaveNoViolations} from 'jest-axe'
 import React from 'react'
 import theme from '../theme'
 import {ActionList} from '../ActionList'
-import {COMMON} from '../constants'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {BaseStyles, ThemeProvider} from '..'
 expect.extend(toHaveNoViolations)
@@ -30,7 +29,6 @@ function SimpleActionList(): JSX.Element {
 describe('ActionList', () => {
   behavesAsComponent({
     Component: ActionList,
-    systemPropArray: [COMMON],
     options: {skipAs: true, skipSx: true},
     toRender: () => <ActionList items={[]} />
   })

--- a/src/__tests__/ActionMenu.tsx
+++ b/src/__tests__/ActionMenu.tsx
@@ -4,7 +4,6 @@ import {axe, toHaveNoViolations} from 'jest-axe'
 import React from 'react'
 import theme from '../theme'
 import {ActionMenu} from '../ActionMenu'
-import {COMMON} from '../constants'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {BaseStyles, SSRProvider, ThemeProvider} from '..'
 import {ItemProps} from '../ActionList/Item'
@@ -40,7 +39,6 @@ describe('ActionMenu', () => {
 
   behavesAsComponent({
     Component: ActionMenu,
-    systemPropArray: [COMMON],
     options: {skipAs: true, skipSx: true},
     toRender: () => (
       <SSRProvider>

--- a/src/__tests__/AnchoredOverlay.tsx
+++ b/src/__tests__/AnchoredOverlay.tsx
@@ -57,7 +57,6 @@ const AnchoredOverlayTestComponent = ({
 describe('AnchoredOverlay', () => {
   behavesAsComponent({
     Component: AnchoredOverlay,
-    systemPropArray: [],
     options: {skipAs: true, skipSx: true},
     toRender: () => <AnchoredOverlayTestComponent />
   })

--- a/src/__tests__/Avatar.tsx
+++ b/src/__tests__/Avatar.tsx
@@ -5,11 +5,10 @@ import {px, render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
-import {COMMON} from '../constants'
 expect.extend(toHaveNoViolations)
 
 describe('Avatar', () => {
-  behavesAsComponent({Component: Avatar, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: Avatar})
 
   checkExports('Avatar', {
     default: Avatar

--- a/src/__tests__/AvatarStack.tsx
+++ b/src/__tests__/AvatarStack.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {AvatarStack} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -26,7 +25,7 @@ const rightAvatarComp = (
 )
 
 describe('Avatar', () => {
-  behavesAsComponent({Component: AvatarStack, systemPropArray: [COMMON], toRender: () => avatarComp})
+  behavesAsComponent({Component: AvatarStack, toRender: () => avatarComp})
 
   checkExports('AvatarStack', {
     default: AvatarStack

--- a/src/__tests__/BorderBox.tsx
+++ b/src/__tests__/BorderBox.tsx
@@ -2,14 +2,13 @@ import React from 'react'
 import theme from '../theme'
 import {BorderBox} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {LAYOUT, COMMON, BORDER, FLEX} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('BorderBox', () => {
-  behavesAsComponent({Component: BorderBox, systemPropArray: [LAYOUT, COMMON, BORDER, FLEX]})
+  behavesAsComponent({Component: BorderBox})
 
   checkExports('BorderBox', {
     default: BorderBox

--- a/src/__tests__/Box.tsx
+++ b/src/__tests__/Box.tsx
@@ -3,13 +3,12 @@ import 'babel-polyfill'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import React from 'react'
 import {Box} from '..'
-import {COMMON, FLEX, LAYOUT} from '../constants'
 import theme from '../theme'
 import {behavesAsComponent, checkExports, render} from '../utils/testing'
 expect.extend(toHaveNoViolations)
 
 describe('Box', () => {
-  behavesAsComponent({Component: Box, systemPropArray: [COMMON, LAYOUT, FLEX]})
+  behavesAsComponent({Component: Box})
 
   checkExports('Box', {
     default: Box

--- a/src/__tests__/BranchName.tsx
+++ b/src/__tests__/BranchName.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {BranchName} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('BranchName', () => {
-  behavesAsComponent({Component: BranchName, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: BranchName})
 
   checkExports('BranchName', {
     default: BranchName

--- a/src/__tests__/Breadcrumbs.tsx
+++ b/src/__tests__/Breadcrumbs.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {Breadcrumbs, Breadcrumb} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Breadcrumbs', () => {
-  behavesAsComponent({Component: Breadcrumbs, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: Breadcrumbs})
 
   checkExports('Breadcrumbs', {
     default: Breadcrumbs,

--- a/src/__tests__/BreadcrumbsItem.tsx
+++ b/src/__tests__/BreadcrumbsItem.tsx
@@ -3,12 +3,11 @@ import 'babel-polyfill'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import React from 'react'
 import {Breadcrumbs} from '..'
-import {COMMON} from '../constants'
 import {behavesAsComponent, render} from '../utils/testing'
 expect.extend(toHaveNoViolations)
 
 describe('Breadcrumbs.Item', () => {
-  behavesAsComponent({Component: Breadcrumbs.Item, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: Breadcrumbs.Item})
 
   it('renders an <a> by default', () => {
     expect(render(<Breadcrumbs.Item />).type).toEqual('a')

--- a/src/__tests__/Button.tsx
+++ b/src/__tests__/Button.tsx
@@ -10,7 +10,6 @@ import {
   ButtonTableList
 } from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON, FLEX, LAYOUT, TYPOGRAPHY} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -20,7 +19,7 @@ expect.extend(toHaveNoViolations)
 function noop() {}
 
 describe('Button', () => {
-  behavesAsComponent({Component: Button, systemPropArray: [COMMON, LAYOUT]})
+  behavesAsComponent({Component: Button})
 
   checkExports('Button', {
     default: Button,
@@ -69,7 +68,7 @@ describe('Button', () => {
 })
 
 describe('ButtonPrimary', () => {
-  behavesAsComponent({Component: ButtonPrimary, systemPropArray: [COMMON, LAYOUT]})
+  behavesAsComponent({Component: ButtonPrimary})
 
   it('renders a <button>', () => {
     expect(render(<ButtonPrimary />).type).toEqual('button')
@@ -82,7 +81,7 @@ describe('ButtonPrimary', () => {
 })
 
 describe('ButtonDanger', () => {
-  behavesAsComponent({Component: ButtonDanger, systemPropArray: [COMMON, LAYOUT]})
+  behavesAsComponent({Component: ButtonDanger})
 
   it('renders a <button>', () => {
     expect(render(<ButtonDanger />).type).toEqual('button')
@@ -95,7 +94,7 @@ describe('ButtonDanger', () => {
 })
 
 describe('ButtonOutline', () => {
-  behavesAsComponent({Component: ButtonOutline, systemPropArray: [COMMON, LAYOUT]})
+  behavesAsComponent({Component: ButtonOutline})
 
   it('renders a <button> by default', () => {
     expect(render(<ButtonOutline />).type).toEqual('button')
@@ -108,7 +107,7 @@ describe('ButtonOutline', () => {
 })
 
 describe('ButtonInvisible', () => {
-  behavesAsComponent({Component: ButtonOutline, systemPropArray: [COMMON, LAYOUT]})
+  behavesAsComponent({Component: ButtonOutline})
 
   it('renders a <button> by default', () => {
     expect(render(<ButtonInvisible />).type).toEqual('button')
@@ -121,9 +120,9 @@ describe('ButtonInvisible', () => {
 })
 
 describe('ButtonGroup', () => {
-  behavesAsComponent({Component: ButtonGroup, systemPropArray: [COMMON, FLEX, LAYOUT]})
+  behavesAsComponent({Component: ButtonGroup})
 })
 
 describe('ButtonTableList', () => {
-  behavesAsComponent({Component: ButtonTableList, systemPropArray: [COMMON, TYPOGRAPHY, LAYOUT]})
+  behavesAsComponent({Component: ButtonTableList})
 })

--- a/src/__tests__/CircleBadge.tsx
+++ b/src/__tests__/CircleBadge.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import {CircleBadge} from '..'
 import {CheckIcon} from '@primer/octicons-react'
 import {render, mount, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -13,7 +12,6 @@ const imgInput = <img alt="" src="primer.jpg" />
 describe('CircleBadge', () => {
   behavesAsComponent({
     Component: CircleBadge,
-    systemPropArray: [COMMON],
     toRender: () => <CircleBadge>{imgInput}</CircleBadge>
   })
 
@@ -24,7 +22,6 @@ describe('CircleBadge', () => {
   describe('CircleBadge.Icon', () => {
     behavesAsComponent({
       Component: CircleBadge.Icon,
-      systemPropArray: [COMMON],
       toRender: () => <CircleBadge.Icon icon={CheckIcon} />
     })
   })

--- a/src/__tests__/CircleOcticon.tsx
+++ b/src/__tests__/CircleOcticon.tsx
@@ -3,7 +3,6 @@ import {CheckIcon} from '@primer/octicons-react'
 import theme from '../theme'
 import {CircleOcticon} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON, FLEX, LAYOUT} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -12,7 +11,6 @@ expect.extend(toHaveNoViolations)
 describe('CircleOcticon', () => {
   behavesAsComponent({
     Component: CircleOcticon,
-    systemPropArray: [COMMON, FLEX, LAYOUT],
     toRender: () => <CircleOcticon icon={CheckIcon} />
   })
 

--- a/src/__tests__/CounterLabel.tsx
+++ b/src/__tests__/CounterLabel.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {CounterLabel} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import theme from '../theme'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
@@ -10,7 +9,7 @@ import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('CounterLabel', () => {
-  behavesAsComponent({Component: CounterLabel, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: CounterLabel})
 
   checkExports('CounterLabel', {
     default: CounterLabel

--- a/src/__tests__/Details.tsx
+++ b/src/__tests__/Details.tsx
@@ -2,14 +2,13 @@ import React from 'react'
 import {Details, useDetails, Button, ButtonPrimary, Box} from '..'
 import {ButtonProps} from '../Button/Button'
 import {mount, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Details', () => {
-  behavesAsComponent({Component: Details, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: Details})
 
   checkExports('Details', {
     default: Details

--- a/src/__tests__/Dialog.tsx
+++ b/src/__tests__/Dialog.tsx
@@ -1,6 +1,5 @@
 import React, {useState, useRef} from 'react'
 import {Dialog, Box, Text, Button} from '..'
-import {COMMON, FLEX, LAYOUT} from '../constants'
 import {render as HTMLRender, cleanup, act, fireEvent} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -75,7 +74,6 @@ describe('Dialog', () => {
   // because Dialog returns a React fragment the as and sx tests fail always, so they are skipped
   behavesAsComponent({
     Component: Dialog,
-    systemPropArray: [COMMON, LAYOUT],
     toRender: () => comp,
     options: {skipAs: true, skipSx: true}
   })
@@ -85,7 +83,7 @@ describe('Dialog', () => {
   })
 
   describe('Dialog.Header', () => {
-    behavesAsComponent({Component: Dialog.Header, systemPropArray: [COMMON, FLEX, LAYOUT]})
+    behavesAsComponent({Component: Dialog.Header})
   })
 
   it('should have no axe violations', async () => {

--- a/src/__tests__/Dropdown.tsx
+++ b/src/__tests__/Dropdown.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {Dropdown} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Dropdown', () => {
-  behavesAsComponent({Component: Dropdown, systemPropArray: [COMMON], toRender: () => <Dropdown>Hello!</Dropdown>})
+  behavesAsComponent({Component: Dropdown, toRender: () => <Dropdown>Hello!</Dropdown>})
 
   checkExports('Dropdown', {
     default: Dropdown
@@ -25,7 +24,6 @@ describe('Dropdown', () => {
 describe('Dropdown.Item', () => {
   behavesAsComponent({
     Component: Dropdown.Item,
-    systemPropArray: [COMMON],
     toRender: () => <Dropdown.Item>Hello!</Dropdown.Item>
   })
 })
@@ -33,19 +31,17 @@ describe('Dropdown.Item', () => {
 describe('Dropdown.Button', () => {
   behavesAsComponent({
     Component: Dropdown.Button,
-    systemPropArray: [COMMON],
     toRender: () => <Dropdown.Button>Hello!</Dropdown.Button>
   })
 })
 
 describe('Dropdown.Caret', () => {
-  behavesAsComponent({Component: Dropdown.Caret, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: Dropdown.Caret})
 })
 
 describe('Dropdown.Menu', () => {
   behavesAsComponent({
     Component: Dropdown.Menu,
-    systemPropArray: [COMMON],
     toRender: () => (
       <Dropdown.Menu>
         <li key="a">1</li>

--- a/src/__tests__/DropdownMenu.tsx
+++ b/src/__tests__/DropdownMenu.tsx
@@ -4,7 +4,6 @@ import {axe, toHaveNoViolations} from 'jest-axe'
 import React from 'react'
 import theme from '../theme'
 import {DropdownMenu, DropdownButton} from '../DropdownMenu'
-import {COMMON} from '../constants'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {BaseStyles, ThemeProvider, SSRProvider} from '..'
 import {ItemInput} from '../ActionList/List'
@@ -41,7 +40,6 @@ describe('DropdownMenu', () => {
 
   behavesAsComponent({
     Component: DropdownMenu,
-    systemPropArray: [COMMON],
     options: {skipAs: true, skipSx: true},
     toRender: () => (
       <SSRProvider>

--- a/src/__tests__/FilterList.tsx
+++ b/src/__tests__/FilterList.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {FilterList} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('FilterList', () => {
-  behavesAsComponent({Component: FilterList, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: FilterList})
 
   checkExports('FilterList', {
     default: FilterList

--- a/src/__tests__/FilterListItem.tsx
+++ b/src/__tests__/FilterListItem.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {FilterList} from '..'
 import {render, behavesAsComponent} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('FilterList.Item', () => {
-  behavesAsComponent({Component: FilterList.Item, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: FilterList.Item})
 
   it('should have no axe violations', async () => {
     const {container} = HTMLRender(<FilterList.Item>stuff</FilterList.Item>)

--- a/src/__tests__/FilteredSearch.tsx
+++ b/src/__tests__/FilteredSearch.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {FilteredSearch} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('FilteredSearch', () => {
-  behavesAsComponent({Component: FilteredSearch, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: FilteredSearch})
 
   checkExports('FilteredSearch', {
     default: FilteredSearch

--- a/src/__tests__/Flash.tsx
+++ b/src/__tests__/Flash.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {Flash} from '..'
-import {COMMON} from '../constants'
 import theme from '../theme'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
@@ -9,7 +8,7 @@ import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Flash', () => {
-  behavesAsComponent({Component: Flash, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: Flash})
 
   checkExports('Flash', {
     default: Flash

--- a/src/__tests__/Flex.tsx
+++ b/src/__tests__/Flex.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {Flex} from '..'
-import {COMMON, FLEX, LAYOUT} from '../constants'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
@@ -8,7 +7,7 @@ import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Flex', () => {
-  behavesAsComponent({Component: Flex, systemPropArray: [COMMON, FLEX, LAYOUT]})
+  behavesAsComponent({Component: Flex})
 
   checkExports('Flex', {
     default: Flex

--- a/src/__tests__/FormGroup.tsx
+++ b/src/__tests__/FormGroup.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {FormGroup} from '..'
-import {COMMON, TYPOGRAPHY} from '../constants'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
@@ -8,7 +7,7 @@ import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('FormGroup', () => {
-  behavesAsComponent({Component: FormGroup, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: FormGroup})
 
   checkExports('FormGroup', {
     default: FormGroup
@@ -28,7 +27,7 @@ describe('FormGroup', () => {
 })
 
 describe('FormGroup.Label', () => {
-  behavesAsComponent({Component: FormGroup.Label, systemPropArray: [COMMON, TYPOGRAPHY]})
+  behavesAsComponent({Component: FormGroup.Label})
 
   it('should have no axe violations', async () => {
     const {container} = HTMLRender(<FormGroup.Label htmlFor="example-text">Example text</FormGroup.Label>)

--- a/src/__tests__/Grid.tsx
+++ b/src/__tests__/Grid.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {Grid} from '..'
-import {COMMON, FLEX, LAYOUT, GRID} from '../constants'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
@@ -8,7 +7,7 @@ import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Grid', () => {
-  behavesAsComponent({Component: Grid, systemPropArray: [COMMON, FLEX, LAYOUT, GRID]})
+  behavesAsComponent({Component: Grid})
 
   checkExports('Grid', {
     default: Grid

--- a/src/__tests__/Header.tsx
+++ b/src/__tests__/Header.tsx
@@ -1,25 +1,24 @@
 import React from 'react'
 import {Header} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {BORDER, COMMON, TYPOGRAPHY} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Header', () => {
-  behavesAsComponent({Component: Header, systemPropArray: [COMMON, BORDER]})
+  behavesAsComponent({Component: Header})
 
   checkExports('Header', {
     default: Header
   })
 
   describe('Header.Item', () => {
-    behavesAsComponent({Component: Header.Item, systemPropArray: [COMMON, BORDER]})
+    behavesAsComponent({Component: Header.Item})
   })
 
   describe('Header.Link', () => {
-    behavesAsComponent({Component: Header.Link, systemPropArray: [COMMON, BORDER, TYPOGRAPHY]})
+    behavesAsComponent({Component: Header.Link})
   })
 
   it('should have no axe violations', async () => {

--- a/src/__tests__/Heading.tsx
+++ b/src/__tests__/Heading.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {Heading} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {TYPOGRAPHY, COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -31,7 +30,7 @@ const theme = {
 }
 
 describe('Heading', () => {
-  behavesAsComponent({Component: Heading, systemPropArray: [COMMON, TYPOGRAPHY]})
+  behavesAsComponent({Component: Heading})
 
   checkExports('Heading', {
     default: Heading

--- a/src/__tests__/Label.tsx
+++ b/src/__tests__/Label.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {Label} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Label', () => {
-  behavesAsComponent({Component: Label, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: Label})
 
   checkExports('Label', {
     default: Label

--- a/src/__tests__/LabelGroup.tsx
+++ b/src/__tests__/LabelGroup.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {LabelGroup, Label} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -16,7 +15,7 @@ const comp = (
 )
 
 describe('LabelGroup', () => {
-  behavesAsComponent({Component: LabelGroup, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: LabelGroup})
 
   checkExports('LabelGroup', {
     default: LabelGroup

--- a/src/__tests__/Link.tsx
+++ b/src/__tests__/Link.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {Link} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON, TYPOGRAPHY} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Link', () => {
-  behavesAsComponent({Component: Link, systemPropArray: [COMMON, TYPOGRAPHY]})
+  behavesAsComponent({Component: Link})
 
   checkExports('Link', {
     default: Link

--- a/src/__tests__/Pagehead.tsx
+++ b/src/__tests__/Pagehead.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {Pagehead} from '..'
-import {COMMON} from '../constants'
 import theme from '../theme'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
@@ -9,7 +8,7 @@ import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Pagehead', () => {
-  behavesAsComponent({Component: Pagehead, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: Pagehead})
 
   checkExports('Pagehead', {
     default: Pagehead

--- a/src/__tests__/Pagination/Pagination.tsx
+++ b/src/__tests__/Pagination/Pagination.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Pagination from '../../Pagination'
 import {behavesAsComponent} from '../../utils/testing'
-import {COMMON} from '../../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -11,7 +10,7 @@ const reqProps = {pageCount: 10, currentPage: 1}
 const comp = <Pagination {...reqProps} />
 
 describe('Pagination', () => {
-  behavesAsComponent({Component: Pagination, systemPropArray: [COMMON], toRender: () => comp})
+  behavesAsComponent({Component: Pagination, toRender: () => comp})
 
   it('should have no axe violations', async () => {
     const {container} = HTMLRender(comp)

--- a/src/__tests__/PointerBox.tsx
+++ b/src/__tests__/PointerBox.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {PointerBox} from '..'
-import {COMMON, LAYOUT, BORDER, FLEX} from '../constants'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
@@ -8,7 +7,7 @@ import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('PointerBox', () => {
-  behavesAsComponent({Component: PointerBox, systemPropArray: [COMMON, LAYOUT, BORDER, FLEX]})
+  behavesAsComponent({Component: PointerBox})
 
   checkExports('PointerBox', {
     default: PointerBox

--- a/src/__tests__/Popover.tsx
+++ b/src/__tests__/Popover.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Popover, {PopoverProps} from '../Popover'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {BORDER, COMMON, LAYOUT, POSITION} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -14,14 +13,14 @@ const comp = (
 )
 
 describe('Popover', () => {
-  behavesAsComponent({Component: Popover, systemPropArray: [COMMON, LAYOUT, POSITION], toRender: () => comp})
+  behavesAsComponent({Component: Popover, toRender: () => comp})
 
   checkExports('Popover', {
     default: Popover
   })
 
   describe('Popover.Content', () => {
-    behavesAsComponent({Component: Popover.Content, systemPropArray: [COMMON, LAYOUT, BORDER], toRender: () => comp})
+    behavesAsComponent({Component: Popover.Content, toRender: () => comp})
   })
 
   it('should have no axe violations', async () => {

--- a/src/__tests__/Position.tsx
+++ b/src/__tests__/Position.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import {LAYOUT, POSITION} from '../constants'
 import {Box, Position, Absolute, Fixed, Relative, Sticky} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
@@ -9,7 +8,7 @@ expect.extend(toHaveNoViolations)
 
 describe('position components', () => {
   describe('Absolute', () => {
-    behavesAsComponent({Component: Absolute, systemPropArray: [LAYOUT, POSITION]})
+    behavesAsComponent({Component: Absolute})
 
     checkExports('Position', {
       default: Position,
@@ -41,7 +40,7 @@ describe('position components', () => {
   })
 
   describe('Fixed', () => {
-    behavesAsComponent({Component: Fixed, systemPropArray: [LAYOUT, POSITION]})
+    behavesAsComponent({Component: Fixed})
 
     it('respects the "as" prop', () => {
       expect(render(<Fixed as="span" />).type).toEqual('span')
@@ -69,7 +68,7 @@ describe('position components', () => {
   })
 
   describe('Relative', () => {
-    behavesAsComponent({Component: Relative, systemPropArray: [LAYOUT, POSITION]})
+    behavesAsComponent({Component: Relative})
 
     it('should have no axe violations', async () => {
       const {container} = HTMLRender(<Relative />)
@@ -93,7 +92,7 @@ describe('position components', () => {
   })
 
   describe('Sticky', () => {
-    behavesAsComponent({Component: Sticky, systemPropArray: [LAYOUT, POSITION]})
+    behavesAsComponent({Component: Sticky})
 
     it('should have no axe violations', async () => {
       const {container} = HTMLRender(<Sticky />)

--- a/src/__tests__/ProgressBar.tsx
+++ b/src/__tests__/ProgressBar.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {ProgressBar} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('ProgressBar', () => {
-  behavesAsComponent({Component: ProgressBar, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: ProgressBar})
 
   checkExports('ProgressBar', {
     default: ProgressBar

--- a/src/__tests__/SelectPanel.tsx
+++ b/src/__tests__/SelectPanel.tsx
@@ -4,7 +4,6 @@ import {axe, toHaveNoViolations} from 'jest-axe'
 import React from 'react'
 import theme from '../theme'
 import {SelectPanel} from '../SelectPanel'
-import {COMMON} from '../constants'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {BaseStyles, SSRProvider, ThemeProvider} from '..'
 import {ItemInput} from '../ActionList/List'
@@ -46,7 +45,6 @@ describe('SelectPanel', () => {
 
   behavesAsComponent({
     Component: SelectPanel,
-    systemPropArray: [COMMON],
     options: {skipAs: true, skipSx: true},
     toRender: () => <SimpleSelectPanel />
   })

--- a/src/__tests__/SideNav.tsx
+++ b/src/__tests__/SideNav.tsx
@@ -1,21 +1,20 @@
 import React from 'react'
 import {SideNav} from '..'
 import {render, behavesAsComponent, mount, checkExports} from '../utils/testing'
-import {BORDER, COMMON, LAYOUT, FLEX, TYPOGRAPHY} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('SideNav', () => {
-  behavesAsComponent({Component: SideNav, systemPropArray: [BORDER, LAYOUT, COMMON, FLEX]})
+  behavesAsComponent({Component: SideNav})
 
   checkExports('SideNav', {
     default: SideNav
   })
 
   describe('SideNav.Link', () => {
-    behavesAsComponent({Component: SideNav.Link, systemPropArray: [COMMON, TYPOGRAPHY]})
+    behavesAsComponent({Component: SideNav.Link})
   })
 
   it('should have no axe violations', async () => {

--- a/src/__tests__/Spinner.tsx
+++ b/src/__tests__/Spinner.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {Spinner, SpinnerProps} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -13,8 +12,7 @@ describe('Spinner', () => {
   })
 
   behavesAsComponent({
-    Component: Spinner,
-    systemPropArray: [COMMON]
+    Component: Spinner
   })
 
   checkExports('Spinner', {

--- a/src/__tests__/StateLabel.tsx
+++ b/src/__tests__/StateLabel.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {StateLabel} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -11,7 +10,6 @@ expect.extend(toHaveNoViolations)
 describe('StateLabel', () => {
   behavesAsComponent({
     Component: StateLabel,
-    systemPropArray: [COMMON],
     toRender: () => <StateLabel status="issueOpened">Open</StateLabel>,
     options: {
       // Rendering a StyledOcticon seems to break getComputedStyles, which

--- a/src/__tests__/StyledOcticon.tsx
+++ b/src/__tests__/StyledOcticon.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import {XIcon} from '@primer/octicons-react'
 import {StyledOcticon} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -11,7 +10,6 @@ expect.extend(toHaveNoViolations)
 describe('StyledOcticon', () => {
   behavesAsComponent({
     Component: StyledOcticon,
-    systemPropArray: [COMMON],
     toRender: () => <StyledOcticon icon={XIcon} />
   })
 

--- a/src/__tests__/SubNav.tsx
+++ b/src/__tests__/SubNav.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {SubNav} from '..'
 import {mount, render, rendersClass, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('SubNav', () => {
-  behavesAsComponent({Component: SubNav, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: SubNav})
 
   checkExports('SubNav', {
     default: SubNav

--- a/src/__tests__/SubNavLink.tsx
+++ b/src/__tests__/SubNavLink.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {SubNav} from '..'
-import {COMMON} from '../constants'
 import {render, behavesAsComponent} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
@@ -8,7 +7,7 @@ import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('SubNav.Link', () => {
-  behavesAsComponent({Component: SubNav.Link, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: SubNav.Link})
 
   it('renders an <a> by default', () => {
     expect(render(<SubNav.Link />).type).toEqual('a')

--- a/src/__tests__/TabNav.tsx
+++ b/src/__tests__/TabNav.tsx
@@ -1,21 +1,20 @@
 import React from 'react'
 import {TabNav} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('TabNav', () => {
-  behavesAsComponent({Component: TabNav, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: TabNav})
 
   checkExports('TabNav', {
     default: TabNav
   })
 
   describe('TabNav.Link', () => {
-    behavesAsComponent({Component: TabNav.Link, systemPropArray: [COMMON]})
+    behavesAsComponent({Component: TabNav.Link})
   })
 
   it('should have no axe violations', async () => {

--- a/src/__tests__/Text.tsx
+++ b/src/__tests__/Text.tsx
@@ -2,14 +2,13 @@ import React from 'react'
 import {Text} from '..'
 import theme from '../theme'
 import {px, render, renderStyles, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON, TYPOGRAPHY} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Text', () => {
-  behavesAsComponent({Component: Text, systemPropArray: [COMMON, TYPOGRAPHY]})
+  behavesAsComponent({Component: Text})
 
   checkExports('Text', {
     default: Text

--- a/src/__tests__/TextInput.tsx
+++ b/src/__tests__/TextInput.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {TextInput} from '..'
 import {render, mount, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('TextInput', () => {
-  behavesAsComponent({Component: TextInput, systemPropArray: [COMMON], options: {skipAs: true}})
+  behavesAsComponent({Component: TextInput, options: {skipAs: true}})
 
   checkExports('TextInput', {
     default: TextInput

--- a/src/__tests__/Timeline.tsx
+++ b/src/__tests__/Timeline.tsx
@@ -1,6 +1,5 @@
 import 'babel-polyfill'
 
-import {COMMON, FLEX, LAYOUT} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import {render, rendersClass, behavesAsComponent, checkExports} from '../utils/testing'
@@ -10,7 +9,7 @@ import {Timeline} from '..'
 expect.extend(toHaveNoViolations)
 
 describe('Timeline', () => {
-  behavesAsComponent({Component: Timeline, systemPropArray: [COMMON, FLEX, LAYOUT]})
+  behavesAsComponent({Component: Timeline})
 
   checkExports('Timeline', {
     default: Timeline
@@ -29,7 +28,7 @@ describe('Timeline', () => {
 })
 
 describe('Timeline.Item', () => {
-  behavesAsComponent({Component: Timeline.Item, systemPropArray: [COMMON, FLEX, LAYOUT]})
+  behavesAsComponent({Component: Timeline.Item})
 
   it('should have no axe violations', async () => {
     const {container} = HTMLRender(<Timeline.Item />)
@@ -48,7 +47,7 @@ describe('Timeline.Item', () => {
 })
 
 describe('Timeline.Badge', () => {
-  behavesAsComponent({Component: Timeline.Badge, systemPropArray: [COMMON, LAYOUT], options: {skipAs: true}})
+  behavesAsComponent({Component: Timeline.Badge, options: {skipAs: true}})
 
   it('should have no axe violations', async () => {
     const {container} = HTMLRender(<Timeline.Badge />)

--- a/src/__tests__/Tooltip.tsx
+++ b/src/__tests__/Tooltip.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import Tooltip, {TooltipProps} from '../Tooltip'
 import {render, renderClasses, rendersClass, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('Tooltip', () => {
-  behavesAsComponent({Component: Tooltip, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: Tooltip})
 
   checkExports('Tooltip', {
     default: Tooltip

--- a/src/__tests__/Truncate.tsx
+++ b/src/__tests__/Truncate.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {Truncate} from '..'
-import {COMMON, TYPOGRAPHY} from '../constants'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
@@ -10,7 +9,6 @@ expect.extend(toHaveNoViolations)
 describe('Truncate', () => {
   behavesAsComponent({
     Component: Truncate,
-    systemPropArray: [COMMON, TYPOGRAPHY],
     toRender: () => <Truncate title="a-long-branch-name" />
   })
 

--- a/src/__tests__/UnderlineNav.tsx
+++ b/src/__tests__/UnderlineNav.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import {UnderlineNav} from '..'
 import {mount, render, rendersClass, behavesAsComponent, checkExports} from '../utils/testing'
-import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('UnderlineNav', () => {
-  behavesAsComponent({Component: UnderlineNav, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: UnderlineNav})
 
   checkExports('UnderlineNav', {
     default: UnderlineNav

--- a/src/__tests__/UnderlineNavLink.tsx
+++ b/src/__tests__/UnderlineNavLink.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {UnderlineNav} from '..'
-import {COMMON} from '../constants'
 import {render, behavesAsComponent} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
@@ -8,7 +7,7 @@ import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
 describe('UnderlineNav.Link', () => {
-  behavesAsComponent({Component: UnderlineNav.Link, systemPropArray: [COMMON]})
+  behavesAsComponent({Component: UnderlineNav.Link})
 
   it('renders an <a> by default', () => {
     expect(render(<UnderlineNav.Link />).type).toEqual('a')

--- a/src/utils/testing.tsx
+++ b/src/utils/testing.tsx
@@ -200,7 +200,6 @@ interface Options {
 interface BehavesAsComponent {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Component: React.ComponentType<any>
-  systemPropArray: unknown[]
   toRender?: () => React.ReactElement
   options?: Options
 }


### PR DESCRIPTION
This argument wasn't being used.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
