### PR TITLE
fix: overriding-styles link href value

### DIFF
--- a/docs/src/props-table.js
+++ b/docs/src/props-table.js
@@ -155,7 +155,7 @@ function SxRow() {
       }
       description={
         <>
-          Style overrides to apply to the component. See also <Link href="/overriding-styles">overriding styles</Link>.
+          Style overrides to apply to the component. See also <Link href="/react/overriding-styles">overriding styles</Link>.
         </>
       }
     />


### PR DESCRIPTION
Describe your changes here.

Fixed broken link href value for overriding styles in SxRow in docs/src/props-table.js

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
