### PR TITLE
Remove hover behaviour and position above live preview for theme switcher

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
@@ -1,13 +1,12 @@
 import {BaseStyles, Box, ThemeProvider, useTheme, DropdownMenu, DropdownButton} from '@primer/components'
 import React from 'react'
 
-function ThemeSwitcher({setIsDropdownOpen}) {
+function ThemeSwitcher() {
   const {theme, dayScheme, setDayScheme} = useTheme()
   const items = Object.keys(theme.colorSchemes).map(scheme => ({text: scheme.replace(/_/g, ' '), key: scheme}))
   const selectedItem = React.useMemo(() => items.find(item => item.key === dayScheme), [items, dayScheme])
   return (
     <DropdownMenu
-      onOpenChange={setIsDropdownOpen}
       renderAnchor={({children, ...anchorProps}) => (
         <DropdownButton variant="small" {...anchorProps}>
           {children}
@@ -25,28 +24,11 @@ function ThemeSwitcher({setIsDropdownOpen}) {
 // Users can shadow this file to wrap live previews.
 // This is useful for applying global styles.
 function LivePreviewWrapper({children}) {
-  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false)
-  const [showSwitcher, setShowSwitcher] = React.useState(false)
   return (
     <ThemeProvider>
-      <Box
-        tabIndex="0"
-        onFocusCapture={() => {
-          setShowSwitcher(true)
-        }}
-        onMouseEnter={() => {
-          setShowSwitcher(true)
-        }}
-        onMouseLeave={() => {
-          !isDropdownOpen && setShowSwitcher(false)
-        }}
-        width="100%"
-        bg="canvas.default"
-        position="relative"
-        sx={{borderTopLeftRadius: 2, borderTopRightRadius: 2}}
-      >
-        <Box p={2} display={showSwitcher ? '' : 'none'} zIndex="1" position="absolute" top="0" right="0">
-          <ThemeSwitcher setIsDropdownOpen={setIsDropdownOpen} />
+      <Box width="100%" bg="canvas.default" sx={{borderTopLeftRadius: 2, borderTopRightRadius: 2}}>
+        <Box p={2} display="flex" justifyContent="flex-end">
+          <ThemeSwitcher />
         </Box>
         <Box p={3}>
           <BaseStyles>{children}</BaseStyles>


### PR DESCRIPTION
Based on feedback I have 
- removed all the hover behaviour. This makes sure that the switcher is easily discoverable and there are no accessibility issues.
- positioned it above the live preview. This is so that the switcher does not obstruct any of the components.

In the future, we want to have theme switcher for the whole documentation site, but that is right now not possible because doctocat is not completely compatible with our themes.

### Screenshots


https://user-images.githubusercontent.com/417268/136175571-cdc3fbc2-1cef-4613-95d5-e5bc176d964f.mov



### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
