### PR TITLE
Dialog no longer accepts styled system props

### DIFF
--- a/.changeset/moody-buttons-swim.md
+++ b/.changeset/moody-buttons-swim.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': major
+---
+
+Dialog no longer accepts styled-system props. Please use the `sx` prop to extend Primer component styling instead. See also https://primer.style/react/overriding-styles for information about `sx` and https://primer.style/react/system-props for context on the removal.

--- a/docs/content/Dialog.md
+++ b/docs/content/Dialog.md
@@ -84,25 +84,22 @@ You can also pass any non-text content into the header:
 </State>
 ```
 
-## System props
-
-<Note variant="warning">
-
-System props are deprecated in all components except [Box](/Box). Please use the [`sx` prop](/overriding-styles) instead.
-
-</Note>
-
-`Dialog` components get the `COMMON` and `LAYOUT` categories of system props. `Dialog.Header` components get `COMMON`, `LAYOUT`, and `FLEX` system props. Read our [System Props](/system-props) doc page for a full list of available props.
-
 ## Component props
 
-| Prop name       | Type      | Description                                                                                                                                               |
-| :-------------- | :-------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| isOpen          | Boolean   | Set whether or not the dialog is shown                                                                                                                    |
-| onDismiss       | Function  | A user-provided function that should close the dialog                                                                                                     |
-| returnFocusRef  | React ref | The element to restore focus back to after the `Dialog` is closed                                                                                         |
-| initialFocusRef | React ref | Element inside of the `Dialog` you'd like to be focused when the Dialog is opened. If nothing is passed to `initialFocusRef` the close button is focused. |
-| aria-labelledby | string    | Pass an id to use for the aria-label. Use either a `aria-label` or an `aria-labelledby` but not both.                                                     |
-| aria-label      | string    | Pass a label to be used to describe the Dialog. Use either a `aria-label` or an `aria-labelledby` but not both.                                           |
+### Dialog
 
-`Dialog.Header` does not take any non-system props.
+| Prop name       | Type              | Default | Description                                                                                                                                               |
+| :-------------- | :---------------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| isOpen          | Boolean           |         | Set whether or not the dialog is shown                                                                                                                    |
+| onDismiss       | Function          |         | A user-provided function that should close the dialog                                                                                                     |
+| returnFocusRef  | React ref         |         | The element to restore focus back to after the `Dialog` is closed                                                                                         |
+| initialFocusRef | React ref         |         | Element inside of the `Dialog` you'd like to be focused when the Dialog is opened. If nothing is passed to `initialFocusRef` the close button is focused. |
+| aria-labelledby | string            |         | Pass an id to use for the aria-label. Use either a `aria-label` or an `aria-labelledby` but not both.                                                     |
+| aria-label      | string            |         | Pass a label to be used to describe the Dialog. Use either a `aria-label` or an `aria-labelledby` but not both.                                           |
+| sx              | SystemStyleObject | {}      | Style to be applied to the component                                                                                                                      |
+
+### Dialog.Header
+
+| Prop name | Type              | Default | Description                          |
+| :-------- | :---------------- | :------ | :----------------------------------- |
+| sx        | SystemStyleObject | {}      | Style to be applied to the component |

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -1,7 +1,7 @@
 import React, {forwardRef, useRef} from 'react'
 import styled from 'styled-components'
 import ButtonClose from './Button/ButtonClose'
-import {COMMON, get, LAYOUT, SystemCommonProps, SystemLayoutProps} from './constants'
+import {get} from './constants'
 import Box from './Box'
 import useDialog from './hooks/useDialog'
 import sx, {SxProp} from './sx'
@@ -14,9 +14,7 @@ const noop = () => null
 type StyledDialogBaseProps = {
   narrow?: boolean
   wide?: boolean
-} & SystemLayoutProps &
-  SystemCommonProps &
-  SxProp
+} & SxProp
 
 const DialogBase = styled.div<StyledDialogBaseProps>`
   box-shadow: ${get('shadows.shadow.large')};
@@ -39,8 +37,6 @@ const DialogBase = styled.div<StyledDialogBaseProps>`
     height: 100vh;
   }
 
-  ${LAYOUT};
-  ${COMMON};
   ${sx};
 `
 

--- a/src/__tests__/Dialog.types.test.tsx
+++ b/src/__tests__/Dialog.types.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import Dialog from '../Dialog'
+
+export function shouldAcceptCallWithNoProps() {
+  return <Dialog />
+}
+
+export function shouldNotAcceptSystemProps() {
+  // @ts-expect-error system props should not be accepted
+  return <Dialog backgroundColor="thistle" />
+}


### PR DESCRIPTION
This PR updates Dialog (AKA src/Dialog.tsx) to no longer accept system props.

See github/primer#296

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
