### PR TITLE
Remove "engines" field from package.json

### DIFF
--- a/.changeset/tidy-maps-care.md
+++ b/.changeset/tidy-maps-care.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Remove "engines" field from package.json

--- a/package.json
+++ b/package.json
@@ -155,9 +155,5 @@
       "webpack": false,
       "running": false
     }
-  ],
-  "engines": {
-    "node": ">=16",
-    "npm": ">=8"
-  }
+  ]
 }


### PR DESCRIPTION
The `engines` field is breaking builds for projects using node <16. Since node 16 is not required to use `@primer/react`, let's remove this field from the package.json.

[<img width="1033" alt="CleanShot 2021-12-09 at 14 53 32@2x" src="https://user-images.githubusercontent.com/4608155/145488605-3ff712cb-096b-4e16-b8f1-25e10eadc823.png">](https://vercel.com/primer/doctocat/41ukG3xkShTswtBLLsHJnKrS1x54)