### PR TITLE
update ActionList status to beta :)

### DIFF
--- a/docs/content/ActionList.mdx
+++ b/docs/content/ActionList.mdx
@@ -1,7 +1,7 @@
 ---
 componentId: action_list
 title: ActionList
-status: Alpha
+status: Beta
 source: https://github.com/primer/react/tree/main/src/ActionList
 storybook: '/react/storybook?path=/story/composite-components-actionlist'
 description: An ActionList is a list of items that can be activated or selected. ActionList is the base component for many menu-type components, including ActionMenu and SelectPanel.
@@ -429,9 +429,9 @@ render(<SelectFields />)
     usedInProduction: true,
     usageExamplesDocumented: true,
     hasStorybookStories: true,
-    designReviewed: false,
-    a11yReviewed: false,
-    stableApi: false,
+    designReviewed: true,
+    a11yReviewed: true,
+    stableApi: false, // TODO: revisit on April 10, 2022
     addressedApiFeedback: false,
     hasDesignGuidelines: true,
     hasFigmaComponent: true


### PR DESCRIPTION
Now that all the items in https://github.com/github/primer/issues/447 are done, we can mark ActionList as `beta` ✨  
 
Note: This does not include ActionMenu, ActionMenu still has [a couple of tasks left](https://github.com/github/primer/issues/488#:~:text=high%20contrast%20mode.-,%5BNew!%5D,-Pressing%20Tab%20while)

```diff
- status: Alpha
- designReviewed: false,
- a11yReviewed: false

+ status: Beta
+ designReviewed: true,
+ a11yReviewed: true
```