### PR TITLE
Use pre-approved environment for main

### DIFF
--- a/.github/workflows/visual_testing.yml
+++ b/.github/workflows/visual_testing.yml
@@ -9,7 +9,7 @@ jobs:
   chromatic:
     name: Visual testing
     runs-on: ubuntu-latest
-    environment: visual-testing
+    environment: ${{ github.ref == 'refs/heads/main' && 'Preview' || 'needs-approval' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Created an environment called `needs-approval`: [settings/environments](https://github.com/primer/react/settings/environments) which is used for branches other than main

