### PR TITLE
Add component ids to component pages

### DIFF
--- a/docs/content/AnchoredOverlay.mdx
+++ b/docs/content/AnchoredOverlay.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: anchored_overlay
 title: AnchoredOverlay
 status: Alpha
 source: https://github.com/primer/react/blob/main/src/AnchoredOverlay/AnchoredOverlay.tsx

--- a/docs/content/Autocomplete.mdx
+++ b/docs/content/Autocomplete.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: autocomplete
 title: Autocomplete
 status: Alpha
 ---

--- a/docs/content/AvatarPair.mdx
+++ b/docs/content/AvatarPair.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: avatar_pair
 title: AvatarPair
 status: Alpha
 source: https://github.com/primer/react/blob/main/src/AvatarPair.tsx

--- a/docs/content/AvatarStack.mdx
+++ b/docs/content/AvatarStack.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: avatar_stack
 title: AvatarStack
 status: Alpha
 description: Use an avatar stack to display two or more avatars in an inline stack.

--- a/docs/content/Box.mdx
+++ b/docs/content/Box.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: box
 title: Box
 status: Beta
 description: A low-level utility component that accepts styled system props to enable custom theme-aware styling

--- a/docs/content/BranchName.mdx
+++ b/docs/content/BranchName.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: branch_name
 title: BranchName
 status: Alpha
 source: https://github.com/primer/react/blob/main/src/BranchName.tsx

--- a/docs/content/Breadcrumbs.mdx
+++ b/docs/content/Breadcrumbs.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: breadcrumbs
 title: Breadcrumbs
 status: Alpha
 description: Use breadcrumbs to show navigational context on pages that are many levels deep in a site’s hierarchy. Breadcrumbs show and link to parent, grandparent, and sometimes great-grandparent pages.

--- a/docs/content/Buttons.md
+++ b/docs/content/Buttons.md
@@ -1,4 +1,5 @@
 ---
+componentId: button
 title: Button
 status: Alpha
 ---

--- a/docs/content/Checkbox.md
+++ b/docs/content/Checkbox.md
@@ -1,4 +1,5 @@
 ---
+componentId: checkbox
 title: Checkbox
 description: Use checkboxes to toggle between checked and unchecked states in a list or as a standalone form field
 status: Alpha

--- a/docs/content/CircleBadge.md
+++ b/docs/content/CircleBadge.md
@@ -1,4 +1,5 @@
 ---
+componentId: circle_badge
 title: CircleBadge
 status: Alpha
 ---

--- a/docs/content/CircleOcticon.md
+++ b/docs/content/CircleOcticon.md
@@ -1,4 +1,5 @@
 ---
+componentId: circle_octicon
 title: CircleOcticon
 status: Alpha
 ---

--- a/docs/content/CounterLabel.md
+++ b/docs/content/CounterLabel.md
@@ -1,4 +1,5 @@
 ---
+componentId: counter_label
 title: CounterLabel
 status: Alpha
 ---

--- a/docs/content/Details.md
+++ b/docs/content/Details.md
@@ -1,4 +1,5 @@
 ---
+componentId: details
 title: Details
 status: Alpha
 ---

--- a/docs/content/DropdownMenu.mdx
+++ b/docs/content/DropdownMenu.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: dropdown_menu
 title: DropdownMenu
 status: Alpha
 ---

--- a/docs/content/FilterList.md
+++ b/docs/content/FilterList.md
@@ -1,4 +1,5 @@
 ---
+componentId: filter_list
 title: FilterList
 status: Alpha
 ---

--- a/docs/content/FilteredSearch.md
+++ b/docs/content/FilteredSearch.md
@@ -1,4 +1,5 @@
 ---
+componentId: filtered_search
 title: FilteredSearch
 status: Alpha
 ---

--- a/docs/content/Flash.md
+++ b/docs/content/Flash.md
@@ -1,4 +1,5 @@
 ---
+componentId: flash
 title: Flash
 status: Alpha
 ---

--- a/docs/content/FormGroup.md
+++ b/docs/content/FormGroup.md
@@ -1,4 +1,5 @@
 ---
+componentId: form_group
 title: FormGroup
 status: Alpha
 ---

--- a/docs/content/Header.md
+++ b/docs/content/Header.md
@@ -1,4 +1,5 @@
 ---
+componentId: header
 title: Header
 status: Alpha
 ---

--- a/docs/content/Heading.md
+++ b/docs/content/Heading.md
@@ -1,4 +1,5 @@
 ---
+componentId: heading
 title: Heading
 status: Alpha
 ---

--- a/docs/content/Label.md
+++ b/docs/content/Label.md
@@ -1,4 +1,5 @@
 ---
+componentId: label
 title: Label
 status: Alpha
 ---

--- a/docs/content/LabelGroup.md
+++ b/docs/content/LabelGroup.md
@@ -1,4 +1,5 @@
 ---
+componentId: label_group
 title: LabelGroup
 status: Alpha
 ---

--- a/docs/content/Link.mdx
+++ b/docs/content/Link.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: link
 title: Link
 status: Alpha
 source: https://github.com/primer/react/blob/main/src/Link.tsx

--- a/docs/content/Overlay.mdx
+++ b/docs/content/Overlay.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: overlay
 title: Overlay
 status: Alpha
 ---

--- a/docs/content/Pagehead.md
+++ b/docs/content/Pagehead.md
@@ -1,4 +1,5 @@
 ---
+componentId: pagehead
 title: Pagehead
 status: Alpha
 ---

--- a/docs/content/Pagination.md
+++ b/docs/content/Pagination.md
@@ -1,4 +1,5 @@
 ---
+compnoentId: pagination
 title: Pagination
 status: Alpha
 ---

--- a/docs/content/PointerBox.md
+++ b/docs/content/PointerBox.md
@@ -1,4 +1,5 @@
 ---
+componentId: pointer_box
 title: PointerBox
 status: Alpha
 ---

--- a/docs/content/Popover.md
+++ b/docs/content/Popover.md
@@ -1,4 +1,5 @@
 ---
+componentId: popover
 title: Popover
 status: Alpha
 ---

--- a/docs/content/Portal.mdx
+++ b/docs/content/Portal.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: portal
 title: Portal
 status: Alpha
 ---

--- a/docs/content/ProgressBar.mdx
+++ b/docs/content/ProgressBar.mdx
@@ -1,6 +1,6 @@
 ---
-title: ProgressBar
 componentId: progress_bar
+title: ProgressBar
 status: Alpha
 source: https://github.com/primer/react/blob/main/src/ProgressBar.tsx
 ---

--- a/docs/content/Radio.md
+++ b/docs/content/Radio.md
@@ -1,4 +1,5 @@
 ---
+componentId: radio
 title: Radio
 description: Use radios when a user needs to select one option from a list
 status: Alpha

--- a/docs/content/SelectPanel.mdx
+++ b/docs/content/SelectPanel.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: select_panel
 title: SelectPanel
 status: Alpha
 ---

--- a/docs/content/SideNav.md
+++ b/docs/content/SideNav.md
@@ -1,4 +1,5 @@
 ---
+componentId: side_nav
 title: SideNav
 status: Alpha
 ---

--- a/docs/content/StateLabel.md
+++ b/docs/content/StateLabel.md
@@ -1,4 +1,5 @@
 ---
+componentId: spinner
 title: StateLabel
 status: Alpha
 ---

--- a/docs/content/StateLabel.md
+++ b/docs/content/StateLabel.md
@@ -1,5 +1,5 @@
 ---
-componentId: spinner
+componentId: state_label
 title: StateLabel
 status: Alpha
 ---

--- a/docs/content/StyledOcticon.md
+++ b/docs/content/StyledOcticon.md
@@ -1,4 +1,5 @@
 ---
+componentId: styled_octicon
 title: StyledOcticon
 status: Alpha
 ---

--- a/docs/content/SubNav.md
+++ b/docs/content/SubNav.md
@@ -1,4 +1,5 @@
 ---
+componentId: sub_nav
 title: SubNav
 status: Alpha
 ---

--- a/docs/content/TabNav.md
+++ b/docs/content/TabNav.md
@@ -1,4 +1,5 @@
 ---
+componentId: tab_nav
 title: TabNav
 status: Alpha
 ---

--- a/docs/content/Text.md
+++ b/docs/content/Text.md
@@ -1,4 +1,5 @@
 ---
+componentId: text
 title: Text
 status: Alpha
 ---

--- a/docs/content/TextInput.mdx
+++ b/docs/content/TextInput.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: text_input
 title: TextInput
 status: Alpha
 source: https://github.com/primer/react/blob/main/src/TextInput.tsx

--- a/docs/content/TextInputWithTokens.mdx
+++ b/docs/content/TextInputWithTokens.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: text_input_with_tokens
 title: TextInputWithTokens
 status: Alpha
 source: https://github.com/primer/react/tree/main/src/TextInputWithTokens.tsx

--- a/docs/content/Timeline.md
+++ b/docs/content/Timeline.md
@@ -1,4 +1,5 @@
 ---
+componentId: timeline
 title: Timeline
 status: Alpha
 ---

--- a/docs/content/Token.mdx
+++ b/docs/content/Token.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: token
 title: Token
 status: Alpha
 source: https://github.com/primer/react/tree/main/src/Token

--- a/docs/content/Tooltip.md
+++ b/docs/content/Tooltip.md
@@ -1,4 +1,5 @@
 ---
+componentId: tooltip
 title: Tooltip
 status: Alpha
 ---

--- a/docs/content/Truncate.md
+++ b/docs/content/Truncate.md
@@ -1,4 +1,5 @@
 ---
+componentId: truncate
 title: Truncate
 status: Alpha
 ---

--- a/docs/content/UnderlineNav.md
+++ b/docs/content/UnderlineNav.md
@@ -1,4 +1,5 @@
 ---
+componentId: underline_nav
 title: UnderlineNav
 status: Alpha
 ---

--- a/docs/content/deprecated/BorderBox.md
+++ b/docs/content/deprecated/BorderBox.md
@@ -1,4 +1,5 @@
 ---
+componentId: border_box
 title: BorderBox
 status: Deprecated
 ---

--- a/docs/content/deprecated/Flex.md
+++ b/docs/content/deprecated/Flex.md
@@ -1,4 +1,5 @@
 ---
+componentId: flex
 title: Flex
 status: Deprecated
 ---

--- a/docs/content/deprecated/Grid.md
+++ b/docs/content/deprecated/Grid.md
@@ -1,4 +1,5 @@
 ---
+componentId: grid
 title: Grid
 status: Deprecated
 ---

--- a/docs/content/deprecated/Position.md
+++ b/docs/content/deprecated/Position.md
@@ -1,4 +1,5 @@
 ---
+componentId: position
 title: Position
 status: Deprecated
 ---


### PR DESCRIPTION
Adds `componentId` frontmatter to all our component pages so that they show up in our new [cross-implementation status page](https://github.com/primer/primer.style/pull/282#discussion_r770851845)

![image](https://user-images.githubusercontent.com/4608155/146435588-e6af0c7d-3be4-4ebd-9dd2-a7ae29c945cd.png)
