### PR TITLE
Fix auxiliaryText in ActionList/Header.tsx

### DIFF
--- a/.changeset/quick-ducks-camp.md
+++ b/.changeset/quick-ducks-camp.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Fix `auxiliaryText` in ActionList Group header

--- a/src/ActionList/Header.tsx
+++ b/src/ActionList/Header.tsx
@@ -68,7 +68,7 @@ export function Header({
   return (
     <StyledHeader role="heading" variant={variant} {...props}>
       {title}
-      {auxiliaryText && <span>auxiliaryText</span>}
+      {auxiliaryText && <span>{auxiliaryText}</span>}
     </StyledHeader>
   )
 }


### PR DESCRIPTION
the auxiliaryText property are not displayed due to missing curly braces

Describe your changes here.

Closes # (type the issue number after # if applicable; otherwise remove this line)

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
