### PR TITLE
TextInput trailing action design and API update

### DIFF
--- a/docs/content/TextInput.mdx
+++ b/docs/content/TextInput.mdx
@@ -111,37 +111,21 @@ render(<WithIconAndLoadingIndicator />)
 ### With trailing action
 
 ```jsx live
-<Box display="grid" sx={{gap: 3}}>
-  <FormControl>
-    <FormControl.Label>Icon action</FormControl.Label>
-    <TextInput
-      trailingAction={
-        <TextInput.Action
-          onClick={() => {
-            alert('clear input')
-          }}
-          icon={XIcon}
-          aria-label="Clear input"
-          sx={{color: 'fg.subtle'}}
-        />
-      }
-    />
-  </FormControl>
-  <FormControl>
-    <FormControl.Label>Text action</FormControl.Label>
-    <TextInput
-      trailingAction={
-        <TextInput.Action
-          onClick={() => {
-            alert('clear input')
-          }}
-        >
-          Clear
-        </TextInput.Action>
-      }
-    />
-  </FormControl>
-</Box>
+<FormControl>
+  <FormControl.Label>Icon action</FormControl.Label>
+  <TextInput
+    trailingAction={
+      <TextInput.Action
+        onClick={() => {
+          alert('clear input')
+        }}
+        icon={XIcon}
+        aria-label="Clear input"
+        sx={{color: 'fg.subtle'}}
+      />
+    }
+  />
+</FormControl>
 ```
 
 ### With error and warning states

--- a/docs/content/TextInput.mdx
+++ b/docs/content/TextInput.mdx
@@ -299,7 +299,8 @@ render(<WithIconAndLoadingIndicator />)
   <PropsTableRow
     name="variant"
     type="'default' | 'primary' | 'invisible' | 'danger'"
-    description="Determine's the styles on a button"
+    description="(Deprecated so that only the 'invisible' variant is used) Determine's the styles on a button"
+    deprecated
   />
   <PropsTableBasePropRows
     elementType="button"

--- a/src/_TextInputInnerAction.tsx
+++ b/src/_TextInputInnerAction.tsx
@@ -5,13 +5,14 @@ import {ButtonProps} from './Button'
 import {BetterSystemStyleObject, merge, SxProp} from './sx'
 
 type TextInputActionProps = Omit<React.HTMLProps<HTMLButtonElement>, 'aria-label' | 'size'> & {
-  /** @deprecated Text input action buttons will only use icon buttons */
+  /** @deprecated Text input action buttons should only use icon buttons */
   children?: React.ReactNode
   /** Text that appears in a tooltip. If an icon is passed, this is also used as the label used by assistive technologies. */
   ['aria-label']?: string
   /** The icon to render inside the button */
   icon?: React.FunctionComponent<IconProps>
   /**
+   * @deprecated Text input action buttons should only use the 'invisible' button variant
    * Determine's the styles on a button one of 'default' | 'primary' | 'invisible' | 'danger'
    */
   variant?: ButtonProps['variant']

--- a/src/_TextInputInnerAction.tsx
+++ b/src/_TextInputInnerAction.tsx
@@ -16,7 +16,29 @@ type TextInputActionProps = Omit<React.HTMLProps<HTMLButtonElement>, 'aria-label
 } & SxProp
 
 const invisibleButtonStyleOverrides = {
-  color: 'fg.default'
+  color: 'fg.default',
+  margin: 1,
+  paddingTop: '2px',
+  paddingRight: '4px',
+  paddingBottom: '2px',
+  paddingLeft: '4px',
+  position: 'relative',
+
+  '@media (pointer: fine)': {
+    ':after': {
+      content: '""',
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      transform: 'translateY(-50%)',
+      top: '50%',
+      minHeight: '44px'
+    }
+  }
+}
+
+const solidButtonStyleOverrides = {
+  margin: 1
 }
 
 const ConditionalTooltip: React.FC<{
@@ -44,7 +66,9 @@ const ConditionalTooltip: React.FC<{
 const TextInputAction = forwardRef<HTMLButtonElement, TextInputActionProps>(
   ({'aria-label': ariaLabel, children, icon, sx: sxProp, variant, ...rest}, forwardedRef) => {
     const sx =
-      variant === 'invisible' ? merge<BetterSystemStyleObject>(invisibleButtonStyleOverrides, sxProp || {}) : sxProp
+      variant === 'invisible'
+        ? merge<BetterSystemStyleObject>(invisibleButtonStyleOverrides, sxProp || {})
+        : merge<BetterSystemStyleObject>(solidButtonStyleOverrides, sxProp || {})
 
     if ((icon && !ariaLabel) || (!children && !ariaLabel)) {
       // eslint-disable-next-line no-console
@@ -60,6 +84,7 @@ const TextInputAction = forwardRef<HTMLButtonElement, TextInputActionProps>(
               type="button"
               icon={icon}
               aria-label={ariaLabel}
+              size="small"
               sx={sx}
               {...rest}
               ref={forwardedRef}

--- a/src/_TextInputInnerAction.tsx
+++ b/src/_TextInputInnerAction.tsx
@@ -5,6 +5,8 @@ import {ButtonProps} from './Button'
 import {BetterSystemStyleObject, merge, SxProp} from './sx'
 
 type TextInputActionProps = Omit<React.HTMLProps<HTMLButtonElement>, 'aria-label' | 'size'> & {
+  /** @deprecated Text input action buttons will only use icon buttons */
+  children?: React.ReactNode
   /** Text that appears in a tooltip. If an icon is passed, this is also used as the label used by assistive technologies. */
   ['aria-label']?: string
   /** The icon to render inside the button */

--- a/src/_TextInputInnerAction.tsx
+++ b/src/_TextInputInnerAction.tsx
@@ -27,7 +27,7 @@ const invisibleButtonStyleOverrides = {
   paddingLeft: '4px',
   position: 'relative',
 
-  '@media (pointer: fine)': {
+  '@media (pointer: coarse)': {
     ':after': {
       content: '""',
       position: 'absolute',

--- a/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1179,14 +1179,16 @@ exports[`TextInput renders trailingAction icon button 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  padding-left: 8px;
-  padding-right: 8px;
-  font-size: 14px;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  padding-left: 4px;
+  padding-right: 4px;
+  font-size: 12px;
   color: #24292f;
   background-color: transparent;
   box-shadow: none;
+  margin: 4px;
+  position: relative;
 }
 
 .c3:disabled {
@@ -1203,7 +1205,7 @@ exports[`TextInput renders trailingAction icon button 1`] = `
 }
 
 .c3 [data-component=ButtonCounter] {
-  font-size: 14px;
+  font-size: 12px;
 }
 
 .c3:hover:not([disabled]) {
@@ -1540,6 +1542,20 @@ exports[`TextInput renders trailingAction icon button 1`] = `
   }
 }
 
+@media (pointer:fine) {
+  .c3:after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    -webkit-transform: translateY(-50%);
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+    top: 50%;
+    min-height: 44px;
+  }
+}
+
 @media (min-width:768px) {
   .c0 {
     font-size: 14px;
@@ -1630,14 +1646,16 @@ exports[`TextInput renders trailingAction text button 1`] = `
   text-align: center;
   display: grid;
   grid-template-areas: "leadingIcon text trailingIcon";
-  padding-top: 4px;
-  padding-bottom: 4px;
-  padding-left: 12px;
-  padding-right: 12px;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  padding-left: 4px;
+  padding-right: 4px;
   font-size: 12px;
   color: #24292f;
   background-color: transparent;
   box-shadow: none;
+  margin: 4px;
+  position: relative;
 }
 
 .c2:disabled {
@@ -1788,6 +1806,20 @@ exports[`TextInput renders trailingAction text button 1`] = `
   }
 }
 
+@media (pointer:fine) {
+  .c2:after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    -webkit-transform: translateY(-50%);
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+    top: 50%;
+    min-height: 44px;
+  }
+}
+
 @media (min-width:768px) {
   .c0 {
     font-size: 14px;
@@ -1851,14 +1883,16 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
   text-align: center;
   display: grid;
   grid-template-areas: "leadingIcon text trailingIcon";
-  padding-top: 4px;
-  padding-bottom: 4px;
-  padding-left: 12px;
-  padding-right: 12px;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  padding-left: 4px;
+  padding-right: 4px;
   font-size: 12px;
   color: #24292f;
   background-color: transparent;
   box-shadow: none;
+  margin: 4px;
+  position: relative;
 }
 
 .c3:disabled {
@@ -2226,6 +2260,20 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
 @media (forced-colors:active) {
   .c3:focus {
     outline: solid 1px transparent;
+  }
+}
+
+@media (pointer:fine) {
+  .c3:after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    -webkit-transform: translateY(-50%);
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+    top: 50%;
+    min-height: 44px;
   }
 }
 

--- a/src/stories/TextInput.stories.tsx
+++ b/src/stories/TextInput.stories.tsx
@@ -149,43 +149,24 @@ export const WithTrailingAction = (args: TextInputProps) => {
 
   return (
     <form>
-      <Box display="grid" sx={{gap: 3}}>
-        <FormControl>
-          <FormControl.Label>Icon action</FormControl.Label>
-          <TextInput
-            trailingAction={
-              <TextInput.Action
-                onClick={() => {
-                  setValue('')
-                }}
-                icon={XCircleFillIcon}
-                aria-label="Clear input"
-                sx={{color: 'fg.subtle'}}
-              />
-            }
-            value={value}
-            onChange={handleChange}
-            {...args}
-          />
-        </FormControl>
-        <FormControl>
-          <FormControl.Label>Text action</FormControl.Label>
-          <TextInput
-            trailingAction={
-              <TextInput.Action
-                onClick={() => {
-                  setValue('')
-                }}
-              >
-                Clear
-              </TextInput.Action>
-            }
-            value={value}
-            onChange={handleChange}
-            {...args}
-          />
-        </FormControl>
-      </Box>
+      <FormControl>
+        <FormControl.Label>Icon action</FormControl.Label>
+        <TextInput
+          trailingAction={
+            <TextInput.Action
+              onClick={() => {
+                setValue('')
+              }}
+              icon={XCircleFillIcon}
+              aria-label="Clear input"
+              sx={{color: 'fg.subtle'}}
+            />
+          }
+          value={value}
+          onChange={handleChange}
+          {...args}
+        />
+      </FormControl>
     </form>
   )
 }


### PR DESCRIPTION
Changes:
- Inner action's hover bg should not touch the text input edges
- Increases touch target area of the inner action button
- Deprecation: we only want to allow inner action buttons to be icon buttons
- Deprecation: we only want to allow inner action buttons to be the 'invisible' variant

### Screenshots

Before:
![innerAction-before](https://user-images.githubusercontent.com/2313998/164017779-b1efa149-3739-4087-bb59-9870add2c54c.gif)

After:
![innerAction-after](https://user-images.githubusercontent.com/2313998/164017805-69730821-8972-4252-83d9-159b88623939.gif)

### Merge checklist

- [n/a] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
