### PR TITLE
SubNav no longer accepts styled system props

### DIFF
--- a/.changeset/new-tigers-yawn.md
+++ b/.changeset/new-tigers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': major
+---
+
+SubNav no longer accepts styled-system props. Please use the `sx` prop to extend Primer component styling instead. See also https://primer.style/react/overriding-styles for information about `sx` and https://primer.style/react/system-props for context on the removal.

--- a/docs/content/SubNav.md
+++ b/docs/content/SubNav.md
@@ -72,31 +72,29 @@ This ensures that the NavLink gets `activeClassName='selected'`
 </SubNav>
 ```
 
-## System props
-
-<Note variant="warning">
-
-System props are deprecated in all components except [Box](/Box). Please use the [`sx` prop](/overriding-styles) instead.
-
-</Note>
-
-SubNav and SubNav.Link components get `COMMON` system props. Read our [System Props](/system-props) doc page for a full list of available props.
-
 ## Component props
 
 ### SubNav
 
-| Prop name  | Type    | Description                                                                            |
-| :--------- | :------ | :------------------------------------------------------------------------------------- |
-| actions    | Node    | Place another element, such as a button, to the opposite side of the navigation items. |
-| align      | String  | Use `right` to have navigation items aligned right.                                    |
-| full       | Boolean | Used to make navigation fill the width of the container.                               |
-| aria-label | String  | Used to set the `aria-label` on the top level `<nav>` element.                         |
+| Name       | Type              | Default | Description                                                                            |
+| :--------- | :---------------- | :-----: | :------------------------------------------------------------------------------------- |
+| actions    | Node              |         | Place another element, such as a button, to the opposite side of the navigation items. |
+| align      | String            |         | Use `right` to have navigation items aligned right.                                    |
+| full       | Boolean           |         | Used to make navigation fill the width of the container.                               |
+| aria-label | String            |         | Used to set the `aria-label` on the top level `<nav>` element.                         |
+| sx         | SystemStyleObject |   {}    | Style to be applied to the component                                                   |
 
 ### SubNav.Link
 
-| Prop name | Type    | Description                                      |
-| :-------- | :------ | :----------------------------------------------- |
-| as        | String  | sets the HTML tag for the component              |
-| href      | String  | URL to be used for the Link                      |
-| selected  | Boolean | Used to style the link as selected or unselected |
+| Name     | Type              | Default | Description                                      |
+| :------- | :---------------- | :-----: | :----------------------------------------------- |
+| as       | String            |         | sets the HTML tag for the component              |
+| href     | String            |         | URL to be used for the Link                      |
+| selected | Boolean           |         | Used to style the link as selected or unselected |
+| sx       | SystemStyleObject |   {}    | Style to be applied to the component             |
+
+### SubNav.Links
+
+| Name | Type              | Default | Description                          |
+| :--- | :---------------- | :-----: | :----------------------------------- |
+| sx   | SystemStyleObject |   {}    | Style to be applied to the component |

--- a/src/SubNav.tsx
+++ b/src/SubNav.tsx
@@ -3,15 +3,14 @@ import classnames from 'classnames'
 import * as History from 'history'
 import React from 'react'
 import styled from 'styled-components'
-import {COMMON, FLEX, get, SystemBorderProps, SystemCommonProps, SystemFlexProps} from './constants'
-import Box, {BoxProps} from './Box'
+import {get} from './constants'
 import sx, {SxProp} from './sx'
 import {ComponentProps} from './utils/types'
 
 const ITEM_CLASS = 'SubNav-item'
 const SELECTED_CLASS = 'selected'
 
-const SubNavBase = styled.nav<SystemFlexProps & SystemCommonProps & SxProp>`
+const SubNavBase = styled.nav<SxProp>`
   display: flex;
   justify-content: space-between;
 
@@ -32,8 +31,6 @@ const SubNavBase = styled.nav<SystemFlexProps & SystemCommonProps & SxProp>`
     align-self: center;
   }
 
-  ${COMMON};
-  ${FLEX};
   ${sx};
 `
 
@@ -54,18 +51,17 @@ function SubNav({actions, className, children, label, ...rest}: SubNavProps) {
   )
 }
 
-export type SubNavLinksProps = BoxProps
+export type SubNavLinksProps = SxProp
 
-function SubNavLinks(props: SubNavLinksProps) {
-  return <Box display="flex" {...props} />
-}
+const SubNavLinks = styled.div<SubNavLinksProps>`
+  display: flex;
+  ${sx};
+`
 
 type StyledSubNavLinkProps = {
   to?: History.LocationDescriptor
   selected?: boolean
-} & SystemCommonProps &
-  SxProp &
-  SystemBorderProps
+} & SxProp
 
 const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
   activeClassName: typeof props.to === 'string' ? 'selected' : '',
@@ -117,7 +113,6 @@ const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
     }
   }
 
-  ${COMMON};
   ${sx};
 `
 

--- a/src/__tests__/SubNav.types.test.tsx
+++ b/src/__tests__/SubNav.types.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import SubNav from '../SubNav'
+
+export function shouldAcceptCallWithNoProps() {
+  return (
+    <>
+      <SubNav />
+      <SubNav.Link />
+      <SubNav.Links />
+    </>
+  )
+}
+
+export function shouldNotAcceptSystemProps() {
+  return (
+    <>
+      {/* @ts-expect-error system props should not be accepted */}
+      <SubNav backgroundColor="thistle" />
+      {/* @ts-expect-error system props should not be accepted */}
+      <SubNav.Link backgroundColor="thistle" />
+      {/* @ts-expect-error system props should not be accepted */}
+      <SubNav.Links backgroundColor="thistle" />
+    </>
+  )
+}


### PR DESCRIPTION
This PR updates SubNav to no longer accept system props.

See https://github.com/github/primer/issues/296

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
