### PR TITLE
ActionList: Use icon instead of input for multiple selection

### DIFF
--- a/.changeset/action-list-selection-a11y.md
+++ b/.changeset/action-list-selection-a11y.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': patch
+---
+
+ActionList: Use icon instead of input for multiple selection in ActionList

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -333,8 +333,16 @@ const DescriptionContainer = styled.span`
   flex-basis: var(--description-container-flex-basis);
 `
 
-const MultiSelectInput = styled.input`
-  pointer-events: none;
+const MultiSelectIcon = styled.svg<{selected?: boolean}>`
+  rect {
+    fill: ${({selected}) => (selected ? get('colors.accent.fg') : get('colors.canvas.default'))};
+    stroke: ${({selected}) => (selected ? get('colors.accent.fg') : get('colors.border.default'))};
+  }
+  path {
+    fill: ${get('colors.fg.onEmphasis')};
+    boxshadow: ${get('shadow.small')};
+    opacity: ${({selected}) => (selected ? 1 : 0)};
+  }
 `
 
 /**
@@ -372,11 +380,6 @@ export const Item = React.forwardRef((itemProps, ref) => {
         return
       }
       onKeyPress?.(event)
-      const isCheckbox = event.target instanceof HTMLInputElement && event.target.type === 'checkbox'
-      if (isCheckbox && event.key === ' ') {
-        // space key on a checkbox will also trigger a click event.  Ignore the space key so we don't get double events
-        return
-      }
 
       if (!event.defaultPrevented && [' ', 'Enter'].includes(event.key)) {
         onAction?.(itemProps, event)
@@ -425,19 +428,26 @@ export const Item = React.forwardRef((itemProps, ref) => {
         <BaseVisualContainer>
           {selectionVariant === 'multiple' ? (
             <>
-              {/*
-               * readOnly is required because we are doing a one-way bind to `checked`.
-               * aria-readonly="false" tells screen that they can still interact with the checkbox
+              {/**
+               * we use a svg instead of an input because there should not
+               * be an interactive element inside an option
+               * svg copied from primer/css
                */}
-              <MultiSelectInput
-                disabled={disabled}
-                tabIndex={-1}
-                type="checkbox"
-                checked={selected}
-                aria-label={text}
-                readOnly
-                aria-readonly="false"
-              />
+              <MultiSelectIcon
+                selected={selected}
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <rect x="2" y="2" width="12" height="12" rx="4"></rect>
+                <path
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                />
+              </MultiSelectIcon>
             </>
           ) : (
             selected && <CheckIcon fill={theme?.colors.fg.default} />

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -295,6 +295,9 @@ const BaseVisualContainer = styled.div<{variant?: ItemProps['variant']; disabled
   height: 20px;
   width: ${get('space.3')};
   margin-right: ${get('space.2')};
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `
 
 const ColoredVisualContainer = styled(BaseVisualContainer)`

--- a/src/ActionList2/Item.tsx
+++ b/src/ActionList2/Item.tsx
@@ -190,7 +190,7 @@ export const Item = React.forwardRef<HTMLLIElement, ItemProps>(
             {...props}
           >
             <_PrivateItemWrapper>
-              <Selection selected={selected} disabled={disabled} />
+              <Selection selected={selected} />
               {slots.LeadingVisual}
               <Box
                 data-component="ActionList.Item--DividerContainer"

--- a/src/ActionList2/Selection.tsx
+++ b/src/ActionList2/Selection.tsx
@@ -5,8 +5,8 @@ import {GroupContext} from './Group'
 import {ItemProps} from './Item'
 import {LeadingVisualContainer} from './Visuals'
 
-type SelectionProps = Pick<ItemProps, 'selected' | 'disabled'>
-export const Selection: React.FC<SelectionProps> = ({selected, disabled}) => {
+type SelectionProps = Pick<ItemProps, 'selected'>
+export const Selection: React.FC<SelectionProps> = ({selected}) => {
   const {selectionVariant: listSelectionVariant} = React.useContext(ListContext)
   const {selectionVariant: groupSelectionVariant} = React.useContext(GroupContext)
 

--- a/src/ActionList2/Selection.tsx
+++ b/src/ActionList2/Selection.tsx
@@ -29,12 +29,32 @@ export const Selection: React.FC<SelectionProps> = ({selected, disabled}) => {
 
   /**
    * selectionVariant is multiple
-   * readOnly is required because we are doing a one-way bind to `checked`
-   * aria-readonly="false" tells screen that they can still interact with the checkbox
+   * we use a svg instead of an input because there should not
+   * be an interactive element inside an option
+   * svg copied from primer/css
    */
   return (
-    <LeadingVisualContainer sx={{input: {margin: 0, pointerEvents: 'none'}}}>
-      <input type="checkbox" checked={selected} disabled={disabled} tabIndex={-1} readOnly aria-readonly="false" />
+    <LeadingVisualContainer
+      sx={{
+        rect: {
+          fill: selected ? 'accent.fg' : 'canvas.default',
+          stroke: selected ? 'accent.fg' : 'border.default'
+        },
+        path: {
+          fill: 'fg.onEmphasis',
+          boxShadow: 'shadow.small',
+          opacity: selected ? 1 : 0
+        }
+      }}
+    >
+      <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <rect x="2" y="2" width="12" height="12" rx="4"></rect>
+        <path
+          fillRule="evenodd"
+          strokeWidth="0"
+          d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+        />
+      </svg>
     </LeadingVisualContainer>
   )
 }

--- a/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -456,12 +456,36 @@ Array [
   height: 20px;
   width: 16px;
   margin-right: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c10 {
   height: 20px;
   width: 16px;
   margin-right: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -483,8 +507,14 @@ Array [
   font-size: 12px;
 }
 
-.c6 {
-  pointer-events: none;
+.c6 rect {
+  fill: #ffffff;
+  stroke: #d0d7de;
+}
+
+.c6 path {
+  fill: #ffffff;
+  opacity: 0;
 }
 
 .c1 {
@@ -531,15 +561,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="zero"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -574,15 +617,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="one"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -617,15 +673,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="two"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -660,15 +729,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="three"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -703,15 +785,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="four"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -746,15 +841,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="five"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -789,15 +897,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="six"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -832,15 +953,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="seven"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -875,15 +1009,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="twenty"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -918,15 +1065,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="twentyone"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1202,10 +1362,28 @@ Array [
   height: 20px;
   width: 16px;
   margin-right: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
-.c6 {
-  pointer-events: none;
+.c6 rect {
+  fill: #ffffff;
+  stroke: #d0d7de;
+}
+
+.c6 path {
+  fill: #ffffff;
+  opacity: 0;
 }
 
 .c1 {
@@ -1252,15 +1430,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="zero"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1295,15 +1486,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="one"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1338,15 +1542,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="two"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1381,15 +1598,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="three"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1424,15 +1654,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="four"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1467,15 +1710,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="five"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1510,15 +1766,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="six"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1553,15 +1822,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="seven"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1596,15 +1878,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="twenty"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1639,15 +1934,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="twentyone"
-                aria-readonly="false"
-                checked={false}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1824,11 +2132,11 @@ Array [
   margin-right: 8px;
 }
 
-.c4:not(:first-of-type):not(.c11 + .c3):not(.c10 + .c3) {
+.c4:not(:first-of-type):not(.c12 + .c3):not(.c11 + .c3) {
   margin-top: 0;
 }
 
-.c4:not(:first-of-type):not(.c11 + .c3):not(.c10 + .c3) .c7::before {
+.c4:not(:first-of-type):not(.c12 + .c3):not(.c11 + .c3) .c7::before {
   content: ' ';
   display: block;
   position: absolute;
@@ -1871,10 +2179,38 @@ Array [
   height: 20px;
   width: 16px;
   margin-right: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
-.c6 {
-  pointer-events: none;
+.c10 rect {
+  fill: #ffffff;
+  stroke: #d0d7de;
+}
+
+.c10 path {
+  fill: #ffffff;
+  opacity: 0;
+}
+
+.c6 rect {
+  fill: #0969da;
+  stroke: #0969da;
+}
+
+.c6 path {
+  fill: #ffffff;
+  opacity: 1;
 }
 
 .c1 {
@@ -1921,15 +2257,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="zero"
-                aria-readonly="false"
-                checked={true}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={true}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -1964,15 +2313,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="one"
-                aria-readonly="false"
-                checked={true}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={true}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -2007,15 +2369,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="two"
-                aria-readonly="false"
-                checked={true}
+              <svg
+                aria-hidden="true"
                 className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+                height="16"
+                selected={true}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -2050,15 +2425,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="three"
-                aria-readonly="false"
-                checked={false}
-                className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+              <svg
+                aria-hidden="true"
+                className="c10"
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -2093,15 +2481,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="four"
-                aria-readonly="false"
-                checked={false}
-                className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+              <svg
+                aria-hidden="true"
+                className="c10"
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -2136,15 +2537,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="five"
-                aria-readonly="false"
-                checked={false}
-                className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+              <svg
+                aria-hidden="true"
+                className="c10"
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -2179,15 +2593,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="six"
-                aria-readonly="false"
-                checked={false}
-                className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+              <svg
+                aria-hidden="true"
+                className="c10"
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -2222,15 +2649,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="seven"
-                aria-readonly="false"
-                checked={false}
-                className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+              <svg
+                aria-hidden="true"
+                className="c10"
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -2265,15 +2705,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="twenty"
-                aria-readonly="false"
-                checked={false}
-                className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+              <svg
+                aria-hidden="true"
+                className="c10"
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"
@@ -2308,15 +2761,28 @@ Array [
             <div
               className="c5"
             >
-              <input
-                aria-label="twentyone"
-                aria-readonly="false"
-                checked={false}
-                className="c6"
-                readOnly={true}
-                tabIndex={-1}
-                type="checkbox"
-              />
+              <svg
+                aria-hidden="true"
+                className="c10"
+                height="16"
+                selected={false}
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="12"
+                  rx="4"
+                  width="12"
+                  x="2"
+                  y="2"
+                />
+                <path
+                  d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z"
+                  fillRule="evenodd"
+                  strokeWidth="0"
+                />
+              </svg>
             </div>
             <div
               className="c7 c8"


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/447
Fixes half of https://github.com/github/primer/issues/228

Nested interactive controls are not announced by screen readers, the accessibility advice here is not use interactive elements for presentation.

- [x] Replace readonly `input type="checkbox"` with svg from [primer/css](https://primer.style/css/components/action-list#leading-action-multi-select)
- [x] Bonus: checkmark consistency across browsers :)

Future - The svg used here has a short life and will get replaced with the [Checklist component](https://github.com/primer/react/pull/1606) when it's ready

### Screenshots

look pretty ActionList:
![image](https://user-images.githubusercontent.com/1863771/141126300-053801e7-3d5e-4ac8-aa6e-055434261a65.png)

also shared in AutoComplete:

![Screenshot 2021-11-12 at 11 15 34 AM](https://user-images.githubusercontent.com/1863771/141450741-86f3a745-ad49-4c65-aafa-4833593a2d45.png)


&nbsp;

Accessibility violations:

Before: 

![image](https://user-images.githubusercontent.com/1863771/141126246-5b4b5867-6005-4fcd-ba7d-884e0bd4ac99.png)

After: 

![image](https://user-images.githubusercontent.com/1863771/141126113-a07e7309-e990-4b28-8064-4d225ce6ee32.png)




Please provide before/after screenshots for any visual changes

### Merge checklist

- NA Added/updated tests
- NA Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge


