### PR TITLE
Firefox bug - fix contrast of <select> options in dark mode

### DIFF
--- a/.changeset/healthy-cooks-draw.md
+++ b/.changeset/healthy-cooks-draw.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Ensures select option text has acceptable contrast in Firefox when in dark mode

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -16,6 +16,10 @@ const StyledSelect = styled.select`
   outline: none;
   width: 100%;
 
+  option {
+    color: initial;
+  }
+
   /* colors the select input's placeholder text */
   &:invalid {
     color: ${get('colors.fg.subtle')};

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -24,11 +24,6 @@ const StyledSelect = styled.select`
   &:invalid {
     color: ${get('colors.fg.subtle')};
   }
-
-  /* For Firefox: reverts color of non-placeholder options in the dropdown */
-  &:invalid option:not(:first-child) {
-    color: ${get('colors.fg.default')};
-  }
 `
 
 const ArrowIndicatorSVG: React.FC<{className?: string}> = ({className}) => (


### PR DESCRIPTION
The options were inheriting the color from the `<select>` parent.

### Screenshots

Before:
<img width="139" alt="Screen Shot 2022-03-17 at 6 16 09 PM" src="https://user-images.githubusercontent.com/2313998/158903345-2de3ab64-f0d6-4b8d-a2b2-ba5e1aeb368d.png">

After:
<img width="160" alt="Screen Shot 2022-03-17 at 6 13 54 PM" src="https://user-images.githubusercontent.com/2313998/158903290-dd53be13-d894-4a66-8049-c97bb04771e1.png">


### Merge checklist

- [x] Added/updated tests
- [na] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
