### PR TITLE
ActionList: Add comment to avoid import confusion

### DIFF
--- a/docs/content/ActionList2.mdx
+++ b/docs/content/ActionList2.mdx
@@ -58,7 +58,8 @@ import {ActionList} from '@primer/components/unreleased'
 ## Minimal example
 
 ```javascript live noinline
-const {ActionList} = unreleased
+// import {ActionList} from '@primer/components/unreleased'
+const {ActionList} = unreleased // ignore this, import like that ↑
 
 render(
   <ActionList>
@@ -79,7 +80,8 @@ Leading visuals are optional and appear at the start of an item. They can be oct
 
 <!-- prettier-ignore -->
 ```javascript live noinline
-const {ActionList} = unreleased
+// import {ActionList} from '@primer/components/unreleased'
+const {ActionList} = unreleased // ignore this, import like that ↑
 
 render(
   <ActionList>
@@ -106,7 +108,8 @@ render(
 Trailing visual and trailing text can display auxiliary information. They're placed at the right of the item, and can denote status, keyboard shortcuts, or be used to set expectations about what the action does.
 
 ```javascript live noinline
-const {ActionList} = unreleased
+// import {ActionList} from '@primer/components/unreleased'
+const {ActionList} = unreleased // ignore this, import like that ↑
 
 render(
   <ActionList>
@@ -137,7 +140,8 @@ render(
 Item dividers allow users to parse heavier amounts of information. They're placed between items and are useful in complex lists, particularly when descriptions or multi-line text is present.
 
 ```javascript live noinline
-const {ActionList} = unreleased
+// import {ActionList} from '@primer/components/unreleased'
+const {ActionList} = unreleased // ignore this, import like that ↑
 
 render(
   <ActionList showDividers>
@@ -172,7 +176,8 @@ When you want to add links to the List instead of actions, use `ActionList.LinkI
 
 <!-- prettier-ignore -->
 ```javascript live noinline
-const {ActionList} = unreleased
+// import {ActionList} from '@primer/components/unreleased'
+const {ActionList} = unreleased // ignore this, import like that ↑
 
 render(
   <ActionList>
@@ -207,7 +212,8 @@ render(
 ## With Groups
 
 ```javascript live noinline
-const {ActionList} = unreleased
+// import {ActionList} from '@primer/components/unreleased'
+const {ActionList} = unreleased // ignore this, import like that ↑
 
 const SelectFields = () => {
   const [options, setOptions] = React.useState([


### PR DESCRIPTION
In the docs, because we have multiple ActionLists now, we import it ActionList2 from a different scope:

```jsx
const {ActionList} = unreleased

render(
  <ActionList>
    ...
  </ActionList>
)
```

This causes confusion in where does `unreleased` come from?

The long term fix would be to modify the scope conditionally by tagging the code block with "unreleased": ` ```javascript live unreleased `.

For now, the bandaid is the add a comment to ignore the internal silliness and import from the path

```jsx
// import {ActionList} from '@primer/components/unreleased'
const {ActionList} = unreleased // ignore this, import like that ↑
```

We mention this import path at the [start of the page](https://primer-components-fasv5eaxn-primer.vercel.app/react/ActionList2) as well

### Screenshots

![image](https://user-images.githubusercontent.com/1863771/141796119-012118ec-7aa8-41d1-a474-0aad092805ea.png)

### Merge checklist

- NA Added/updated tests
- [x] Added/updated documentation
- NA Tested in Chrome
- NA Tested in Firefox
- NA Tested in Safari
- NA Tested in Edge