### PR TITLE
Upgrading primer/primitives@7.1.1

### DIFF
--- a/.changeset/clever-chairs-look.md
+++ b/.changeset/clever-chairs-look.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Upgrading primer/primitives@7.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@primer/components",
-  "version": "31.1.0",
+  "version": "32.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/components",
-      "version": "31.1.0",
+      "version": "32.0.0",
       "license": "MIT",
       "dependencies": {
         "@primer/octicons-react": "^16.1.0",
-        "@primer/primitives": "7.0.1",
+        "@primer/primitives": "7.1.1",
         "@radix-ui/react-polymorphic": "0.0.14",
         "@react-aria/ssr": "3.1.0",
         "@styled-system/css": "5.1.5",
@@ -7561,9 +7561,9 @@
       }
     },
     "node_modules/@primer/primitives": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.0.1.tgz",
-      "integrity": "sha512-Ddmi5Fuck3nsHt1+uvZiVzLwtjNrBloWq8FfQz74Qd9TXKxvHxrGxQuEJ21T3PxJMMwwEsKo7fk18oy1rTmFiA=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.1.1.tgz",
+      "integrity": "sha512-+Gwo89YK1OFi6oubTlah/zPxxzMNaMLy+inECAYI646KIFdzzhAsKWb3z5tSOu5Ff7no4isRV64rWfMSKLZclw=="
     },
     "node_modules/@radix-ui/react-polymorphic": {
       "version": "0.0.14",
@@ -43351,9 +43351,9 @@
       "requires": {}
     },
     "@primer/primitives": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.0.1.tgz",
-      "integrity": "sha512-Ddmi5Fuck3nsHt1+uvZiVzLwtjNrBloWq8FfQz74Qd9TXKxvHxrGxQuEJ21T3PxJMMwwEsKo7fk18oy1rTmFiA=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.1.1.tgz",
+      "integrity": "sha512-+Gwo89YK1OFi6oubTlah/zPxxzMNaMLy+inECAYI646KIFdzzhAsKWb3z5tSOu5Ff7no4isRV64rWfMSKLZclw=="
     },
     "@radix-ui/react-polymorphic": {
       "version": "0.0.14",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "dependencies": {
     "@primer/octicons-react": "^16.1.0",
-    "@primer/primitives": "7.0.1",
+    "@primer/primitives": "7.1.1",
     "@radix-ui/react-polymorphic": "0.0.14",
     "@react-aria/ssr": "3.1.0",
     "@styled-system/css": "5.1.5",


### PR DESCRIPTION
Upgrading primer/primitives to the latest version to include light high contrast colors. Unblocks https://github.com/github/memex/pull/6331

https://github.com/primer/primitives/releases/tag/v7.1.1

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
