### PR TITLE
Prefix component with types exported from ActionList2 and ActionMenu2

### DIFF
--- a/.changeset/actionlist2-actionmenu2-prefix-types.md
+++ b/.changeset/actionlist2-actionmenu2-prefix-types.md
@@ -1,0 +1,17 @@
+---
+'@primer/react': major
+---
+
+Prefix ActionList for exported types from ActionList2
+
+ListProps → ActionListProps
+GroupProps → ActionListGroupProps
+ItemProps → ActionListItemProps
+DescriptionProps → ActionListDescriptionProps
+LeadingVisualProps → ActionListLeadingVisualProps,
+TrailingVisualProps → ActionListTrailingVisualProps
+
+Prefix ActionMenu for exported types from ActionMenu2
+
+MenuButtonProps → ActionMenuButtonProps
+MenuAnchorProps → ActionMenuAnchorProps

--- a/.changeset/actionlist2-actionmenu2-prefix-types.md
+++ b/.changeset/actionlist2-actionmenu2-prefix-types.md
@@ -2,16 +2,20 @@
 '@primer/react': major
 ---
 
-Prefix ActionList for exported types from ActionList2
+`ActionList2` exported types are now prefixed with `ActionList`:
 
+```
 ListProps → ActionListProps
 GroupProps → ActionListGroupProps
 ItemProps → ActionListItemProps
 DescriptionProps → ActionListDescriptionProps
 LeadingVisualProps → ActionListLeadingVisualProps,
 TrailingVisualProps → ActionListTrailingVisualProps
+```
 
-Prefix ActionMenu for exported types from ActionMenu2
+`ActionMenu2` exported types are now prefixed with `ActionMenu`:
 
+```
 MenuButtonProps → ActionMenuButtonProps
 MenuAnchorProps → ActionMenuAnchorProps
+```

--- a/src/ActionList2/index.ts
+++ b/src/ActionList2/index.ts
@@ -7,10 +7,13 @@ import {Description} from './Description'
 import {LeadingVisual, TrailingVisual} from './Visuals'
 
 export type {ListProps as ActionListProps} from './List'
-export type {GroupProps} from './Group'
-export type {ItemProps} from './Item'
-export type {DescriptionProps} from './Description'
-export type {LeadingVisualProps, TrailingVisualProps} from './Visuals'
+export type {GroupProps as ActionListGroupProps} from './Group'
+export type {ItemProps as ActionListItemProps} from './Item'
+export type {DescriptionProps as ActionListDescriptionProps} from './Description'
+export type {
+  LeadingVisualProps as ActionListLeadingVisualProps,
+  TrailingVisualProps as ActionListTrailingVisualProps
+} from './Visuals'
 
 /**
  * Collection of list-related components.

--- a/src/ActionMenu2.tsx
+++ b/src/ActionMenu2.tsx
@@ -64,15 +64,15 @@ const Menu: React.FC<ActionMenuProps> = ({
   )
 }
 
-export type MenuAnchorProps = {children: React.ReactElement}
-const Anchor = React.forwardRef<AnchoredOverlayProps['anchorRef'], MenuAnchorProps>(
+export type ActionMenuAnchorProps = {children: React.ReactElement}
+const Anchor = React.forwardRef<AnchoredOverlayProps['anchorRef'], ActionMenuAnchorProps>(
   ({children, ...anchorProps}, anchorRef) => {
     return React.cloneElement(children, {...anchorProps, ref: anchorRef})
   }
 )
 
 /** this component is syntactical sugar 🍭 */
-export type MenuButtonProps = ButtonProps
+export type ActionMenuButtonProps = ButtonProps
 const MenuButton = React.forwardRef<AnchoredOverlayProps['anchorRef'], ButtonProps>((props, anchorRef) => {
   return (
     <Anchor ref={anchorRef}>


### PR DESCRIPTION
ActionList2:
ListProps → ActionListProps
GroupProps → ActionListGroupProps
ItemProps → ActionListItemProps
DescriptionProps → ActionListDescriptionProps
LeadingVisualProps → ActionListLeadingVisualProps,
TrailingVisualProps → ActionListTrailingVisualProps

ActionMenu2:
MenuButtonProps → ActionMenuButtonProps
MenuAnchorProps → ActionMenuAnchorProps

We do this to avoid any conflicts with other component with similar types.
