### PR TITLE
Consolidate storybook colormode change options to just the dayScheme

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,9 +10,9 @@ const GlobalStyle = createGlobalStyle`
   }
 `
 export const globalTypes = {
-  colorMode: {
-    name: 'Day color scheme',
-    description: 'Day color scheme',
+  colorScheme: {
+    name: 'Color scheme',
+    description: 'Color scheme',
     defaultValue: 'light',
     toolbar: {
       icon: 'circlehollow',
@@ -25,7 +25,7 @@ export const globalTypes = {
 // context.globals.X references items in globalTypes
 const withThemeProvider = (Story, context) => {
   return (
-    <ThemeProvider colorMode={'day'} dayScheme={context.globals.colorMode} nightScheme={'dark'}>
+    <ThemeProvider colorMode={'day'} dayScheme={context.globals.colorScheme}>
       <GlobalStyle />
       <Story {...context} />
     </ThemeProvider>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -11,32 +11,11 @@ const GlobalStyle = createGlobalStyle`
 `
 export const globalTypes = {
   colorMode: {
-    name: 'Color mode',
-    description: 'Color mode (day, night, auto)',
-    defaultValue: 'day',
-    toolbar: {
-      icon: 'paintbrush',
-      // array of colorMode items
-      items: ['day', 'night', 'auto'],
-      showName: true
-    }
-  },
-  dayScheme: {
     name: 'Day color scheme',
     description: 'Day color scheme',
     defaultValue: 'light',
     toolbar: {
       icon: 'circlehollow',
-      items: Object.keys(theme.colorSchemes),
-      showName: true
-    }
-  },
-  nightScheme: {
-    name: 'Night color scheme',
-    description: 'Night color scheme',
-    defaultValue: 'dark',
-    toolbar: {
-      icon: 'circle',
       items: Object.keys(theme.colorSchemes),
       showName: true
     }
@@ -46,11 +25,7 @@ export const globalTypes = {
 // context.globals.X references items in globalTypes
 const withThemeProvider = (Story, context) => {
   return (
-    <ThemeProvider
-      colorMode={context.globals.colorMode}
-      dayScheme={context.globals.dayScheme}
-      nightScheme={context.globals.nightScheme}
-    >
+    <ThemeProvider colorMode={'day'} dayScheme={context.globals.colorMode} nightScheme={'dark'}>
       <GlobalStyle />
       <Story {...context} />
     </ThemeProvider>


### PR DESCRIPTION
Storybook change: Consolidate storybook colormode change options to just the dayScheme

Closes # https://github.com/github/primer/issues/325

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
