### PR TITLE
ActionList: Better label & description for Item

### DIFF
--- a/.changeset/action-list-description-a11y.md
+++ b/.changeset/action-list-description-a11y.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': patch
+---
+
+ActionList: Better labels and description for accessible ActionList.Item

--- a/src/ActionList2/Item.tsx
+++ b/src/ActionList2/Item.tsx
@@ -180,13 +180,8 @@ export const Item = React.forwardRef<HTMLLIElement, ItemProps>(
             aria-selected={selected}
             aria-disabled={disabled ? true : undefined}
             tabIndex={disabled ? undefined : -1}
-            aria-labelledby={labelId}
-            aria-describedby={[
-              slots.InlineDescription && inlineDescriptionId,
-              slots.BlockDescription && blockDescriptionId
-            ]
-              .filter(Boolean)
-              .join(' ')}
+            aria-labelledby={`${labelId} ${slots.InlineDescription ? inlineDescriptionId : ''}`}
+            aria-describedby={slots.BlockDescription ? blockDescriptionId : undefined}
             {...props}
           >
             <_PrivateItemWrapper>

--- a/src/stories/ActionList2.stories.tsx
+++ b/src/stories/ActionList2.stories.tsx
@@ -161,12 +161,16 @@ export function WithAvatar(): JSX.Element {
 }
 WithAvatar.storyName = 'With Avatar'
 
-const projects = [
-  {name: 'Primer Backlog', scope: 'GitHub'},
-  {name: 'Accessibility', scope: 'GitHub'},
-  {name: 'Octicons', scope: 'github/primer'},
-  {name: 'Primer React', scope: 'github/primer'}
+const labels = [
+  {name: 'blocked', color: '#86181d', description: 'Someone or something is preventing this from moving forward'},
+  {name: 'dependencies', color: '#0366d6', description: 'Pull requests that update a dependency file'},
+  {name: 'duplicate', color: '#cfd3d7', description: 'This issue or pull request already exists'},
+  {name: 'good first issue', color: '#7057ff', description: 'Good for newcomers'}
 ]
+
+const LabelColor: React.FC<{color: string}> = ({color}) => (
+  <Box sx={{backgroundColor: color, width: '14px', height: '14px', borderRadius: 3}} />
+)
 
 export function WithDescription(): JSX.Element {
   return (
@@ -184,13 +188,13 @@ export function WithDescription(): JSX.Element {
             </ActionList.Item>
           ))}
           <ActionList.Divider />
-          {projects.map((project, index) => (
+          {labels.map((label, index) => (
             <ActionList.Item key={index}>
               <ActionList.LeadingVisual>
-                <TableIcon />
+                <LabelColor color={label.color} />
               </ActionList.LeadingVisual>
-              {project.name}
-              <ActionList.Description variant="block">{project.scope}</ActionList.Description>
+              {label.name}
+              <ActionList.Description variant="block">{label.description}</ActionList.Description>
             </ActionList.Item>
           ))}
         </ActionList>
@@ -199,6 +203,13 @@ export function WithDescription(): JSX.Element {
   )
 }
 WithDescription.storyName = 'With Description & Dividers'
+
+const projects = [
+  {name: 'Primer Backlog', scope: 'GitHub'},
+  {name: 'Accessibility', scope: 'GitHub'},
+  {name: 'Octicons', scope: 'github/primer'},
+  {name: 'Primer React', scope: 'github/primer'}
+]
 
 export function SingleSelectListStory(): JSX.Element {
   const [selectedIndex, setSelectedIndex] = React.useState(1)


### PR DESCRIPTION
Change base after https://github.com/primer/react/pull/1517 is merged
Part of https://github.com/github/primer/issues/447

- [x] Bring inline description to be part of label.
- [x] Block description is describedby


This is the generated HTML, formatted for legibility:

![image](https://user-images.githubusercontent.com/1863771/140772222-d512b070-ed42-43af-b613-5d44ec092f0d.png)

```html
<ul>
  <li aria-labelledby="react-aria-1 react-aria-2">
    <span><img src="https://github.com/pksjce.png"/></span>
    <div data-component="ActionList.Item--DividerContainer">
      <div>
        <span id="react-aria-1">pksjce</span>
        <div id="react-aria-2" title="Pavithra Kodmad">Pavithra Kodmad</div>
      </div>
    </div>
  </li>
  <li>...</li>
  <li role="separator"></li>
  <li aria-labelledby="react-aria-3 " aria-describedby="react-aria-4">
    <span><span class="label-circle"></span></span>
    <div data-component="ActionList.Item--DividerContainer">
      <span id="react-aria-3">blocked</span>
      <span id="react-aria-4">
        Someone or something is preventing this from moving forward
      </span>
    </div>
  </li>
  <li>...</li>
</ul>

```

### Merge checklist

- [x] Added/updated tests, but in a different PR: https://github.com/primer/react/pull/1597
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

