### PR TITLE
Uncomment docs deployment guard

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -35,7 +35,7 @@ jobs:
   deploy:
     name: Production
     needs: [guard]
-    #if: ${{ needs.guard.outputs.should_deploy == true }}
+    if: ${{ needs.guard.outputs.should_deploy == 'true' }}
     uses: primer/.github/.github/workflows/deploy.yml@main
     with:
       node_version: 16


### PR DESCRIPTION
Fixes https://github.com/primer/react/issues/2070

We already had a deployment guard based on changesets, but it was commented out 😅 

Tested with and without changesets in https://github.com/primer/react/pull/2089

<img width="921" alt="image" src="https://user-images.githubusercontent.com/1863771/169336476-7cb13a67-c057-48c8-ab38-0aeb21c2ea68.png">

---

Is there a way to mention a reason why the job was skipped? Update: There isn't without creating an additional check, which leads to duplicate checks, not ideal either.