### PR TITLE
FilteredActionList inherits height and maxHeight from its parent

### DIFF
--- a/.changeset/slow-badgers-relate.md
+++ b/.changeset/slow-badgers-relate.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': patch
+---
+
+Fixed a bug where SelectPanel would not scroll with height:'auto'; maxHeight:'medium' passed to Overlay (https://github.com/github/primer/issues/333)

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -120,7 +120,7 @@ export function FilteredActionList({
   useScrollFlash(scrollContainerRef)
 
   return (
-    <Box display="flex" flexDirection="column" overflow="hidden">
+    <Box display="flex" flexDirection="column" overflow="hidden" height="inherit" maxHeight="inherit">
       <StyledHeader>
         <TextInput
           ref={inputRef}

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -6,7 +6,6 @@ import {FocusZoneHookSettings} from '../hooks/useFocusZone'
 import {DropdownButton} from '../DropdownMenu'
 import {ItemProps} from '../ActionList'
 import {AnchoredOverlay, AnchoredOverlayProps} from '../AnchoredOverlay'
-import Box from '../Box'
 import {TextInputProps} from '../TextInput'
 import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
 import {AnchoredOverlayWrapperAnchorProps} from '../AnchoredOverlay/AnchoredOverlay'
@@ -153,18 +152,16 @@ export function SelectPanel({
       focusTrapSettings={focusTrapSettings}
       focusZoneSettings={focusZoneSettings}
     >
-      <Box display="flex" flexDirection="column" width="100%" height="100%">
-        <FilteredActionList
-          filterValue={filterValue}
-          onFilterChange={onFilterChange}
-          {...listProps}
-          role="listbox"
-          items={itemsToRender}
-          selectionVariant={isMultiSelectVariant(selected) ? 'multiple' : 'single'}
-          textInputProps={extendedTextInputProps}
-          inputRef={inputRef}
-        />
-      </Box>
+      <FilteredActionList
+        filterValue={filterValue}
+        onFilterChange={onFilterChange}
+        {...listProps}
+        role="listbox"
+        items={itemsToRender}
+        selectionVariant={isMultiSelectVariant(selected) ? 'multiple' : 'single'}
+        textInputProps={extendedTextInputProps}
+        inputRef={inputRef}
+      />
     </AnchoredOverlay>
   )
 }

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -298,3 +298,56 @@ export function SelectPanelAboveTallBody(): JSX.Element {
   )
 }
 SelectPanelAboveTallBody.storyName = 'SelectPanel, Above a Tall Body'
+
+export function SelectPanelHeightAndScroll(): JSX.Element {
+  const longItems = [...items, ...items, ...items, ...items, ...items, ...items, ...items, ...items]
+  const [selectedA, setSelectedA] = React.useState<ItemInput | undefined>(longItems[0])
+  const [selectedB, setSelectedB] = React.useState<ItemInput | undefined>(longItems[0])
+  const [filter, setFilter] = React.useState('')
+  const filteredItems = longItems.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
+  const [openA, setOpenA] = useState(false)
+  const [openB, setOpenB] = useState(false)
+
+  return (
+    <>
+      <h2>With height:medium</h2>
+      <SelectPanel
+        renderAnchor={({children, 'aria-labelledby': ariaLabelledBy, ...anchorProps}) => (
+          <DropdownButton aria-labelledby={` ${ariaLabelledBy}`} {...anchorProps}>
+            {children ?? 'Select Labels'}
+          </DropdownButton>
+        )}
+        placeholderText="Filter Labels"
+        open={openA}
+        onOpenChange={setOpenA}
+        items={filteredItems}
+        selected={selectedA}
+        onSelectedChange={setSelectedA}
+        onFilterChange={setFilter}
+        showItemDividers={true}
+        overlayProps={{height: 'medium'}}
+      />
+      <h2>With height:auto, maxheight:medium</h2>
+      <SelectPanel
+        renderAnchor={({children, 'aria-labelledby': ariaLabelledBy, ...anchorProps}) => (
+          <DropdownButton aria-labelledby={` ${ariaLabelledBy}`} {...anchorProps}>
+            {children ?? 'Select Labels'}
+          </DropdownButton>
+        )}
+        placeholderText="Filter Labels"
+        open={openB}
+        onOpenChange={setOpenB}
+        items={filteredItems}
+        selected={selectedB}
+        onSelectedChange={setSelectedB}
+        onFilterChange={setFilter}
+        showItemDividers={true}
+        overlayProps={{
+          height: 'auto',
+          maxHeight: 'medium'
+        }}
+      />
+    </>
+  )
+}
+SelectPanelHeightAndScroll.storyName = 'SelectPanel, Height and Scroll'


### PR DESCRIPTION
This PR updates `FilteredActionList` so that its root HTML element is styled with `height: inherit; max-height: inherit`. This prevents [a bug](https://github.com/github/primer/issues/333) where `FilteredActionList` sizes itself larger than the `Overlay` that contains it, preventing scrolling.

Closes https://github.com/github/primer/issues/333

### Screenshots

before:

https://user-images.githubusercontent.com/21195/135500609-79855ea8-be0e-40e9-80bd-2cf4a58e89d7.mp4

after:

https://user-images.githubusercontent.com/21195/136087446-d0f6b3a9-516b-42d0-9e58-acd7c79f8460.mp4

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
