### PR TITLE
Fix theming with SSR with CSRF safe approach

### DIFF
--- a/.changeset/safe-ssr-theming.md
+++ b/.changeset/safe-ssr-theming.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Fixes the theming implementation with server side rendering to use a CSRF safe approach

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -39,12 +39,11 @@ const ThemeContext = React.createContext<{
 
 // inspired from __NEXT_DATA__, we use application/json to avoid CSRF policy with inline scripts
 const getServerHandoff = () => {
-  if (typeof document !== 'undefined' && document.getElementById('__PRIMER_DATA__')?.textContent) {
-    try {
-      return JSON.parse(document.getElementById('__PRIMER_DATA__')?.textContent as string)
-    } catch (error) {
+  try {
+    const serverData = document?.getElementById('__PRIMER_DATA__')?.textContent
+    if (serverData) return JSON.parse(serverData)
+  } catch (error) {
       // if JSON is invalid, supress error
-    }
   }
   return {}
 }

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -40,10 +40,10 @@ const ThemeContext = React.createContext<{
 // inspired from __NEXT_DATA__, we use application/json to avoid CSRF policy with inline scripts
 const getServerHandoff = () => {
   try {
-    const serverData = document?.getElementById('__PRIMER_DATA__')?.textContent
+    const serverData = document.getElementById('__PRIMER_DATA__')?.textContent
     if (serverData) return JSON.parse(serverData)
   } catch (error) {
-      // if JSON is invalid, supress error
+    // if document/element does not exist or JSON is invalid, supress error
   }
   return {}
 }

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -38,7 +38,7 @@ const ThemeContext = React.createContext<{
 })
 
 // inspired from __NEXT_DATA__, we use application/json to avoid CSRF policy with inline scripts
-const getSeverHandoff = () => {
+const getServerHandoff = () => {
   if (typeof document !== 'undefined' && document.getElementById('__PRIMER_DATA__')?.textContent) {
     try {
       return JSON.parse(document.getElementById('__PRIMER_DATA__')?.textContent as string)
@@ -61,7 +61,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({children, ...props}
   // Initialize state
   const theme = props.theme ?? fallbackTheme ?? defaultTheme
 
-  const {resolvedServerColorMode} = getSeverHandoff()
+  const {resolvedServerColorMode} = getServerHandoff()
   const resolvedColorModePassthrough = React.useRef(resolvedServerColorMode)
 
   const [colorMode, setColorMode] = React.useState(props.colorMode ?? fallbackColorMode ?? defaultColorMode)


### PR DESCRIPTION
Following up on https://github.com/primer/react/pull/1868, the approach I chose relied on injecting an inline script to set a variable. This doesn't work in [github/docs-internal](https://github.com/github/docs-internal/pull/24123) because secure applications prevent executing inline scripts injected in the DOM 😇 

Inspired by `__NEXT_DATA__` from next.js, I've changed the implementation to inject a `<script type="application/json">` instead of `<script type="text/javascript">`.

[Tested with docs-internal](https://github.com/github/docs-internal/pull/24123/commits/625e6b4f6268e39e836375ac494a3f26f2c89dce#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R16), it works!