### PR TITLE
Avatar, BranchName, Details, Heading, and ProgressBar no longer accept styled-system props.

### DIFF
--- a/.changeset/clean-clocks-warn.md
+++ b/.changeset/clean-clocks-warn.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': major
+---
+
+Details no longer accepts styled-system props. Please use the `sx` prop to extend Primer component styling instead. See also https://primer.style/react/overriding-styles for information about `sx` and https://primer.style/react/system-props for context on the removal.

--- a/.changeset/rude-squids-lick.md
+++ b/.changeset/rude-squids-lick.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': major
+---
+
+Avatar no longer accepts styled-system props. Please use the `sx` prop to extend Primer component styling instead. See also https://primer.style/react/overriding-styles for information about `sx` and https://primer.style/react/system-props for context on the removal.

--- a/.changeset/ten-doors-arrive.md
+++ b/.changeset/ten-doors-arrive.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': major
+---
+
+BranchName no longer accepts styled-system props. Please use the `sx` prop to extend Primer component styling instead. See also https://primer.style/react/overriding-styles for information about `sx` and https://primer.style/react/system-props for context on the removal.

--- a/.changeset/three-moose-impress.md
+++ b/.changeset/three-moose-impress.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': major
+---
+
+Heading no longer accepts styled-system props. Please use the `sx` prop to extend Primer component styling instead. See also https://primer.style/react/overriding-styles for information about `sx` and https://primer.style/react/system-props for context on the removal.

--- a/docs/content/BranchName.md
+++ b/docs/content/BranchName.md
@@ -12,15 +12,16 @@ BranchName is a label-type component rendered as an `<a>` tag by default with mo
 
 ## Props
 
-| Name | Type   | Default | Description                         |
-| :--- | :----- | :-----: | :---------------------------------- |
-| as   | String |  `<a>`  | sets the HTML tag for the component |
-| href | String |         | a URL to link the component to      |
+| Name | Type              | Default | Description                          |
+| :--- | :---------------- | :-----: | :----------------------------------- |
+| as   | String            |  `<a>`  | sets the HTML tag for the component  |
+| href | String            |         | a URL to link the component to       |
+| sx   | SystemStyleObject |   {}    | Style to be applied to the component |
 
 ## Component status
 
 <ComponentChecklist
-  items={{
+items={{
     propsDocumented: true,
     noUnnecessaryDeps: true,
     adaptsToThemes: true,

--- a/docs/content/Details.md
+++ b/docs/content/Details.md
@@ -79,15 +79,11 @@ In previous versions of Primer React Components, we allowed users to pass in a c
 </State>
 ```
 
-## `Details` System props
+## Details props
 
-<Note variant="warning">
-
-System props are deprecated in all components except [Box](/Box). Please use the [`sx` prop](/overriding-styles) instead.
-
-</Note>
-
-Details components get `COMMON` system props. Read our [System Props](/system-props) doc page for a full list of available props.
+| Name | Type              | Default | Description                          |
+| :--- | :---------------- | :-----: | :----------------------------------- |
+| sx   | SystemStyleObject |   {}    | Style to be applied to the component |
 
 ## `useDetails` hook configuration options
 

--- a/docs/content/Heading.md
+++ b/docs/content/Heading.md
@@ -10,17 +10,12 @@ The Heading component will render an html `h2` tag without any default styling. 
 ## Default example
 
 ```jsx live
-<Heading fontSize={1} mb={2}>
-  H2 heading with fontSize={1}
-</Heading>
+<Heading sx={{fontSize: 1, mb: 2}}>H2 heading with fontSize={1}</Heading>
 ```
-
-## System props
-
-Heading components get `TYPOGRAPHY` and `COMMON` system props. Read our [System Props](/system-props) doc page for a full list of available props.
 
 ## Component props
 
-| Prop name | Type                    | Description                         |
-| :-------- | :---------------------- | :---------------------------------- |
-| as        | String or React element | sets the HTML tag for the component |
+| Name | Type                    | Default | Description                          |
+| :--- | :---------------------- | :-----: | :----------------------------------- |
+| as   | String or React element |         | sets the HTML tag for the component  |
+| sx   | SystemStyleObject       |   {}    | Style to be applied to the component |

--- a/docs/content/Label.md
+++ b/docs/content/Label.md
@@ -41,10 +41,9 @@ The Label component is used to add contextual metadata to a design. Visually it 
 
 ## Component props
 
-| Name       | Type              |        Default         | Description                                                                    |
-| :--------- | :---------------- | :--------------------: | :----------------------------------------------------------------------------- |
-| outline    | Boolean           |                        | Creates an outline style label                                                 |
-| variant    | String            |        'medium'        | Can be one of `small`, `medium` (default), `large` or `xl` .                   |
-| dropshadow | Boolean           |                        | Adds a dropshadow to the label                                                 |
-| bg         | String            | 'label.primary.border' | Part of the `COMMON` system props, used to change the background of the label. |
-| sx         | SystemStyleObject |           {}           | Style to be applied to the component                                           |
+| Name       | Type              | Default  | Description                                                  |
+| :--------- | :---------------- | :------: | :----------------------------------------------------------- |
+| outline    | Boolean           |          | Creates an outline style label                               |
+| variant    | String            | 'medium' | Can be one of `small`, `medium` (default), `large` or `xl` . |
+| dropshadow | Boolean           |          | Adds a dropshadow to the label                               |
+| sx         | SystemStyleObject |    {}    | Style to be applied to the component                         |

--- a/docs/content/ProgressBar.mdx
+++ b/docs/content/ProgressBar.mdx
@@ -22,9 +22,10 @@ If you'd like to use ProgressBar inline, pass the `inline` boolean prop & **be s
 
 ## Component props
 
-| Name     | Type    |       Default       | Description                                                                                                                      |
-| :------- | :------ | :-----------------: | :------------------------------------------------------------------------------------------------------------------------------- |
-| progress | Number  |                     | Used to set the size of the green bar                                                                                            |
-| barSize  | String  |      'default'      | Controls the height of the progress bar. Can be 'small', 'large', or 'default'. If omitted, height is set to the default height. |
-| inline   | Boolean |        false        | Styles the progress bar inline                                                                                                   |
-| bg       | String  | 'bg.successInverse' | Set the progress bar color, defaults to bg-green                                                                                 |
+| Name     | Type              |       Default       | Description                                                                                                                      |
+| :------- | :---------------- | :-----------------: | :------------------------------------------------------------------------------------------------------------------------------- |
+| progress | Number            |                     | Used to set the size of the green bar                                                                                            |
+| barSize  | String            |      'default'      | Controls the height of the progress bar. Can be 'small', 'large', or 'default'. If omitted, height is set to the default height. |
+| inline   | Boolean           |        false        | Styles the progress bar inline                                                                                                   |
+| bg       | String            | 'bg.successInverse' | Set the progress bar color, defaults to bg-green                                                                                 |
+| sx       | SystemStyleObject |         {}          | Style to be applied to the component                                                                                             |

--- a/docs/content/Text.md
+++ b/docs/content/Text.md
@@ -23,12 +23,6 @@ The Text component is a wrapper component that will apply typography styles to t
 
 ## System props
 
-<Note variant="warning">
-
-System props are deprecated in all components except [Box](/Box). Please use the [`sx` prop](/overriding-styles) instead.
-
-</Note>
-
 Text components get `TYPOGRAPHY` and `COMMON` system props. Read our [System Props](/system-props) doc page for a full list of available props.
 
 ## Component props

--- a/docs/content/system-props.mdx
+++ b/docs/content/system-props.mdx
@@ -6,7 +6,7 @@ import {PropsList, COMMON, LAYOUT, BORDER, TYPOGRAPHY, FLEX, POSITION, GRID} fro
 
 <Note variant="warning">
 
-System props are deprecated in all components except [Box](/Box). Please use the [`sx` prop](/overriding-styles) instead.
+System props are deprecated in all components except [Box](/Box) and [Text](/Text). Please use the [`sx` prop](/overriding-styles) instead.
 
 </Note>
 

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import {COMMON, get, SystemCommonProps} from './constants'
+import {get} from './constants'
 import sx, {SxProp} from './sx'
 import {ComponentProps} from './utils/types'
 
@@ -12,8 +12,7 @@ type StyledAvatarProps = {
   src: string
   /** Provide alt text when the Avatar is used without the user's name next to it. */
   alt?: string
-} & SystemCommonProps &
-  SxProp
+} & SxProp
 
 function getBorderRadius({size, square}: StyledAvatarProps) {
   if (square) {
@@ -32,7 +31,6 @@ const Avatar = styled.img.attrs<StyledAvatarProps>(props => ({
   line-height: ${get('lineHeights.condensedUltra')};
   vertical-align: middle;
   border-radius: ${props => getBorderRadius(props)};
-  ${COMMON};
   ${sx}
 `
 

--- a/src/BranchName.tsx
+++ b/src/BranchName.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components'
-import {COMMON, get, SystemCommonProps} from './constants'
+import {get} from './constants'
 import sx, {SxProp} from './sx'
 import {ComponentProps} from './utils/types'
 
-const BranchName = styled.a<SystemCommonProps & SxProp>`
+const BranchName = styled.a<SxProp>`
   display: inline-block;
   padding: 2px 6px;
   font-size: ${get('fontSizes.0')};
@@ -11,7 +11,7 @@ const BranchName = styled.a<SystemCommonProps & SxProp>`
   color: ${get('colors.fg.muted')};
   background-color: ${get('colors.accent.subtle')};
   border-radius: ${get('radii.2')};
-  ${COMMON};
+
   ${sx};
 `
 

--- a/src/Details.tsx
+++ b/src/Details.tsx
@@ -1,11 +1,8 @@
 import styled from 'styled-components'
-import {COMMON, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
 import {ComponentProps} from './utils/types'
 
-type StyledDetailsProps = SystemCommonProps & SxProp
-
-const Details = styled.details<StyledDetailsProps>`
+const Details = styled.details<SxProp>`
   & > summary {
     list-style: none;
   }
@@ -13,7 +10,6 @@ const Details = styled.details<StyledDetailsProps>`
     display: none;
   }
 
-  ${COMMON}
   ${sx};
 `
 

--- a/src/Heading.tsx
+++ b/src/Heading.tsx
@@ -1,21 +1,14 @@
 import styled from 'styled-components'
-import {COMMON, get, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from './constants'
+import {get} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
-const Heading = styled.h2<SystemTypographyProps & SystemCommonProps & SxProp>`
+const Heading = styled.h2<SxProp>`
   font-weight: ${get('fontWeights.bold')};
   font-size: ${get('fontSizes.5')};
   margin: 0;
-  ${TYPOGRAPHY};
-  ${COMMON};
   ${sx};
 `
-
-Heading.defaultProps = {
-  theme
-}
 
 export type HeadingProps = ComponentProps<typeof Heading>
 export default Heading

--- a/src/ProgressBar.tsx
+++ b/src/ProgressBar.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import styled from 'styled-components'
 import {width, WidthProps} from 'styled-system'
-import {COMMON, get, SystemCommonProps} from './constants'
+import {get} from './constants'
 import sx, {SxProp} from './sx'
-import {ComponentProps} from './utils/types'
 
-const Bar = styled.span<{progress?: string | number} & SystemCommonProps>`
+type ProgressProp = {progress?: string | number}
+
+const Bar = styled.span<ProgressProp & SxProp>`
   width: ${props => (props.progress ? `${props.progress}%` : 0)};
-  ${COMMON}
+
+  ${sx};
 `
 
 const sizeMap = {
@@ -20,7 +22,6 @@ type StyledProgressContainerProps = {
   inline?: boolean
   barSize?: keyof typeof sizeMap
 } & WidthProps &
-  SystemCommonProps &
   SxProp
 
 const ProgressContainer = styled.span<StyledProgressContainerProps>`
@@ -29,17 +30,17 @@ const ProgressContainer = styled.span<StyledProgressContainerProps>`
   background-color: ${get('colors.border.default')};
   border-radius: ${get('radii.1')};
   height: ${props => sizeMap[props.barSize || 'default']};
-  ${COMMON}
+
   ${width}
   ${sx};
 `
 
-export type ProgressBarProps = ComponentProps<typeof ProgressContainer> & ComponentProps<typeof Bar>
+export type ProgressBarProps = {bg: string} & StyledProgressContainerProps & ProgressProp
 
-function ProgressBar({progress, bg, theme, ...rest}: ProgressBarProps) {
+function ProgressBar({progress, bg, ...rest}: ProgressBarProps) {
   return (
-    <ProgressContainer theme={theme} {...rest}>
-      <Bar progress={progress} bg={bg} theme={theme} />
+    <ProgressContainer {...rest}>
+      <Bar progress={progress} sx={{bg}} />
     </ProgressContainer>
   )
 }

--- a/src/Spinner.tsx
+++ b/src/Spinner.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import {COMMON, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
 import {ComponentProps} from './utils/types'
 
@@ -40,7 +39,7 @@ function Spinner({size: sizeKey = 'medium', ...props}: SpinnerInternalProps) {
   )
 }
 
-const StyledSpinner = styled(Spinner)<SystemCommonProps & SxProp>`
+const StyledSpinner = styled(Spinner)<SxProp>`
   @keyframes rotate-keyframes {
     100% {
       transform: rotate(360deg);
@@ -49,7 +48,6 @@ const StyledSpinner = styled(Spinner)<SystemCommonProps & SxProp>`
 
   animation: rotate-keyframes 1s linear infinite;
 
-  ${COMMON}
   ${sx}
 `
 

--- a/src/__tests__/Avatar.test.tsx
+++ b/src/__tests__/Avatar.test.tsx
@@ -39,6 +39,6 @@ describe('Avatar', () => {
   })
 
   it('respects margin props', () => {
-    expect(render(<Avatar m={2} src="primer.png" alt="" />)).toHaveStyleRule('margin', px(theme.space[2]))
+    expect(render(<Avatar src="primer.png" alt="" sx={{m: 2}} />)).toHaveStyleRule('margin', px(theme.space[2]))
   })
 })

--- a/src/__tests__/Avatar.types.test.tsx
+++ b/src/__tests__/Avatar.types.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import Avatar from '../Avatar'
+
+export function shouldAcceptCallWithNoProps() {
+  return <Avatar src="https://avatars.githubusercontent.com/primer" />
+}
+
+export function shouldNotAcceptSystemProps() {
+  // @ts-expect-error system props should not be accepted
+  return <Avatar src="https://avatars.githubusercontent.com/primer" backgroundColor="thistle" />
+}

--- a/src/__tests__/BranchName.types.test.tsx
+++ b/src/__tests__/BranchName.types.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import BranchName from '../BranchName'
+
+export function shouldAcceptCallWithNoProps() {
+  return <BranchName />
+}
+
+export function shouldNotAcceptSystemProps() {
+  // @ts-expect-error system props should not be accepted
+  return <BranchName backgroundColor="thistle" />
+}

--- a/src/__tests__/Details.types.test.tsx
+++ b/src/__tests__/Details.types.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import Details from '../Details'
+
+export function shouldAcceptCallWithNoProps() {
+  return <Details />
+}
+
+export function shouldNotAcceptSystemProps() {
+  // @ts-expect-error system props should not be accepted
+  return <Details backgroundColor="thistle" />
+}

--- a/src/__tests__/Heading.test.tsx
+++ b/src/__tests__/Heading.test.tsx
@@ -4,6 +4,7 @@ import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
+import ThemeProvider from '../ThemeProvider'
 expect.extend(toHaveNoViolations)
 
 const theme = {
@@ -48,44 +49,89 @@ describe('Heading', () => {
   })
 
   it('respects fontWeight', () => {
-    expect(render(<Heading fontWeight="bold" theme={theme} />)).toHaveStyleRule('font-weight', theme.fontWeights.bold)
-    expect(render(<Heading fontWeight="normal" theme={theme} />)).toHaveStyleRule(
-      'font-weight',
-      theme.fontWeights.normal
-    )
-    expect(render(<Heading fontWeight="semibold" theme={theme} />)).toHaveStyleRule(
-      'font-weight',
-      theme.fontWeights.semibold
-    )
-    expect(render(<Heading fontWeight="light" theme={theme} />)).toHaveStyleRule('font-weight', theme.fontWeights.light)
+    expect(
+      render(
+        <ThemeProvider theme={theme}>
+          <Heading sx={{fontWeight: 'bold'}} />
+        </ThemeProvider>
+      )
+    ).toHaveStyleRule('font-weight', theme.fontWeights.bold)
+    expect(
+      render(
+        <ThemeProvider theme={theme}>
+          <Heading sx={{fontWeight: 'normal'}} />
+        </ThemeProvider>
+      )
+    ).toHaveStyleRule('font-weight', theme.fontWeights.normal)
+    expect(
+      render(
+        <ThemeProvider theme={theme}>
+          <Heading sx={{fontWeight: 'semibold'}} />
+        </ThemeProvider>
+      )
+    ).toHaveStyleRule('font-weight', theme.fontWeights.semibold)
+    expect(
+      render(
+        <ThemeProvider theme={theme}>
+          <Heading sx={{fontWeight: 'light'}} />
+        </ThemeProvider>
+      )
+    ).toHaveStyleRule('font-weight', theme.fontWeights.light)
   })
 
   it('respects lineHeight', () => {
-    expect(render(<Heading lineHeight="normal" theme={theme} />)).toHaveStyleRule(
-      'line-height',
-      String(theme.lineHeights.normal)
-    )
-    expect(render(<Heading lineHeight="condensed" theme={theme} />)).toHaveStyleRule(
-      'line-height',
-      String(theme.lineHeights.condensed)
-    )
-    expect(render(<Heading lineHeight="condensedUltra" theme={theme} />)).toHaveStyleRule(
-      'line-height',
-      String(theme.lineHeights.condensedUltra)
-    )
+    expect(
+      render(
+        <ThemeProvider theme={theme}>
+          <Heading sx={{lineHeight: 'normal'}} />
+        </ThemeProvider>
+      )
+    ).toHaveStyleRule('line-height', String(theme.lineHeights.normal))
+    expect(
+      render(
+        <ThemeProvider theme={theme}>
+          <Heading sx={{lineHeight: 'condensed'}} />
+        </ThemeProvider>
+      )
+    ).toHaveStyleRule('line-height', String(theme.lineHeights.condensed))
+    expect(
+      render(
+        <ThemeProvider theme={theme}>
+          <Heading sx={{lineHeight: 'condensedUltra'}} />
+        </ThemeProvider>
+      )
+    ).toHaveStyleRule('line-height', String(theme.lineHeights.condensedUltra))
   })
 
   it('respects fontFamily="mono"', () => {
-    expect(render(<Heading fontFamily="mono" theme={theme} />)).toHaveStyleRule('font-family', theme.fonts.mono)
+    expect(
+      render(
+        <ThemeProvider theme={theme}>
+          <Heading sx={{fontFamily: 'mono'}} />
+        </ThemeProvider>
+      )
+    ).toHaveStyleRule('font-family', theme.fonts.mono)
   })
 
   it('renders fontSize', () => {
     for (const fontSize of theme.fontSizes) {
-      expect(render(<Heading fontSize={fontSize} theme={theme} />)).toHaveStyleRule('font-size', `${fontSize}`)
+      expect(
+        render(
+          <ThemeProvider theme={theme}>
+            <Heading sx={{fontSize}} />
+          </ThemeProvider>
+        )
+      ).toHaveStyleRule('font-size', `${fontSize}`)
     }
   })
 
   it('respects the "fontStyle" prop', () => {
-    expect(render(<Heading fontStyle="italic" />)).toHaveStyleRule('font-style', 'italic')
+    expect(
+      render(
+        <ThemeProvider theme={theme}>
+          <Heading sx={{fontStyle: 'italic'}} />
+        </ThemeProvider>
+      )
+    ).toHaveStyleRule('font-style', 'italic')
   })
 })

--- a/src/__tests__/Heading.types.test.tsx
+++ b/src/__tests__/Heading.types.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import Heading from '../Heading'
+
+export function shouldAcceptCallWithNoProps() {
+  return <Heading />
+}
+
+export function shouldNotAcceptSystemProps() {
+  // @ts-expect-error system props should not be accepted
+  return <Heading backgroundColor="thistle" />
+}


### PR DESCRIPTION
I went to clean up some docs and noticed I missed a few in the first pass.

See https://github.com/github/primer/issues/296.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
