### PR TITLE
Remove unneeded imports in markdown files

### DIFF
--- a/docs/content/ActionList2.mdx
+++ b/docs/content/ActionList2.mdx
@@ -8,7 +8,6 @@ description: An ActionList is a list of items which can be activated or selected
 
 import {BorderBox, Avatar} from '@primer/components'
 import {ActionList} from '@primer/components/drafts'
-import {Props} from '../src/props'
 
 import {ImageContainer} from '@primer/gatsby-theme-doctocat'
 import {LinkIcon, AlertIcon, ArrowRightIcon} from '@primer/octicons-react'

--- a/docs/content/Autocomplete.mdx
+++ b/docs/content/Autocomplete.mdx
@@ -3,7 +3,6 @@ title: Autocomplete
 status: Alpha
 ---
 
-import {Props} from '../src/props'
 import {Autocomplete} from '@primer/components'
 
 The `Autocomplete` components are used to render a text input that allows a user to quickly filter through a list of options to pick one or more values. It is comprised of an `Autocomplete.Input` component that a user types into, and a `Autocomplete.Menu` component that displays the list of selectable values.

--- a/docs/content/Avatar.mdx
+++ b/docs/content/Avatar.mdx
@@ -4,7 +4,6 @@ componentId: avatar
 source: https://github.com/primer/react/blob/main/src/Avatar.tsx
 ---
 
-import {Props} from '../src/props'
 import {Avatar} from '@primer/components'
 
 ```jsx live

--- a/docs/content/AvatarStack.mdx
+++ b/docs/content/AvatarStack.mdx
@@ -2,7 +2,6 @@
 title: AvatarStack
 ---
 
-import {Props} from '../src/props'
 import {AvatarStack} from '@primer/components'
 
 AvatarStack is used to display more than one Avatar in an inline stack.

--- a/docs/content/Box.mdx
+++ b/docs/content/Box.mdx
@@ -5,10 +5,6 @@ description: A low-level utility component that accepts styled system props to e
 source: https://github.com/primer/react/blob/main/src/Box.tsx
 ---
 
-import {Props} from '../src/props'
-import {ComponentChecklist} from '../src/component-checklist'
-import {Box} from '@primer/components'
-
 ```jsx live
 <Box color="fg.muted" bg="canvas.subtle" p={3}>
   Hello

--- a/docs/content/Spinner.mdx
+++ b/docs/content/Spinner.mdx
@@ -6,7 +6,6 @@ componentId: spinner
 source: https://github.com/primer/components/blob/main/src/Spinner.tsx
 ---
 
-import {Props} from '../src/props'
 import {Spinner} from '@primer/components'
 
 ```jsx live

--- a/docs/content/TextInputTokens.mdx
+++ b/docs/content/TextInputTokens.mdx
@@ -4,7 +4,6 @@ status: Alpha
 source: https://github.com/primer/react/tree/main/src/TextInputWithTokens.tsx
 ---
 
-import {Props} from '../src/props'
 import {TextInputWithTokens} from '@primer/components'
 
 A `TextInputWithTokens` component is used to show multiple values in one field.

--- a/docs/content/TextInputWithTokens.mdx
+++ b/docs/content/TextInputWithTokens.mdx
@@ -4,7 +4,6 @@ status: Alpha
 source: https://github.com/primer/react/tree/main/src/TextInputWithTokens.tsx
 ---
 
-import {Props} from '../src/props'
 import {TextInputWithTokens} from '@primer/components'
 
 A `TextInputWithTokens` component is used to show multiple values in one field.

--- a/docs/content/Token.mdx
+++ b/docs/content/Token.mdx
@@ -4,7 +4,6 @@ status: Alpha
 source: https://github.com/primer/react/tree/main/src/Token
 ---
 
-import {Props} from '../src/props'
 import {AvatarToken, IssueLabelToken, Token} from '@primer/components'
 
 A Token represents a piece of data. They are typically used to show a collection of related attributes.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -805,9 +805,9 @@
       }
     },
     "@babel/plugin-transform-react-display-name": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.15.1.tgz",
-      "integrity": "sha512-yQZ/i/pUCJAHI/LbtZr413S3VT26qNrEm0M5RRxQJA947/YNYwbZbBaXGDrq6CG5QsZycI1VIP6d7pQaBfP+8Q==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.0.tgz",
+      "integrity": "sha512-FJFdJAqaCpndL+pIf0aeD/qlQwT7QXOvR6Cc8JPvNhKJBi2zc/DPc4g05Y3fbD/0iWAMQFGij4+Xw+4L/BMpTg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -832,27 +832,27 @@
       }
     },
     "@babel/plugin-transform-react-jsx-development": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.14.5.tgz",
-      "integrity": "sha512-rdwG/9jC6QybWxVe2UVOa7q6cnTpw8JRRHOxntG/h6g/guAOe6AhtQHJuJh5FwmnXIT1bdm5vC2/5huV8ZOorQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.0.tgz",
+      "integrity": "sha512-qq65iSqBRq0Hr3wq57YG2AmW0H6wgTnIzpffTphrUWUgLCOK+zf1f7G0vuOiXrp7dU1qq+fQBoqZ3wCDAkhFzw==",
       "requires": {
-        "@babel/plugin-transform-react-jsx": "^7.14.5"
+        "@babel/plugin-transform-react-jsx": "^7.16.0"
       },
       "dependencies": {
         "@babel/helper-annotate-as-pure": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
-          "integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
+          "integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-module-imports": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
-          "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+          "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-plugin-utils": {
@@ -866,51 +866,51 @@
           "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
         },
         "@babel/plugin-syntax-jsx": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-          "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.0.tgz",
+          "integrity": "sha512-8zv2+xiPHwly31RK4RmnEYY5zziuF3O7W2kIDW+07ewWDh6Oi0dRq8kwvulRkFgt6DB97RlKs5c1y068iPlCUg==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.14.5"
           }
         },
         "@babel/plugin-transform-react-jsx": {
-          "version": "7.14.9",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
-          "integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.0.tgz",
+          "integrity": "sha512-rqDgIbukZ44pqq7NIRPGPGNklshPkvlmvqjdx3OZcGPk4zGIenYkxDTvl3LsSL8gqcc3ZzGmXPE6hR/u/voNOw==",
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.14.5",
-            "@babel/helper-module-imports": "^7.14.5",
+            "@babel/helper-annotate-as-pure": "^7.16.0",
+            "@babel/helper-module-imports": "^7.16.0",
             "@babel/helper-plugin-utils": "^7.14.5",
-            "@babel/plugin-syntax-jsx": "^7.14.5",
-            "@babel/types": "^7.14.9"
+            "@babel/plugin-syntax-jsx": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
+            "@babel/helper-validator-identifier": "^7.15.7",
             "to-fast-properties": "^2.0.0"
           }
         }
       }
     },
     "@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.14.5.tgz",
-      "integrity": "sha512-3X4HpBJimNxW4rhUy/SONPyNQHp5YRr0HhJdT2OH1BRp0of7u3Dkirc7x9FRJMKMqTBI079VZ1hzv7Ouuz///g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.16.0.tgz",
+      "integrity": "sha512-NC/Bj2MG+t8Ef5Pdpo34Ay74X4Rt804h5y81PwOpfPtmAK3i6CizmQqwyBQzIepz1Yt8wNr2Z2L7Lu3qBMfZMA==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5"
       },
       "dependencies": {
         "@babel/helper-annotate-as-pure": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
-          "integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
+          "integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-plugin-utils": {
@@ -924,11 +924,11 @@
           "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
         },
         "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
+            "@babel/helper-validator-identifier": "^7.15.7",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -1211,32 +1211,32 @@
       }
     },
     "@babel/preset-react": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.14.5.tgz",
-      "integrity": "sha512-XFxBkjyObLvBaAvkx1Ie95Iaq4S/GUEIrejyrntQ/VCMKUYvKLoyKxOBzJ2kjA3b6rC9/KL6KXfDC2GqvLiNqQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.16.0.tgz",
+      "integrity": "sha512-d31IFW2bLRB28uL1WoElyro8RH5l6531XfxMtCeCmp6RVAF1uTfxxUA0LH1tXl+psZdwfmIbwoG4U5VwgbhtLw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
-        "@babel/plugin-transform-react-display-name": "^7.14.5",
-        "@babel/plugin-transform-react-jsx": "^7.14.5",
-        "@babel/plugin-transform-react-jsx-development": "^7.14.5",
-        "@babel/plugin-transform-react-pure-annotations": "^7.14.5"
+        "@babel/plugin-transform-react-display-name": "^7.16.0",
+        "@babel/plugin-transform-react-jsx": "^7.16.0",
+        "@babel/plugin-transform-react-jsx-development": "^7.16.0",
+        "@babel/plugin-transform-react-pure-annotations": "^7.16.0"
       },
       "dependencies": {
         "@babel/helper-annotate-as-pure": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
-          "integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
+          "integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-module-imports": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
-          "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+          "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-plugin-utils": {
@@ -1255,31 +1255,31 @@
           "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
         },
         "@babel/plugin-syntax-jsx": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-          "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.0.tgz",
+          "integrity": "sha512-8zv2+xiPHwly31RK4RmnEYY5zziuF3O7W2kIDW+07ewWDh6Oi0dRq8kwvulRkFgt6DB97RlKs5c1y068iPlCUg==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.14.5"
           }
         },
         "@babel/plugin-transform-react-jsx": {
-          "version": "7.14.9",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
-          "integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.0.tgz",
+          "integrity": "sha512-rqDgIbukZ44pqq7NIRPGPGNklshPkvlmvqjdx3OZcGPk4zGIenYkxDTvl3LsSL8gqcc3ZzGmXPE6hR/u/voNOw==",
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.14.5",
-            "@babel/helper-module-imports": "^7.14.5",
+            "@babel/helper-annotate-as-pure": "^7.16.0",
+            "@babel/helper-module-imports": "^7.16.0",
             "@babel/helper-plugin-utils": "^7.14.5",
-            "@babel/plugin-syntax-jsx": "^7.14.5",
-            "@babel/types": "^7.14.9"
+            "@babel/plugin-syntax-jsx": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
+            "@babel/helper-validator-identifier": "^7.15.7",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -1352,9 +1352,9 @@
       }
     },
     "@base2/pretty-print-object": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz",
-      "integrity": "sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@base2/pretty-print-object/-/pretty-print-object-1.0.1.tgz",
+      "integrity": "sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
@@ -2161,9 +2161,9 @@
       }
     },
     "@primer/gatsby-theme-doctocat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-2.0.0.tgz",
-      "integrity": "sha512-TeskQMyjvrWtXXKNPbcBItHsjLTmziV9R9+I/MKgJhB9GuBadjHL6siOO8vh0lo6OHT/CUPUEqBnwn0LV76ANQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-3.0.0.tgz",
+      "integrity": "sha512-XzMPJlMUYcor0yJyQlh7pWrNba99+G5tXIK3Jp1AGglD+CtH3ypiU4JO+GaYIc5m9xqGiJsKXyulvuzXoxYdsw==",
       "requires": {
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",
@@ -2175,7 +2175,7 @@
         "@styled-system/theme-get": "^5.0.12",
         "@testing-library/jest-dom": "^4.1.0",
         "@testing-library/react": "^9.1.3",
-        "axios": "^0.19.0",
+        "axios": "^0.21.2",
         "babel-jest": "^24.9.0",
         "copy-to-clipboard": "^3.2.0",
         "date-fns": "^2.0.1",
@@ -2195,7 +2195,7 @@
         "gatsby-transformer-yaml": "^2.2.0",
         "get-pkg-repo": "^4.1.0",
         "github-slugger": "^1.2.1",
-        "html-react-parser": "^0.9.1",
+        "html-react-parser": "^1.4.0",
         "jest": "^24.9.0",
         "lodash.debounce": "4.0.8",
         "lodash.uniqby": "^4.7.0",
@@ -2203,7 +2203,7 @@
         "pluralize": "^8.0.0",
         "preval.macro": "^3.0.0",
         "prism-react-renderer": "^1.2.0",
-        "prismjs": "^1.22.0",
+        "prismjs": "^1.25.0",
         "react-addons-text-content": "^0.0.4",
         "react-element-to-jsx-string": "^14.0.3",
         "react-focus-on": "^3.3.0",
@@ -2219,9 +2219,9 @@
       },
       "dependencies": {
         "@primer/octicons-react": {
-          "version": "16.0.0",
-          "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-16.0.0.tgz",
-          "integrity": "sha512-1/DszHbG39lJO5w5el/Eej3Qu2TW0ecDDeYGq5T1cwNsgCWgJmtk2bmyPYJRQyRtGzRQQ8db03E8OeM7ATPSbQ=="
+          "version": "16.1.1",
+          "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-16.1.1.tgz",
+          "integrity": "sha512-xCxQ5z23ol7yDuJs85Lc4ARzyoay+b3zOhAKkEMU7chk0xi2hT2OnRP23QUudNNDPTGozX268RGYLexUa6P4xw=="
         }
       }
     },
@@ -2593,11 +2593,6 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
-    "@types/domhandler": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/domhandler/-/domhandler-2.4.1.tgz",
-      "integrity": "sha512-cfBw6q6tT5sa1gSPFSRKzF/xxYrrmeiut7E0TxNBObiLSBTuFEHibcfEe3waQPEDbqBsq+ql/TOniw65EyDFMA=="
-    },
     "@types/eslint": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.13.tgz",
@@ -2786,9 +2781,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
-      "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
+      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "requires": {
         "@types/react": "*"
       }
@@ -3491,9 +3486,9 @@
       }
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -3603,11 +3598,18 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.14.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.14.5",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+          "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+        }
       }
     },
     "axobject-query": {
@@ -3789,14 +3791,46 @@
       "integrity": "sha512-PkHJuRodMp4p617a/ZVhV8elBhRoFpOTpdu2DaApXJFIsDJWhjZ8d4BGbbFCT/yKJrhRDTdqg1r5AhWEaEUKkw=="
     },
     "babel-plugin-styled-components": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.13.2.tgz",
-      "integrity": "sha512-Vb1R3d4g+MUfPQPVDMCGjm3cDocJEUTR7Xq7QS95JWWeksN1wdFRYpD2kulDgI3Huuaf1CZd+NK4KQmqUFh5dA==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.13.3.tgz",
+      "integrity": "sha512-meGStRGv+VuKA/q0/jXxrPNWEm4LPfYIqxooDTdmh8kFsP/Ph7jJG5rUPwUPX3QHUvggwdbgdGpo88P/rRYsVw==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-module-imports": "^7.15.4",
         "babel-plugin-syntax-jsx": "^6.18.0",
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
+          "integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+          "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "babel-plugin-syntax-jsx": {
@@ -5483,9 +5517,9 @@
       }
     },
     "core-js": {
-      "version": "3.18.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.3.tgz",
-      "integrity": "sha512-tReEhtMReZaPFVw7dajMx0vlsz3oOb8ajgPoHVYGxr8ErnZ6PcYEvvmjGmXlfpnxpkYSdOQttjB+MvVbCGfvLw=="
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.1.tgz",
+      "integrity": "sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg=="
     },
     "core-js-compat": {
       "version": "3.13.0",
@@ -11611,13 +11645,63 @@
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
     },
     "html-dom-parser": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-0.2.3.tgz",
-      "integrity": "sha512-GdzE63/U0IQEvcpAz0cUdYx2zQx0Ai+HWvE9TXEgwP27+SymUzKa7iB4DhjYpf2IdNLfTTOBuMS5nxeWOosSMQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.0.2.tgz",
+      "integrity": "sha512-Jq4oVkVSn+10ut3fyc2P/Fs1jqTo0l45cP6Q8d2ef/9jfkYwulO0QXmyLI0VUiZrXF4czpGgMEJRa52CQ6Fk8Q==",
       "requires": {
-        "@types/domhandler": "2.4.1",
-        "domhandler": "2.4.2",
-        "htmlparser2": "3.10.1"
+        "domhandler": "4.2.2",
+        "htmlparser2": "6.1.0"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
+        "domhandler": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+          "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "domutils": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        },
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        },
+        "htmlparser2": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.5.2",
+            "entities": "^2.0.0"
+          }
+        }
       }
     },
     "html-encoding-sniffer": {
@@ -11639,22 +11723,27 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
     "html-react-parser": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-0.9.2.tgz",
-      "integrity": "sha512-EMf70HXgojCC9D1w9EmjdxDVXGqPkwtTa8Bmj1ePDWh7f2CbyEcS4WNDGS+I6ipS0ovUh5Ofe2kkGeW4XuvpaA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.0.tgz",
+      "integrity": "sha512-v8Kxy+7L90ZFSM690oJWBNRzZWZOQquYPpQt6kDQPzQyZptXgOJ69kHSi7xdqNdm1mOfsDPwF4K9Bo/dS5gRTQ==",
       "requires": {
-        "@types/domhandler": "2.4.1",
-        "html-dom-parser": "0.2.3",
-        "react-property": "1.0.1",
-        "style-to-object": "0.2.3"
+        "domhandler": "4.2.2",
+        "html-dom-parser": "1.0.2",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.0"
       },
       "dependencies": {
-        "style-to-object": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.2.3.tgz",
-          "integrity": "sha512-1d/k4EY2N7jVLOqf2j04dTc37TPOv/hHxZmvpg8Pdh8UYydxeu/C1W1U4vD8alzf5V2Gt7rLsmkr4dxAlDm9ng==",
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
+        "domhandler": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+          "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
           "requires": {
-            "inline-style-parser": "0.1.1"
+            "domelementtype": "^2.2.0"
           }
         }
       }
@@ -13654,11 +13743,11 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "makeerror": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "requires": {
-        "tmpl": "1.0.x"
+        "tmpl": "1.0.5"
       }
     },
     "map-age-cleaner": {
@@ -16287,18 +16376,24 @@
       }
     },
     "react-element-to-jsx-string": {
-      "version": "14.3.2",
-      "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.2.tgz",
-      "integrity": "sha512-WZbvG72cjLXAxV7VOuSzuHEaI3RHj10DZu8EcKQpkKcAj7+qAkG5XUeSdX5FXrA0vPrlx0QsnAzZEBJwzV0e+w==",
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.4.tgz",
+      "integrity": "sha512-t4ZwvV6vwNxzujDQ+37bspnLwA4JlgUPWhLjBJWsNIDceAf6ZKUTCjdm08cN6WeZ5pTMKiCJkmAYnpmR4Bm+dg==",
       "requires": {
-        "@base2/pretty-print-object": "1.0.0",
-        "is-plain-object": "3.0.1"
+        "@base2/pretty-print-object": "1.0.1",
+        "is-plain-object": "5.0.0",
+        "react-is": "17.0.2"
       },
       "dependencies": {
         "is-plain-object": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
-          "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g=="
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         }
       }
     },
@@ -16313,12 +16408,12 @@
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "react-focus-lock": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.2.tgz",
-      "integrity": "sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.6.0.tgz",
+      "integrity": "sha512-2yB5KWyaefbvFDgqvsg/KpIjbqVlhIY2c/dyDcokDLhB3Ib7I4bjsrta5OkI5euUoIu5xBTyBwIQZPykUJAr1g==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.9.1",
+        "focus-lock": "^0.9.2",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.5",
         "use-callback-ref": "^1.2.5",
@@ -16326,16 +16421,24 @@
       }
     },
     "react-focus-on": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.5.2.tgz",
-      "integrity": "sha512-tpPxLqw9tEuElWmcr5jqw/ULfJjdHEnom0nBW9p6y75Zsa0wOfwQNqCHqCoJcHUqSBtKXqTuYduZoSTfTOTdJw==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.5.4.tgz",
+      "integrity": "sha512-HnU0YGKhNSUsC4k6K8L+2wk8mC/qdg+CsS7A1bWLMgK7UuBphdECs2esnS6cLmBoVNjsFnCm/vMypeezKOdK3A==",
       "requires": {
-        "aria-hidden": "^1.1.2",
-        "react-focus-lock": "^2.5.0",
+        "aria-hidden": "^1.1.3",
+        "react-focus-lock": "^2.6.0",
         "react-remove-scroll": "^2.4.1",
         "react-style-singleton": "^2.1.1",
+        "tslib": "^2.3.1",
         "use-callback-ref": "^1.2.5",
         "use-sidecar": "^1.0.5"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "react-frame-component": {
@@ -16391,9 +16494,9 @@
       }
     },
     "react-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-property/-/react-property-1.0.1.tgz",
-      "integrity": "sha512-1tKOwxFn3dXVomH6pM9IkLkq2Y8oh+fh/lYW3MJ/B03URswUTqttgckOlbxY2XHF3vPG6uanSc4dVsLW/wk3wQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+      "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
     },
     "react-refresh": {
       "version": "0.9.0",
@@ -18497,6 +18600,14 @@
         }
       }
     },
+    "style-to-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.0.tgz",
+      "integrity": "sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==",
+      "requires": {
+        "style-to-object": "0.3.0"
+      }
+    },
     "style-to-object": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
@@ -19963,11 +20074,11 @@
       "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag=="
     },
     "walker": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "requires": {
-        "makeerror": "1.0.x"
+        "makeerror": "1.0.12"
       }
     },
     "watchpack": {
@@ -20407,11 +20518,11 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "widest-line": {
@@ -20477,9 +20588,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "node": ">= 10.x"
   },
   "dependencies": {
-    "@primer/gatsby-theme-doctocat": "^2.0.0",
+    "@primer/gatsby-theme-doctocat": "^3.0.0",
     "@primer/octicons-react": "^10.0.0",
     "@primer/primitives": "4.1.0",
     "@styled-system/prop-types": "^5.1.0",

--- a/docs/src/@primer/gatsby-theme-doctocat/mdx-components.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/mdx-components.js
@@ -1,0 +1,9 @@
+import {ComponentChecklist} from '../../component-checklist'
+import {Props} from '../../props'
+import {Box} from '@primer/components'
+
+export default {
+  Box,
+  ComponentChecklist,
+  Props
+}


### PR DESCRIPTION
Now that Doctocat allows to make custom components globally available in markdown files (https://github.com/primer/doctocat/pull/294), we can use `Box`, `Props`, and `ComponentChecklist` in our markdown files without importing them.