### PR TITLE
Adapt to right aligned items in live preview wrapper

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
@@ -1,13 +1,12 @@
 import {BaseStyles, Box, ThemeProvider, useTheme, DropdownMenu, DropdownButton} from '@primer/components'
 import React from 'react'
 
-function ThemeSwitcher({setIsDropdownOpen}) {
+function ThemeSwitcher() {
   const {theme, dayScheme, setDayScheme} = useTheme()
   const items = Object.keys(theme.colorSchemes).map(scheme => ({text: scheme.replace(/_/g, ' '), key: scheme}))
   const selectedItem = React.useMemo(() => items.find(item => item.key === dayScheme), [items, dayScheme])
   return (
     <DropdownMenu
-      onOpenChange={setIsDropdownOpen}
       renderAnchor={({children, ...anchorProps}) => (
         <DropdownButton variant="small" {...anchorProps}>
           {children}
@@ -25,21 +24,9 @@ function ThemeSwitcher({setIsDropdownOpen}) {
 // Users can shadow this file to wrap live previews.
 // This is useful for applying global styles.
 function LivePreviewWrapper({children}) {
-  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false)
-  const [showSwitcher, setShowSwitcher] = React.useState(false)
   return (
     <ThemeProvider>
       <Box
-        tabIndex="0"
-        onFocusCapture={() => {
-          setShowSwitcher(true)
-        }}
-        onMouseEnter={() => {
-          setShowSwitcher(true)
-        }}
-        onMouseLeave={() => {
-          !isDropdownOpen && setShowSwitcher(false)
-        }}
         width="100%"
         bg="canvas.default"
         position="relative"
@@ -48,8 +35,8 @@ function LivePreviewWrapper({children}) {
         <Box p={3} sx={{flexGrow: 1}}>
           <BaseStyles>{children}</BaseStyles>
         </Box>
-        <Box p={2} display={showSwitcher ? '' : 'none'}>
-          <ThemeSwitcher setIsDropdownOpen={setIsDropdownOpen} />
+        <Box p={2}>
+          <ThemeSwitcher />
         </Box>
       </Box>
     </ThemeProvider>

--- a/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
@@ -43,13 +43,13 @@ function LivePreviewWrapper({children}) {
         width="100%"
         bg="canvas.default"
         position="relative"
-        sx={{borderTopLeftRadius: 2, borderTopRightRadius: 2}}
+        sx={{borderTopLeftRadius: 2, borderTopRightRadius: 2, display: 'flex'}}
       >
-        <Box p={2} display={showSwitcher ? '' : 'none'} zIndex="1" position="absolute" top="0" right="0">
-          <ThemeSwitcher setIsDropdownOpen={setIsDropdownOpen} />
-        </Box>
-        <Box p={3}>
+        <Box p={3} sx={{flexGrow: 1}}>
           <BaseStyles>{children}</BaseStyles>
+        </Box>
+        <Box p={2} display={showSwitcher ? '' : 'none'}>
+          <ThemeSwitcher setIsDropdownOpen={setIsDropdownOpen} />
         </Box>
       </Box>
     </ThemeProvider>


### PR DESCRIPTION
First of all, congratulations @pksjce on your great work with #1466! Just fixing a small visual bug I noticed with elements that either take the whole space or are right aligned (such as ``AvatarStack``).

### Screenshots

Before:

![before](https://user-images.githubusercontent.com/2181866/135708240-d679feb1-b758-4e08-9c47-bb87de025c24.gif)

After:

![after](https://user-images.githubusercontent.com/2181866/135708243-6346a9ec-fb1b-4fbd-9692-aec8f6dca852.gif)

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

