### PR TITLE
Fix broken inline component links

### DIFF
--- a/.changeset/empty-geese-return.md
+++ b/.changeset/empty-geese-return.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fixes broken links in the documentation

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -329,7 +329,7 @@ render(
   <PropsTablePassthroughPropsRow
     elementName="Button"
     isPolymorphic
-    passthroughPropsLink={<Link href="react/Button">Button docs</Link>}
+    passthroughPropsLink={<Link href="/react/Button">Button docs</Link>}
   />
 </PropsTable>
 
@@ -346,7 +346,7 @@ render(
   <PropsTableRow name="align" type="start | center | end" defaultValue="start" />
   <PropsTablePassthroughPropsRow
     elementName="Overlay"
-    passthroughPropsLink={<Link href="react/Overlay">Overlay docs</Link>}
+    passthroughPropsLink={<Link href="/react/Overlay">Overlay docs</Link>}
   />
 </PropsTable>
 

--- a/docs/content/AnchoredOverlay.mdx
+++ b/docs/content/AnchoredOverlay.mdx
@@ -108,7 +108,7 @@ See also [Overlay positioning](/Overlay#positioning).
     name="overlayProps"
     type={
       <>
-        Partial&lt;<Link href="/Overlay#props">OverlayProps</Link>&gt;
+        Partial&lt;<Link href="/react/Overlay#props">OverlayProps</Link>&gt;
       </>
     }
     description={
@@ -121,7 +121,7 @@ See also [Overlay positioning](/Overlay#positioning).
     name="focusTrapSettings"
     type={
       <>
-        Partial&lt;<Link href="/focusTrap#focustraphooksettings-interface">FocusTrapHookSettings</Link>&gt;
+        Partial&lt;<Link href="/react/focusTrap#focustraphooksettings-interface">FocusTrapHookSettings</Link>&gt;
       </>
     }
     description={
@@ -134,7 +134,7 @@ See also [Overlay positioning](/Overlay#positioning).
     name="focusZoneSettings"
     type={
       <>
-        Partial&lt;<Link href="/focusZone#focuszonehooksettings-interface">FocusZoneHookSettings</Link>&gt;
+        Partial&lt;<Link href="/react/focusZone#focuszonehooksettings-interface">FocusZoneHookSettings</Link>&gt;
       </>
     }
     description={

--- a/docs/content/Autocomplete.mdx
+++ b/docs/content/Autocomplete.mdx
@@ -590,7 +590,7 @@ render(<MultiSelectAddNewItem />)
     isPolymorphic
     passthroughPropsLink={
       <>
-        the <Link href="/TextInput">TextInput docs</Link>
+        the <Link href="/react/TextInput">TextInput docs</Link>
       </>
     }
   />


### PR DESCRIPTION
Updates `<Link />` `href` paths that link to React components

Closes https://github.com/github/primer/issues/1008

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
