### PR TITLE
Add align prop on ActionMenu.Overlay to pass through to AnchoredOverlay

### DIFF
--- a/.changeset/actionmenu-add-align-prop.md
+++ b/.changeset/actionmenu-add-align-prop.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Add align prop on ActionMenu.Overlay to pass through to AnchoredOverlay

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -305,10 +305,11 @@ render(
 
 ### ActionMenu.Overlay
 
-| Name                                     | Type                  |       Default       | Description                                                                                   |
-| :--------------------------------------- | :-------------------- | :-----------------: | :-------------------------------------------------------------------------------------------- |
-| children\*                               | `React.ReactElement[] | React.ReactElement` | Required. Recommended: [`ActionList`](/ActionList)                                            |
-| [OverlayProps](/Overlay#component-props) | -                     |          -          | Optional. Props to be spread on the internal [`AnchoredOverlay`](/AnchoredOverlay) component. |
+| Name                                     | Type                                               | Default | Description                                                                             |
+| :--------------------------------------- | :------------------------------------------------- | :-----: | :-------------------------------------------------------------------------------------- |
+| children\*                               | `React.ReactElement` &#124; `React.ReactElement[]` |    -    | Required. Recommended: [`ActionList`](/ActionList)                                      |
+| align                                    | 'start' &#124; 'center' &#124; 'end'               | 'start' | Optional. Passed down to internal [`AnchoredOverlay`](/AnchoredOverlay#props) component |
+| [OverlayProps](/Overlay#component-props) | -                                                  |    -    | Optional. Props to be spread on the internal [`Overlay`](/Overlay) component.           |
 
 ## Status
 

--- a/docs/content/AnchoredOverlay.mdx
+++ b/docs/content/AnchoredOverlay.mdx
@@ -20,7 +20,11 @@ See also [Overlay positioning](/Overlay#positioning).
     const closeOverlay = React.useCallback(() => setIsOpen(false), [setIsOpen])
     return (
       <AnchoredOverlay
-        renderAnchor={anchorProps => <DropdownButton {...anchorProps}>Click me to open</DropdownButton>}
+        renderAnchor={anchorProps => (
+          <Button {...anchorProps} trailingIcon={TriangleDownIcon}>
+            Click me to open
+          </Button>
+        )}
         open={isOpen}
         onOpen={openOverlay}
         onClose={closeOverlay}

--- a/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
@@ -29,7 +29,8 @@ import {
   TypographyIcon,
   VersionsIcon,
   XIcon,
-  ZapIcon
+  ZapIcon,
+  TriangleDownIcon
 } from '@primer/octicons-react'
 import * as primerComponents from '@primer/react'
 import * as drafts from '@primer/react/drafts'
@@ -85,6 +86,7 @@ export default function resolveScope(metastring) {
     IterationsIcon,
     NumberIcon,
     SingleSelectIcon,
+    TriangleDownIcon,
     Dialog2,
     ConfirmationDialog,
     useConfirm,

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -81,13 +81,14 @@ const MenuButton = React.forwardRef<AnchoredOverlayProps['anchorRef'], ButtonPro
   )
 })
 
-type MenuOverlayProps = Partial<OverlayProps> & {
-  /**
-   * Recommended: `ActionList`
-   */
-  children: React.ReactElement[] | React.ReactElement
-}
-const Overlay: React.FC<MenuOverlayProps> = ({children, ...overlayProps}) => {
+type MenuOverlayProps = Partial<OverlayProps> &
+  Pick<AnchoredOverlayProps, 'align'> & {
+    /**
+     * Recommended: `ActionList`
+     */
+    children: React.ReactElement[] | React.ReactElement
+  }
+const Overlay: React.FC<MenuOverlayProps> = ({children, align = 'start', ...overlayProps}) => {
   // we typecast anchorRef as required instead of optional
   // because we know that we're setting it in context in Menu
   const {anchorRef, renderAnchor, anchorId, open, onOpen, onClose} = React.useContext(MenuContext) as MandateProps<
@@ -107,6 +108,7 @@ const Overlay: React.FC<MenuOverlayProps> = ({children, ...overlayProps}) => {
       open={open}
       onOpen={openWithFocus}
       onClose={onClose}
+      align={align}
       overlayProps={overlayProps}
       focusZoneSettings={{focusOutBehavior: 'wrap'}}
     >

--- a/src/stories/ActionMenu/fixtures.stories.tsx
+++ b/src/stories/ActionMenu/fixtures.stories.tsx
@@ -604,30 +604,33 @@ export function OverlayProps(): JSX.Element {
         Disable `onClickOutside` and `onEscape`. Only way to close is to select an action which takes focus on a
         TextInput
       </p>
-      <ActionMenu open={open} onOpenChange={setOpen}>
-        <ActionMenu.Button>Menu</ActionMenu.Button>
-        <ActionMenu.Overlay
-          width="large"
-          onClickOutside={() => {
-            /* do nothing, keep it open*/
-          }}
-          onEscape={() => {
-            /* do nothing, keep it open*/
-          }}
-          returnFocusRef={inputRef}
-        >
-          <ActionList>
-            <ActionList.Item>Option 1</ActionList.Item>
-            <ActionList.Item>Option 2</ActionList.Item>
-            <ActionList.Item>Option 2</ActionList.Item>
-            <ActionList.Item>Option 2</ActionList.Item>
-            <ActionList.Item>Option 2</ActionList.Item>
-            <ActionList.Item>Option 2</ActionList.Item>
-            <ActionList.Item>Option 2</ActionList.Item>
-            <ActionList.Item>Option 2</ActionList.Item>
-          </ActionList>
-        </ActionMenu.Overlay>
-      </ActionMenu>
+      <Box sx={{display: 'flex', justifyContent: 'center'}}>
+        <ActionMenu open={open} onOpenChange={setOpen}>
+          <ActionMenu.Button>Menu</ActionMenu.Button>
+          <ActionMenu.Overlay
+            width="large"
+            align="center"
+            onClickOutside={() => {
+              /* do nothing, keep it open*/
+            }}
+            onEscape={() => {
+              /* do nothing, keep it open*/
+            }}
+            returnFocusRef={inputRef}
+          >
+            <ActionList>
+              <ActionList.Item>Option 1</ActionList.Item>
+              <ActionList.Item>Option 2</ActionList.Item>
+              <ActionList.Item>Option 2</ActionList.Item>
+              <ActionList.Item>Option 2</ActionList.Item>
+              <ActionList.Item>Option 2</ActionList.Item>
+              <ActionList.Item>Option 2</ActionList.Item>
+              <ActionList.Item>Option 2</ActionList.Item>
+              <ActionList.Item>Option 2</ActionList.Item>
+            </ActionList>
+          </ActionMenu.Overlay>
+        </ActionMenu>
+      </Box>
       <br />
       <br />
       <TextInput type="text" ref={inputRef} placeholder="Random input to return focus to" sx={{width: 280}} />


### PR DESCRIPTION
Makes it possible to change the alignment of `ActionMenu.Overlay` with `align: 'start' | 'center' | 'end'` that's passed down to `AnchoredOverlay` (not Overlay)