### PR TITLE
Stories: Add example of onEscape for Overlay

### DIFF
--- a/src/stories/Overlay.stories.tsx
+++ b/src/stories/Overlay.stories.tsx
@@ -330,7 +330,9 @@ export const OverrideOnEscape = () => {
   const buttonRef = useRef<HTMLButtonElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const onInputKeyDown = () => alert("Don't close the menu")
+  const onInputKeyUp = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') alert('Did not close the menu')
+  }
 
   return (
     <div>
@@ -351,9 +353,9 @@ export const OverrideOnEscape = () => {
           top={60}
           left={16}
         >
-          <Box sx={{display: 'flex', flexDirection: 'column', p: 2, gap: 2}}>
-            <TextInput ref={inputRef} placeholder="Hit escape when input has focus" onKeyUp={onInputKeyDown} />
-            <ButtonPrimary>Save</ButtonPrimary>
+          <Box onSubmit={() => setOpen(false)} as="form" sx={{display: 'flex', flexDirection: 'column', p: 2, gap: 2}}>
+            <TextInput ref={inputRef} placeholder="Hit escape when input has focus" onKeyUp={onInputKeyUp} />
+            <ButtonPrimary>Hit escape when button has focus</ButtonPrimary>
           </Box>
         </Overlay>
       )}

--- a/src/stories/Overlay.stories.tsx
+++ b/src/stories/Overlay.stories.tsx
@@ -323,3 +323,40 @@ export const NestedOverlays = () => {
     </div>
   )
 }
+
+export const OverrideOnEscape = () => {
+  const [open, setOpen] = React.useState(false)
+
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const onInputKeyDown = () => alert("Don't close the menu")
+
+  return (
+    <div>
+      <Button ref={buttonRef} onClick={() => setOpen(!open)}>
+        Open Overlay
+      </Button>
+
+      {open && (
+        <Overlay
+          width="medium"
+          onEscape={() => {
+            if (inputRef.current === document.activeElement) return
+            setOpen(false)
+          }}
+          onClickOutside={() => setOpen(false)}
+          returnFocusRef={buttonRef}
+          ignoreClickRefs={[buttonRef]}
+          top={60}
+          left={16}
+        >
+          <Box sx={{display: 'flex', flexDirection: 'column', p: 2, gap: 2}}>
+            <TextInput ref={inputRef} placeholder="Hit escape when input has focus" onKeyUp={onInputKeyDown} />
+            <ButtonPrimary>Save</ButtonPrimary>
+          </Box>
+        </Overlay>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Add story to override `onEscape` with Overlay

Story: https://primer-react-gqp6t9wxq-primer.vercel.app/react/storybook?path=/story/internal-components-overlay--override-on-escape