### PR TITLE
FilteredSearch no longer accepts styled system props

### DIFF
--- a/.changeset/swift-days-hammer.md
+++ b/.changeset/swift-days-hammer.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': major
+---
+
+FilteredSearch no longer accepts styled-system props. Please use the `sx` prop to extend Primer component styling instead. See also https://primer.style/react/overriding-styles for information about `sx` and https://primer.style/react/system-props for context on the removal.

--- a/docs/content/FilteredSearch.md
+++ b/docs/content/FilteredSearch.md
@@ -22,18 +22,11 @@ The FilteredSearch component helps style a Dropdown and a TextInput side-by-side
 </FilteredSearch>
 ```
 
-## System props
-
-<Note variant="warning">
-
-System props are deprecated in all components except [Box](/Box). Please use the [`sx` prop](/overriding-styles) instead.
-
-</Note>
-
-FilteredSearch gets `COMMON` system props. Read our [System Props](/system-props) doc page for a full list of available props.
-
 ## Component props
 
 #### FilteredSearch.Children
 
-FilteredSearch is expected to contain a [`Dropdown`](/Dropdown) followed by a [`TextInput`](/TextInput).
+| Name     | Type              | Default | Description                                                                                              |
+| :------- | :---------------- | :-----: | :------------------------------------------------------------------------------------------------------- |
+| children |                   |         | FilteredSearch is expected to contain a [`Dropdown`](/Dropdown) followed by a [`TextInput`](/TextInput). |
+| sx       | SystemStyleObject |   {}    | Style to be applied to the component                                                                     |

--- a/src/FilteredSearch.tsx
+++ b/src/FilteredSearch.tsx
@@ -1,10 +1,9 @@
 import styled from 'styled-components'
-import {COMMON, get, SystemCommonProps} from './constants'
+import {get} from './constants'
 import sx, {SxProp} from './sx'
 import {ComponentProps} from './utils/types'
 
-const FilteredSearch = styled.div<SystemCommonProps & SxProp>`
-  ${COMMON};
+const FilteredSearch = styled.div<SxProp>`
   display: flex;
   align-items: stretch;
 

--- a/src/__tests__/FilteredSearch.types.test.tsx
+++ b/src/__tests__/FilteredSearch.types.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import FilteredSearch from '../FilteredSearch'
+
+export function shouldAcceptCallWithNoProps() {
+  return <FilteredSearch />
+}
+
+export function shouldNotAcceptSystemProps() {
+  // @ts-expect-error system props should not be accepted
+  return <FilteredSearch backgroundColor="rosybrown" />
+}


### PR DESCRIPTION
This PR updates FilteredSearch to no longer accept system props.

See https://github.com/github/primer/issues/296

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
