### PR TITLE
NavList Docs: aria-current should be undefined instead of false

### DIFF
--- a/docs/content/NavList.mdx
+++ b/docs/content/NavList.mdx
@@ -184,7 +184,7 @@ function NavItem({to, children}) {
   const resolved = useResolvedPath(to)
   const isCurrent = useMatch({path: resolved.pathname, end: true})
   return (
-    <NavList.Item as={Link} to={to} aria-current={isCurrent ? 'page' : false}>
+    <NavList.Item as={Link} to={to} aria-current={isCurrent ? 'page' : undefined}>
       {children}
     </NavList.Item>
   )


### PR DESCRIPTION
We should not recommend setting `aria-current=false` in the docs.

This also breaks subNav logic because we only check for the first element with `aria-current` instead of `aria-current != false` (https://github.com/primer/react/blob/main/src/NavList/NavList.tsx#L115-L116)