### PR TITLE
ActionMenu: Inline label

### DIFF
--- a/.changeset/odd-bobcats-cheer.md
+++ b/.changeset/odd-bobcats-cheer.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+ActionMenu: Option to add inline label for accessible menus. ([Read more](https://primer.react/ActionMenu#accessibility))

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -289,11 +289,13 @@ render(
 
 ### Single Selection
 
-It is recommended to have a visual label for `ActionMenu.Button`. This can either be an external label or an inline label.
+For menus with selection, it's common to show the selected value in the button. To give context to the user, it's important to show the purpose of the menu as well.
 
-If you have an external label, it's important to add an `aria-label` to `ActionMenu.Button` which contains both the purpose and current selected value, example: _"Field type: Number"_. In addition to that, you must add `aria-label` to the `ActionList` with the purpose of the menu, example: _"Field type"_.
+Visually, this can be an external label above the button or an inline label inside the button. In both cases, the label for screen readers should have both purpose and value, example: "Field type: Number".
 
-Alternatively, you can add an inline label by adding `label`, example: _"Field type"_ on `ActionMenu.Button` instead of `aria-label` which will add `aria-label` on the button and `aria-labelledby` on the menu for you.
+If you have an external label, you can achieve that by adding an `aria-label` to `ActionMenu.Button` which contains both the purpose and current selected value, example: _"Field type: Number"_. In addition to that, you must also add `aria-label` to the `ActionList` with the purpose of the menu, example: _"Field type"_.
+
+Alternatively, you can add an inline label by passing `label` to `ActionMenu.Button` instead of `aria-label`, example: _"Field type"_, which will add the correct `aria-label` (_Field type: Number_) on the button and `aria-labelledby` (_Field type_) on the menu for you.
 
 ```javascript live noinline
 const fieldTypes = [

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -219,7 +219,9 @@ render(<Example />)
 
 ### With External Anchor
 
-To create an anchor outside of the menu, you need to switch to controlled mode for the menu and pass it as `anchorRef` to `ActionMenu`. Make sure you add `aria-expanded` and `aria-haspopup` to the external anchor:
+To create an anchor outside of the menu, you need to switch to controlled mode for the menu and pass it as `anchorRef` to `ActionMenu`. Make sure you add `aria-expanded` and `aria-haspopup` to the external anchor.
+
+Make sure to add `aria-label` to `ActionList` with the purpose of the menu, example: "File options".
 
 ```javascript live noinline
 const Example = () => {
@@ -232,7 +234,7 @@ const Example = () => {
         {open ? 'Close Menu' : 'Open Menu'}
       </Button>
 
-      <ActionMenu open={open} onOpenChange={setOpen} anchorRef={anchorRef}>
+      <ActionMenu aria-label="File options" open={open} onOpenChange={setOpen} anchorRef={anchorRef}>
         <ActionMenu.Overlay>
           <ActionList>
             <ActionList.Item>Copy link</ActionList.Item>
@@ -259,7 +261,7 @@ const handleEscape = () => alert('you hit escape!')
 
 render(
   <ActionMenu>
-    <ActionMenu.Button>Open Actions Menu</ActionMenu.Button>
+    <ActionMenu.Button>Actions Menu</ActionMenu.Button>
     <ActionMenu.Overlay width="medium" onEscape={handleEscape}>
       <ActionList>
         <ActionList.Item>

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -291,7 +291,7 @@ render(
 
 It is recommended to have a visual label for `ActionMenu.Button`. This can either be an external label or an inline label.
 
-If you already have an external label, it's important to add an `aria-label` to `ActionMenu.Button` which contains both the purpose and current selected value, example: _"Field type: Number"_. In addition to that, you must add `aria-label` to the `ActionList` with the purpose of the menu, example: _"Field type"_.
+If you have an external label, it's important to add an `aria-label` to `ActionMenu.Button` which contains both the purpose and current selected value, example: _"Field type: Number"_. In addition to that, you must add `aria-label` to the `ActionList` with the purpose of the menu, example: _"Field type"_.
 
 Alternatively, you can add an inline label by adding `label`, example: _"Field type"_ on `ActionMenu.Button` instead of `aria-label` which will add `aria-label` on the button and `aria-labelledby` on the menu for you.
 

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -79,7 +79,7 @@ You can choose to have a different _anchor_ for the Menu dependending on the app
 ```jsx live
 <ActionMenu>
   <ActionMenu.Anchor>
-    <IconButton icon={KebabHorizontalIcon} variant="invisible" aria-label="Open column options" />
+    <IconButton icon={KebabHorizontalIcon} variant="invisible" aria-label="Column options" />
   </ActionMenu.Anchor>
 
   <ActionMenu.Overlay>

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -293,7 +293,7 @@ For menus with selection, it's common to show the selected value in the button. 
 
 Visually, this can be an external label above the button or an inline label inside the button. In both cases, the label for screen readers should have both purpose and value, example: "Field type: Number".
 
-If you have an external label, you can achieve that by adding an `aria-label` to `ActionMenu.Button` which contains both the purpose and current selected value, example: _"Field type: Number"_. In addition to that, you must also add `aria-label` to the `ActionList` with the purpose of the menu, example: _"Field type"_.
+If you have an external label, you can achieve that by adding an `aria-label` to `ActionMenu.Button` which contains both the purpose and current selected value, example: _"Field type: Number"_. In addition to that, you must also add `aria-labelledby` to the `ActionList` with the id of the external label to indicate the purpose of the menu.
 
 Alternatively, you can add an inline label by passing `label` to `ActionMenu.Button` instead of `aria-label`, example: _"Field type"_, which will add the correct `aria-label` (_Field type: Number_) on the button and `aria-labelledby` (_Field type_) on the menu for you.
 
@@ -312,15 +312,15 @@ const ExternalLabel = () => {
 
   return (
     <>
-      <Heading as="h2" sx={{fontSize: 1, mb: 2}}>
-        Field type:
+      <Heading as="h2" id="purpose" sx={{fontSize: 1, mb: 2}}>
+        Field type
       </Heading>
       <ActionMenu>
         <ActionMenu.Button aria-label={`Field type: ${selectedType.name}`} leadingIcon={selectedType.icon}>
           {selectedType.name}
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium">
-          <ActionList selectionVariant="single" aria-label="Field type">
+          <ActionList selectionVariant="single" aria-labelledby="purpose">
             {fieldTypes.map((type, index) => (
               <ActionList.Item key={index} selected={index === selectedIndex} onSelect={() => setSelectedIndex(index)}>
                 <ActionList.LeadingVisual>

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -326,6 +326,8 @@ render(
 
 <PropsTable>
   <PropsTableRow name="children" required type="React.ReactElement" />
+  <PropsTableRow name="aria-label" required type="string" />
+  <PropsTableRow name="includeLabel" type="boolean" />
   <PropsTablePassthroughPropsRow
     elementName="Button"
     isPolymorphic

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -291,7 +291,7 @@ render(
 
 It is recommended to have a visual label for `ActionMenu.Button`. This can either be an external label or an inline label.
 
-For external label, it's important to add an `aria-label` to `ActionMenu.Button` which contains both the purpose and current selected value, example: _"Field type: Number"_. In addition to that, you must add `aria-label` to the `ActionList` with the purpose of the menu, example: _"Field type"_.
+If you already have an external label, it's important to add an `aria-label` to `ActionMenu.Button` which contains both the purpose and current selected value, example: _"Field type: Number"_. In addition to that, you must add `aria-label` to the `ActionList` with the purpose of the menu, example: _"Field type"_.
 
 Alternatively, you can add an inline label by adding `label`, example: _"Field type"_ on `ActionMenu.Button` instead of `aria-label` which will add `aria-label` on the button and `aria-labelledby` on the menu for you.
 

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -217,6 +217,72 @@ const Example = () => {
 render(<Example />)
 ```
 
+### With External Anchor
+
+To create an anchor outside of the menu, you need to switch to controlled mode for the menu and pass it as `anchorRef` to `ActionMenu`. Make sure you add `aria-expanded` and `aria-haspopup` to the external anchor:
+
+```javascript live noinline
+const Example = () => {
+  const [open, setOpen] = React.useState(false)
+  const anchorRef = React.createRef()
+
+  return (
+    <>
+      <Button ref={anchorRef} aria-haspopup="true" aria-expanded={open} onClick={() => setOpen(!open)}>
+        {open ? 'Close Menu' : 'Open Menu'}
+      </Button>
+
+      <ActionMenu open={open} onOpenChange={setOpen} anchorRef={anchorRef}>
+        <ActionMenu.Overlay>
+          <ActionList>
+            <ActionList.Item>Copy link</ActionList.Item>
+            <ActionList.Item>Quote reply</ActionList.Item>
+            <ActionList.Item>Edit comment</ActionList.Item>
+            <ActionList.Divider />
+            <ActionList.Item variant="danger">Delete file</ActionList.Item>
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+    </>
+  )
+}
+
+render(<Example />)
+```
+
+### With Overlay Props
+
+To create an anchor outside of the menu, you need to switch to controlled mode for the menu and pass it as `anchorRef` to `ActionMenu`:
+
+```javascript live noinline
+const handleEscape = () => alert('you hit escape!')
+
+render(
+  <ActionMenu>
+    <ActionMenu.Button>Open Actions Menu</ActionMenu.Button>
+    <ActionMenu.Overlay width="medium" onEscape={handleEscape}>
+      <ActionList>
+        <ActionList.Item>
+          Open current Codespace
+          <ActionList.Description variant="block">
+            Your existing Codespace will be opened to its previous state, and you&apos;ll be asked to manually switch to
+            new-branch.
+          </ActionList.Description>
+          <ActionList.TrailingVisual>⌘O</ActionList.TrailingVisual>
+        </ActionList.Item>
+        <ActionList.Item>
+          Create new Codespace
+          <ActionList.Description variant="block">
+            Create a brand new Codespace with a fresh image and checkout this branch.
+          </ActionList.Description>
+          <ActionList.TrailingVisual>⌘C</ActionList.TrailingVisual>
+        </ActionList.Item>
+      </ActionList>
+    </ActionMenu.Overlay>
+  </ActionMenu>
+)
+```
+
 ## Accessibility
 
 ### Single Selection
@@ -300,72 +366,6 @@ render(
       <InlineLabel />
     </div>
   </div>
-)
-```
-
-### With External Anchor
-
-To create an anchor outside of the menu, you need to switch to controlled mode for the menu and pass it as `anchorRef` to `ActionMenu`. Make sure you add `aria-expanded` and `aria-haspopup` to the external anchor:
-
-```javascript live noinline
-const Example = () => {
-  const [open, setOpen] = React.useState(false)
-  const anchorRef = React.createRef()
-
-  return (
-    <>
-      <Button ref={anchorRef} aria-haspopup="true" aria-expanded={open} onClick={() => setOpen(!open)}>
-        {open ? 'Close Menu' : 'Open Menu'}
-      </Button>
-
-      <ActionMenu open={open} onOpenChange={setOpen} anchorRef={anchorRef}>
-        <ActionMenu.Overlay>
-          <ActionList>
-            <ActionList.Item>Copy link</ActionList.Item>
-            <ActionList.Item>Quote reply</ActionList.Item>
-            <ActionList.Item>Edit comment</ActionList.Item>
-            <ActionList.Divider />
-            <ActionList.Item variant="danger">Delete file</ActionList.Item>
-          </ActionList>
-        </ActionMenu.Overlay>
-      </ActionMenu>
-    </>
-  )
-}
-
-render(<Example />)
-```
-
-### With Overlay Props
-
-To create an anchor outside of the menu, you need to switch to controlled mode for the menu and pass it as `anchorRef` to `ActionMenu`:
-
-```javascript live noinline
-const handleEscape = () => alert('you hit escape!')
-
-render(
-  <ActionMenu>
-    <ActionMenu.Button>Open Actions Menu</ActionMenu.Button>
-    <ActionMenu.Overlay width="medium" onEscape={handleEscape}>
-      <ActionList>
-        <ActionList.Item>
-          Open current Codespace
-          <ActionList.Description variant="block">
-            Your existing Codespace will be opened to its previous state, and you&apos;ll be asked to manually switch to
-            new-branch.
-          </ActionList.Description>
-          <ActionList.TrailingVisual>⌘O</ActionList.TrailingVisual>
-        </ActionList.Item>
-        <ActionList.Item>
-          Create new Codespace
-          <ActionList.Description variant="block">
-            Create a brand new Codespace with a fresh image and checkout this branch.
-          </ActionList.Description>
-          <ActionList.TrailingVisual>⌘C</ActionList.TrailingVisual>
-        </ActionList.Item>
-      </ActionList>
-    </ActionMenu.Overlay>
-  </ActionMenu>
 )
 ```
 

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -189,8 +189,90 @@ const Example = () => {
   const selectedType = fieldTypes[selectedIndex]
 
   return (
+    <>
+      <Heading as="h2" sx={{fontSize: 1, mb: 2}}>
+        Field type:
+      </Heading>
+      <ActionMenu>
+        <ActionMenu.Button aria-label={`Field type: ${selectedType.name}`} leadingIcon={selectedType.icon}>
+          {selectedType.name}
+        </ActionMenu.Button>
+        <ActionMenu.Overlay width="medium">
+          <ActionList selectionVariant="single" aria-label="Field type">
+            {fieldTypes.map((type, index) => (
+              <ActionList.Item key={index} selected={index === selectedIndex} onSelect={() => setSelectedIndex(index)}>
+                <ActionList.LeadingVisual>
+                  <type.icon />
+                </ActionList.LeadingVisual>
+                {type.name}
+              </ActionList.Item>
+            ))}
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+    </>
+  )
+}
+
+render(<Example />)
+```
+
+## Accessibility
+
+### Single Selection
+
+It is recommended to have a visual label for `ActionMenu.Button`. This can either be an external label or an inline label.
+
+For external label, it's important to add an `aria-label` to `ActionMenu.Button` which contains both the purpose and current selected value, example: _"Field type: Number"_. In addition to that, you must add `aria-label` to the `ActionList` with the purpose of the menu, example: _"Field type"_.
+
+Alternatively, you can add an inline label by adding `label`, example: _"Field type"_ on `ActionMenu.Button` instead of `aria-label` which will add `aria-label` on the button and `aria-labelledby` on the menu for you.
+
+```javascript live noinline
+const fieldTypes = [
+  {icon: TypographyIcon, name: 'Text'},
+  {icon: NumberIcon, name: 'Number'},
+  {icon: CalendarIcon, name: 'Date'},
+  {icon: SingleSelectIcon, name: 'Single select'},
+  {icon: IterationsIcon, name: 'Iteration'}
+]
+
+const ExternalLabel = () => {
+  const [selectedIndex, setSelectedIndex] = React.useState(1)
+  const selectedType = fieldTypes[selectedIndex]
+
+  return (
+    <>
+      <Heading as="h2" sx={{fontSize: 1, mb: 2}}>
+        Field type:
+      </Heading>
+      <ActionMenu>
+        <ActionMenu.Button aria-label={`Field type: ${selectedType.name}`} leadingIcon={selectedType.icon}>
+          {selectedType.name}
+        </ActionMenu.Button>
+        <ActionMenu.Overlay width="medium">
+          <ActionList selectionVariant="single" aria-label="Field type">
+            {fieldTypes.map((type, index) => (
+              <ActionList.Item key={index} selected={index === selectedIndex} onSelect={() => setSelectedIndex(index)}>
+                <ActionList.LeadingVisual>
+                  <type.icon />
+                </ActionList.LeadingVisual>
+                {type.name}
+              </ActionList.Item>
+            ))}
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+    </>
+  )
+}
+
+const InlineLabel = () => {
+  const [selectedIndex, setSelectedIndex] = React.useState(1)
+  const selectedType = fieldTypes[selectedIndex]
+
+  return (
     <ActionMenu>
-      <ActionMenu.Button aria-label="Select field type" leadingIcon={selectedType.icon}>
+      <ActionMenu.Button label="Field type" leadingIcon={selectedType.icon}>
         {selectedType.name}
       </ActionMenu.Button>
       <ActionMenu.Overlay width="medium">
@@ -209,7 +291,16 @@ const Example = () => {
   )
 }
 
-render(<Example />)
+render(
+  <div style={{display: 'flex', alignItems: 'end'}}>
+    <div style={{width: '50%'}}>
+      <ExternalLabel />
+    </div>
+    <div style={{width: '50%'}}>
+      <InlineLabel />
+    </div>
+  </div>
+)
 ```
 
 ### With External Anchor
@@ -326,8 +417,8 @@ render(
 
 <PropsTable>
   <PropsTableRow name="children" required type="React.ReactElement" />
-  <PropsTableRow name="aria-label" required type="string" />
-  <PropsTableRow name="includeLabel" type="boolean" />
+  <PropsTableRow name="aria-label" type="string" description="Label for button, also used to label the menu" />
+  <PropsTableRow name="label" type="string" description="Add an inline label, as a replacement for aria-label" />
   <PropsTablePassthroughPropsRow
     elementName="Button"
     isPolymorphic

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -22,6 +22,9 @@ export type ActionListProps = {
    * The ARIA role describing the function of `List` component. `listbox` or `menu` are a common values.
    */
   role?: AriaRole
+
+  'aria-label'?: string
+  'aria-labelledby'?: string
 } & SxProp
 
 type ContextProps = Pick<ActionListProps, 'variant' | 'selectionVariant' | 'showDividers' | 'role'>
@@ -51,8 +54,11 @@ export const List = React.forwardRef<HTMLUListElement, ActionListProps>(
       <ListBox
         sx={merge(styles, sxProp as SxProp)}
         role={role || listRole}
-        aria-labelledby={listLabelledBy}
         {...props}
+        aria-labelledby={
+          /* give user defined aria labels preference over automatic label (listLabelledBy) */
+          props['aria-labelledby'] || (props['aria-label'] ? undefined : listLabelledBy)
+        }
         ref={forwardedRef}
       >
         <ListContext.Provider

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -56,7 +56,11 @@ export const List = React.forwardRef<HTMLUListElement, ActionListProps>(
         role={role || listRole}
         {...props}
         aria-labelledby={
-          /* give user defined aria labels preference over automatic label (listLabelledBy) */
+          /* 
+            Give preference to user defined aria labels over automatic label.
+            aria-labelledby has higher specificity than aria-label,
+            that's why we set our aria-labelledby to undefined
+          */
           props['aria-labelledby'] || (props['aria-label'] ? undefined : listLabelledBy)
         }
         ref={forwardedRef}

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -7,14 +7,16 @@ import {useProvidedRefOrCreate, useProvidedStateOrCreate, useMenuInitialFocus, u
 import {Divider} from './ActionList/Divider'
 import {ActionListContainerContext} from './ActionList/ActionListContainerContext'
 import {Button, ButtonProps} from './Button'
+import Text from './Text'
+import StyledOcticon from './StyledOcticon'
 import {MandateProps} from './utils/types'
 import {SxProp, merge} from './sx'
 
 type MenuContextProps = Pick<
   AnchoredOverlayProps,
   'anchorRef' | 'renderAnchor' | 'open' | 'onOpen' | 'onClose' | 'anchorId'
->
-const MenuContext = React.createContext<MenuContextProps>({renderAnchor: null, open: false})
+> & {includeLabel: boolean}
+const MenuContext = React.createContext<MenuContextProps>({renderAnchor: null, includeLabel: false, open: false})
 
 export type ActionMenuProps = {
   /**
@@ -45,6 +47,7 @@ const Menu: React.FC<ActionMenuProps> = ({
 
   const anchorRef = useProvidedRefOrCreate(externalAnchorRef)
   const anchorId = useSSRSafeId()
+  let includeLabel = false
   let renderAnchor: AnchoredOverlayProps['renderAnchor'] = null
 
   // 🚨 Hack for good API!
@@ -52,6 +55,7 @@ const Menu: React.FC<ActionMenuProps> = ({
   // with additional props for accessibility
   const contents = React.Children.map(children, child => {
     if (child.type === MenuButton || child.type === Anchor) {
+      includeLabel = child.props.includeLabel
       renderAnchor = anchorProps => React.cloneElement(child, anchorProps)
       return null
     }
@@ -59,7 +63,9 @@ const Menu: React.FC<ActionMenuProps> = ({
   })
 
   return (
-    <MenuContext.Provider value={{anchorRef, renderAnchor, anchorId, open: combinedOpenState, onOpen, onClose}}>
+    <MenuContext.Provider
+      value={{anchorRef, renderAnchor, anchorId, includeLabel, open: combinedOpenState, onOpen, onClose}}
+    >
       {contents}
     </MenuContext.Provider>
   )
@@ -73,9 +79,11 @@ const Anchor = React.forwardRef<AnchoredOverlayProps['anchorRef'], ActionMenuAnc
 )
 
 /** this component is syntactical sugar 🍭 */
-export type ActionMenuButtonProps = ButtonProps
+export type ActionMenuButtonProps = ButtonProps & {includeLabel: boolean}
 const MenuButton = React.forwardRef<AnchoredOverlayProps['anchorRef'], ButtonProps>(
-  ({sx: sxProp = {}, ...props}, anchorRef) => {
+  ({sx: sxProp = {}, includeLabel = false, 'aria-label': ariaLabel, leadingIcon, ...props}, anchorRef) => {
+    const {anchorId} = React.useContext(MenuContext)
+
     return (
       <Anchor ref={anchorRef}>
         <Button
@@ -88,8 +96,20 @@ const MenuButton = React.forwardRef<AnchoredOverlayProps['anchorRef'], ButtonPro
             },
             sxProp as SxProp
           )}
+          aria-label={includeLabel ? undefined : ariaLabel}
+          aria-labelledby={includeLabel ? `${anchorId}-purpose ${anchorId}-divider ${anchorId}-value` : undefined}
+          leadingVisual={includeLabel ? undefined : leadingIcon}
           {...props}
-        />
+        >
+          {includeLabel ? (
+            <Text sx={{color: 'fg.muted', fontWeight: 'normal', mr: 1}}>
+              <span id={`${anchorId}-purpose`}>{ariaLabel}</span>
+              {props.children && <span id={`${anchorId}-divider`}>:</span>}
+            </Text>
+          ) : null}
+          {leadingIcon && <StyledOcticon icon={leadingIcon} sx={{mr: 2}} />}
+          <span id={`${anchorId}-value`}>{props.children}</span>
+        </Button>
       </Anchor>
     )
   }
@@ -105,10 +125,9 @@ type MenuOverlayProps = Partial<OverlayProps> &
 const Overlay: React.FC<MenuOverlayProps> = ({children, align = 'start', ...overlayProps}) => {
   // we typecast anchorRef as required instead of optional
   // because we know that we're setting it in context in Menu
-  const {anchorRef, renderAnchor, anchorId, open, onOpen, onClose} = React.useContext(MenuContext) as MandateProps<
-    MenuContextProps,
-    'anchorRef'
-  >
+  const {anchorRef, renderAnchor, anchorId, includeLabel, open, onOpen, onClose} = React.useContext(
+    MenuContext
+  ) as MandateProps<MenuContextProps, 'anchorRef'>
 
   const containerRef = React.createRef<HTMLDivElement>()
   const {openWithFocus} = useMenuInitialFocus(open, onOpen, containerRef)
@@ -131,7 +150,7 @@ const Overlay: React.FC<MenuOverlayProps> = ({children, align = 'start', ...over
           value={{
             container: 'ActionMenu',
             listRole: 'menu',
-            listLabelledBy: anchorId,
+            listLabelledBy: includeLabel ? `${anchorId}-purpose` : anchorId,
             selectionAttribute: 'aria-checked', // Should this be here?
             afterSelect: onClose
           }}

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -106,9 +106,11 @@ const MenuButton = React.forwardRef<AnchoredOverlayProps['anchorRef'], ButtonPro
                 {props.children && <span id={`${anchorId}-divider`}>:</span>}
               </Text>
               {leadingIcon && <StyledOcticon icon={leadingIcon} sx={{mr: 2}} />}
+              {props.children && <span id={`${anchorId}-value`}>{props.children}</span>}
             </>
-          ) : null}
-          {props.children && <span id={`${anchorId}-value`}>{props.children}</span>}
+          ) : (
+            props.children
+          )}
         </Button>
       </Anchor>
     )

--- a/src/__tests__/ActionMenu.test.tsx
+++ b/src/__tests__/ActionMenu.test.tsx
@@ -108,7 +108,7 @@ describe('ActionMenu', () => {
         <SingleSelection />
       </ThemeProvider>
     )
-    const button = component.getByLabelText('Select field type')
+    const button = component.getByLabelText('Field type')
     fireEvent.click(button)
 
     // select first item by role, that would close the menu
@@ -127,7 +127,7 @@ describe('ActionMenu', () => {
         <MixedSelection />
       </ThemeProvider>
     )
-    const button = component.getByLabelText('Select field type to group by')
+    const button = component.getByLabelText('Group by')
     fireEvent.click(button)
 
     expect(component.getByLabelText('Status')).toHaveAttribute('role', 'menuitemradio')

--- a/src/__tests__/__snapshots__/TextInputWithTokens.test.tsx.snap
+++ b/src/__tests__/__snapshots__/TextInputWithTokens.test.tsx.snap
@@ -768,6 +768,11 @@ exports[`TextInputWithTokens renders a truncated set of tokens 1`] = `
   flex-grow: 1;
 }
 
+.c7 {
+  font-size: 16px;
+  color: #57606a;
+}
+
 .c0 {
   font-size: 14px;
   line-height: 20px;
@@ -868,11 +873,6 @@ exports[`TextInputWithTokens renders a truncated set of tokens 1`] = `
 
 .c3:focus {
   outline: 0;
-}
-
-.c7 {
-  font-size: 16px;
-  color: #57606a;
 }
 
 .c4 {

--- a/src/stories/ActionMenu/examples.stories.tsx
+++ b/src/stories/ActionMenu/examples.stories.tsx
@@ -83,55 +83,56 @@ export function SingleSelection(): JSX.Element {
   const [selectedIndex, setSelectedIndex] = React.useState(1)
   const selectedType = fieldTypes[selectedIndex]
   return (
-    <div style={{display: 'flex'}}>
-      <div>
-        <Heading as="h3" sx={{fontSize: 1, mb: 2}}>
-          Field type:
-        </Heading>
-        <ActionMenu>
-          <ActionMenu.Button aria-label={`Field type: ${selectedType.name}`} leadingIcon={selectedType.icon}>
-            {selectedType.name}
-          </ActionMenu.Button>
-          <ActionMenu.Overlay width="medium">
-            <ActionList selectionVariant="single" aria-label="Field type">
-              {fieldTypes.map((type, index) => (
-                <ActionList.Item
-                  key={index}
-                  selected={index === selectedIndex}
-                  id={index === selectedIndex ? 'selected-item' : undefined}
-                  onSelect={() => setSelectedIndex(index)}
-                  disabled={index === 3}
-                >
-                  <type.icon /> {type.name}
-                </ActionList.Item>
-              ))}
-            </ActionList>
-          </ActionMenu.Overlay>
-        </ActionMenu>
-      </div>
-      <div>
-        <ActionMenu>
-          <ActionMenu.Button label="Field type" leadingIcon={selectedType.icon}>
-            {selectedType.name}
-          </ActionMenu.Button>
-          <ActionMenu.Overlay width="medium">
-            <ActionList selectionVariant="single">
-              {fieldTypes.map((type, index) => (
-                <ActionList.Item
-                  key={index}
-                  selected={index === selectedIndex}
-                  id={index === selectedIndex ? 'selected-item' : undefined}
-                  onSelect={() => setSelectedIndex(index)}
-                  disabled={index === 3}
-                >
-                  <type.icon /> {type.name}
-                </ActionList.Item>
-              ))}
-            </ActionList>
-          </ActionMenu.Overlay>
-        </ActionMenu>
-      </div>
-    </div>
+    <>
+      <h2>Single Selection with external label</h2>
+
+      <Heading as="h3" sx={{fontSize: 1, mb: 2}}>
+        Field type:
+      </Heading>
+      <ActionMenu>
+        <ActionMenu.Button aria-label={`Field type: ${selectedType.name}`} leadingIcon={selectedType.icon}>
+          {selectedType.name}
+        </ActionMenu.Button>
+        <ActionMenu.Overlay width="medium">
+          <ActionList selectionVariant="single" aria-label="Field type">
+            {fieldTypes.map((type, index) => (
+              <ActionList.Item
+                key={index}
+                selected={index === selectedIndex}
+                id={index === selectedIndex ? 'selected-item' : undefined}
+                onSelect={() => setSelectedIndex(index)}
+                disabled={index === 3}
+              >
+                <type.icon /> {type.name}
+              </ActionList.Item>
+            ))}
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+
+      <h2>Single Selection with inline label</h2>
+
+      <ActionMenu>
+        <ActionMenu.Button label="Field type" leadingIcon={selectedType.icon}>
+          {selectedType.name}
+        </ActionMenu.Button>
+        <ActionMenu.Overlay width="medium">
+          <ActionList selectionVariant="single">
+            {fieldTypes.map((type, index) => (
+              <ActionList.Item
+                key={index}
+                selected={index === selectedIndex}
+                id={index === selectedIndex ? 'selected-item' : undefined}
+                onSelect={() => setSelectedIndex(index)}
+                disabled={index === 3}
+              >
+                <type.icon /> {type.name}
+              </ActionList.Item>
+            ))}
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+    </>
   )
 }
 

--- a/src/stories/ActionMenu/examples.stories.tsx
+++ b/src/stories/ActionMenu/examples.stories.tsx
@@ -84,12 +84,34 @@ export function SingleSelection(): JSX.Element {
   const selectedType = fieldTypes[selectedIndex]
   return (
     <>
-      <h1>Single Selection - with aria-describedby</h1>
+      <h1>Single Selection - with label</h1>
 
       <ActionMenu>
-        <ActionMenu.Button aria-label="Field type" aria-describedby="selected-value">
-          <Text sx={{color: 'fg.muted', fontWeight: 'normal'}}>Field type:</Text>{' '}
-          <StyledOcticon icon={selectedType.icon} /> <span id="selected-value">{selectedType.name}</span>
+        <ActionMenu.Button aria-label="Field type" includeLabel leadingIcon={selectedType.icon}>
+          {selectedType.name}
+        </ActionMenu.Button>
+        <ActionMenu.Overlay width="medium">
+          <ActionList selectionVariant="single">
+            {fieldTypes.map((type, index) => (
+              <ActionList.Item
+                key={index}
+                selected={index === selectedIndex}
+                id={index === selectedIndex ? 'selected-item' : undefined}
+                onSelect={() => setSelectedIndex(index)}
+                disabled={index === 3}
+              >
+                <type.icon /> {type.name}
+              </ActionList.Item>
+            ))}
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+
+      <h2>Single Selection - without label</h2>
+
+      <ActionMenu>
+        <ActionMenu.Button aria-label="Field type" leadingIcon={selectedType.icon}>
+          {selectedType.name}
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium">
           <ActionList selectionVariant="single">
@@ -122,8 +144,8 @@ export function SingleSelectionWithPlaceholder(): JSX.Element {
       <p>This pattern has a placeholder in menu button when no value is selected yet</p>
 
       <ActionMenu>
-        <ActionMenu.Button aria-label="Select field type" leadingIcon={selectedType.icon}>
-          {selectedType.name || 'Pick a field type'}
+        <ActionMenu.Button aria-label="Field type" includeLabel leadingIcon={selectedType.icon}>
+          {selectedType.name}
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium">
           <ActionList selectionVariant="single">
@@ -312,11 +334,8 @@ export function MixedSelection(): JSX.Element {
       </p>
 
       <ActionMenu>
-        <ActionMenu.Button
-          aria-label="Select field type to group by"
-          leadingIcon={selectedOption && selectedOption.icon}
-        >
-          {selectedOption ? `Group by ${selectedOption.text}` : 'Group items by'}
+        <ActionMenu.Button aria-label="Group by" includeLabel leadingIcon={selectedOption && selectedOption.icon}>
+          {selectedOption && selectedOption.text}
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium">
           <ActionList>

--- a/src/stories/ActionMenu/examples.stories.tsx
+++ b/src/stories/ActionMenu/examples.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Meta} from '@storybook/react'
-import {ThemeProvider, BaseStyles, Box, Text, Avatar, ActionMenu, ActionList, StyledOcticon} from '../..'
+import {ThemeProvider, BaseStyles, Box, Text, Avatar, ActionMenu, ActionList, StyledOcticon, Heading} from '../..'
 import {
   GearIcon,
   MilestoneIcon,
@@ -84,14 +84,17 @@ export function SingleSelection(): JSX.Element {
   const selectedType = fieldTypes[selectedIndex]
   return (
     <>
-      <h1>Single Selection - with label</h1>
+      <h2>Single Selection with external label</h2>
 
+      <Heading as="h3" sx={{fontSize: 1, mb: 2}}>
+        Field type:
+      </Heading>
       <ActionMenu>
-        <ActionMenu.Button aria-label="Field type" includeLabel leadingIcon={selectedType.icon}>
+        <ActionMenu.Button aria-label={`Field type: ${selectedType.name}`} leadingIcon={selectedType.icon}>
           {selectedType.name}
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium">
-          <ActionList selectionVariant="single">
+          <ActionList selectionVariant="single" aria-label="Field type">
             {fieldTypes.map((type, index) => (
               <ActionList.Item
                 key={index}
@@ -107,10 +110,10 @@ export function SingleSelection(): JSX.Element {
         </ActionMenu.Overlay>
       </ActionMenu>
 
-      <h2>Single Selection - without label</h2>
+      <h2>Single Selection with inline label</h2>
 
       <ActionMenu>
-        <ActionMenu.Button aria-label="Field type" leadingIcon={selectedType.icon}>
+        <ActionMenu.Button label="Field type" leadingIcon={selectedType.icon}>
           {selectedType.name}
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium">
@@ -144,7 +147,7 @@ export function SingleSelectionWithPlaceholder(): JSX.Element {
       <p>This pattern has a placeholder in menu button when no value is selected yet</p>
 
       <ActionMenu>
-        <ActionMenu.Button aria-label="Field type" includeLabel leadingIcon={selectedType.icon}>
+        <ActionMenu.Button label="Field type" leadingIcon={selectedType.icon}>
           {selectedType.name}
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium">
@@ -334,7 +337,7 @@ export function MixedSelection(): JSX.Element {
       </p>
 
       <ActionMenu>
-        <ActionMenu.Button aria-label="Group by" includeLabel leadingIcon={selectedOption && selectedOption.icon}>
+        <ActionMenu.Button label="Group by" leadingIcon={selectedOption && selectedOption.icon}>
           {selectedOption && selectedOption.text}
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium">

--- a/src/stories/ActionMenu/examples.stories.tsx
+++ b/src/stories/ActionMenu/examples.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Meta} from '@storybook/react'
-import {ThemeProvider, BaseStyles, Box, Text, Avatar, ActionMenu, ActionList, StyledOcticon, Heading} from '../..'
+import {ThemeProvider, BaseStyles, Box, Text, Avatar, ActionMenu, ActionList, Heading} from '../..'
 import {
   GearIcon,
   MilestoneIcon,

--- a/src/stories/ActionMenu/examples.stories.tsx
+++ b/src/stories/ActionMenu/examples.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Meta} from '@storybook/react'
-import {ThemeProvider, BaseStyles, Box, Text, Avatar, ActionMenu, ActionList} from '../..'
+import {ThemeProvider, BaseStyles, Box, Text, Avatar, ActionMenu, ActionList, StyledOcticon} from '../..'
 import {
   GearIcon,
   MilestoneIcon,
@@ -80,17 +80,16 @@ const fieldTypes = [
 ]
 
 export function SingleSelection(): JSX.Element {
-  const [selectedIndex, setSelectedIndex] = React.useState(0)
+  const [selectedIndex, setSelectedIndex] = React.useState(1)
   const selectedType = fieldTypes[selectedIndex]
   return (
     <>
-      <h1>Single Selection</h1>
-
-      <p>This pattern has a single section with the selected value shown in the button</p>
+      <h1>Single Selection - with aria-describedby</h1>
 
       <ActionMenu>
-        <ActionMenu.Button aria-label="Select field type" leadingIcon={selectedType.icon}>
-          {selectedType.name}
+        <ActionMenu.Button aria-label="Field type" aria-describedby="selected-value">
+          <Text sx={{color: 'fg.muted', fontWeight: 'normal'}}>Field type:</Text>{' '}
+          <StyledOcticon icon={selectedType.icon} /> <span id="selected-value">{selectedType.name}</span>
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium">
           <ActionList selectionVariant="single">
@@ -98,6 +97,7 @@ export function SingleSelection(): JSX.Element {
               <ActionList.Item
                 key={index}
                 selected={index === selectedIndex}
+                id={index === selectedIndex ? 'selected-item' : undefined}
                 onSelect={() => setSelectedIndex(index)}
                 disabled={index === 3}
               >

--- a/src/stories/ActionMenu/examples.stories.tsx
+++ b/src/stories/ActionMenu/examples.stories.tsx
@@ -83,56 +83,55 @@ export function SingleSelection(): JSX.Element {
   const [selectedIndex, setSelectedIndex] = React.useState(1)
   const selectedType = fieldTypes[selectedIndex]
   return (
-    <>
-      <h2>Single Selection with external label</h2>
-
-      <Heading as="h3" sx={{fontSize: 1, mb: 2}}>
-        Field type:
-      </Heading>
-      <ActionMenu>
-        <ActionMenu.Button aria-label={`Field type: ${selectedType.name}`} leadingIcon={selectedType.icon}>
-          {selectedType.name}
-        </ActionMenu.Button>
-        <ActionMenu.Overlay width="medium">
-          <ActionList selectionVariant="single" aria-label="Field type">
-            {fieldTypes.map((type, index) => (
-              <ActionList.Item
-                key={index}
-                selected={index === selectedIndex}
-                id={index === selectedIndex ? 'selected-item' : undefined}
-                onSelect={() => setSelectedIndex(index)}
-                disabled={index === 3}
-              >
-                <type.icon /> {type.name}
-              </ActionList.Item>
-            ))}
-          </ActionList>
-        </ActionMenu.Overlay>
-      </ActionMenu>
-
-      <h2>Single Selection with inline label</h2>
-
-      <ActionMenu>
-        <ActionMenu.Button label="Field type" leadingIcon={selectedType.icon}>
-          {selectedType.name}
-        </ActionMenu.Button>
-        <ActionMenu.Overlay width="medium">
-          <ActionList selectionVariant="single">
-            {fieldTypes.map((type, index) => (
-              <ActionList.Item
-                key={index}
-                selected={index === selectedIndex}
-                id={index === selectedIndex ? 'selected-item' : undefined}
-                onSelect={() => setSelectedIndex(index)}
-                disabled={index === 3}
-              >
-                <type.icon /> {type.name}
-              </ActionList.Item>
-            ))}
-          </ActionList>
-        </ActionMenu.Overlay>
-      </ActionMenu>
-    </>
+    <div style={{display: 'flex'}}>
+      <div>
+        <Heading as="h3" sx={{fontSize: 1, mb: 2}}>
+          Field type:
+        </Heading>
+        <ActionMenu>
+          <ActionMenu.Button aria-label={`Field type: ${selectedType.name}`} leadingIcon={selectedType.icon}>
+            {selectedType.name}
+          </ActionMenu.Button>
+          <ActionMenu.Overlay width="medium">
+            <ActionList selectionVariant="single" aria-label="Field type">
+              {fieldTypes.map((type, index) => (
+                <ActionList.Item
+                  key={index}
+                  selected={index === selectedIndex}
+                  id={index === selectedIndex ? 'selected-item' : undefined}
+                  onSelect={() => setSelectedIndex(index)}
+                  disabled={index === 3}
+                >
+                  <type.icon /> {type.name}
+                </ActionList.Item>
+              ))}
+            </ActionList>
+          </ActionMenu.Overlay>
+        </ActionMenu>
+      </div>
+      <div>
+        <ActionMenu>
+          <ActionMenu.Button label="Field type" leadingIcon={selectedType.icon}>
+            {selectedType.name}
+          </ActionMenu.Button>
+          <ActionMenu.Overlay width="medium">
+            <ActionList selectionVariant="single">
+              {fieldTypes.map((type, index) => (
+                <ActionList.Item
+                  key={index}
+                  selected={index === selectedIndex}
+                  id={index === selectedIndex ? 'selected-item' : undefined}
+                  onSelect={() => setSelectedIndex(index)}
+                  disabled={index === 3}
+                >
+                  <type.icon /> {type.name}
+                </ActionList.Item>
+              ))}
+            </ActionList>
+          </ActionMenu.Overlay>
+        </ActionMenu>
+      </div>
+    </div>
   )
 }
 

--- a/src/stories/ActionMenu/fixtures.stories.tsx
+++ b/src/stories/ActionMenu/fixtures.stories.tsx
@@ -11,7 +11,8 @@ import {
   ActionMenu,
   ActionList,
   Button,
-  IconButton
+  IconButton,
+  Heading
 } from '../..'
 import {
   ServerIcon,
@@ -207,7 +208,7 @@ export function CustomAnchor(): JSX.Element {
       <h2>Last option activated: {actionFired}</h2>
       <ActionMenu>
         <ActionMenu.Anchor>
-          <summary style={{cursor: 'pointer'}} aria-label="Open column options">
+          <summary style={{cursor: 'pointer'}} aria-label="Column options">
             <KebabHorizontalIcon />
           </summary>
         </ActionMenu.Anchor>
@@ -497,6 +498,9 @@ export function MemexIteration(): JSX.Element {
     <>
       <h1>Memex Iteration Menu</h1>
 
+      <Heading as="h3" id="purpose" sx={{fontSize: 1}}>
+        Iteration duration
+      </Heading>
       <ActionMenu>
         <ActionMenu.Button
           variant="invisible"
@@ -505,12 +509,12 @@ export function MemexIteration(): JSX.Element {
             color: 'fg.muted',
             ':hover, :focus': {background: 'none !important', color: 'accent.fg'}
           }}
-          aria-label="Select iteration duration"
+          aria-label={`Iteration duration: ${duration} ${duration > 1 ? 'weeks' : 'week'}`}
         >
           {duration} {duration > 1 ? 'weeks' : 'week'}
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium">
-          <ActionList selectionVariant="single">
+          <ActionList selectionVariant="single" aria-labelledby="purpose">
             {[1, 2, 3, 4, 5, 6].map(weeks => (
               <ActionList.Item key={weeks} selected={duration === weeks} onSelect={() => setDuration(weeks)}>
                 {weeks} {weeks > 1 ? 'weeks' : 'week'}
@@ -548,7 +552,7 @@ export function MemexAddColumn(): JSX.Element {
         </FormControl>
         <ActionMenu>
           <ActionMenu.Button
-            aria-label="Select field type"
+            aria-label={`Field type: ${selectedType.name}`}
             leadingIcon={selectedType.icon}
             sx={{
               gridTemplateColumns: 'min-content 1fr min-content',
@@ -558,7 +562,7 @@ export function MemexAddColumn(): JSX.Element {
             {selectedType.name}
           </ActionMenu.Button>
           <ActionMenu.Overlay width="medium">
-            <ActionList selectionVariant="single">
+            <ActionList selectionVariant="single" aria-label="Field type">
               {fieldTypes.map((type, index) => (
                 <ActionList.Item
                   key={index}
@@ -582,7 +586,7 @@ export function MemexAddColumn(): JSX.Element {
           <ActionMenu>
             <ActionMenu.Button
               id="duration"
-              aria-label="Select field type"
+              aria-label={`Duration unit: ${durationUnit}`}
               sx={{
                 textAlign: 'left',
                 ml: 2,
@@ -594,7 +598,7 @@ export function MemexAddColumn(): JSX.Element {
               {durationUnit}
             </ActionMenu.Button>
             <ActionMenu.Overlay width="medium">
-              <ActionList selectionVariant="single">
+              <ActionList selectionVariant="single" aria-label="Duration unit">
                 <ActionList.Item selected={durationUnit === 'weeks'} onSelect={() => setDurationUnit('weeks')}>
                   weeks
                 </ActionList.Item>

--- a/src/stories/ActionMenu/fixtures.stories.tsx
+++ b/src/stories/ActionMenu/fixtures.stories.tsx
@@ -498,7 +498,7 @@ export function MemexIteration(): JSX.Element {
     <>
       <h1>Memex Iteration Menu</h1>
 
-      <Heading as="h3" id="purpose" sx={{fontSize: 1}}>
+      <Heading as="h1" id="purpose" sx={{fontSize: 1}}>
         Iteration duration
       </Heading>
       <ActionMenu>

--- a/src/stories/ActionMenu/fixtures.stories.tsx
+++ b/src/stories/ActionMenu/fixtures.stories.tsx
@@ -61,7 +61,7 @@ export function ActionsStory(): JSX.Element {
       <h1>Actions</h1>
 
       <ActionMenu>
-        <ActionMenu.Button aria-label="Open Actions Menu" trailingIcon={null}>
+        <ActionMenu.Button aria-label="Actions Menu" trailingIcon={null}>
           <ServerIcon />
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium">
@@ -115,7 +115,7 @@ export function ExternalAnchor(): JSX.Element {
 
       <ActionMenu open={open} onOpenChange={setOpen} anchorRef={anchorRef}>
         <ActionMenu.Overlay>
-          <ActionList>
+          <ActionList aria-label="File options">
             <ActionList.Item onSelect={() => onSelect('Copy link')}>
               Copy link
               <ActionList.TrailingVisual>⌘C</ActionList.TrailingVisual>


### PR DESCRIPTION
- Based on https://github.com/github/primer/discussions/696
- Fixes https://github.com/github/primer/issues/994
- Fixes https://github.com/github/primer/issues/995
- Fixes https://github.com/github/primer/issues/993

.
- [See new section about accessibility in docs →](https://primer-01ca87129d-13348165.drafts.github.io/ActionMenu#accessibility)

---

Open questions:

1. Is the prop `label` too similar to `aria-label`, can that cause confusion? Should we call it `inlineLabel` instead to add some weight?
2. Is there something we can do to simplify the a11y needs with an external label as well? [Right now, we defer this responsibility to the user](https://primer-01ca87129d-13348165.drafts.github.io/ActionMenu#:~:text=If%20you%20have%20an%20external%20label%2C). For example, we could split the `label` prop into `label` & `showLabel`. `label` would be used to create `aria-label` on button and `aria-labelledby` for action list. it will only be shown visually if `showLabel` or `withInlineLabel` is passed.


---

### Explanation

&nbsp;

Goal:

For menus with selection, it's common to show the selected value inside the button. To give context, it's important to show purpose of the menu as well. Visually, this can be an external label above the button or an inline label inside the button (new!)

In both cases, the label for screen readers (with aria-label or aria-labelledby) should have both purpose and value, example: "Field type: Number".

We want to add the option to add an inline number (left) as an alternative to [external label](https://primer-01ca87129d-13348165.drafts.github.io/storybook/?path=/story/composite-components-actionmenu-examples--single-selection) (right)

<img width="769" alt="image" src="https://user-images.githubusercontent.com/1863771/171213015-01458182-5f69-497a-93bd-85ad997ce110.png">


a11y tree:
```
► combobox "Field type: Number"
► menu "Field type"
```


&nbsp;

To achieve this today, users have to write something like this:

```jsx
<ActionMenu>
  <ActionMenu.Button 
    aria-label={'Field type: ' + selectedOption.name}
    leadingIcon={selectedOption.value}
  >
    <Text sx={{ color: 'fg.muted' }}>Field type:</Text>
    {selectedOption.name}
  </ActionMenu.Button>
  <ActionList
    selectionVariant="single"
    aria-label="Field type"
   >
    ...
   </ActionList>
</ActionMenu>
```

Suggested API in this pull request: 

1. use `label` instead of `aria-label` on `ActionMenu.Button`
2. labels for button and menu are created automatically

```diff
<ActionMenu>
  <ActionMenu.Button 
-   aria-label={'Field type: ' + selectedOption.name}
+   label="Field type"
    leadingIcon={selectedOption.value}
  >
-   <Text sx={{ color: 'fg.muted' }}>Field type:</Text>
    {selectedOption.name}
  </ActionMenu.Button>
  <ActionList
    selectionVariant="single"
-   aria-label="Field type"
   >
    ...
   </ActionList>
</ActionMenu>
```

html output:

```html
<button aria-labelledby="purpose divider value"> 
  <span id="purpose">Field type</span><span id="divider">:</span> 
  <svg aria-hidden="true"></svg>
  <span id="value">Iteration</span>
<button>
<div role="menu" aria-labelledby="purpose"></div>
```

a11y tree:
```
► combobox "Field type : Number"
► menu "Field type"
```



