### PR TITLE
Button v2 - Fix font family

### DIFF
--- a/.changeset/tiny-cows-fold.md
+++ b/.changeset/tiny-cows-fold.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Button v2 - Fix font family

--- a/src/NewButton/styles.ts
+++ b/src/NewButton/styles.ts
@@ -191,6 +191,7 @@ export const getBaseStyles = (theme?: Theme) => ({
   borderRadius: '2',
   border: '1px solid',
   borderColor: theme?.colors.btn.border,
+  fontFamily: 'inherit',
   fontWeight: 'bold',
   lineHeight: TEXT_ROW_HEIGHT,
   whiteSpace: 'nowrap',

--- a/src/__tests__/__snapshots__/NewButton.test.tsx.snap
+++ b/src/__tests__/__snapshots__/NewButton.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Button renders consistently 1`] = `
   border-radius: 6px;
   border: 1px solid;
   border-color: rgba(27,31,36,0.15);
+  font-family: inherit;
   font-weight: 600;
   line-height: 20px;
   white-space: nowrap;
@@ -92,6 +93,7 @@ exports[`Button styles danger button appropriately 1`] = `
 .c0 {
   border-radius: 2;
   border: 1px solid;
+  font-family: inherit;
   font-weight: bold;
   line-height: 20px;
   white-space: nowrap;
@@ -199,6 +201,7 @@ exports[`Button styles invisible button appropriately 1`] = `
 .c0 {
   border-radius: 2;
   border: 0;
+  font-family: inherit;
   font-weight: bold;
   line-height: 20px;
   white-space: nowrap;
@@ -286,6 +289,7 @@ exports[`Button styles outline button appropriately 1`] = `
 .c0 {
   border-radius: 2;
   border: 1px solid;
+  font-family: inherit;
   font-weight: bold;
   line-height: 20px;
   white-space: nowrap;
@@ -393,6 +397,7 @@ exports[`Button styles primary button appropriately 1`] = `
   border-radius: 2;
   border: 1px solid;
   border-color: border.subtle;
+  font-family: inherit;
   font-weight: bold;
   line-height: 20px;
   white-space: nowrap;


### PR DESCRIPTION
Describe your changes here.

Button v1 [has `font-family: inherit`](https://github.com/primer/react/blob/main/src/Button/ButtonStyles.tsx#L8), this was missing from NewButton which made it use Arial on Chrome instead of system-font

### Screenshots

before:
<img width="274" alt="Before fix, Button has Arial" src="https://user-images.githubusercontent.com/1863771/146056913-6f58ee9a-76e1-4b03-bc9f-162dec2dc7f2.png">

after:
<img width="355" alt="Before fix, Button has system font" src="https://user-images.githubusercontent.com/1863771/146056928-df91fbf0-a7aa-49f0-9451-59d8d38f9399.png">
