### PR TITLE
Fix title and subtitle tag for Dialog2 and ConfirmationDialog

### DIFF
--- a/.changeset/dialogs-title-tag.md
+++ b/.changeset/dialogs-title-tag.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fix title and subtitle tag for Dialog2 and ConfirmationDialog

--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -45,11 +45,12 @@ const StyledConfirmationHeader = styled.header`
   display: flex;
   flex-direction: row;
 `
-const StyledTitle = styled(Box)`
+const StyledTitle = styled(Box).attrs({as: 'h1'})`
   font-size: ${get('fontSizes.3')};
   font-weight: ${get('fontWeights.bold')};
   padding: 6px ${get('space.2')};
   flex-grow: 1;
+  margin: 0; /* override default margin */
 `
 const ConfirmationHeader: React.FC<DialogHeaderProps> = ({title, onClose, dialogLabelId}) => {
   const onCloseClick = useCallback(() => {

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -314,17 +314,18 @@ const Header = styled.div.attrs<SxProp>({as: 'header'})`
   flex-shrink: 0;
 `
 
-const Title = styled.div<SxProp>`
+const Title = styled.h1<SxProp>`
   font-size: ${get('fontSizes.1')};
   font-weight: ${get('fontWeights.bold')};
-
+  margin: 0; /* override default margin */
   ${sx};
 `
 
-const Subtitle = styled.div<SxProp>`
+const Subtitle = styled.h2<SxProp>`
   font-size: ${get('fontSizes.0')};
-  margin-top: ${get('space.1')};
   color: ${get('colors.fg.muted')};
+  margin: 0; /* override default margin */
+  margin-top: ${get('space.1')};
 
   ${sx};
 `


### PR DESCRIPTION
Fixes https://github.com/primer/react/issues/1753

title should use h1 and subtitle should use h2 instead of div

### Merge checklist

- NA Added/updated tests
- NA Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
