### PR TITLE
Add todo for removing components deprecated in v35.0.0.0

### DIFF
--- a/src/deprecated/index.ts
+++ b/src/deprecated/index.ts
@@ -6,7 +6,7 @@
  *  example: import {FormGroup} from '@primer/react/deprecated
  */
 
-// Deprecated in v35.0.0 on March 9, 2022. 
+// Deprecated in v35.0.0 on March 9, 2022
 // TODO: We can remove these 6 months after release: September 10, 2022
 export {default as BorderBox} from './BorderBox'
 export type {BorderBoxProps} from './BorderBox'

--- a/src/deprecated/index.ts
+++ b/src/deprecated/index.ts
@@ -6,6 +6,8 @@
  *  example: import {FormGroup} from '@primer/react/deprecated
  */
 
+// Deprecated in v35.0.0 on March 9, 2022. 
+// TODO: We can remove these 6 months after release: September 10, 2022
 export {default as BorderBox} from './BorderBox'
 export type {BorderBoxProps} from './BorderBox'
 export {default as ChoiceFieldset, Item} from './ChoiceFieldset'
@@ -69,3 +71,4 @@ export type {
   ButtonTableListProps,
   ButtonCloseProps
 } from './Button'
+// end of v35.0.0


### PR DESCRIPTION
Leave a `todo` with date for removing components deprecated in v35.0.0, there is also an accompanying calendar event to remind us :)