### PR TITLE
ActionMenu: adjust width based on padding

### DIFF
--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -162,7 +162,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       appearance: 'none',
       background: 'unset',
       border: 'unset',
-      width: '100%',
+      width: 'calc(100% - 16px)',
       fontFamily: 'unset',
       textAlign: 'unset',
       marginY: 'unset',

--- a/src/NavList/__snapshots__/NavList.test.tsx.snap
+++ b/src/NavList/__snapshots__/NavList.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`NavList renders a simple list 1`] = `
   appearance: none;
   background: unset;
   border: unset;
-  width: 100%;
+  width: calc(100% - 16px);
   font-family: unset;
   text-align: unset;
   margin-top: unset;
@@ -139,7 +139,7 @@ exports[`NavList renders a simple list 1`] = `
   appearance: none;
   background: unset;
   border: unset;
-  width: 100%;
+  width: calc(100% - 16px);
   font-family: unset;
   text-align: unset;
   margin-top: unset;
@@ -456,7 +456,7 @@ exports[`NavList renders with groups 1`] = `
   appearance: none;
   background: unset;
   border: unset;
-  width: 100%;
+  width: calc(100% - 16px);
   font-family: unset;
   text-align: unset;
   margin-top: unset;
@@ -540,7 +540,7 @@ exports[`NavList renders with groups 1`] = `
   appearance: none;
   background: unset;
   border: unset;
-  width: 100%;
+  width: calc(100% - 16px);
   font-family: unset;
   text-align: unset;
   margin-top: unset;
@@ -888,7 +888,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
   appearance: none;
   background: unset;
   border: unset;
-  width: 100%;
+  width: calc(100% - 16px);
   font-family: unset;
   text-align: unset;
   margin-top: unset;
@@ -1008,7 +1008,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
   appearance: none;
   background: unset;
   border: unset;
-  width: 100%;
+  width: calc(100% - 16px);
   font-family: unset;
   text-align: unset;
   margin-top: unset;
@@ -1390,7 +1390,7 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
   appearance: none;
   background: unset;
   border: unset;
-  width: 100%;
+  width: calc(100% - 16px);
   font-family: unset;
   text-align: unset;
   margin-top: unset;


### PR DESCRIPTION
Changed in https://github.com/primer/react/pull/2064, skipping changeset because we haven't published this change yet.

before:
<img width="289" alt="image" src="https://user-images.githubusercontent.com/1863771/168853006-6e5a5650-c459-40d8-a38c-4e776f9fea57.png">


after: 
<img width="261" alt="image" src="https://user-images.githubusercontent.com/1863771/168852879-c4301ef2-3a2e-48f3-adf7-d08cdffbd59d.png">
