### PR TITLE
ActionList: Fix multiple selection svg by overriding global shape-rendering for github.com

### DIFF
--- a/.changeset/actionlist-fix-selection-rendering.md
+++ b/.changeset/actionlist-fix-selection-rendering.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': patch
+---
+
+ActionList: Fix multiple selection svg by overriding global shape-rendering for github.com

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -317,6 +317,7 @@ const MultiSelectIcon = styled.svg<{selected?: boolean}>`
   rect {
     fill: ${({selected}) => (selected ? get('colors.accent.fg') : get('colors.canvas.default'))};
     stroke: ${({selected}) => (selected ? get('colors.accent.fg') : get('colors.border.default'))};
+    shape-rendering: auto; // this is a workaround to override global style in github/github
   }
   path {
     fill: ${get('colors.fg.onEmphasis')};

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -317,7 +317,7 @@ const MultiSelectIcon = styled.svg<{selected?: boolean}>`
   rect {
     fill: ${({selected}) => (selected ? get('colors.accent.fg') : get('colors.canvas.default'))};
     stroke: ${({selected}) => (selected ? get('colors.accent.fg') : get('colors.border.default'))};
-    shape-rendering: auto; // this is a workaround to override global style in github/github
+    shape-rendering: auto; // this is a workaround to override global style in github/github, see primer/react#1666
   }
   path {
     fill: ${get('colors.fg.onEmphasis')};

--- a/src/ActionList2/Selection.tsx
+++ b/src/ActionList2/Selection.tsx
@@ -39,7 +39,7 @@ export const Selection: React.FC<SelectionProps> = ({selected}) => {
         rect: {
           fill: selected ? 'accent.fg' : 'canvas.default',
           stroke: selected ? 'accent.fg' : 'border.default',
-          shapeRendering: 'auto' // this is a workaround to override global style in github/github
+          shapeRendering: 'auto' // this is a workaround to override global style in github/github, see primer/react#1666
         },
         path: {
           fill: 'fg.onEmphasis',

--- a/src/ActionList2/Selection.tsx
+++ b/src/ActionList2/Selection.tsx
@@ -38,7 +38,8 @@ export const Selection: React.FC<SelectionProps> = ({selected}) => {
       sx={{
         rect: {
           fill: selected ? 'accent.fg' : 'canvas.default',
-          stroke: selected ? 'accent.fg' : 'border.default'
+          stroke: selected ? 'accent.fg' : 'border.default',
+          shapeRendering: 'auto' // this is a workaround to override global style in github/github
         },
         path: {
           fill: 'fg.onEmphasis',

--- a/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -510,6 +510,7 @@ Array [
 .c6 rect {
   fill: #ffffff;
   stroke: #d0d7de;
+  shape-rendering: auto;
 }
 
 .c6 path {
@@ -1380,6 +1381,7 @@ Array [
 .c6 rect {
   fill: #ffffff;
   stroke: #d0d7de;
+  shape-rendering: auto;
 }
 
 .c6 path {
@@ -2197,6 +2199,7 @@ Array [
 .c10 rect {
   fill: #ffffff;
   stroke: #d0d7de;
+  shape-rendering: auto;
 }
 
 .c10 path {
@@ -2207,6 +2210,7 @@ Array [
 .c6 rect {
   fill: #0969da;
   stroke: #0969da;
+  shape-rendering: auto;
 }
 
 .c6 path {


### PR DESCRIPTION
Fixes https://github.com/primer/react/issues/1666


There is a global declaration in `github.com` in [commit-acitivity.scss#L17](https://github.com/github/github/blob/deab55d89c624406e4a92c9493be98633c0446af/app/assets/stylesheets/custom/github/commit-acitivity.scss#L17) which makes the multi-selection look strange:

```css
rect {
  shape-rendering: crispedges;
}
```

The ideal fix would be to remove the global style declaration but that's not going to a trivial task as this [line is pretty old](https://app.slack.com/client/T0CA8C346/threads/thread/C01L618AEP9-1638279425.298600) with implicit dependencies across the codebase.

We can absorb this override into the component as a workaround. Hopefully we can remove this in the future.

### Screenshots


Before: 

![the selection svg has rough edges](https://user-images.githubusercontent.com/1863771/144064628-435093be-8dda-4983-aca9-bee5894026d2.png)


After:
![the selection svg has smooth edges](https://user-images.githubusercontent.com/1863771/144064582-8a2dd617-f50d-497d-a0ee-6f6a0bcfe537.png)


### Merge checklist

- NA Added/updated tests
- NA Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge