### PR TITLE
Adds a note to docs about using theme instances other than the ThemeContext's theme

### DIFF
--- a/docs/content/theming.md
+++ b/docs/content/theming.md
@@ -54,7 +54,7 @@ You can reference theme values in your application using [system props](/system-
 
 <Note variant="warning">
 
-Only use `theme` objects accessed via Primer's theme context to ensure your application’s styling draws from the same theme as Primer Components’ internal styling. The `sx` prop, styled system props, and `themeGet` all use the theme from context.
+Only use `theme` objects accessed via Primer's theme context to ensure your application’s styling draws from the same theme as Primer components’ internal styling. The `sx` prop, styled system props, `themeGet`, and `useTheme` all use the theme from context.
 
 <DoDontContainer>
   <Do>


### PR DESCRIPTION
Adds a note about a pattern I've seen in a few places.

### Screenshots

<img width="1036" alt="CleanShot 2021-10-28 at 12 34 57@2x" src="https://user-images.githubusercontent.com/21195/139323445-7ffe8e37-513a-4052-a546-7735dc5a68f3.png">

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
