### PR TITLE
Button v2: Fix icon positions for block buttons

### DIFF
--- a/.changeset/button2-block-position.md
+++ b/.changeset/button2-block-position.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Button 2: Fix icon positions for block buttons

--- a/src/NewButton/styles.ts
+++ b/src/NewButton/styles.ts
@@ -225,11 +225,13 @@ export const getButtonStyles = (theme?: Theme) => {
       gridArea: 'leadingIcon'
     },
     '[data-component="text"]': {
-      gridArea: 'text',
-      textAlign: 'left'
+      gridArea: 'text'
     },
     '[data-component="trailingIcon"]': {
       gridArea: 'trailingIcon'
+    },
+    '[data-component="leadingIcon"] + [data-component="text"]': {
+      textAlign: 'left'
     }
   }
   return styles

--- a/src/NewButton/styles.ts
+++ b/src/NewButton/styles.ts
@@ -217,6 +217,7 @@ export const getButtonStyles = (theme?: Theme) => {
     ...getBaseStyles(theme),
     display: 'grid',
     gridTemplateAreas: '"leadingIcon text trailingIcon"',
+    gridTemplateColumns: 'min-content 1fr min-content',
     '& > :not(:last-child)': {
       mr: '2'
     },
@@ -224,7 +225,8 @@ export const getButtonStyles = (theme?: Theme) => {
       gridArea: 'leadingIcon'
     },
     '[data-component="text"]': {
-      gridArea: 'text'
+      gridArea: 'text',
+      textAlign: 'left'
     },
     '[data-component="trailingIcon"]': {
       gridArea: 'trailingIcon'

--- a/src/__tests__/__snapshots__/NewButton.test.tsx.snap
+++ b/src/__tests__/__snapshots__/NewButton.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Button renders consistently 1`] = `
   text-align: center;
   display: grid;
   grid-template-areas: "leadingIcon text trailingIcon";
+  grid-template-columns: min-content 1fr min-content;
   padding-top: 5px;
   padding-bottom: 5px;
   padding-left: 16px;
@@ -61,6 +62,10 @@ exports[`Button renders consistently 1`] = `
 
 .c0 [data-component="trailingIcon"] {
   grid-area: trailingIcon;
+}
+
+.c0 [data-component="leadingIcon"] + [data-component="text"] {
+  text-align: left;
 }
 
 .c0 [data-component="ButtonCounter"] {
@@ -111,6 +116,7 @@ exports[`Button styles danger button appropriately 1`] = `
   text-align: center;
   display: grid;
   grid-template-areas: "leadingIcon text trailingIcon";
+  grid-template-columns: min-content 1fr min-content;
   padding-top: 5px;
   padding-bottom: 5px;
   padding-left: 16px;
@@ -154,6 +160,10 @@ exports[`Button styles danger button appropriately 1`] = `
 
 .c0 [data-component="trailingIcon"] {
   grid-area: trailingIcon;
+}
+
+.c0 [data-component="leadingIcon"] + [data-component="text"] {
+  text-align: left;
 }
 
 .c0 [data-component="ButtonCounter"] {
@@ -219,6 +229,7 @@ exports[`Button styles invisible button appropriately 1`] = `
   text-align: center;
   display: grid;
   grid-template-areas: "leadingIcon text trailingIcon";
+  grid-template-columns: min-content 1fr min-content;
   padding-top: 6px;
   padding-bottom: 6px;
   padding-left: 16px;
@@ -256,6 +267,10 @@ exports[`Button styles invisible button appropriately 1`] = `
 
 .c0 [data-component="trailingIcon"] {
   grid-area: trailingIcon;
+}
+
+.c0 [data-component="leadingIcon"] + [data-component="text"] {
+  text-align: left;
 }
 
 .c0 [data-component="ButtonCounter"] {
@@ -307,6 +322,7 @@ exports[`Button styles outline button appropriately 1`] = `
   text-align: center;
   display: grid;
   grid-template-areas: "leadingIcon text trailingIcon";
+  grid-template-columns: min-content 1fr min-content;
   padding-top: 5px;
   padding-bottom: 5px;
   padding-left: 16px;
@@ -349,6 +365,10 @@ exports[`Button styles outline button appropriately 1`] = `
 
 .c0 [data-component="trailingIcon"] {
   grid-area: trailingIcon;
+}
+
+.c0 [data-component="leadingIcon"] + [data-component="text"] {
+  text-align: left;
 }
 
 .c0 [data-component="ButtonCounter"] {
@@ -415,6 +435,7 @@ exports[`Button styles primary button appropriately 1`] = `
   text-align: center;
   display: grid;
   grid-template-areas: "leadingIcon text trailingIcon";
+  grid-template-columns: min-content 1fr min-content;
   padding-top: 5px;
   padding-bottom: 5px;
   padding-left: 16px;
@@ -453,6 +474,10 @@ exports[`Button styles primary button appropriately 1`] = `
 
 .c0 [data-component="trailingIcon"] {
   grid-area: trailingIcon;
+}
+
+.c0 [data-component="leadingIcon"] + [data-component="text"] {
+  text-align: left;
 }
 
 .c0 [data-component="ButtonCounter"] {

--- a/src/stories/NewButton.stories.tsx
+++ b/src/stories/NewButton.stories.tsx
@@ -149,7 +149,13 @@ export const blockButton = ({...args}: ButtonProps) => {
       <Button {...args} sx={{width: '100%', mb: 2}}>
         Block
       </Button>
-      <Button leadingIcon={EyeIcon} trailingIcon={TriangleDownIcon} {...args} sx={{width: '100%'}}>
+      <Button leadingIcon={EyeIcon} trailingIcon={TriangleDownIcon} {...args} sx={{width: '100%', mb: 2}}>
+        Watch
+      </Button>
+      <Button trailingIcon={TriangleDownIcon} {...args} sx={{width: '100%', mb: 2}}>
+        Watch
+      </Button>
+      <Button leadingIcon={EyeIcon} {...args} sx={{width: '100%'}}>
         Watch
       </Button>
     </>

--- a/src/stories/NewButton.stories.tsx
+++ b/src/stories/NewButton.stories.tsx
@@ -145,9 +145,14 @@ export const caretButton = ({...args}: ButtonProps) => {
 
 export const blockButton = ({...args}: ButtonProps) => {
   return (
-    <Button {...args} sx={{width: '100%'}}>
-      Block
-    </Button>
+    <>
+      <Button {...args} sx={{width: '100%', mb: 2}}>
+        Block
+      </Button>
+      <Button leadingIcon={EyeIcon} trailingIcon={TriangleDownIcon} {...args} sx={{width: '100%'}}>
+        Watch
+      </Button>
+    </>
   )
 }
 


### PR DESCRIPTION
With a block button, the icon and text alignment is a bit strange

### Screenshots

![image](https://user-images.githubusercontent.com/1863771/146051527-b1862f8b-f86d-4d2c-a9e3-0c896f5bdc77.png)

![image](https://user-images.githubusercontent.com/1863771/146051781-1e21445f-fd8e-4581-a70a-2eb962699bd7.png)
Please provide before/after screenshots for any visual changes

The chromatic tests (see checks below)  show that there are no visual regressions :)

### Merge checklist

- [x] Added/updated tests
- NA Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
