### PR TITLE
Bump "version" in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/react",
-  "version": "34.2.0",
+  "version": "34.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/react",
-      "version": "34.2.0",
+      "version": "34.3.0",
       "license": "MIT",
       "dependencies": {
         "@primer/behaviors": "1.0.3",


### PR DESCRIPTION
This bumps the library "version" field in package-lock.json to match package.json. Otherwise, running `npm install` in this repository results in changes to package-lock.json (i.e. it introduces changes not likely unrelated to what the author is working on).
