### PR TITLE
Make KeyPaths not require @ts-ignore

### DIFF
--- a/src/__tests__/KeyPaths.types.test.ts
+++ b/src/__tests__/KeyPaths.types.test.ts
@@ -1,5 +1,5 @@
 import {Union} from 'ts-toolbelt'
-import {KeyPaths} from '../utils/types/KeyPaths'
+import {KeyPaths, KP} from '../utils/types/KeyPaths'
 
 type NestedObject = {
   a: string

--- a/src/utils/types/KeyPaths.ts
+++ b/src/utils/types/KeyPaths.ts
@@ -1,10 +1,4 @@
 // Produces a union of dot-delimited keypaths to the string values in a nested object:
-export type KeyPaths<O extends Record<string, unknown>> = {
-  [K in keyof O]: K extends string
-    ? O[K] extends string
-      ? `${K}`
-      : // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore TypeScript has bested me, but the KeyPaths type is tested.
-        `${K}.${KeyPaths<O[K]>}`
-    : never
+export type KeyPaths<O> = {
+  [K in keyof O]: K extends string ? (O[K] extends string ? `${K}` : `${K}.${KeyPaths<O[K]>}`) : never
 }[keyof O]

--- a/src/utils/types/KeyPaths.ts
+++ b/src/utils/types/KeyPaths.ts
@@ -1,4 +1,4 @@
 // Produces a union of dot-delimited keypaths to the string values in a nested object:
 export type KeyPaths<O> = {
-  [K in keyof O]: K extends string ? (O[K] extends string ? `${K}` : `${K}.${KeyPaths<O[K]>}`) : never
+  [K in keyof O]: K extends string ? (O[K] extends Record<string, unknown> ? `${K}.${KeyPaths<O[K]>}` : `${K}`) : never
 }[keyof O]


### PR DESCRIPTION
Currently, `KeyPaths` requires a `@ts-ignore` line, because TypeScript can't verify that `O[K]` is a `Record<string, unknown>`.

In order to fix this, we can change `KeyPaths<O extends Record<string, unknown>>` to just `KeyPaths<O>`, but internally still verify that when recursing through `O`, we only recurse when `O[K] extends Record<string, unknown>`.

This makes it so that `KeyPaths` can be called on _any_ value and I'm not sure if the repercussions of that are relevant. However, we should avoid `@ts-ignore` in types that are potentially consumed by projects using @primer/react, otherwise we essentially require that they have `skipLibCheck: true` in their TS config files.

There may be some better way of solving this, but my TypeScript knowledge isn't strong enough to figure it out 😄 