### PR TITLE
Menu: Fix typeahead with leading visuals

### DIFF
--- a/.changeset/slimy-garlics-wash.md
+++ b/.changeset/slimy-garlics-wash.md
@@ -2,4 +2,4 @@
 "@primer/react": patch
 ---
 
-Menu: Fix typeahead with leading visuals
+ActionMenu: Fix typeahead with leading visuals

--- a/.changeset/slimy-garlics-wash.md
+++ b/.changeset/slimy-garlics-wash.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Menu: Fix typeahead with leading visuals

--- a/src/hooks/useTypeaheadFocus.ts
+++ b/src/hooks/useTypeaheadFocus.ts
@@ -49,7 +49,7 @@ export const useTypeaheadFocus = (open: boolean, providedRef?: React.RefObject<H
 
       const focusNextMatch = () => {
         const itemsStartingWithKey = focusableItems.filter(item => {
-          return item.textContent?.toLowerCase().startsWith(query)
+          return item.textContent?.toLowerCase().trim().startsWith(query)
         })
 
         const currentActiveIndex = itemsStartingWithKey.indexOf(activeElement)


### PR DESCRIPTION
When there is a leading visual present, the `textContent` has an extra space which means we are not able to find the matching item. Add a `trim()` solves this issue.


<img width="370" alt="image" src="https://user-images.githubusercontent.com/1863771/156210735-5e80e51c-ebc5-4c52-a5ff-caf95a5a557f.png">


Without trim:  `' Text'`, `' Number'`
With trim: `'Text'`, `'Number'`


