### PR TITLE
Add outline background and border color

### DIFF
--- a/.changeset/three-papayas-beg.md
+++ b/.changeset/three-papayas-beg.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Add outline background and border color

--- a/src/Button2/styles.ts
+++ b/src/Button2/styles.ts
@@ -111,6 +111,8 @@ export const getVariantStyles = (variant: VariantType = 'default', theme?: Theme
     outline: {
       color: 'btn.outline.text',
       boxShadow: `${theme?.shadows.btn.shadow}`,
+      borderColor: 'btn.border',
+      backgroundColor: 'btn.bg',
 
       '&:hover:not([disabled])': {
         color: 'btn.outline.hoverText',

--- a/src/__tests__/__snapshots__/Button2.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Button2.test.tsx.snap
@@ -285,6 +285,7 @@ exports[`Button styles outline button appropriately 1`] = `
 .c0 {
   border-radius: 2;
   border: 1px solid;
+  border-color: btn.border;
   font-family: inherit;
   font-weight: bold;
   line-height: 20px;
@@ -310,6 +311,7 @@ exports[`Button styles outline button appropriately 1`] = `
   font-size: 14px;
   color: btn.outline.text;
   box-shadow: undefined;
+  background-color: btn.bg;
 }
 
 .c0:focus {


### PR DESCRIPTION
Describe your changes here.

The dark mode of outline button had the wrong background.
 
Before

![image](https://user-images.githubusercontent.com/417268/156956588-bc5a1826-27f0-4cea-9207-728ee0c28c58.png)

After

![image](https://user-images.githubusercontent.com/417268/156956617-818345bc-a984-4146-b1cb-c7312329d2e5.png)

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
