### PR TITLE
Temporarily hide form field layout components from React docs sidebar

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -53,10 +53,12 @@
       url: /Buttons
     - title: Checkbox
       url: /Checkbox
-    - title: ChoiceFieldset
-      url: /ChoiceFieldset
-    - title: ChoiceInputField
-      url: /ChoiceInputField
+    # Temporarily hiding form field layout components due to
+    # feedback about the names being unclear
+    # - title: ChoiceFieldset
+    #   url: /ChoiceFieldset
+    # - title: ChoiceInputField
+    #   url: /ChoiceInputField
     - title: CircleBadge
       url: /CircleBadge
     - title: CircleOcticon
@@ -77,8 +79,10 @@
       url: /Header
     - title: Heading
       url: /Heading
-    - title: InputField
-      url: /InputField
+    # Temporarily hiding form field layout components due to
+    # feedback about the names being unclear
+    # - title: InputField
+    #   url: /InputField
     - title: Label
       url: /Label
     - title: LabelGroup


### PR DESCRIPTION
There has been some feedback that the components' names/API are unclear. We want to avoid consumers using these components until we resolve any issues that will cause breaking changes.

This is going to be discussed in the 01/18/2022 Primer Patterns sync.