### PR TITLE
Move `flex-shrink: 0` to `BaseVisualContainer`.

### DIFF
--- a/.changeset/grumpy-tomatoes-chew.md
+++ b/.changeset/grumpy-tomatoes-chew.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': patch
+---
+
+Fix alignment of items in ActionList (single-select) if some of the items have wrapping text.

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -275,6 +275,7 @@ const BaseVisualContainer = styled.div<{variant?: ItemProps['variant']; disabled
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-shrink: 0;
 `
 
 const ColoredVisualContainer = styled(BaseVisualContainer)`
@@ -285,7 +286,6 @@ const ColoredVisualContainer = styled(BaseVisualContainer)`
 `
 
 const LeadingVisualContainer = styled(ColoredVisualContainer)`
-  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -468,6 +468,9 @@ Array [
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 .c10 {
@@ -1375,6 +1378,9 @@ Array [
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 .c6 rect {
@@ -2192,6 +2198,9 @@ Array [
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 .c10 rect {


### PR DESCRIPTION
This is to address a bug where in a single-select action menu, if an item wraps, it will become misaligned with other items in the list.

Closes #1595 

### Screenshots

Before:
![Image showing misaslignment of the a wrapping item](https://user-images.githubusercontent.com/5487287/141179333-a23afcb7-15f3-4814-b073-695a2d4eb0e7.png)

After:
![Image showing list items aligned](https://user-images.githubusercontent.com/5487287/141179584-8380bdc5-bad7-45dd-9c2e-ee1b94062ef6.png)

Story changes (not included in PR) that I made to repro this scenario:

```diff
@dmarcey ➜ /workspaces/react (main ✗) $ git diff src/stories/ActionList.stories.tsx 
diff --git a/src/stories/ActionList.stories.tsx b/src/stories/ActionList.stories.tsx
index 46e21e2c..0c03ccbe 100644
--- a/src/stories/ActionList.stories.tsx
+++ b/src/stories/ActionList.stories.tsx
@@ -106,13 +106,15 @@ const selectListItems = new Array(6).fill(undefined).map((_, i) => {
     id: i
   }
 })
+selectListItems.push({id: 6, text: 'Item with a really really long text value that should wrap'})
 
 export function SingleSelectListStory(): JSX.Element {
   return (
     <>
       <h1>Single Select List</h1>
-      <ErsatzOverlay>
+      <ErsatzOverlay maxWidth="300px">
         <ActionList
+          showItemDividers={true}
           items={selectListItems.map((item, index) => ({
             ...item,
             selected: index === 1
```

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

