### PR TITLE
Update label `componentId`

### DIFF
--- a/docs/content/Label.mdx
+++ b/docs/content/Label.mdx
@@ -3,7 +3,7 @@ title: Label
 description: Use Label components to add contextual metadata to a design.
 status: Alpha
 source: https://github.com/primer/react/blob/main/src/Label.tsx
-componentId: label_group
+componentId: label
 ---
 
 ## Example


### PR DESCRIPTION
The React `Label` component wasn't being displayed correctly on the primer.style/status page because the `componentId` in our docs was `label_group` instead of `label`.
