### PR TITLE
Button: Update active styles + use them for aria-expanded

### DIFF
--- a/.changeset/healthy-dots-chew.md
+++ b/.changeset/healthy-dots-chew.md
@@ -1,0 +1,6 @@
+---
+"@primer/react": patch
+---
+
+- Update styles for default variant of Button's active state
+- Use active state for Button when it is used to open an Overlay

--- a/src/Button/styles.ts
+++ b/src/Button/styles.ts
@@ -17,16 +17,16 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
         boxShadow: `${theme?.shadows.btn.focusShadow}`
       },
       '&:active:not([disabled])': {
-        backgroundColor: 'btn.selectedBg',
-        boxShadow: `${theme?.shadows.btn.shadowActive}`
+        backgroundColor: 'btn.activeBg',
+        borderColor: 'btn.activeBorder'
       },
       '&:disabled': {
         color: 'primer.fg.disabled',
         backgroundColor: 'btn.disabledBg'
       },
       '&[aria-expanded=true]': {
-        backgroundColor: 'btn.selectedBg',
-        boxShadow: `${theme?.shadows.btn.shadowActive}`
+        backgroundColor: 'btn.activeBg',
+        borderColor: 'btn.activeBorder'
       }
     },
     primary: {

--- a/src/Button/styles.ts
+++ b/src/Button/styles.ts
@@ -23,6 +23,10 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
       '&:disabled': {
         color: 'primer.fg.disabled',
         backgroundColor: 'btn.disabledBg'
+      },
+      '&[aria-expanded=true]': {
+        backgroundColor: 'btn.selectedBg',
+        boxShadow: `${theme?.shadows.btn.shadowActive}`
       }
     },
     primary: {
@@ -49,6 +53,10 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
       '[data-component="ButtonCounter"]': {
         backgroundColor: 'btn.primary.counterBg',
         color: 'btn.primary.text'
+      },
+      '&[aria-expanded=true]': {
+        backgroundColor: 'btn.primary.selectedBg',
+        boxShadow: `${theme?.shadows.btn.primary.selectedShadow}`
       }
     },
     danger: {
@@ -87,6 +95,12 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
       '[data-component="ButtonCounter"]': {
         color: 'btn.danger.text',
         backgroundColor: 'btn.danger.counterBg'
+      },
+      '&[aria-expanded=true]': {
+        color: 'btn.danger.selectedText',
+        backgroundColor: 'btn.danger.selectedBg',
+        boxShadow: `${theme?.shadows.btn.danger.selectedShadow}`,
+        borderColor: 'btn.danger.selectedBorder'
       }
     },
     invisible: {
@@ -106,6 +120,9 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
       },
       '&:disabled': {
         color: 'primer.fg.disabled'
+      },
+      '&[aria-expanded=true]': {
+        backgroundColor: 'btn.selectedBg'
       }
     },
     outline: {
@@ -146,6 +163,12 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
       '[data-component="ButtonCounter"]': {
         backgroundColor: 'btn.outline.counterBg',
         color: 'btn.outline.text'
+      },
+      '&[aria-expanded=true]': {
+        color: 'btn.outline.selectedText',
+        backgroundColor: 'btn.outline.selectedBg',
+        boxShadow: `${theme?.shadows.btn.outline.selectedShadow}`,
+        borderColor: 'btn.outline.selectedBorder'
       }
     }
   }

--- a/src/__tests__/__snapshots__/ActionMenu.test.tsx.snap
+++ b/src/__tests__/__snapshots__/ActionMenu.test.tsx.snap
@@ -87,8 +87,13 @@ exports[`ActionMenu renders consistently 1`] = `
 }
 
 .c1:active:not([disabled]) {
-  background-color: hsla(220,14%,94%,1);
-  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
+  background-color: hsla(220,14%,93%,1);
+  border-color: rgba(27,31,36,0.15);
+}
+
+.c1[aria-expanded=true] {
+  background-color: hsla(220,14%,93%,1);
+  border-color: rgba(27,31,36,0.15);
 }
 
 <div

--- a/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -76,8 +76,13 @@ exports[`Button renders consistently 1`] = `
 }
 
 .c0:active:not([disabled]) {
-  background-color: hsla(220,14%,94%,1);
-  box-shadow: inset 0 0.15em 0.3em rgba(27,31,36,0.15);
+  background-color: hsla(220,14%,93%,1);
+  border-color: rgba(27,31,36,0.15);
+}
+
+.c0[aria-expanded=true] {
+  background-color: hsla(220,14%,93%,1);
+  border-color: rgba(27,31,36,0.15);
 }
 
 <button
@@ -182,6 +187,13 @@ exports[`Button styles danger button appropriately 1`] = `
   border-color: btn.danger.selectedBorder;
 }
 
+.c0[aria-expanded=true] {
+  color: btn.danger.selectedText;
+  background-color: btn.danger.selectedBg;
+  box-shadow: undefined;
+  border-color: btn.danger.selectedBorder;
+}
+
 <button
   class="c0"
 >
@@ -267,6 +279,10 @@ exports[`Button styles invisible button appropriately 1`] = `
 }
 
 .c0:active:not([disabled]) {
+  background-color: btn.selectedBg;
+}
+
+.c0[aria-expanded=true] {
   background-color: btn.selectedBg;
 }
 
@@ -377,6 +393,13 @@ exports[`Button styles outline button appropriately 1`] = `
   border-color: btn.outline.selectedBorder;
 }
 
+.c0[aria-expanded=true] {
+  color: btn.outline.selectedText;
+  background-color: btn.outline.selectedBg;
+  box-shadow: undefined;
+  border-color: btn.outline.selectedBorder;
+}
+
 <button
   class="c0"
 >
@@ -467,6 +490,11 @@ exports[`Button styles primary button appropriately 1`] = `
 }
 
 .c0:active:not([disabled]) {
+  background-color: btn.primary.selectedBg;
+  box-shadow: undefined;
+}
+
+.c0[aria-expanded=true] {
   background-color: btn.primary.selectedBg;
   box-shadow: undefined;
 }

--- a/src/stories/ActionMenu/examples.stories.tsx
+++ b/src/stories/ActionMenu/examples.stories.tsx
@@ -164,7 +164,7 @@ export function GroupsAndDescription(): JSX.Element {
               paddingX: 0,
               gridTemplateColumns: 'min-content 1fr min-content',
               textAlign: 'left',
-              ':hover, :focus': {background: 'none !important', color: 'accent.fg'}
+              ':hover, :focus, &[aria-expanded=true]': {background: 'none !important', color: 'accent.fg'}
             }}
           >
             Milestone
@@ -260,7 +260,7 @@ export function MultipleSelection(): JSX.Element {
               paddingX: 0,
               gridTemplateColumns: 'min-content 1fr min-content',
               textAlign: 'left',
-              ':hover, :focus': {background: 'none !important', color: 'accent.fg'}
+              ':hover, :focus, &[aria-expanded=true]': {background: 'none !important', color: 'accent.fg'}
             }}
           >
             Assignees


### PR DESCRIPTION
2 changes here:

1. Update active style for default variant of Button to match new designs & primer-css. The other variants are the same

| Before | After |
|--------|--------|
| <img width="149" alt="Button with pressed shadow" src="https://user-images.githubusercontent.com/1863771/156776355-ea2ed4e8-61fc-4a19-b3ed-3ac6c4399e2f.png"> | <img width="141" alt="Button with pressed background" src="https://user-images.githubusercontent.com/1863771/156776412-a3189edf-d827-4b91-b456-2422962a7de0.png"> |


2. Add `aria-expanded` to reuse active styles. This would be useful for all Buttons that open an Overlay. For now, focused on ActionMenu

| Before | After |
|--------|--------|
<img width="246" alt="button stays in it's default state when menu is open" src="https://user-images.githubusercontent.com/1863771/156776629-d2acb7d2-dfc2-42cb-997f-4f40f479dde7.png"> | <img width="233" alt="button is active or pressed when the menu is opened" src="https://user-images.githubusercontent.com/1863771/156776658-5339fd2a-e48f-4851-be52-d35acc5c8f2d.png"> |

#### Question for the reviewer: Is the right way to add a pressed state for Button triggers?