### PR TITLE
Add side effects false to package.json

### DIFF
--- a/.changeset/dull-dots-act.md
+++ b/.changeset/dull-dots-act.md
@@ -1,5 +1,0 @@
----
-'@primer/react': patch
----
-
-adds sideEffects false back to package.json

--- a/.changeset/dull-dots-act.md
+++ b/.changeset/dull-dots-act.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+adds sideEffects false back to package.json

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "lib-esm/index.js",
   "typings": "lib/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "setup": "./script/setup",
     "build": "./script/build",


### PR DESCRIPTION
Describe your changes here.

Fixes a bundler related bug introduced via #1700 where the sideEffects declaration was removed from package.json, potentially causing bundlers to not properly treeshake unused modules. 

#1332 introduced this fix initially, but had to declare specific files as containing sideEffects, due to their implementation.  When removing these files to a dependency, this should have been left in

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
