### PR TITLE
Visual testing: Add environment with approval step

### DIFF
--- a/.github/workflows/visual_testing.yml
+++ b/.github/workflows/visual_testing.yml
@@ -9,6 +9,7 @@ jobs:
   chromatic:
     name: Visual testing
     runs-on: ubuntu-latest
+    environment: visual-testing
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
To reduce the number of builds for visual testing, added new environment ([visual-testing](https://github.com/primer/react/settings/environments/370424068/edit)) that requires an manual approval from `@primer/react-reviewers` before starting job

Right now, visual tests run for every commit. The idea is to approve visual tests on the PR yourself when you're ready for them.

#### Screenshots:


1. New deployment on the PR with the message: `This branch is waiting to be deployed`

![image](https://user-images.githubusercontent.com/1863771/148413434-bc3a98af-af45-496d-a277-3c20173e3d0c.png)

2. "siddharthkp requested your review to deploy to visual-testing" `Review deployment` to approve

![image](https://user-images.githubusercontent.com/1863771/148412875-b3a1d16a-0569-4554-a78a-d0dca6be616d.png)

3. Approve to start the job

![image](https://user-images.githubusercontent.com/1863771/148412904-bff03e56-6732-4775-a296-a15ad33ead9d.png)


Note: After approval, the tests wouldn't actually run because our account is on pause. More on that on [slack](https://app.slack.com/client/T0CA8C346/C02NUUQ9C30)
