### PR TITLE
Export SelectPanel from the package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,8 @@ export type {
   SelectMenuTabPanelProps,
   SelectMenuLoadingAnimationProps
 } from './SelectMenu'
+export {SelectPanel} from './SelectPanel'
+export type {SelectPanelProps} from './SelectPanel'
 export {default as SideNav} from './SideNav'
 export type {SideNavProps, SideNavLinkProps} from './SideNav'
 export {default as Spinner} from './Spinner'


### PR DESCRIPTION
As described in https://github.com/primer/react/issues/1768, SelectPanel is not exported nor is the documentation displayed. 
But the [component status page](https://primer.style/react/status) lists it as alpha.
Since it's quite an old component, I'm thinking we missed exporting it.

lmk if its otherwise.
