### PR TITLE
Add next major to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,23 @@ on:
   push:
     branches:
       - main
-      - 'next/**'
+      - next-major
 
 jobs:
-  release:
-    name: Release
+  release-main:
+    if: github.ref_name == 'main'
+    name: Main
     uses: primer/.github/.github/workflows/release.yml@main
+    secrets:
+      gh_token: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
+      npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
+
+  release-next-major:
+    if: github.ref_name == 'next-major'
+    name: Next major
+    uses: primer/.github/.github/workflows/release.yml@main
+    with:
+      title: Release tracking (next major)
     secrets:
       gh_token: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
       npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches-ignore:
       - 'main'
-      - 'changeset-release/main'
+      - 'next-major'
+      - 'changeset-release/**'
 
 jobs:
   release-canary:

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -4,11 +4,23 @@ on:
   push:
     branches:
       - 'changeset-release/main'
+      - 'changeset-release/next-major'
 
 jobs:
   release-candidate:
-    name: Candidate
+    if: github.ref_name == 'changeset-release/main'
+    name: Candidate (@next)
     uses: primer/.github/.github/workflows/release_candidate.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
+      
+  release-candidate-next-major:
+    if: github.ref_name == 'changeset-release/next-major'
+    name: Candidate (@next-major)
+    uses: primer/.github/.github/workflows/release_candidate.yml@main
+    with:
+      tag: next-major
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}


### PR DESCRIPTION
## Motivation

We want to reduce the frequency of major releases of `@primer/react` without slowing down the release cadence of minor and patch releases. 

## Solution

This PR implements workflow changes that allow us to merge breaking changes into a `next-major` branch (instead of `main`) that can be tracked and released independently of minor and patch versions.

![image](https://user-images.githubusercontent.com/4608155/156058959-8271a032-f0e4-41c3-b639-9dc79db217dc.png)
