### PR TITLE
Use loose versioning for @primer/octicons-react

### DIFF
--- a/.changeset/wise-onions-itch.md
+++ b/.changeset/wise-onions-itch.md
@@ -1,0 +1,6 @@
+---
+"@primer/react": patch
+---
+
+Use loose versioning for @primer/octicons-react dependency
+ 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@primer/behaviors": "1.1.0",
-    "@primer/octicons-react": "16.1.1",
+    "@primer/octicons-react": "^16.1.1",
     "@primer/primitives": "7.1.1",
     "@radix-ui/react-polymorphic": "0.0.14",
     "@react-aria/ssr": "3.1.0",


### PR DESCRIPTION
Use loose versioning for @primer/octicons-react dependency to prevent consumers from accidentally installing two versions of octicons ([slack thread for context](https://github.slack.com/archives/C01L618AEP9/p1647040084073399?thread_ts=1647036308.411569&cid=C01L618AEP9))
