### PR TITLE
"fixes" a tsc error. Adds ts-toolbelt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/components",
-  "version": "31.0.1",
+  "version": "31.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/components",
-      "version": "31.0.1",
+      "version": "31.1.0",
       "license": "MIT",
       "dependencies": {
         "@primer/octicons-react": "^13.0.0",
@@ -100,6 +100,7 @@
         "size-limit": "5.0.2",
         "storybook-addon-performance": "0.16.1",
         "styled-components": "4.4.1",
+        "ts-toolbelt": "9.6.0",
         "typescript": "4.2.2"
       },
       "peerDependencies": {
@@ -35601,6 +35602,12 @@
         }
       }
     },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "dev": true
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -64791,6 +64798,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
+      "dev": true
+    },
+    "ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
       "dev": true
     },
     "tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "size-limit": "5.0.2",
     "storybook-addon-performance": "0.16.1",
     "styled-components": "4.4.1",
+    "ts-toolbelt": "9.6.0",
     "typescript": "4.2.2"
   },
   "peerDependencies": {

--- a/src/__tests__/KeyPaths.types.test.ts
+++ b/src/__tests__/KeyPaths.types.test.ts
@@ -1,3 +1,4 @@
+import {Union} from 'ts-toolbelt'
 import {KeyPaths} from '../utils/types/KeyPaths'
 
 type NestedObject = {
@@ -8,6 +9,6 @@ type NestedObject = {
   }
 }
 
-export function generatesKeyPathsFromObject(x: KeyPaths<NestedObject>): 'a' | 'b.b1' | 'b.b2' {
+export function generatesKeyPathsFromObject(x: Union.Diff<KeyPaths<NestedObject>, 'a' | 'b.b1' | 'b.b2'>): never {
   return x
 }

--- a/src/utils/types/KeyPaths.ts
+++ b/src/utils/types/KeyPaths.ts
@@ -1,4 +1,10 @@
 // Produces a union of dot-delimited keypaths to the string values in a nested object:
 export type KeyPaths<O extends Record<string, unknown>> = {
-  [K in keyof O]: K extends string ? (O[K] extends string ? `${K}` : `${K}.${KeyPaths<O[K]>}`) : never
+  [K in keyof O]: K extends string
+    ? O[K] extends string
+      ? `${K}`
+      : // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore TypeScript has bested me, but the KeyPaths type is tested.
+        `${K}.${KeyPaths<O[K]>}`
+    : never
 }[keyof O]


### PR DESCRIPTION
This was broken in main. See also https://github.com/primer/react/pull/1551. It's not a great fix, but after a few hours I decided to just `ts-ignore` this type I believe to be working correctly (and we've validated the output).

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
