### PR TITLE
Ensure that the build script returns an error code when a subcommand fails

### DIFF
--- a/script/build
+++ b/script/build
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Clean up
 rm -rf dist
 rm -rf lib


### PR DESCRIPTION
I noticed today that `npx tsc` was failing on main for me. I believe the reason this wasn't caught in CI is because our build script was not surfacing errors in its subcommand.

This PR is going to fail CI until a couple TypeScript errors get fixed. That's how we know it's working! I'll try to address those issues in separate PRs.

[Here's documentation](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html) for `set`.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
