### PR TITLE
Fix CI for Node 16.15.1

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -13,7 +13,7 @@ jobs:
     name: Preview
     uses: primer/.github/.github/workflows/deploy_preview.yml@main
     with:
-      node_version: 16
+      node_version: 14
       install: npm ci && cd docs && npm ci && cd ..
       build: npm run build:docs:preview
       output_dir: docs/public

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -38,7 +38,7 @@ jobs:
     if: ${{ needs.guard.outputs.should_deploy == 'true' }}
     uses: primer/.github/.github/workflows/deploy.yml@main
     with:
-      node_version: 16
+      node_version: 14
       install: npm ci && cd docs && npm ci && cd ..
       build: npm run build:docs
       output_dir: docs/public

--- a/package-lock.json
+++ b/package-lock.json
@@ -32074,12 +32074,6 @@
         "react-dom": ">= 16.3.0"
       }
     },
-    "node_modules/styled-components/node_modules/stylis": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
-      "dev": true
-    },
     "node_modules/styled-system": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.1.5.tgz",
@@ -32099,6 +32093,12 @@
         "@styled-system/variant": "^5.1.5",
         "object-assign": "^4.1.1"
       }
+    },
+    "node_modules/stylis": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
+      "dev": true
     },
     "node_modules/stylis-rule-sheet": {
       "version": "0.0.10",
@@ -59244,14 +59244,6 @@
         "stylis": "^3.5.0",
         "stylis-rule-sheet": "^0.0.10",
         "supports-color": "^5.5.0"
-      },
-      "dependencies": {
-        "stylis": {
-          "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-          "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
-          "dev": true
-        }
       }
     },
     "styled-system": {
@@ -59273,6 +59265,12 @@
         "@styled-system/variant": "^5.1.5",
         "object-assign": "^4.1.1"
       }
+    },
+    "stylis": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
+      "dev": true
     },
     "stylis-rule-sheet": {
       "version": "0.0.10",


### PR DESCRIPTION
Something changed between 16.15.0 (npm 8.5.5, [see CI action logs](https://github.com/primer/react/runs/6803999761?check_suite_focus=true)) and 16.15.1 (npm 8.11.0, [see CI action logs](https://github.com/primer/react/runs/6821886462?check_suite_focus=true))

- Upgraded local node to 16.15.1 (`nvm install --lts`)
- ran `npm install`
- committed changed `package-lock.json`

Doing the same didn't fix docs & preview deployment, so as a hot fix, changed the node version to Node 14 (npm 6.14.17), 

We can swap it out with Node 16 after fixing other issues.

---

@colebemis looks like doctocat expects `gatsby: 2.x` as [peer dependency](https://github.com/primer/doctocat/blob/main/theme/package.json#L26) 🤔 





<details>
<summary>install logs</summary>

```
● docs:node-16.15.1 $ npm install

npm WARN config init.license Use `--init-license` instead.
npm WARN config init.author.name Use `--init-author-name` instead.
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @primer/gatsby-theme-doctocat@4.0.0
npm ERR! Found: gatsby@3.7.2
npm ERR! node_modules/gatsby
npm ERR!   gatsby@"^3.7.2" from the root project
npm ERR!   peer gatsby@">2.0.0" from gatsby-plugin-alias-imports@1.0.5
npm ERR!   node_modules/gatsby-plugin-alias-imports
npm ERR!     gatsby-plugin-alias-imports@"^1.0.5" from the root project
npm ERR!   4 more (babel-plugin-remove-graphql-queries, ...)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer gatsby@"2.x" from @primer/gatsby-theme-doctocat@4.0.0
npm ERR! node_modules/@primer/gatsby-theme-doctocat
npm ERR!   @primer/gatsby-theme-doctocat@"^4.0.0" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: gatsby@2.32.13
npm ERR! node_modules/gatsby
npm ERR!   peer gatsby@"2.x" from @primer/gatsby-theme-doctocat@4.0.0
npm ERR!   node_modules/@primer/gatsby-theme-doctocat
npm ERR!     @primer/gatsby-theme-doctocat@"^4.0.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/sid/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/sid/.npm/_logs/2022-06-14T10_19_44_659Z-debug-0.log
```

</details>