### PR TITLE
Add `skip changeset` label to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    labels:
+      - "dependencies"
+      - "skip changeset"
 
   - package-ecosystem: 'npm'
     directory: '/docs'
@@ -16,3 +19,6 @@ updates:
       interval: 'weekly'
     allow:
       - dependency-name: '@primer/gatsby-theme-doctocat'
+    labels:
+      - "dependencies"
+      - "skip changeset"


### PR DESCRIPTION
Configures dependabot to automatically add the `skip changeset` label to dependabot PRs