### PR TITLE
Create `ComponentChecklist` component

### DIFF
--- a/docs/content/Box.mdx
+++ b/docs/content/Box.mdx
@@ -1,10 +1,12 @@
 ---
 title: Box
+status: Alpha
 description: A low-level utility component that accepts styled system props to enable custom theme-aware styling
 source: https://github.com/primer/react/blob/main/src/Box.tsx
 ---
 
 import {Props} from '../src/props'
+import {ComponentChecklist} from '../src/component-checklist'
 import {Box} from '@primer/components'
 
 ```jsx live
@@ -72,3 +74,23 @@ Use Box to create [grid](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_
   </Box>
 </Box>
 ```
+
+## Component checklist
+
+<ComponentChecklist
+  items={{
+    propsDocumented: true,
+    noUnnecessaryDeps: true,
+    adaptsToThemes: true,
+    adaptsToScreenSizes: true,
+    fullTestCoverage: true,
+    usedInProduction: true,
+    usageExamplesDocumented: true,
+    designReviewed: null,
+    a11yReviewed: null,
+    stableApi: false,
+    addressedApiFeedback: false,
+    hasDesignGuidelines: null,
+    hasFigmaComponent: null
+  }}
+/>

--- a/docs/content/Box.mdx
+++ b/docs/content/Box.mdx
@@ -75,7 +75,7 @@ Use Box to create [grid](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_
 </Box>
 ```
 
-## Component checklist
+## Component status
 
 <ComponentChecklist
   items={{

--- a/docs/content/Box.mdx
+++ b/docs/content/Box.mdx
@@ -1,6 +1,6 @@
 ---
 title: Box
-status: Alpha
+status: Beta
 description: A low-level utility component that accepts styled system props to enable custom theme-aware styling
 source: https://github.com/primer/react/blob/main/src/Box.tsx
 ---

--- a/docs/src/component-checklist.js
+++ b/docs/src/component-checklist.js
@@ -3,7 +3,7 @@ import {H3} from '@primer/gatsby-theme-doctocat/src/components/heading'
 import {CheckCircleFillIcon, CircleIcon, SkipIcon} from '@primer/octicons-react'
 import React from 'react'
 
-/** Render component maturity checklist in documentation pages */
+/** Render component status checklist in documentation pages */
 export function ComponentChecklist({items}) {
   return (
     <>

--- a/docs/src/component-checklist.js
+++ b/docs/src/component-checklist.js
@@ -1,4 +1,4 @@
-import {Box, StyledOcticon, Link} from '@primer/components'
+import {Box, StyledOcticon, Link, Text} from '@primer/components'
 import {H3} from '@primer/gatsby-theme-doctocat/src/components/heading'
 import {CheckCircleFillIcon, CircleIcon, SkipIcon} from '@primer/octicons-react'
 import React from 'react'
@@ -67,12 +67,15 @@ Checklist.Item = ({checked, children}) => {
         {checked ? (
           <StyledOcticon aria-label="Completed" icon={CheckCircleFillIcon} sx={{color: 'success.fg'}} />
         ) : checked === null ? (
-          <StyledOcticon aria-label="Not applicable" icon={SkipIcon} sx={{color: 'neutral.emphasis'}} />
+          <StyledOcticon icon={SkipIcon} sx={{color: 'fg.subtle'}} />
         ) : (
-          <StyledOcticon aria-label="To do" icon={CircleIcon} sx={{color: 'neutral.emphasis'}} />
+          <StyledOcticon aria-label="To do" icon={CircleIcon} sx={{color: 'fg.subtle'}} />
         )}
       </Box>
-      <span>{children}</span>
+      <Text color={checked === null ? 'fg.subtle' : 'fg.default'}>
+        {checked === null ? <Text color="fg.subtle">N/A: </Text> : null}
+        {children}
+      </Text>
     </Box>
   )
 }

--- a/docs/src/component-checklist.js
+++ b/docs/src/component-checklist.js
@@ -1,0 +1,78 @@
+import {Box, StyledOcticon, Link} from '@primer/components'
+import {H3} from '@primer/gatsby-theme-doctocat/src/components/heading'
+import {CheckCircleFillIcon, CircleIcon, SkipIcon} from '@primer/octicons-react'
+import React from 'react'
+
+/** Render component maturity checklist in documentation pages */
+export function ComponentChecklist({items}) {
+  return (
+    <>
+      <H3>Alpha</H3>
+      <Checklist aria-describedby="alpha">
+        <Checklist.Item checked={items.propsDocumented}>Component props are documented.</Checklist.Item>
+        <Checklist.Item checked={items.noUnnecessaryDeps}>
+          Component does not have any unnecessary third-party dependencies.
+        </Checklist.Item>
+        <Checklist.Item checked={items.adaptsToThemes}>Component can adapt to different themes.</Checklist.Item>
+        <Checklist.Item checked={items.adaptsToScreenSizes}>
+          Component can adapt to different screen sizes.
+        </Checklist.Item>
+        <Checklist.Item checked={items.fullTestCoverage}>Component has 100% test coverage.</Checklist.Item>
+      </Checklist>
+      <H3>Beta</H3>
+      <Checklist aria-describedby="beta">
+        <Checklist.Item checked={items.usedInProduction}>Component is used in a production application.</Checklist.Item>
+        <Checklist.Item checked={items.usageExamplesDocumented}>Common usage examples are documented.</Checklist.Item>
+        <Checklist.Item checked={items.designReviewed}>
+          Component has been reviewed by a systems designer and any resulting issues have been addressed.
+        </Checklist.Item>
+        <Checklist.Item checked={items.a11yReviewed}>
+          Component has been manually reviewed by the accessibility team and any resulting issues have been addressed.
+        </Checklist.Item>
+      </Checklist>
+      <H3>Stable</H3>
+      <Checklist aria-describedby="stable">
+        <Checklist.Item checked={items.apiIsStable}>
+          Component API has been stable with no breaking changes for at least one month.
+        </Checklist.Item>
+        <Checklist.Item checked={items.addressedApiFeedback}>
+          Feedback on API usability has been sought from developers using the component and any resulting issues have
+          been addressed.
+        </Checklist.Item>
+        <Checklist.Item checked={items.hasDesignGuidelines}>
+          Component has corresponding design guidelines documented in the{' '}
+          <Link href="https://primer.style/design/">interface guidelines</Link>.
+        </Checklist.Item>
+        <Checklist.Item checked={items.hasFigmaComponent}>
+          Component has corresponding Figma component in the Primer Web library.
+        </Checklist.Item>
+      </Checklist>
+    </>
+  )
+}
+
+// TODO: This component should live in Doctocat
+function Checklist({'aria-describedby': ariaDescribedby, children}) {
+  return (
+    <Box aria-describedby={ariaDescribedby} as="ul" display="grid" gridGap={2} p={0} m={0} mb={3}>
+      {children}
+    </Box>
+  )
+}
+
+Checklist.Item = ({checked, children}) => {
+  return (
+    <Box as="li" display="grid" gridTemplateColumns="auto 1fr" gridGap={2} sx={{listStyleType: 'none'}}>
+      <Box height="24px" display="flex" alignItems="center">
+        {checked ? (
+          <StyledOcticon aria-label="Completed" icon={CheckCircleFillIcon} sx={{color: 'success.fg'}} />
+        ) : checked === null ? (
+          <StyledOcticon aria-label="Not applicable" icon={SkipIcon} sx={{color: 'neutral.emphasis'}} />
+        ) : (
+          <StyledOcticon aria-label="To do" icon={CircleIcon} sx={{color: 'neutral.emphasis'}} />
+        )}
+      </Box>
+      <span>{children}</span>
+    </Box>
+  )
+}


### PR DESCRIPTION
Adds a `ComponentChecklist` component in the `/docs` directory that will enable us to document the maturity of our components.

```
## Component checklist

<ComponentChecklist
  items={{
    propsDocumented: true,
    noUnnecessaryDeps: true,
    adaptsToThemes: true,
    adaptsToScreenSizes: true,
    fullTestCoverage: true,
    usedInProduction: true,
    usageExamplesDocumented: true,
    designReviewed: null,
    a11yReviewed: null,
    stableApi: false,
    addressedApiFeedback: false,
    hasDesignGuidelines: null,
    hasFigmaComponent: null
  }}
/>
```

![CleanShot 2021-11-18 at 17 16 07](https://user-images.githubusercontent.com/4608155/142528445-59e624f9-fb75-4574-ac55-61f5bc05918e.png)

## Known issues

Here are list of known issues with `ComponentChecklist` that I think are out of scope for this PR:

* **The component is not written in TypeScript.** We don't have Gatsby configured to work with TypeScript yet so I wrote the component in vanilla JavaScript. Updating our Gatsby configuration to work with TypeScript felt out of scope for this PR.
* **The `ComponentChecklist` component needs to be imported in every markdown file that uses it.** I plan to make a change in Doctocat that will allow us to make `ComponentChecklist` globally available in all markdown files. Until I make that change, `ComponentChecklist` will need to be explicitly imported.
* **`ComponentChecklist` items are hard to guess.** You'll need to look at the definition of `ComponentChecklist` to know which checklist items to pass. I imagine most people will use `ComponentChecklist` by copying and pasting from other documentation pages, so I don't think this is a dealbreaker
* **You need to add the checklist heading in markdown.** The heading (i.e. `## Component checklist`) needs to be written directly in the `.md` or `.mdx` file. The heading can't be included in the `ComponentChecklist` component because it won't be listed in the table of contents.

## Open questions

- What should the heading of this checklist be? I'm using `Component checklist` for now but I'm open to other ideas.
- Is the `n/a` state for a checklist item visually clear? I'm using the same icon that we use to represent a "skipped" GitHub action.

## Next steps

- [ ] Render this checklist on every component documentation page


## Notes

This is a departure from my original implementation plan for component checklists. I wrote about why changed my implementation plan [here](https://github.com/github/primer/issues/339#issuecomment-972370931).