### PR TITLE
metadata: Add componentId to ActionList and ActionMenu for status page

### DIFF
--- a/docs/content/ActionList.mdx
+++ b/docs/content/ActionList.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: action_list
 title: ActionList
 status: Alpha
 source: https://github.com/primer/react/tree/main/src/ActionList

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: action_menu
 title: ActionMenu
 ---
 

--- a/docs/content/drafts/ActionList2.mdx
+++ b/docs/content/drafts/ActionList2.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: action_list2
 title: ActionList v2
 status: Alpha
 source: https://github.com/primer/react/tree/main/src/ActionList2

--- a/docs/content/drafts/ActionMenu2.mdx
+++ b/docs/content/drafts/ActionMenu2.mdx
@@ -1,4 +1,5 @@
 ---
+componentId: action_menu2
 title: ActionMenu v2
 status: Alpha
 source: https://github.com/primer/react/tree/main/src/ActionMenu


### PR DESCRIPTION
Added `componentId` in the style of PVC for ActionList and ActionMenu so that they show up in status page :)