### PR TITLE
Add history dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "color2k": "1.2.4",
         "deepmerge": "4.2.2",
         "focus-visible": "5.2.0",
+        "history": "5.0.0",
         "styled-system": "5.1.5"
       },
       "devDependencies": {
@@ -21056,7 +21057,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.0.0.tgz",
       "integrity": "sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
@@ -53100,7 +53100,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.0.0.tgz",
       "integrity": "sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.7.6"
       }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "color2k": "1.2.4",
     "deepmerge": "4.2.2",
     "focus-visible": "5.2.0",
+    "history": "5.0.0",
     "styled-system": "5.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Since the "history" package is used by [UnderlineNav](https://github.com/primer/react/blob/1c4786c7d99fe083b47902acff5326c44a7c8288/src/UnderlineNav.tsx#L2), it should be in @primer/react's direct production dependencies. This ensures that its types are properly exposed to consumers of @primer/react that do not have `skipLibCheck` enabled.

Since this doesn't actually change anything in @primer/react at runtime or even in development, I don't believe this is worth a changelog.