### PR TITLE
ThemeProvider: Fix setColorMode

### DIFF
--- a/.changeset/pretty-cougars-walk.md
+++ b/.changeset/pretty-cougars-walk.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+ThemeProvider: Fix `setColorMode`. Broken in `34.6.0`

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -99,7 +99,11 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({children, ...props}
   // Update state if props change
   React.useEffect(() => {
     setColorMode(props.colorMode ?? fallbackColorMode ?? defaultColorMode)
-  }, [props.colorMode, resolvedColorMode, fallbackColorMode])
+  }, [props.colorMode, fallbackColorMode])
+
+  React.useEffect(() => {
+    setColorMode(resolvedColorMode)
+  }, [resolvedColorMode])
 
   React.useEffect(() => {
     setDayScheme(props.dayScheme ?? fallbackDayScheme ?? defaultDayScheme)


### PR DESCRIPTION
https://github.com/primer/react/pull/1868 breaks `setColorMode` by [overriding `colorMode`](https://github.com/primer/react/pull/1868/files#diff-693c129d15d32a073c701ec06dc3d82242e49ff8f561501e2bd9f87d33892882R94) immediately after it is set with `setCodeMode`.  (my bad!)

The fix is straight forward, these are 2 unrelated effects and should be separate.

Before:  

https://user-images.githubusercontent.com/1863771/157272418-590a1635-6cae-4ded-9846-dd5ca79e2ae5.mov

After:

https://user-images.githubusercontent.com/1863771/157272410-6e5e08b1-8e1a-418d-be27-1197155c6d9d.mov






