### PR TITLE
Enforce correct semantics for TabNav

### DIFF
--- a/src/TabNav.tsx
+++ b/src/TabNav.tsx
@@ -10,25 +10,27 @@ import getGlobalFocusStyles from './_getGlobalFocusStyles'
 const ITEM_CLASS = 'TabNav-item'
 const SELECTED_CLASS = 'selected'
 
-const TabNavBase = styled.div<SxProp>`
-  margin-top: 0;
-  border-bottom: 1px solid ${get('colors.border.default')};
-  ${sx}
-`
-
-const TabNavBody = styled.nav`
+const TabNavTabList = styled.div<SxProp>`
   display: flex;
   margin-bottom: -1px;
   overflow: auto;
 `
 
-export type TabNavProps = ComponentProps<typeof TabNavBase>
+const TabNavBody = styled.nav`
+  margin-top: 0;
+  border-bottom: 1px solid ${get('colors.border.default')};
+  ${sx}
+`
+
+export type TabNavProps = ComponentProps<typeof TabNavTabList>
 
 function TabNav({children, 'aria-label': ariaLabel, ...rest}: TabNavProps) {
   return (
-    <TabNavBase {...rest}>
-      <TabNavBody aria-label={ariaLabel}>{children}</TabNavBody>
-    </TabNavBase>
+    <TabNavBody aria-label={ariaLabel}>
+      <TabNavTabList role="tablist" {...rest}>
+        {children}
+      </TabNavTabList>
+    </TabNavBody>
   )
 }
 
@@ -39,7 +41,8 @@ type StyledTabNavLinkProps = {
 
 const TabNavLink = styled.a.attrs<StyledTabNavLinkProps>(props => ({
   activeClassName: typeof props.to === 'string' ? 'selected' : '',
-  className: classnames(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className)
+  className: classnames(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
+  role: 'tab'
 }))<StyledTabNavLinkProps>`
   padding: 8px 12px;
   font-size: ${get('fontSizes.1')};

--- a/src/TabNav.tsx
+++ b/src/TabNav.tsx
@@ -10,27 +10,30 @@ import getGlobalFocusStyles from './_getGlobalFocusStyles'
 const ITEM_CLASS = 'TabNav-item'
 const SELECTED_CLASS = 'selected'
 
+const TabNavBase = styled.div<SxProp>`
+  ${sx}
+`
+
 const TabNavTabList = styled.div<SxProp>`
   display: flex;
   margin-bottom: -1px;
   overflow: auto;
 `
 
-const TabNavBody = styled.nav`
+const TabNavNav = styled.nav`
   margin-top: 0;
   border-bottom: 1px solid ${get('colors.border.default')};
-  ${sx}
 `
 
 export type TabNavProps = ComponentProps<typeof TabNavTabList>
 
 function TabNav({children, 'aria-label': ariaLabel, ...rest}: TabNavProps) {
   return (
-    <TabNavBody aria-label={ariaLabel}>
-      <TabNavTabList role="tablist" {...rest}>
-        {children}
-      </TabNavTabList>
-    </TabNavBody>
+    <TabNavBase {...rest}>
+      <TabNavNav aria-label={ariaLabel}>
+        <TabNavTabList role="tablist">{children}</TabNavTabList>
+      </TabNavNav>
+    </TabNavBase>
   )
 }
 

--- a/src/__tests__/__snapshots__/TabNav.test.tsx.snap
+++ b/src/__tests__/__snapshots__/TabNav.test.tsx.snap
@@ -46,15 +46,11 @@ exports[`TabNav TabNav.Link renders consistently 1`] = `
 
 <a
   className="c0 TabNav-item"
+  role="tab"
 />
 `;
 
 exports[`TabNav renders consistently 1`] = `
-.c0 {
-  margin-top: 0;
-  border-bottom: 1px solid #d0d7de;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -64,11 +60,21 @@ exports[`TabNav renders consistently 1`] = `
   overflow: auto;
 }
 
+.c0 {
+  margin-top: 0;
+  border-bottom: 1px solid #d0d7de;
+}
+
 <div
-  className="c0"
+  className=""
 >
   <nav
-    className="c1"
-  />
+    className="c0"
+  >
+    <div
+      className="c1"
+      role="tablist"
+    />
+  </nav>
 </div>
 `;


### PR DESCRIPTION
Enforces the containing `div` to have `role="tablist"` and the item elements to have `role="tab"` - tabs should avoid having focusable elements as children.

### Screenshots

Before:
![Before screenshot showing 3 tabs](https://user-images.githubusercontent.com/4696224/173810345-8093a084-577b-433e-b485-74f8341f51f4.png)

After:
![After screenshot showing 3 tabs that are styled the same](https://user-images.githubusercontent.com/4696224/173810914-fc68562f-c031-4f9a-a338-f3bfa65cb4e5.png)


### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

