### PR TITLE
Rename "component statuses" to "component status"

### DIFF
--- a/docs/content/status.mdx
+++ b/docs/content/status.mdx
@@ -1,5 +1,5 @@
 ---
-title: Component statuses
+title: Component status
 description: Check the current status of Primer React components
 ---
 

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -19,7 +19,7 @@
       url: /overriding-styles
     - title: Server-side rendering
       url: /ssr
-    - title: Component statuses
+    - title: Component status
       url: /status
 - title: Hooks
   children:


### PR DESCRIPTION
From @yaili:

> can we rename the page to “Component status” - I think the plural of status can be both, and it looks nicer :smile: