### PR TITLE
Check for changesets 

### DIFF
--- a/.github/workflows/check_for_changeset.yml
+++ b/.github/workflows/check_for_changeset.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           file-pattern: ".changeset/*.md"
           skip-label: "skip changeset"
-          failure-message: "No changeset found. If these changes should result in a version bump, please add a changeset (https://git.io/J6QvQ). If these changes should not result in a new version, apply the ${skip-label} label to this pull request. "
+          failure-message: "No changeset found. If these changes should not result in a new version, apply the ${skip-label} label to this pull request. If these changes should result in a version bump, please add a changeset https://git.io/J6QvQ"


### PR DESCRIPTION
## Problem

It's easy to accidentally merge pull requests that are missing [changesets](https://github.com/atlassian/changesets/blob/main/docs/adding-a-changeset.md). Pull requests merged without changesets won't be included in the release notes for the next release. 

## Solution

I added a GitHub Actions workflow that will fail if no changeset is found in a PR. If a changeset was intentionally not included (because the PR shouldn't cause a version bump), we can add the `skip changeset` label.

This will prevent us from accidentally merging pull requests without changesets.
