### PR TITLE
chore(package-lock): remove git conflict, invalid versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/react",
-  "version": "34.3.0",
+  "version": "34.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/react",
-      "version": "34.3.0",
+      "version": "34.5.0",
       "license": "MIT",
       "dependencies": {
         "@primer/behaviors": "1.0.3",
@@ -110,7 +110,7 @@
         "storybook-addon-performance": "0.16.1",
         "styled-components": "4.4.1",
         "ts-toolbelt": "9.6.0",
-        "typescript": "4.4.4"
+        "typescript": "4.5.4"
       },
       "engines": {
         "node": ">=12",
@@ -5710,15 +5710,9 @@
       }
     },
     "node_modules/@primer/behaviors": {
-<<<<<<< HEAD
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.0.3.tgz",
       "integrity": "sha512-zh1FKvAXLjKs0rr9Ik9E5M3Q9/npa9hmpuHKmYZn7u9QnSl+X13jFPme3AmtokOlfduFYeHfQyzSIJEhSEVl3w=="
-=======
-      "version": "0.0.0-2022020145740",
-      "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-0.0.0-2022020145740.tgz",
-      "integrity": "sha512-VViqEjOCcgHn+etCVwFR5PXBCTMK8/uFpEgFql4adKK1EG3RAIxvlOVXsBPGFKfbR9JZft2xOnutq32sRFtUAA=="
->>>>>>> e86d01e9 (Add exports to package.json)
     },
     "node_modules/@primer/octicons-react": {
       "version": "16.1.1",
@@ -35493,9 +35487,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -41404,15 +41398,9 @@
       "dev": true
     },
     "@primer/behaviors": {
-<<<<<<< HEAD
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.0.3.tgz",
       "integrity": "sha512-zh1FKvAXLjKs0rr9Ik9E5M3Q9/npa9hmpuHKmYZn7u9QnSl+X13jFPme3AmtokOlfduFYeHfQyzSIJEhSEVl3w=="
-=======
-      "version": "0.0.0-2022020145740",
-      "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-0.0.0-2022020145740.tgz",
-      "integrity": "sha512-VViqEjOCcgHn+etCVwFR5PXBCTMK8/uFpEgFql4adKK1EG3RAIxvlOVXsBPGFKfbR9JZft2xOnutq32sRFtUAA=="
->>>>>>> e86d01e9 (Add exports to package.json)
     },
     "@primer/octicons-react": {
       "version": "16.1.1",


### PR DESCRIPTION
Invalid typescript version makes `npm ci` fail in the latest npm https://github.com/npm/cli/pull/4363

Merge conflict was introduced in https://github.com/primer/react/pull/1771