### PR TITLE
Add selected state to Button

### DIFF
--- a/docs/content/drafts/Button2.mdx
+++ b/docs/content/drafts/Button2.mdx
@@ -65,6 +65,20 @@ The `invisible` variant of `Button` indicates that the action is a low priority 
 </>
 ```
 
+### Selected button
+
+`Button` can be set to in a "selected" state in two ways. You can use a `selected` class or set `aria-selected ="true"`.
+This is in many cases similar to the active state of the button. Usually used in `ButtonGroup` when like tabs.
+
+```jsx live
+<>
+  <drafts.Button aria-selected="true">Search</drafts.Button>
+  <drafts.Button aria-selected="true" variant="danger">
+    Delete
+  </drafts.Button>
+</>
+```
+
 ### Appending an icon
 
 We can place an inside the `Button` in either the leading or the trailing position to enhance the visual context.

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -31,6 +31,11 @@ const Button = styled(ButtonBase)<ButtonBaseProps & SxProp>`
     background-color: ${get('colors.btn.bg')};
     border-color: ${get('colors.btn.border')};
   }
+  &.selected,
+  &[aria-selected='true'] {
+    background-color: ${get('colors.btn.selectedBg')};
+    box-shadow: ${get('colors.primer.shadow.inset')};
+  }
 
   ${sx};
 `

--- a/src/Button/ButtonDanger.tsx
+++ b/src/Button/ButtonDanger.tsx
@@ -22,7 +22,9 @@ const ButtonDanger = styled(ButtonBase)<ButtonBaseProps & SxProp>`
     box-shadow: ${get('shadows.btn.danger.focusShadow')};
   }
 
-  &:active {
+  &:active,
+  &.selected,
+  &[aria-selected='true'] {
     color: ${get('colors.btn.danger.selectedText')};
     background-color: ${get('colors.btn.danger.selectedBg')};
     box-shadow: ${get('shadows.btn.danger.selectedShadow')};

--- a/src/Button/ButtonInvisible.tsx
+++ b/src/Button/ButtonInvisible.tsx
@@ -20,7 +20,9 @@ const ButtonInvisible = styled(ButtonBase)<ButtonBaseProps & SxProp>`
   &:hover {
     background-color: ${get('colors.btn.hoverBg')};
   }
-  &:active {
+  &:active,
+  $.selected,
+  &[aria-selected='true'] {
     background-color: ${get('colors.btn.selectedBg')};
   }
 

--- a/src/Button/ButtonOutline.tsx
+++ b/src/Button/ButtonOutline.tsx
@@ -22,7 +22,9 @@ const ButtonOutline = styled(ButtonBase)<ButtonBaseProps & SxProp>`
     box-shadow: ${get('shadows.btn.outline.focusShadow')};
   }
 
-  &:active {
+  &:active,
+  $.selected,
+  &[aria-selected='true'] {
     color: ${get('colors.btn.outline.selectedText')};
     background-color: ${get('colors.btn.outline.selectedBg')};
     box-shadow: ${get('shadows.btn.outline.selectedShadow')};

--- a/src/Button/ButtonPrimary.tsx
+++ b/src/Button/ButtonPrimary.tsx
@@ -22,7 +22,9 @@ export const ButtonPrimary = styled(ButtonBase)<ButtonBaseProps & SxProp>`
     box-shadow: ${get('shadows.btn.primary.focusShadow')};
   }
 
-  &:active {
+  &:active,
+  $.selected,
+  &[aria-selected='true'] {
     background-color: ${get('colors.btn.primary.selectedBg')};
     box-shadow: ${get('shadows.btn.primary.selectedShadow')};
   }

--- a/src/Button2/Button2.stories.tsx
+++ b/src/Button2/Button2.stories.tsx
@@ -25,6 +25,12 @@ export default {
         type: 'radio',
         options: ['small', 'medium', 'large']
       }
+    },
+    'aria-selected': {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
+      }
     }
   }
 } as Meta

--- a/src/Button2/styles.ts
+++ b/src/Button2/styles.ts
@@ -23,6 +23,10 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
       '&:disabled': {
         color: 'primer.fg.disabled',
         backgroundColor: 'btn.disabledBg'
+      },
+      '&.selected, &[aria-selected="true"]': {
+        backgroundColor: 'btn.selectedBg',
+        boxShadow: 'primer.shadow.inset'
       }
     },
     primary: {
@@ -38,7 +42,7 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
       '&:focus:not([disabled])': {
         boxShadow: `${theme?.shadows.btn.primary.focusShadow}`
       },
-      '&:active:not([disabled])': {
+      '&:active:not([disabled]),&.selected, &[aria-selected="true"]': {
         backgroundColor: 'btn.primary.selectedBg',
         boxShadow: `${theme?.shadows.btn.primary.selectedShadow}`
       },
@@ -70,7 +74,7 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
         borderColor: 'btn.danger.focusBorder',
         boxShadow: `${theme?.shadows.btn.danger.focusShadow}`
       },
-      '&:active:not([disabled])': {
+      '&:active:not([disabled]),&.selected, &[aria-selected="true"]': {
         color: 'btn.danger.selectedText',
         backgroundColor: 'btn.danger.selectedBg',
         boxShadow: `${theme?.shadows.btn.danger.selectedShadow}`,
@@ -101,7 +105,7 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
       '&:focus:not([disabled])': {
         boxShadow: `${theme?.shadows.btn.focusShadow}`
       },
-      '&:active:not([disabled])': {
+      '&:active:not([disabled]),&.selected, &[aria-selected="true"]': {
         backgroundColor: 'btn.selectedBg'
       },
       '&:disabled': {
@@ -128,7 +132,7 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
         boxShadow: `${theme?.shadows.btn.outline.focusShadow}`
       },
 
-      '&:active:not([disabled])': {
+      '&:active:not([disabled]),&.selected, &[aria-selected="true"]': {
         color: 'btn.outline.selectedText',
         backgroundColor: 'btn.outline.selectedBg',
         boxShadow: `${theme?.shadows.btn.outline.selectedShadow}`,

--- a/src/__tests__/__snapshots__/ActionMenu.test.tsx.snap
+++ b/src/__tests__/__snapshots__/ActionMenu.test.tsx.snap
@@ -67,6 +67,11 @@ exports[`ActionMenu renders consistently 1`] = `
   border-color: rgba(27,31,36,0.15);
 }
 
+.c0.selected,
+.c0[aria-selected='true'] {
+  background-color: hsla(220,14%,94%,1);
+}
+
 <button
   aria-expanded={false}
   aria-haspopup="true"

--- a/src/__tests__/__snapshots__/ActionMenu2.test.tsx.snap
+++ b/src/__tests__/__snapshots__/ActionMenu2.test.tsx.snap
@@ -91,6 +91,12 @@ exports[`ActionMenu renders consistently 1`] = `
   box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
 }
 
+.c1.selected,
+.c1[aria-selected="true"] {
+  background-color: hsla(220,14%,94%,1);
+  box-shadow: inset 0 1px 0 rgba(208,215,222,0.2);
+}
+
 <div
   className="c0"
   color="fg.default"

--- a/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
+++ b/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
@@ -73,6 +73,11 @@ exports[`AnchoredOverlay renders consistently 1`] = `
   border-color: rgba(27,31,36,0.15);
 }
 
+.c1.selected,
+.c1[aria-selected='true'] {
+  background-color: hsla(220,14%,94%,1);
+}
+
 <div
   className="c0"
   color="fg.default"
@@ -164,6 +169,11 @@ exports[`AnchoredOverlay should render consistently when open 1`] = `
   color: #8c959f;
   background-color: #f6f8fa;
   border-color: rgba(27,31,36,0.15);
+}
+
+.c1.selected,
+.c1[aria-selected='true'] {
+  background-color: hsla(220,14%,94%,1);
 }
 
 .c2 {

--- a/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -67,6 +67,11 @@ exports[`Button renders consistently 1`] = `
   border-color: rgba(27,31,36,0.15);
 }
 
+.c0.selected,
+.c0[aria-selected='true'] {
+  background-color: hsla(220,14%,94%,1);
+}
+
 <button
   className="c0"
 />
@@ -139,6 +144,11 @@ exports[`Button respects the "disabled" prop 1`] = `
   border-color: rgba(27,31,36,0.15);
 }
 
+.c0.selected,
+.c0[aria-selected='true'] {
+  background-color: hsla(220,14%,94%,1);
+}
+
 <button
   className="c0"
   disabled={true}
@@ -203,7 +213,9 @@ exports[`ButtonDanger renders consistently 1`] = `
   box-shadow: 0 0 0 3px rgba(164,14,38,0.4);
 }
 
-.c0:active {
+.c0:active,
+.c0.selected,
+.c0[aria-selected='true'] {
   color: #ffffff;
   background-color: hsla(356,72%,44%,1);
   box-shadow: inset 0 1px 0 rgba(76,0,20,0.2);
@@ -278,7 +290,9 @@ exports[`ButtonDanger renders correct disabled styles 1`] = `
   box-shadow: 0 0 0 3px rgba(164,14,38,0.4);
 }
 
-.c0:active {
+.c0:active,
+.c0.selected,
+.c0[aria-selected='true'] {
   color: #ffffff;
   background-color: hsla(356,72%,44%,1);
   box-shadow: inset 0 1px 0 rgba(76,0,20,0.2);
@@ -406,7 +420,9 @@ exports[`ButtonInvisible renders consistently 1`] = `
   box-shadow: 0 0 0 3px rgba(5,80,174,0.4);
 }
 
-.c0:active {
+.c0:active,
+.c0 $.selected,
+.c0[aria-selected='true'] {
   color: #ffffff;
   background-color: hsla(212,92%,42%,1);
   box-shadow: inset 0 1px 0 rgba(0,33,85,0.2);
@@ -483,7 +499,9 @@ exports[`ButtonInvisible renders correct disabled styles 1`] = `
   background-color: #f3f4f6;
 }
 
-.c0:active {
+.c0:active,
+.c0 $.selected,
+.c0[aria-selected='true'] {
   background-color: hsla(220,14%,94%,1);
 }
 
@@ -551,7 +569,9 @@ exports[`ButtonOutline renders consistently 1`] = `
   box-shadow: 0 0 0 3px rgba(5,80,174,0.4);
 }
 
-.c0:active {
+.c0:active,
+.c0 $.selected,
+.c0[aria-selected='true'] {
   color: #ffffff;
   background-color: hsla(212,92%,42%,1);
   box-shadow: inset 0 1px 0 rgba(0,33,85,0.2);
@@ -627,7 +647,9 @@ exports[`ButtonOutline renders correct disabled styles 1`] = `
   box-shadow: 0 0 0 3px rgba(5,80,174,0.4);
 }
 
-.c0:active {
+.c0:active,
+.c0 $.selected,
+.c0[aria-selected='true'] {
   color: #ffffff;
   background-color: hsla(212,92%,42%,1);
   box-shadow: inset 0 1px 0 rgba(0,33,85,0.2);
@@ -702,7 +724,9 @@ exports[`ButtonPrimary renders consistently 1`] = `
   box-shadow: 0 0 0 3px rgba(45,164,78,0.4);
 }
 
-.c0:active {
+.c0:active,
+.c0 $.selected,
+.c0[aria-selected='true'] {
   background-color: hsla(137,55%,36%,1);
   box-shadow: inset 0 1px 0 rgba(0,45,17,0.2);
 }
@@ -774,7 +798,9 @@ exports[`ButtonPrimary renders correct disabled styles 1`] = `
   box-shadow: 0 0 0 3px rgba(45,164,78,0.4);
 }
 
-.c0:active {
+.c0:active,
+.c0 $.selected,
+.c0[aria-selected='true'] {
   background-color: hsla(137,55%,36%,1);
   box-shadow: inset 0 1px 0 rgba(0,45,17,0.2);
 }

--- a/src/__tests__/__snapshots__/Button2.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Button2.test.tsx.snap
@@ -80,6 +80,12 @@ exports[`Button renders consistently 1`] = `
   box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
 }
 
+.c0.selected,
+.c0[aria-selected="true"] {
+  background-color: hsla(220,14%,94%,1);
+  box-shadow: inset 0 1px 0 rgba(208,215,222,0.2);
+}
+
 <button
   className="c0"
 >
@@ -179,7 +185,9 @@ exports[`Button styles danger button appropriately 1`] = `
   box-shadow: undefined;
 }
 
-.c0:active:not([disabled]) {
+.c0:active:not([disabled]),
+.c0.selected,
+.c0[aria-selected="true"] {
   color: btn.danger.selectedText;
   background-color: btn.danger.selectedBg;
   box-shadow: undefined;
@@ -270,7 +278,9 @@ exports[`Button styles invisible button appropriately 1`] = `
   box-shadow: undefined;
 }
 
-.c0:active:not([disabled]) {
+.c0:active:not([disabled]),
+.c0.selected,
+.c0[aria-selected="true"] {
   background-color: btn.selectedBg;
 }
 
@@ -374,7 +384,9 @@ exports[`Button styles outline button appropriately 1`] = `
   box-shadow: undefined;
 }
 
-.c0:active:not([disabled]) {
+.c0:active:not([disabled]),
+.c0.selected,
+.c0[aria-selected="true"] {
   color: btn.outline.selectedText;
   background-color: btn.outline.selectedBg;
   box-shadow: undefined;
@@ -470,7 +482,9 @@ exports[`Button styles primary button appropriately 1`] = `
   box-shadow: undefined;
 }
 
-.c0:active:not([disabled]) {
+.c0:active:not([disabled]),
+.c0.selected,
+.c0[aria-selected="true"] {
   background-color: btn.primary.selectedBg;
   box-shadow: undefined;
 }

--- a/src/__tests__/__snapshots__/ConfirmationDialog.test.tsx.snap
+++ b/src/__tests__/__snapshots__/ConfirmationDialog.test.tsx.snap
@@ -73,6 +73,11 @@ exports[`ConfirmationDialog renders consistently 1`] = `
   border-color: rgba(27,31,36,0.15);
 }
 
+.c1.selected,
+.c1[aria-selected='true'] {
+  background-color: hsla(220,14%,94%,1);
+}
+
 <div
   className="c0"
   color="fg.default"

--- a/src/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -89,6 +89,11 @@ exports[`Dropdown.Button renders consistently 1`] = `
   border-color: rgba(27,31,36,0.15);
 }
 
+.c0.selected,
+.c0[aria-selected='true'] {
+  background-color: hsla(220,14%,94%,1);
+}
+
 .c1 {
   border: 4px solid transparent;
   margin-left: 12px;

--- a/src/__tests__/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/src/__tests__/__snapshots__/DropdownMenu.test.tsx.snap
@@ -67,6 +67,11 @@ exports[`DropdownMenu renders consistently 1`] = `
   border-color: rgba(27,31,36,0.15);
 }
 
+.c0.selected,
+.c0[aria-selected='true'] {
+  background-color: hsla(220,14%,94%,1);
+}
+
 .c1 {
   margin-left: 4px;
 }

--- a/src/__tests__/__snapshots__/SelectMenu.test.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectMenu.test.tsx.snap
@@ -67,6 +67,11 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   border-color: rgba(27,31,36,0.15);
 }
 
+.c1.selected,
+.c1[aria-selected='true'] {
+  background-color: hsla(220,14%,94%,1);
+}
+
 .c6 {
   padding: 4px 16px;
   margin: 0;

--- a/src/__tests__/__snapshots__/SelectPanel.test.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectPanel.test.tsx.snap
@@ -73,6 +73,11 @@ exports[`SelectPanel renders consistently 1`] = `
   border-color: rgba(27,31,36,0.15);
 }
 
+.c1.selected,
+.c1[aria-selected='true'] {
+  background-color: hsla(220,14%,94%,1);
+}
+
 .c2 {
   margin-left: 4px;
 }

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -52,6 +52,12 @@ export default {
         type: 'radio',
         options: ['small', 'medium', 'large']
       }
+    },
+    'aria-selected': {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
+      }
     }
   }
 } as Meta


### PR DESCRIPTION
Describe your changes here.

I have added `selected` state as described in https://primer.style/css/components/buttons#selected. I used the same styles as https://github.com/primer/css/blob/e8d5402a26f0e4428cb0cd0694569da3c2ed505e/src/buttons/button.scss#L86

I have implemented this for both `Button` and `Button2`.

Closes # (https://github.com/github/primer/issues/639)

### Screenshots

Checkout the storybook in 

Please provide before/after screenshots for any visual changes

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
