### PR TITLE
Docs: Remove LinkButton from navigation

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -89,8 +89,6 @@
       url: /LabelGroup
     - title: Link
       url: /Link
-    - title: LinkButton
-      url: /LinkButton
     - title: Overlay
       url: /Overlay
     - title: Pagehead


### PR DESCRIPTION
Closes https://github.com/primer/react/issues/1972

LinkButton was removed in https://github.com/primer/react/pull/1880, but is still visible in navigation