### PR TITLE
Add aria-hidden to InputLabel required asterisk

### DIFF
--- a/.changeset/breezy-coats-play.md
+++ b/.changeset/breezy-coats-play.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Adds aria-hidden="true" to InputLabel required asterisk

--- a/docs/content/InputField.mdx
+++ b/docs/content/InputField.mdx
@@ -3,7 +3,7 @@ componentId: inputField
 title: InputField
 status: Alpha
 description: The InputField component is used to render a labelled text input and, optionally, associated validation text and hint text.
-source: https://github.com/primer/react/blob/main/src/InputField.tsx
+source: https://github.com/primer/react/blob/main/src/InputField/InputField.tsx
 storybook: '/react/storybook?path=/story/forms-inputfield--text-input-field'
 ---
 

--- a/src/_InputLabel.tsx
+++ b/src/_InputLabel.tsx
@@ -25,7 +25,7 @@ const InputLabel: React.FC<Props> = ({children, disabled, required, visuallyHidd
       {required ? (
         <Box display="flex" as="span">
           <Box mr={1}>{children}</Box>
-          <span>*</span>
+          <span aria-hidden="true">*</span>
         </Box>
       ) : (
         children


### PR DESCRIPTION
The required asterisk needs the `aria-hidden="true"` attribute so that it doesn't get announced by screen readers.

I discovered this issue since switching my input components to `<InputField/>` caused testing-library's `getByLabelText` to fail. That selector uses the accessibility tree (as pictured in screenshots) and looks for exact name matches, so `getByLabelText("Name")` would fail as the name would be "Name *" and not "Name".

I also fixed the broken InputField source link in the docs.

### Screenshots
Before, asterisk was included in name property:
![image](https://user-images.githubusercontent.com/5218175/148159674-8ff84a33-5ab2-4f1f-be78-a1d38f102c7a.png)

After, asterisk is no longer included in name property but still displays properly:
![image](https://user-images.githubusercontent.com/5218175/148159632-4d811906-55bf-465f-9f91-a153964691dd.png)


### Merge checklist

- [X] Added/updated tests
- [X] Added/updated documentation
- [X] Tested in Chrome
- [X] Tested in Firefox
- [ ] Tested in Safari -> Unable to since I'm on Windows
- [X] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
