### PR TITLE
fix: restore string (pathname) in union type for previous LocationDescriptor

### DIFF
--- a/.changeset/unlucky-jobs-tickle.md
+++ b/.changeset/unlucky-jobs-tickle.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fix type errors due to missing pathname (string) in union type for LocationDescriptor

--- a/src/Breadcrumbs.tsx
+++ b/src/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import {Location} from 'history'
+import {Location, Pathname} from 'history'
 import React from 'react'
 import styled from 'styled-components'
 import Box from './Box'
@@ -54,7 +54,7 @@ function Breadcrumbs({className, children, sx: sxProp}: React.PropsWithChildren<
 }
 
 type StyledBreadcrumbsItemProps = {
-  to?: Location
+  to?: Location | Pathname
   selected?: boolean
 } & SxProp
 

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,4 +1,4 @@
-import {Location} from 'history'
+import {Location, Pathname} from 'history'
 import styled, {css} from 'styled-components'
 import {get} from './constants'
 import sx, {SxProp} from './sx'
@@ -6,7 +6,7 @@ import {ComponentProps} from './utils/types'
 
 type StyledHeaderItemProps = {full?: boolean} & SxProp
 type StyledHeaderProps = SxProp
-type StyledHeaderLinkProps = {to?: Location} & SxProp
+type StyledHeaderLinkProps = {to?: Location | Pathname} & SxProp
 
 const Header = styled.div<StyledHeaderProps>`
   z-index: 32;

--- a/src/SideNav.tsx
+++ b/src/SideNav.tsx
@@ -1,4 +1,4 @@
-import {Location} from 'history'
+import {Location, Pathname} from 'history'
 
 import {get} from './constants'
 import styled, {css} from 'styled-components'
@@ -54,7 +54,7 @@ const SideNav = styled(SideNavBase)<SxProp>`
   ${sx};
 `
 type StyledSideNavLinkProps = {
-  to?: Location
+  to?: Location | Pathname
   selected?: boolean
   variant?: 'full' | 'normal'
 }

--- a/src/SubNav.tsx
+++ b/src/SubNav.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import {Location} from 'history'
+import {Location, Pathname} from 'history'
 import React from 'react'
 import styled from 'styled-components'
 import {get} from './constants'
@@ -58,7 +58,7 @@ const SubNavLinks = styled.div<SubNavLinksProps>`
 `
 
 type StyledSubNavLinkProps = {
-  to?: Location
+  to?: Location | Pathname
   selected?: boolean
 } & SxProp
 

--- a/src/TabNav.tsx
+++ b/src/TabNav.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import {Location} from 'history'
+import {Location, Pathname} from 'history'
 import React from 'react'
 import styled from 'styled-components'
 import {get} from './constants'
@@ -32,7 +32,7 @@ function TabNav({children, 'aria-label': ariaLabel, ...rest}: TabNavProps) {
 }
 
 type StyledTabNavLinkProps = {
-  to?: Location
+  to?: Location | Pathname
   selected?: boolean
 } & SxProp
 

--- a/src/UnderlineNav.tsx
+++ b/src/UnderlineNav.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import {Location} from 'history'
+import {Location, Pathname} from 'history'
 import React from 'react'
 import styled from 'styled-components'
 import {get} from './constants'
@@ -59,7 +59,7 @@ function UnderlineNav({actions, className, align, children, full, label, theme, 
 }
 
 type StyledUnderlineNavLinkProps = {
-  to?: Location
+  to?: Location | Pathname
   selected?: boolean
 } & SxProp
 


### PR DESCRIPTION
There is a TypeScript error occurring on all components that use the `Location` definitions from `history`. This was introduced recently to replace `LocationDescriptor`, which was recently deprecated as of `history@v5`.

Error noticed during a smoke test for release candidate on memex:
![Screenshot 2022-01-13 at 13 42 32](https://user-images.githubusercontent.com/13340707/149341161-770d3d4e-7bb7-4065-a941-9fe91d619cec.png)

Solution:
The correct type definition should [be a union](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d9dfffd682553d6fa7321fa44e534c2f9e98131f/types/history/v2/index.d.ts#L75) of `Location` and `string` to restore parity with `LocationDescriptor`. I've used `Pathname` instead, so it's easier to reason around why string is valid here.

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
