### PR TITLE
Fix for SelectPanel Filter width

### DIFF
--- a/.changeset/shaggy-hounds-decide.md
+++ b/.changeset/shaggy-hounds-decide.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Fix for SelectPanel Filter width

--- a/src/FilteredActionList/FilteredActionList.stories.tsx
+++ b/src/FilteredActionList/FilteredActionList.stories.tsx
@@ -2,7 +2,6 @@ import {Meta} from '@storybook/react'
 import React from 'react'
 import {ThemeProvider} from '..'
 import {FilteredActionList} from '../FilteredActionList'
-import {ItemInput} from '../ActionList/List'
 import BaseStyles from '../BaseStyles'
 import Box from '../Box'
 
@@ -54,7 +53,6 @@ const items = [
 ]
 
 export function Default(): JSX.Element {
-  const [selected, setSelected] = React.useState<ItemInput[]>([items[0], items[1]])
   const [filter, setFilter] = React.useState('')
   const filteredItems = items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
 

--- a/src/FilteredActionList/FilteredActionList.stories.tsx
+++ b/src/FilteredActionList/FilteredActionList.stories.tsx
@@ -1,0 +1,73 @@
+import {Meta} from '@storybook/react'
+import React from 'react'
+import {ThemeProvider} from '..'
+import {FilteredActionList} from '../FilteredActionList'
+import {ItemInput} from '../ActionList/List'
+import BaseStyles from '../BaseStyles'
+import Box from '../Box'
+
+const meta: Meta = {
+  title: 'Composite components/FilteredActionList',
+  component: FilteredActionList,
+  decorators: [
+    (Story: React.ComponentType): JSX.Element => (
+      <ThemeProvider>
+        <BaseStyles>
+          <Story />
+        </BaseStyles>
+      </ThemeProvider>
+    )
+  ],
+  parameters: {
+    controls: {
+      disable: true
+    }
+  }
+}
+export default meta
+
+function getColorCircle(color: string) {
+  return function () {
+    return (
+      <Box
+        bg={color}
+        borderColor={color}
+        width={14}
+        height={14}
+        borderRadius={10}
+        margin="auto"
+        borderWidth="1px"
+        borderStyle="solid"
+      />
+    )
+  }
+}
+
+const items = [
+  {leadingVisual: getColorCircle('#a2eeef'), text: 'enhancement', id: 1},
+  {leadingVisual: getColorCircle('#d73a4a'), text: 'bug', id: 2},
+  {leadingVisual: getColorCircle('#0cf478'), text: 'good first issue', id: 3},
+  {leadingVisual: getColorCircle('#ffd78e'), text: 'design', id: 4},
+  {leadingVisual: getColorCircle('#ff0000'), text: 'blocker', id: 5},
+  {leadingVisual: getColorCircle('#a4f287'), text: 'backend', id: 6},
+  {leadingVisual: getColorCircle('#8dc6fc'), text: 'frontend', id: 7}
+]
+
+export function Default(): JSX.Element {
+  const [selected, setSelected] = React.useState<ItemInput[]>([items[0], items[1]])
+  const [filter, setFilter] = React.useState('')
+  const filteredItems = items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
+
+  return (
+    <>
+      <h1>Filtered Action List</h1>
+      <div>Please select labels that describe your issue:</div>
+      <FilteredActionList
+        placeholderText="Filter Labels"
+        items={filteredItems}
+        onFilterChange={setFilter}
+        sx={{border: '1px solid', padding: '8px'}}
+      />
+    </>
+  )
+}

--- a/src/_TextInputWrapper.tsx
+++ b/src/_TextInputWrapper.tsx
@@ -135,6 +135,7 @@ const TextInputWrapper = styled.span<StyledWrapperProps>`
     props.block &&
     css`
       width: 100%;
+      display: flex;
     `}
   
     // Ensures inputs don' t zoom on mobile but are body-font size on desktop

--- a/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -123,6 +123,10 @@ exports[`TextInput renders block 1`] = `
   padding-left: 0;
   padding-right: 0;
   width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c0 >:not(:last-child) {

--- a/src/__tests__/__snapshots__/TextInputWithTokens.test.tsx.snap
+++ b/src/__tests__/__snapshots__/TextInputWithTokens.test.tsx.snap
@@ -452,6 +452,10 @@ exports[`TextInputWithTokens renders as block layout 1`] = `
   padding-left: 0;
   padding-right: 0;
   width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   padding-left: 12px;
   padding-top: calc(12px / 2);
   padding-bottom: calc(12px / 2);


### PR DESCRIPTION
Describe your changes here.

`SelectPanel` uses `TextInput` with `block` prop. The diff previously was missing converting inline to block element when this boolean is present.

- Added fix
- Added relevant storybook (next time chromatic can catch this)

Closes #1741 https://github.com/primer/react/issues/1741

### Screenshots

Before 
<img width="452" alt="Screen Shot 2021-12-16 at 8 36 40 pm" src="https://user-images.githubusercontent.com/417268/146347025-227b81ce-1938-4b2a-8d8f-754ae68e01ce.png">

After
<img width="452" alt="Screen Shot 2021-12-16 at 8 36 49 pm" src="https://user-images.githubusercontent.com/417268/146347067-fab15a2d-7014-47e5-b70d-91a2dc98c49b.png">


### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
