### PR TITLE
Chromatic: auto accept main as baseline

### DIFF
--- a/.github/workflows/visual_testing.yml
+++ b/.github/workflows/visual_testing.yml
@@ -28,3 +28,4 @@ jobs:
         with:
           buildScriptName: build:storybook
           projectToken: 91e12320417c
+          autoAcceptChanges: github.ref == 'refs/heads/main'


### PR DESCRIPTION
We want to keep a clean main branch, so that feature-branches compare with that. If it's merged to master, we want to automatically approve it.

Docs: https://www.chromatic.com/docs/github-actions#maintain-a-clean-main-branch