### PR TITLE
NavList.Item: Go one level deeper for NextJSLikeLink

### DIFF
--- a/src/NavList/NavList.stories.tsx
+++ b/src/NavList/NavList.stories.tsx
@@ -26,7 +26,7 @@ export const Simple: Story = () => (
   </PageLayout>
 )
 
-export const SubItems: Story = () => (
+export const WithSubItems: Story = () => (
   <PageLayout>
     <PageLayout.Pane position="start">
       <NavList>
@@ -41,6 +41,63 @@ export const SubItems: Story = () => (
           </NavList.SubNav>
         </NavList.Item>
         <NavList.Item href="#">Item 3</NavList.Item>
+      </NavList>
+    </PageLayout.Pane>
+    <PageLayout.Content></PageLayout.Content>
+  </PageLayout>
+)
+
+type ReactRouterLikeLinkProps = {to: string; children: React.ReactNode}
+const ReactRouterLikeLink = React.forwardRef<HTMLAnchorElement, ReactRouterLikeLinkProps>(({to, ...props}, ref) => {
+  // eslint-disable-next-line jsx-a11y/anchor-has-content
+  return <a ref={ref} href={to} {...props} />
+})
+
+export const WithReactRouterLink = () => (
+  <PageLayout>
+    <PageLayout.Pane position="start">
+      <NavList>
+        <NavList.Item as={ReactRouterLikeLink} to="#" aria-current="page">
+          Item 1
+        </NavList.Item>
+        <NavList.Item as={ReactRouterLikeLink} to="#">
+          Item 2
+        </NavList.Item>
+        <NavList.Item as={ReactRouterLikeLink} to="#">
+          Item 3
+        </NavList.Item>
+      </NavList>
+    </PageLayout.Pane>
+    <PageLayout.Content></PageLayout.Content>
+  </PageLayout>
+)
+
+type NextJSLinkProps = {href: string; children: React.ReactNode}
+
+const NextJSLikeLink = React.forwardRef<HTMLAnchorElement, NextJSLinkProps>(
+  ({href, children}, ref): React.ReactElement => {
+    const child = React.Children.only(children)
+    const childProps = {
+      ref,
+      href
+    }
+    return <>{React.isValidElement(child) ? React.cloneElement(child, childProps) : null}</>
+  }
+)
+
+export const WithNextJSLink = () => (
+  <PageLayout>
+    <PageLayout.Pane position="start">
+      <NavList>
+        <NextJSLikeLink href="#">
+          <NavList.Item aria-current="page">Item 1</NavList.Item>
+        </NextJSLikeLink>
+        <NextJSLikeLink href="#">
+          <NavList.Item>Item 2</NavList.Item>
+        </NextJSLikeLink>
+        <NextJSLikeLink href="#">
+          <NavList.Item>Item 3</NavList.Item>
+        </NextJSLikeLink>
       </NavList>
     </PageLayout.Pane>
     <PageLayout.Content></PageLayout.Content>

--- a/src/NavList/NavList.test.tsx
+++ b/src/NavList/NavList.test.tsx
@@ -60,6 +60,56 @@ describe('NavList.Item', () => {
     expect(homeLink).toHaveAttribute('aria-current', 'page')
     expect(aboutLink).not.toHaveAttribute('aria-current')
   })
+
+  it('is compatiable with React-Router-like link components', () => {
+    type ReactRouterLikeLinkProps = {to: string; children: React.ReactNode}
+
+    const ReactRouterLikeLink = React.forwardRef<HTMLAnchorElement, ReactRouterLikeLinkProps>(({to, ...props}, ref) => {
+      // eslint-disable-next-line jsx-a11y/anchor-has-content
+      return <a ref={ref} href={to} {...props} />
+    })
+
+    const {getByRole} = render(
+      <NavList>
+        <NavList.Item as={ReactRouterLikeLink} to={'/'} aria-current="page">
+          React Router link
+        </NavList.Item>
+      </NavList>
+    )
+
+    const link = getByRole('link', {name: 'React Router link'})
+
+    expect(link).toHaveAttribute('aria-current', 'page')
+    expect(link).toHaveAttribute('href', '/')
+  })
+
+  it('is compatible with NextJS-like link components', () => {
+    type NextJSLinkProps = {href: string; children: React.ReactNode}
+
+    const NextJSLikeLink = React.forwardRef<HTMLAnchorElement, NextJSLinkProps>(
+      ({href, children}, ref): React.ReactElement => {
+        const child = React.Children.only(children)
+        const childProps = {
+          ref,
+          href
+        }
+        return <>{React.isValidElement(child) ? React.cloneElement(child, childProps) : null}</>
+      }
+    )
+
+    const {getByRole} = render(
+      <NavList>
+        <NextJSLikeLink href="/">
+          <NavList.Item aria-current="page">NextJS link</NavList.Item>
+        </NextJSLikeLink>
+      </NavList>
+    )
+
+    const link = getByRole('link', {name: 'NextJS link'})
+
+    expect(link).toHaveAttribute('href', '/')
+    expect(link).toHaveAttribute('aria-current', 'page')
+  })
 })
 
 describe('NavList.Item with NavList.SubNav', () => {

--- a/src/NavList/NavList.tsx
+++ b/src/NavList/NavList.tsx
@@ -50,7 +50,20 @@ const Item = React.forwardRef<HTMLAnchorElement, NavListItemProps>(
     if (subNav && isValidElement(subNav) && depth < 1) {
       // Search SubNav children for current Item
       const currentItem = React.Children.toArray(subNav.props.children).find(
-        child => isValidElement(child) && child.props['aria-current']
+        (child) => {
+          if (!isValidElement(child)) return false
+
+          // when direct child is SubNav.Item
+          if (child.type === Item) return child.props['aria-current']
+
+          // when direct child isn't SubNav.Item,
+          // it's probably a NextJSLikeLink, go one level deeper
+          const wrappedItem = child.props.children
+          if (typeof wrappedItem === 'object') return wrappedItem.props['aria-current']
+
+          // we don't recognise this API usage
+          return false
+        }
       )
 
       return (

--- a/src/NavList/NavList.tsx
+++ b/src/NavList/NavList.tsx
@@ -49,22 +49,20 @@ const Item = React.forwardRef<HTMLAnchorElement, NavListItemProps>(
     // Render ItemWithSubNav if SubNav is present
     if (subNav && isValidElement(subNav) && depth < 1) {
       // Search SubNav children for current Item
-      const currentItem = React.Children.toArray(subNav.props.children).find(
-        (child) => {
-          if (!isValidElement(child)) return false
+      const currentItem = React.Children.toArray(subNav.props.children).find(child => {
+        if (!isValidElement(child)) return false
 
-          // when direct child is SubNav.Item
-          if (child.type === Item) return child.props['aria-current']
+        // when direct child is SubNav.Item
+        if (child.type === Item) return child.props['aria-current']
 
-          // when direct child isn't SubNav.Item,
-          // it's probably a NextJSLikeLink, go one level deeper
-          const wrappedItem = child.props.children
-          if (typeof wrappedItem === 'object') return wrappedItem.props['aria-current']
+        // when direct child isn't SubNav.Item,
+        // it's probably a NextJSLikeLink, go one level deeper
+        const wrappedItem = child.props.children
+        if (typeof wrappedItem === 'object') return wrappedItem.props['aria-current']
 
-          // we don't recognise this API usage
-          return false
-        }
-      )
+        // we don't recognise this API usage
+        return false
+      })
 
       return (
         <ItemWithSubNav subNav={subNav} subNavContainsCurrentItem={Boolean(currentItem)}>

--- a/src/NavList/NavList.tsx
+++ b/src/NavList/NavList.tsx
@@ -1,4 +1,5 @@
 import {ChevronDownIcon} from '@primer/octicons-react'
+import {ForwardRefComponent as PolymorphicForwardRefComponent} from '@radix-ui/react-polymorphic'
 import {useSSRSafeId} from '@react-aria/ssr'
 import React, {isValidElement} from 'react'
 import {ActionList} from '../ActionList'
@@ -33,9 +34,8 @@ export type NavListItemProps = {
 }
 
 // TODO: sx prop
-// TODO: as prop
 const Item = React.forwardRef<HTMLAnchorElement, NavListItemProps>(
-  ({href, 'aria-current': ariaCurrent, children}, ref) => {
+  ({'aria-current': ariaCurrent, children, ...props}, ref) => {
     const {depth} = React.useContext(SubNavContext)
 
     // Get SubNav from children
@@ -63,7 +63,6 @@ const Item = React.forwardRef<HTMLAnchorElement, NavListItemProps>(
     return (
       <ActionList.LinkItem
         ref={ref}
-        href={href}
         aria-current={ariaCurrent}
         active={Boolean(ariaCurrent) && ariaCurrent !== 'false'}
         sx={{
@@ -71,12 +70,13 @@ const Item = React.forwardRef<HTMLAnchorElement, NavListItemProps>(
           fontSize: depth > 0 ? 0 : null, // Reduce font size of sub-items
           fontWeight: depth > 0 ? 'normal' : null // Sub-items don't get bolded
         }}
+        {...props}
       >
         {children}
       </ActionList.LinkItem>
     )
   }
-)
+) as PolymorphicForwardRefComponent<'a', NavListItemProps>
 
 Item.displayName = 'NavList.Item'
 


### PR DESCRIPTION
Demo: https://1hp8zb.csb.app/2-1
Demo code: https://codesandbox.io/s/nice-firefly-1hp8zb?file=/src/App.tsx&initialpath=/2-1

summary: 

It's not necessary that the direct child of SubNav is `NavList.Item`, there are 3 possibilities:

1. `NavList.Item as={ReactRouterLikeLink}`: this one's pretty easy to check as `aria-current` is still on `NavList.Item` so checking direct children still works. [source](https://codesandbox.io/s/nice-firefly-1hp8zb?file=/src/NavList.tsx:1967-2037&initialpath=/2-1)

    ```jsx
    <NavList.Item
      as={ReactRouterLikeLink}
      to="/3-1"
      aria-current={window.location.pathname === '/3-1'}
    >
      Sub link 3-1
    </NavList.Item>
    ```

2. NextJSLikeLink: This one requires more work because the `NavList.Item` is nested one layer deep, but it's still predictable. [source](https://codesandbox.io/s/nice-firefly-1hp8zb?file=/src/NavList.tsx:2339-2515&initialpath=/2-1)

    ```js
    <NextJSLikeLink href="/2">
      <NavList.Item aria-current={window.location.pathname === '/2'}>Link 2</NavList.Item>
    </NextJSLikeLink>
    ```

3. CustomNavLink: For this one, we cannot rely on children because the `aria-current` is hidden away from SubNav in a different component.

    While not ideal, we could provide some guidance on how to "extend" `NavList.Item` by asking folks to make sure the `aria-current` is present at the site of usage like the second link here:
    
     ```jsx
    <NavList.SubNav>
      <CustomNavLink href="/4-1">
        Sub link 4-1, automatic doesn't work
      </CustomNavLink>
      <CustomNavLink href="/4-2" aria-current={pathname === '/4-1'}>
        {/*                      ↑ ask user to pass it on a direct child        */}
        Sub link 4-2, needs explicit prop to work
      </CustomNavLink>
    </NavList.SubNav>
    ```
    
    It would be even better if we can detect this in dev environments and throw a warning linking to this guidance. [source](https://codesandbox.io/s/nice-firefly-1hp8zb?file=/src/NavList.tsx:1441-1488&initialpath=/2-1)
