### PR TITLE
Pagehead no longer accepts styled system props

### DIFF
--- a/.changeset/chilly-socks-compare.md
+++ b/.changeset/chilly-socks-compare.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': major
+---
+
+Pagehead no longer accepts styled-system props. Please use the `sx` prop to extend Primer component styling instead. See also https://primer.style/react/overriding-styles for information about `sx` and https://primer.style/react/system-props for context on the removal.

--- a/docs/content/Pagehead.md
+++ b/docs/content/Pagehead.md
@@ -10,18 +10,9 @@ Give a page a clear, separated title and optional top nav by using Pagehead.
 <Pagehead>Pagehead</Pagehead>
 ```
 
-## System props
-
-<Note variant="warning">
-
-System props are deprecated in all components except [Box](/Box). Please use the [`sx` prop](/overriding-styles) instead.
-
-</Note>
-
-Pagehead components get `COMMON` system props. Read our [System Props](/system-props) doc page for a full list of available props.
-
 ## Component props
 
-| Name | Type   | Default | Description                         |
-| :--- | :----- | :-----: | :---------------------------------- |
-| as   | String |  `div`  | Sets the HTML tag for the component |
+| Name | Type              | Default | Description                          |
+| :--- | :---------------- | :-----: | :----------------------------------- |
+| as   | String            |  `div`  | Sets the HTML tag for the component  |
+| sx   | SystemStyleObject |   {}    | Style to be applied to the component |

--- a/src/Pagehead.tsx
+++ b/src/Pagehead.tsx
@@ -1,15 +1,14 @@
 import styled from 'styled-components'
-import {COMMON, get, SystemCommonProps} from './constants'
+import {get} from './constants'
 import sx, {SxProp} from './sx'
 import {ComponentProps} from './utils/types'
 
-const Pagehead = styled.div<SystemCommonProps & SxProp>`
+const Pagehead = styled.div<SxProp>`
   position: relative;
   padding-top: ${get('space.4')};
   padding-bottom: ${get('space.4')};
   margin-bottom: ${get('space.4')};
   border-bottom: 1px solid ${get('colors.border.default')};
-  ${COMMON};
   ${sx};
 `
 

--- a/src/__tests__/Pagehead.types.test.tsx
+++ b/src/__tests__/Pagehead.types.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import Pagehead from '../Pagehead'
+
+export function shouldAcceptCallWithNoProps() {
+  return <Pagehead />
+}
+
+export function shouldNotAcceptSystemProps() {
+  // @ts-expect-error system props should not be accepted
+  return <Pagehead backgroundColor="orchid" />
+}


### PR DESCRIPTION
This PR updates Pagehead to no longer accept system props.

See https://github.com/github/primer/issues/296

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
