### PR TITLE
Update prop norm ADR to status: adopted

### DIFF
--- a/contributor-docs/adrs/adr-003-prop-norms.md
+++ b/contributor-docs/adrs/adr-003-prop-norms.md
@@ -45,7 +45,7 @@ All components that accept an `as` prop should accept props en masse for the ele
 
 ### 🔴 Styled System props
 
-Components should not accept Styled System props (except our utility components: `Box` and `Type`)
+Components should not accept Styled System props (except our utility components: `Box` and `Text`)
 
 _Reasoning:_ Utility components are meant to provide a convenient API for writing styles (including styles that reference theme and other context managed within Primer). Non-utility components implement specific design patterns where additional styling is available for exceptional cases.
 

--- a/contributor-docs/adrs/adr-003-prop-norms.md
+++ b/contributor-docs/adrs/adr-003-prop-norms.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Proposed
+Adopted
 
 ## Context
 
-Today our component prop APIs have:
+Our component prop APIs have, at times been a bit of a mess. We've seen:
 
 - Implicit conventions not documented anywhere but consistently reflected in our code (e.g., the type of the `sx` prop)
 - Explicit plans to change some of those (e.g., the deprecation of Styled System props)


### PR DESCRIPTION
This PR updates the status of the prop norm ADR to `adopted`

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
