### PR TITLE
Fix code example renders

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
@@ -12,13 +12,15 @@ const ReactRouterLink = ({to, ...props}) => {
   return <a href={to} {...props} />
 }
 
+delete octicons.default
+
 export default function resolveScope(metastring) {
   return {
     ...doctocatComponents,
     ...primerComponents,
-    ...octicons,
     ...(metastring.includes('drafts') ? drafts : {}),
     ...(metastring.includes('deprecated') ? deprecated : {}),
+    ...octicons,
     ReactRouterLink,
     State,
     Placeholder


### PR DESCRIPTION
We were exporting octicons' deprecated `default` export.