### PR TITLE
Popover no longer accepts styled system props

### DIFF
--- a/.changeset/gentle-birds-cough.md
+++ b/.changeset/gentle-birds-cough.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': major
+---
+
+Popover no longer accepts styled-system props. Please use the `sx` prop to extend Primer component styling instead. See also https://primer.style/react/overriding-styles for information about `sx` and https://primer.style/react/system-props for context on the removal.

--- a/docs/content/Popover.md
+++ b/docs/content/Popover.md
@@ -105,26 +105,17 @@ function CaretSelector(props) {
 render(<PopoverDemo />)
 ```
 
-## System props
-
-<Note variant="warning">
-
-System props are deprecated in all components except [Box](/Box). Please use the [`sx` prop](/overriding-styles) instead.
-
-</Note>
-
-ProgressBar components get `COMMON` system props. Read our [System Props](/system-props) doc page for a full list of available props.
-
 ## Component props
 
 ### Popover
 
-| Name     | Type    | Default | Description                                                                    |
-| :------- | :------ | :-----: | :----------------------------------------------------------------------------- |
-| as       | String  |  'div'  | Sets the HTML tag for the component.                                           |
-| caret    | String  |  'top'  | Controls the position of the caret. See below for the list of caret positions. |
-| open     | Boolean |  false  | Controls the visibility of the popover.                                        |
-| relative | Boolean |  false  | Set to true to render the popover using relative positioning.                  |
+| Name     | Type              | Default | Description                                                                    |
+| :------- | :---------------- | :-----: | :----------------------------------------------------------------------------- |
+| as       | String            |  'div'  | Sets the HTML tag for the component.                                           |
+| caret    | String            |  'top'  | Controls the position of the caret. See below for the list of caret positions. |
+| open     | Boolean           |  false  | Controls the visibility of the popover.                                        |
+| relative | Boolean           |  false  | Set to true to render the popover using relative positioning.                  |
+| sx       | SystemStyleObject |   {}    | Style to be applied to the component                                           |
 
 #### Caret Positions
 
@@ -132,6 +123,7 @@ The `caret` prop can be one of the following values: `top`, `bottom`, `left`, `r
 
 ### Popover.Content
 
-| Name | Type   | Default | Description                          |
-| :--- | :----- | :-----: | :----------------------------------- |
-| as   | String |  'div'  | Sets the HTML tag for the component. |
+| Name | Type              | Default | Description                          |
+| :--- | :---------------- | :-----: | :----------------------------------- |
+| as   | String            |  'div'  | Sets the HTML tag for the component. |
+| sx   | SystemStyleObject |   {}    | Style to be applied to the component |

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -1,7 +1,6 @@
 import classnames from 'classnames'
 import styled from 'styled-components'
-import Box from './Box'
-import {COMMON, get, LAYOUT, POSITION, SystemCommonProps, SystemLayoutProps, SystemPositionProps} from './constants'
+import {get} from './constants'
 import sx, {SxProp} from './sx'
 import {ComponentProps} from './utils/types'
 
@@ -23,10 +22,7 @@ type StyledPopoverProps = {
   caret?: CaretPosition
   relative?: boolean
   open?: boolean
-} & SystemCommonProps &
-  SystemLayoutProps &
-  SystemPositionProps &
-  SxProp
+} & SxProp
 
 const Popover = styled.div.attrs<StyledPopoverProps>(({className, caret}) => {
   return {
@@ -36,14 +32,10 @@ const Popover = styled.div.attrs<StyledPopoverProps>(({className, caret}) => {
   position: ${props => (props.relative ? 'relative' : 'absolute')};
   z-index: 100;
   display: ${props => (props.open ? 'block' : 'none')};
-
-  ${COMMON};
-  ${LAYOUT};
-  ${POSITION};
   ${sx};
 `
 
-const PopoverContent = styled(Box)`
+const PopoverContent = styled.div<SxProp>`
   border: 1px solid ${get('colors.border.default')};
   border-radius: ${get('radii.2')};
   position: relative;
@@ -52,9 +44,6 @@ const PopoverContent = styled(Box)`
   margin-left: auto;
   padding: ${get('space.4')};
   background-color: ${get('colors.canvas.overlay')};
-
-  ${COMMON};
-  ${LAYOUT};
 
   // Carets
   &::before,

--- a/src/__tests__/Popover.types.test.tsx
+++ b/src/__tests__/Popover.types.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import Popover from '../Popover'
+
+export function shouldAcceptCallWithNoProps() {
+  return <Popover />
+}
+
+export function shouldNotAcceptSystemProps() {
+  return (
+    <>
+      {/* @ts-expect-error system props should not be accepted */}
+      <Popover backgroundColor="palegreen" />
+      {/* @ts-expect-error system props should not be accepted */}
+      <Popover.Content backgroundColor="paleturquoise" />
+    </>
+  )
+}


### PR DESCRIPTION
This PR updates Popover to no longer accept system props.

See https://github.com/github/primer/issues/296

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
