### PR TITLE
Docs: Add alternative for deprecated Dropdown

### DIFF
--- a/docs/content/deprecated/Dropdown.md
+++ b/docs/content/deprecated/Dropdown.md
@@ -3,6 +3,12 @@ title: Dropdown
 status: Deprecated
 ---
 
+## Deprecation
+
+Use [DropdownMenu](/DropdownMenu) instead.
+
+---
+
 The Dropdown component is a lightweight context menu for housing navigation and actions.
 
 Use `Dropdown.Button` as the trigger for the dropdown, or use a custom `summary` element if you would like. **You must use a `summary` tag in order for the dropdown to behave properly!**. You should also add `aria-haspopup="true"` to custom dropdown triggers for accessibility purposes. You can use the `Dropdown.Caret` component to add a caret to a custom dropdown trigger.


### PR DESCRIPTION
- Fixes https://github.com/primer/react/issues/1692

Keeping it simple

![Add a link to DropdownMenu](https://user-images.githubusercontent.com/1863771/150091431-31a1ec2c-4e2c-4b40-9fe9-dab76e11c558.png)

_Note: We would update this again at some point this quarter when DropdownMenu v2 comes out of drafts into the main bundle_
