### PR TITLE
Docs: change import to lib-esm for drafts

### DIFF
--- a/docs/content/drafts/ActionList2.mdx
+++ b/docs/content/drafts/ActionList2.mdx
@@ -43,7 +43,7 @@ import InlineCode from '@primer/gatsby-theme-doctocat/src/components/inline-code
 </Box>
 
 ```js
-import {ActionList} from '@primer/react/drafts'
+import {ActionList} from '@primer/react/lib-esm/drafts'
 ```
 
 ## Examples
@@ -51,7 +51,7 @@ import {ActionList} from '@primer/react/drafts'
 ### Minimal example
 
 ```javascript live noinline
-// import {ActionList} from '@primer/react/drafts'
+// import {ActionList} from '@primer/react/lib-esm/drafts'
 const {ActionList} = drafts // ignore docs silliness; import like that ↑
 
 render(
@@ -71,7 +71,7 @@ Leading visuals are optional and appear at the start of an item. They can be oct
 
 <!-- prettier-ignore -->
 ```javascript live noinline
-// import {ActionList} from '@primer/react/drafts'
+// import {ActionList} from '@primer/react/lib-esm/drafts'
 const {ActionList} = drafts // ignore docs silliness; import like that ↑
 
 render(
@@ -97,7 +97,7 @@ render(
 Trailing visual and trailing text can display auxiliary information. They're placed at the right of the item, and can denote status, keyboard shortcuts, or be used to set expectations about what the action does.
 
 ```javascript live noinline
-// import {ActionList} from '@primer/react/drafts'
+// import {ActionList} from '@primer/react/lib-esm/drafts'
 const {ActionList} = drafts // ignore docs silliness; import like that ↑
 
 render(
@@ -127,7 +127,7 @@ render(
 Item dividers allow users to parse heavier amounts of information. They're placed between items and are useful in complex lists, particularly when descriptions or multi-line text is present.
 
 ```javascript live noinline
-// import {ActionList} from '@primer/react/drafts'
+// import {ActionList} from '@primer/react/lib-esm/drafts'
 const {ActionList} = drafts // ignore docs silliness; import like that ↑
 
 render(
@@ -163,7 +163,7 @@ When you want to add links to the List instead of actions, use `ActionList.LinkI
 
 <!-- prettier-ignore -->
 ```javascript live noinline
-// import {ActionList} from '@primer/react/drafts'
+// import {ActionList} from '@primer/react/lib-esm/drafts'
 const {ActionList} = drafts // ignore docs silliness; import like that ↑
 
 render(
@@ -197,7 +197,7 @@ render(
 ### With groups
 
 ```javascript live noinline
-// import {ActionList} from '@primer/react/drafts'
+// import {ActionList} from '@primer/react/lib-esm/drafts'
 const {ActionList} = drafts // ignore docs silliness; import like that ↑
 
 const SelectFields = () => {

--- a/docs/content/drafts/ActionMenu2.mdx
+++ b/docs/content/drafts/ActionMenu2.mdx
@@ -43,7 +43,7 @@ import {Props} from '../../src/props'
 <br />
 
 ```js
-import {ActionMenu} from '@primer/react/drafts'
+import {ActionMenu} from '@primer/react/lib-esm/drafts'
 ```
 
 <br />
@@ -57,7 +57,7 @@ import {ActionMenu} from '@primer/react/drafts'
 &nbsp;
 
 ```javascript live noinline
-// import {ActionMenu, ActionList} from '@primer/react/drafts'
+// import {ActionMenu, ActionList} from '@primer/react/lib-esm/drafts'
 const {ActionMenu, ActionList} = drafts // ignore docs silliness; import like that ↑
 
 render(
@@ -84,7 +84,7 @@ You can choose to have a different _anchor_ for the Menu dependending on the app
 &nbsp;
 
 ```javascript live noinline
-// import {ActionMenu, ActionList} from '@primer/react/drafts'
+// import {ActionMenu, ActionList} from '@primer/react/lib-esm/drafts'
 const {ActionMenu, ActionList} = drafts // ignore docs silliness; import like that ↑
 
 render(
@@ -124,7 +124,7 @@ render(
 ### With Groups
 
 ```javascript live noinline
-// import {ActionMenu, ActionList} from '@primer/react/drafts'
+// import {ActionMenu, ActionList} from '@primer/react/lib-esm/drafts'
 const {ActionMenu, ActionList} = drafts // ignore docs silliness; import like that ↑
 
 render(
@@ -195,7 +195,7 @@ render(
 To create an anchor outside of the menu, you need to switch to controlled mode for the menu and pass it as `anchorRef` to `ActionMenu`. Make sure you add `aria-expanded` and `aria-haspopup` to the external anchor:
 
 ```javascript live noinline
-// import {ActionMenu, ActionList} from '@primer/react/drafts'
+// import {ActionMenu, ActionList} from '@primer/react/lib-esm/drafts'
 const {ActionMenu, ActionList} = drafts // ignore docs silliness; import like that ↑
 
 const Example = () => {
@@ -231,7 +231,7 @@ render(<Example />)
 To create an anchor outside of the menu, you need to switch to controlled mode for the menu and pass it as `anchorRef` to `ActionMenu`:
 
 ```javascript live noinline
-// import {ActionMenu, ActionList} from '@primer/react/drafts'
+// import {ActionMenu, ActionList} from '@primer/react/lib-esm/drafts'
 const {ActionMenu, ActionList} = drafts // ignore docs silliness; import like that ↑
 
 const handleEscape = () => alert('you hit escape!')

--- a/docs/content/drafts/Button2.mdx
+++ b/docs/content/drafts/Button2.mdx
@@ -16,53 +16,70 @@ import {Button, IconButton, LinkButton} from '@primer/react/drafts'
 ### Installation
 
 ```js
-import {Button} from '@primer/react/drafts'
+import {Button} from '@primer/react/lib-esm/drafts'
 ```
 
 ### Default button
 
 This is the default variant for the `Button` component.
 
-```jsx live
-<drafts.Button>Default</drafts.Button>
+```javascript live noinline
+// import {Button} from '@primer/react/lib-esm/drafts'
+const {Button} = drafts // ignore docs silliness; import like that ↑
+
+render(<Button>Default</Button>)
 ```
 
 ### Danger button
 
 The `danger` variant of `Button` is used to warn users about potentially destructive actions
 
-```jsx live
-<drafts.Button variant="danger">Danger</drafts.Button>
+```javascript live noinline
+// import {Button} from '@primer/react/lib-esm/drafts'
+const {Button} = drafts // ignore docs silliness; import like that ↑
+
+render(<Button variant="danger">Danger</Button>)
 ```
 
 ### Outline button
 
 The `outline` variant of `Button` is typically used as a secondary button
 
-```jsx live
-<drafts.Button variant="outline">Outline</drafts.Button>
+```javascript live noinline
+// import {Button} from '@primer/react/lib-esm/drafts'
+const {Button} = drafts // ignore docs silliness; import like that ↑
+
+render(<Button variant="outline">Outline</Button>)
 ```
 
 ### Invisible button
 
 The `invisible` variant of `Button` indicates that the action is a low priority one.
 
-```jsx live
-<drafts.Button variant="invisible">Invisible</drafts.Button>
+```javascript live noinline
+// import {Button} from '@primer/react/lib-esm/drafts'
+const {Button} = drafts // ignore docs silliness; import like that ↑
+
+render(<Button variant="invisible">Invisible</Button>)
 ```
 
 ### Different sized buttons
 
 `Button` component supports three different sizes. `small`, `medium`, `large`.
 
-```jsx live
-<>
-  <drafts.Button size="small">Search</drafts.Button>
-  <drafts.Button sx={{mt: 2}}>Search</drafts.Button>
-  <drafts.Button sx={{mt: 2}} size="large">
-    Search
-  </drafts.Button>
-</>
+```javascript live noinline
+// import {Button} from '@primer/react/lib-esm/drafts'
+const {Button} = drafts // ignore docs silliness; import like that ↑
+
+render(
+  <>
+    <Button size="small">Search</Button>
+    <Button sx={{mt: 2}}>Search</Button>
+    <Button sx={{mt: 2}} size="large">
+      Search
+    </Button>
+  </>
+)
 ```
 
 ### Appending an icon
@@ -70,42 +87,55 @@ The `invisible` variant of `Button` indicates that the action is a low priority 
 We can place an inside the `Button` in either the leading or the trailing position to enhance the visual context.
 It is recommended to use an octicon here.
 
-```jsx live
-<>
-  <drafts.Button leadingIcon={SearchIcon}>Search</drafts.Button>
-  <drafts.Button trailingIcon={SearchIcon} sx={{mt: 2}}>
-    Search
-  </drafts.Button>
-  <drafts.Button leadingIcon={SearchIcon} trailingIcon={CheckIcon} sx={{mt: 2}}>
-    Search
-  </drafts.Button>
-</>
+```javascript live noinline
+// import {Button} from '@primer/react/lib-esm/drafts'
+const {Button} = drafts // ignore docs silliness; import like that ↑
+
+render(
+  <>
+    <Button leadingIcon={SearchIcon}>Search</Button>
+    <Button trailingIcon={SearchIcon} sx={{mt: 2}}>
+      Search
+    </Button>
+    <Button leadingIcon={SearchIcon} trailingIcon={CheckIcon} sx={{mt: 2}}>
+      Search
+    </Button>
+  </>
+)
 ```
 
 ### Icon only button
 
 A separate component called `IconButton` is used if the action shows only an icon with no text. This button will remain square in shape.
 
-```jsx live
-<drafts.IconButton icon={SearchIcon}>Search</drafts.IconButton>
+```javascript live noinline
+// import {Button} from '@primer/react/lib-esm/drafts'
+const {Button, IconButton} = drafts // ignore docs silliness; import like that ↑
+
+render(<IconButton icon={SearchIcon}>Search</IconButton>)
 ```
 
 ### Different sized icon buttons
 
 `IconButton` also supports the three different sizes. `small`, `medium`, `large`.
 
-```jsx live
-<>
-  <drafts.IconButton icon={SearchIcon} size="small">
-    Search
-  </drafts.IconButton>
-  <drafts.IconButton sx={{ml: 2}} icon={SearchIcon}>
-    Search
-  </drafts.IconButton>
-  <drafts.IconButton sx={{ml: 2}} icon={SearchIcon} size="large">
-    Search
-  </drafts.IconButton>
-</>
+```javascript live noinline
+// import {Button} from '@primer/react/lib-esm/drafts'
+const {Button, IconButton} = drafts // ignore docs silliness; import like that ↑
+
+render(
+  <>
+    <IconButton icon={SearchIcon} size="small">
+      Search
+    </IconButton>
+    <IconButton sx={{ml: 2}} icon={SearchIcon}>
+      Search
+    </IconButton>
+    <IconButton sx={{ml: 2}} icon={SearchIcon} size="large">
+      Search
+    </IconButton>
+  </>
+)
 ```
 
 ### Counter component
@@ -114,11 +144,16 @@ A common use case for primer is a button with a counter component which shows th
 We provide `Button.Counter` as a composite component which requires you to provide a number as child.
 The counter will match the `variant` styles of the parent button.
 
-```jsx live
-<drafts.Button>
-  Watch
-  <drafts.Button.Counter>1</drafts.Button.Counter>
-</drafts.Button>
+```javascript live noinline
+// import {Button} from '@primer/react/lib-esm/drafts'
+const {Button} = drafts // ignore docs silliness; import like that ↑
+
+render(
+  <Button>
+    Watch
+    <Button.Counter>1</Button.Counter>
+  </Button>
+)
 ```
 
 ### Styling a button
@@ -126,8 +161,11 @@ The counter will match the `variant` styles of the parent button.
 A button can be styled in an appropriate manner using the `sx` prop. This maybe to change width, or to add margins etc.
 Here's an example of a block button which takes 100% of available width. Checkout [styled-system](https://styled-system.com/) to see what you can send in an `sx` prop.
 
-```jsx live
-<drafts.Button sx={{width: '100%'}}>Block</drafts.Button>
+```javascript live noinline
+// import {Button} from '@primer/react/lib-esm/drafts'
+const {Button} = drafts // ignore docs silliness; import like that ↑
+
+render(<Button sx={{width: '100%'}}>Block</Button>)
 ```
 
 ## API reference

--- a/docs/content/drafts/IconButton.mdx
+++ b/docs/content/drafts/IconButton.mdx
@@ -14,33 +14,41 @@ import {ComponentChecklist} from '../../src/component-checklist'
 ### Installation
 
 ```js
-import {IconButton} from '@primer/react/drafts'
+import {IconButton} from '@primer/react/lib-esm/drafts'
 ```
 
 ### Icon only button
 
 A separate component called `IconButton` is used if the action shows only an icon with no text. This button will remain square in shape.
 
-```jsx live
-<drafts.IconButton icon={SearchIcon}>Search</drafts.IconButton>
+```javascript live noinline
+// import {IconButton} from '@primer/react/lib-esm/drafts'
+const {IconButton} = drafts // ignore docs silliness; import like that ↑
+
+render(<IconButton icon={SearchIcon}>Search</IconButton>)
 ```
 
 ### Different sized icon buttons
 
 `IconButton` also supports the three different sizes. `small`, `medium`, `large`.
 
-```jsx live
-<>
-  <drafts.IconButton icon={SearchIcon} size="small">
-    Search
-  </drafts.IconButton>
-  <drafts.IconButton sx={{ml: 2}} icon={SearchIcon}>
-    Search
-  </drafts.IconButton>
-  <drafts.IconButton sx={{ml: 2}} icon={SearchIcon} size="large">
-    Search
-  </drafts.IconButton>
-</>
+```javascript live noinline
+// import {IconButton} from '@primer/react/lib-esm/drafts'
+const {IconButton} = drafts // ignore docs silliness; import like that ↑
+
+render(
+  <>
+    <IconButton icon={SearchIcon} size="small">
+      Search
+    </IconButton>
+    <IconButton sx={{ml: 2}} icon={SearchIcon}>
+      Search
+    </IconButton>
+    <IconButton sx={{ml: 2}} icon={SearchIcon} size="large">
+      Search
+    </IconButton>
+  </>
+)
 ```
 
 ## API reference

--- a/docs/content/drafts/LinkButton.mdx
+++ b/docs/content/drafts/LinkButton.mdx
@@ -15,17 +15,22 @@ import {ArrowRightIcon} from '@primer/octicons-react'
 ### Installation
 
 ```js
-import {LinkButton} from '@primer/react/drafts'
+import {LinkButton} from '@primer/react/lib-esm/drafts'
 ```
 
 ### Default
 
 The `LinkButton` can be considered an extension of `Button` component. It accepts all of the same props along with new link specific props like `to` and `href`.
 
-```jsx live
-<drafts.LinkButton as="a" href="https://primer.style/">
-  Link to Primer
-</drafts.LinkButton>
+```javascript live noinline
+// import {LinkButton} from '@primer/react/lib-esm/drafts'
+const {LinkButton} = drafts // ignore docs silliness; import like that ↑
+
+render(
+  <LinkButton as="a" href="https://primer.style/">
+    Link to Primer
+  </LinkButton>
+)
 ```
 
 ### Other examples of using a LinkButton
@@ -36,22 +41,27 @@ The `LinkButton` can be considered an extension of `Button` component. It accept
 - supports the different variants in [Button]('../Button2')
 - supports leadingIcon and trailingIcon
 
-```jsx live
-<Box>
-  <drafts.LinkButton>Small link</drafts.LinkButton>
-  <drafts.LinkButton size="large" sx={{mt: 2}}>
-    Large link
-  </drafts.LinkButton>
-  <drafts.LinkButton variant="invisible" sx={{mt: 2}}>
-    Invisible link
-  </drafts.LinkButton>
-  <drafts.LinkButton variant="danger" sx={{mt: 2}}>
-    Danger link
-  </drafts.LinkButton>
-  <drafts.LinkButton trailingIcon={ArrowRightIcon} sx={{mt: 2}}>
-    Link with arrow
-  </drafts.LinkButton>
-</Box>
+```javascript live noinline
+// import {LinkButton} from '@primer/react/lib-esm/drafts'
+const {LinkButton} = drafts // ignore docs silliness; import like that ↑
+
+render(
+  <Box>
+    <LinkButton>Small link</LinkButton>
+    <LinkButton size="large" sx={{mt: 2}}>
+      Large link
+    </LinkButton>
+    <LinkButton variant="invisible" sx={{mt: 2}}>
+      Invisible link
+    </LinkButton>
+    <LinkButton variant="danger" sx={{mt: 2}}>
+      Danger link
+    </LinkButton>
+    <LinkButton trailingIcon={ArrowRightIcon} sx={{mt: 2}}>
+      Link with arrow
+    </LinkButton>
+  </Box>
+)
 ```
 
 ## API reference

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -129,6 +129,18 @@
       url: /Truncate
     - title: UnderlineNav
       url: /UnderlineNav
+- title: Drafts
+  children:
+    - title: Button v2
+      url: /drafts/Button2
+    - title: LinkButton
+      url: /drafts/LinkButton
+    - title: IconButton
+      url: /drafts/IconButton
+    - title: ActionList v2
+      url: /drafts/ActionList2
+    - title: ActionMenu v2
+      url: /drafts/ActionMenu2
 - title: Deprecated
   children:
     - title: BorderBox


### PR DESCRIPTION
Fix import path in docs/examples. draft components cannot be imported from `@primer/react/drafts`, you have to mention the format as well: `@primer/react/lib-esm/drafts` or `@primer/react/lib/drafts`.

More context: https://github.com/primer/react/issues/1768



```js
// before: 
import {Button} from '@primer/react/drafts'

// after: 
import {Button} from '@primer/react/lib-esm/drafts'
```

```jsx
// before: 

<drafts.Button>Default</drafts.Button>

// after:

// import {Button} from '@primer/react/lib-esm/drafts'
const {Button} = drafts // ignore docs silliness; import like that ↑

render(<Button>Default</Button>)
```


