### PR TITLE
Exclude the next_major changeset release from canary releases.

### DIFF
--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -5,6 +5,7 @@ on:
       - 'main'
       - 'next_major'
       - 'changeset-release/main'
+      - 'changeset-release/next_major'
     # To avoid unnecessary noise, we don't create canary releases when these paths change:
     paths-ignore:
       - '.changeset/**'


### PR DESCRIPTION
This PR adds the branch `changeset-release/next_major` to the list of branches excluded from the release_canary workflow.

My expectation is that this will fix [this issue](https://github.com/primer/react/runs/4267480983?check_suite_focus=true).

After merging this I will manually rebase `next_major` on `main` to pick up this config.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
