### PR TITLE
Tests: Add tests for lockfile version

### DIFF
--- a/src/__tests__/lockfile-version.test.ts
+++ b/src/__tests__/lockfile-version.test.ts
@@ -1,0 +1,10 @@
+import lockFile from '../../package-lock.json'
+import docsLockFile from '../../docs/package-lock.json'
+
+test('root: lockfileVersion should be 2', async () => {
+  expect(lockFile.lockfileVersion).toEqual(2)
+})
+
+test('docs: lockfileVersion should be 2', async () => {
+  expect(docsLockFile.lockfileVersion).toEqual(2)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
     "typeRoots": ["./node_modules/@types", "./@types"]
   },
   "include": ["@types/**/*.ts", "src/**/*.js", "src/**/*.ts", "src/**/*.tsx", "script/**/*.ts"]


### PR DESCRIPTION
Every once in a while, a PR accidentally switches the lockfile version from 2 to 1 (examples: [1](https://github.com/primer/react/pull/2053/files), [2](https://github.com/primer/react/pull/1736/files)), this can lead to unreliable installations for local development and publishing in CI

These happens automatically when the version of node or npm is an older one and is hard to catch in code reviews because the contents of package-lock.json are usually hidden even with small-ish changes, but especially with big changes (see screenshots below)

The easy fix is to add tests for this that run in CI :)

---

<img width="619" alt="image" src="https://user-images.githubusercontent.com/1863771/171025598-1268345b-9a30-4051-a17c-d9a540cf5d0f.png">

<img width="612" alt="image" src="https://user-images.githubusercontent.com/1863771/171025445-0cd45369-bed5-47ab-b135-0ca4c15b4275.png">

<img width="613" alt="image" src="https://user-images.githubusercontent.com/1863771/171025491-f732703e-c4d5-478d-a038-3485f2f80d71.png">
