### PR TITLE
Export NavList from the main bundle

### DIFF
--- a/.changeset/stale-hounds-notice.md
+++ b/.changeset/stale-hounds-notice.md
@@ -1,0 +1,9 @@
+---
+"@primer/react": minor
+---
+
+[NavList](https://primer.style/NavList) is ready to use. You can now import it from the main bundle:
+
+```js
+import {NavList} from '@primer/react'
+```

--- a/docs/content/NavList.mdx
+++ b/docs/content/NavList.mdx
@@ -1,12 +1,13 @@
 ---
 title: NavList
-status: Draft
-description: Use nav list to render a vertical list of navigation links.
+status: Alpha
+description: Use a nav list to render a vertical list of navigation links.
 source: https://github.com/primer/react/tree/main/src/NavList
+storybook: '/react/storybook/?path=/story/composite-components-navlist--simple'
 ---
 
 ```js
-import {NavList} from '@primer/react/drafts'
+import {NavList} from '@primer/react'
 ```
 
 ## Examples
@@ -333,9 +334,9 @@ function App() {
     adaptsToThemes: true,
     adaptsToScreenSizes: true,
     fullTestCoverage: true,
-    usedInProduction: false,
+    usedInProduction: true,
     usageExamplesDocumented: true,
-    hasStorybookStories: false,
+    hasStorybookStories: true,
     designReviewed: false,
     a11yReviewed: false,
     stableApi: false,

--- a/docs/content/NavList.mdx
+++ b/docs/content/NavList.mdx
@@ -1,6 +1,7 @@
 ---
 title: NavList
 status: Alpha
+componentId: nav_list
 description: Use a nav list to render a vertical list of navigation links.
 source: https://github.com/primer/react/tree/main/src/NavList
 storybook: '/react/storybook/?path=/story/composite-components-navlist--simple'

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -90,6 +90,8 @@
       url: /LabelGroup
     - title: Link
       url: /Link
+    - title: NavList
+      url: /NavList
     - title: Overlay
       url: /Overlay
     - title: Pagehead

--- a/src/ActionList/Divider.tsx
+++ b/src/ActionList/Divider.tsx
@@ -4,11 +4,12 @@ import {get} from '../constants'
 import {Theme} from '../ThemeProvider'
 import {SxProp, merge} from '../sx'
 
+export type ActionListDividerProps = SxProp
+
 /**
  * Visually separates `Item`s or `Group`s in an `ActionList`.
  */
-
-export const Divider: React.FC<SxProp> = ({sx = {}}) => {
+export const Divider: React.FC<ActionListDividerProps> = ({sx = {}}) => {
   return (
     <Box
       as="li"

--- a/src/ActionList/index.ts
+++ b/src/ActionList/index.ts
@@ -10,6 +10,7 @@ export type {ActionListProps} from './List'
 export type {ActionListGroupProps} from './Group'
 export type {ActionListItemProps} from './Item'
 export type {ActionListLinkItemProps} from './LinkItem'
+export type {ActionListDividerProps} from './Divider'
 export type {ActionListDescriptionProps} from './Description'
 export type {ActionListLeadingVisualProps, ActionListTrailingVisualProps} from './Visuals'
 

--- a/src/NavList/NavList.tsx
+++ b/src/NavList/NavList.tsx
@@ -3,7 +3,12 @@ import {ForwardRefComponent as PolymorphicForwardRefComponent} from '@radix-ui/r
 import {useSSRSafeId} from '@react-aria/ssr'
 import React, {isValidElement} from 'react'
 import styled from 'styled-components'
-import {ActionList} from '../ActionList'
+import {
+  ActionList,
+  ActionListDividerProps,
+  ActionListLeadingVisualProps,
+  ActionListTrailingVisualProps
+} from '../ActionList'
 import Box from '../Box'
 import StyledOcticon from '../StyledOcticon'
 import sx, {merge, SxProp} from '../sx'
@@ -154,7 +159,7 @@ function ItemWithSubNav({children, subNav, sx: sxProp = {}}: ItemWithSubNavProps
 // ----------------------------------------------------------------------------
 // NavList.SubNav
 
-type NavListSubNavProps = {
+export type NavListSubNavProps = {
   children: React.ReactNode
 } & SxProp
 
@@ -203,12 +208,16 @@ SubNav.displayName = 'NavList.SubNav'
 // ----------------------------------------------------------------------------
 // NavList.LeadingVisual
 
+export type NavListLeadingVisualProps = ActionListLeadingVisualProps
+
 const LeadingVisual = ActionList.LeadingVisual
 
 LeadingVisual.displayName = 'NavList.LeadingVisual'
 
 // ----------------------------------------------------------------------------
 // NavList.TrailingVisual
+
+export type NavListTrailingVisualProps = ActionListTrailingVisualProps
 
 const TrailingVisual = ActionList.TrailingVisual
 
@@ -217,6 +226,8 @@ TrailingVisual.displayName = 'NavList.TrailingVisual'
 // ----------------------------------------------------------------------------
 // NavList.Divider
 
+export type NavListDividerProps = ActionListDividerProps
+
 const Divider = ActionList.Divider
 
 Divider.displayName = 'NavList.Divider'
@@ -224,7 +235,7 @@ Divider.displayName = 'NavList.Divider'
 // ----------------------------------------------------------------------------
 // NavList.Group
 
-type NavListGroupProps = {
+export type NavListGroupProps = {
   children: React.ReactNode
   title?: string
 } & SxProp

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,16 @@ export {default as LabelGroup} from './LabelGroup'
 export type {LabelGroupProps} from './LabelGroup'
 export {default as Link} from './Link'
 export type {LinkProps} from './Link'
+export {NavList} from './NavList'
+export type {
+  NavListProps,
+  NavListItemProps,
+  NavListSubNavProps,
+  NavListGroupProps,
+  NavListLeadingVisualProps,
+  NavListTrailingVisualProps,
+  NavListDividerProps
+} from './NavList'
 export {default as Overlay} from './Overlay'
 export type {OverlayProps} from './Overlay'
 export {default as Pagehead} from './Pagehead'

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export type {
   ActionListGroupProps,
   ActionListItemProps,
   ActionListLinkItemProps,
+  ActionListDividerProps,
   ActionListDescriptionProps,
   ActionListLeadingVisualProps,
   ActionListTrailingVisualProps


### PR DESCRIPTION
The NavList component is feature-complete and used in our documentation sites. It's time to export it from the main bundle so Primer React consumers can start using it:

```js
import {NavList} from '@primer/react'
```

Closes https://github.com/github/primer/issues/637
