### PR TITLE
Remove workflow configurations for next_major

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - next_major
 jobs:
   release:
     name: Release

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -3,9 +3,7 @@ on:
   push:
     branches-ignore:
       - 'main'
-      - 'next_major'
       - 'changeset-release/main'
-      - 'changeset-release/next_major'
     # To avoid unnecessary noise, we don't create canary releases when these paths change:
     paths-ignore:
       - '.changeset/**'


### PR DESCRIPTION
This removes the special workflow branch configurations for a `next_major` branch, as it doesn't sound like we'll be using that approach again any time soon.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
