### PR TITLE
Use useFocusZone hook in ActionList

### DIFF
--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -264,11 +264,12 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
             onClick={clickHandler}
             onKeyPress={keyPressHandler}
             aria-disabled={disabled ? true : undefined}
-            tabIndex={disabled || _PrivateItemWrapper ? undefined : 0}
+            tabIndex={-1} // Since we're using the useFocus hook for the whole ActionList, all non-iteractive ActionListItem need to have tabindex="-1" (See iterate-focusable-elements.ts in primer/behavior)
             aria-labelledby={`${labelId} ${slots.InlineDescription ? inlineDescriptionId : ''}`}
             aria-describedby={slots.BlockDescription ? blockDescriptionId : undefined}
+            aria-selected={selected} // option should never have checkboxes (so no aria-checked)
             role={role || itemRole}
-            {...(selectionAttribute && {[selectionAttribute]: selected})}
+            {...(selectionAttribute && {[selectionAttribute]: selected})} // Remove?
             {...props}
           >
             <ItemWrapper>

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import sx, {SxProp, merge} from '../sx'
 import {AriaRole} from '../utils/types'
 import {ActionListContainerContext} from './ActionListContainerContext'
+import {FocusKeys, useFocusZone} from '../hooks/useFocusZone'
 
 export type ActionListProps = {
   /**
@@ -47,25 +48,30 @@ export const List = React.forwardRef<HTMLUListElement, ActionListProps>(
       selectionVariant: containerSelectionVariant // TODO: Remove after DropdownMenu2 deprecation
     } = React.useContext(ActionListContainerContext)
 
+    const {containerRef} = useFocusZone({bindKeys: FocusKeys.ArrowVertical | FocusKeys.HomeAndEnd})
+
     return (
-      <ListBox
-        sx={merge(styles, sxProp as SxProp)}
-        role={role || listRole}
-        aria-labelledby={listLabelledBy}
-        {...props}
-        ref={forwardedRef}
-      >
-        <ListContext.Provider
-          value={{
-            variant,
-            selectionVariant: selectionVariant || containerSelectionVariant,
-            showDividers,
-            role: role || listRole
-          }}
+      <div ref={containerRef as React.RefObject<HTMLDivElement>}>
+        <ListBox
+          sx={merge(styles, sxProp as SxProp)}
+          role={role || listRole}
+          aria-labelledby={listLabelledBy}
+          aria-multiselectable={containerSelectionVariant === 'multiple'}
+          {...props}
+          ref={forwardedRef}
         >
-          {props.children}
-        </ListContext.Provider>
-      </ListBox>
+          <ListContext.Provider
+            value={{
+              variant,
+              selectionVariant: selectionVariant || containerSelectionVariant,
+              showDividers,
+              role: role || listRole
+            }}
+          >
+            {props.children}
+          </ListContext.Provider>
+        </ListBox>
+      </div>
     )
   }
 ) as PolymorphicForwardRefComponent<'ul', ActionListProps>


### PR DESCRIPTION
### What are you trying to accomplish?

Some accessibility issues in the [Primer React ActionList component](https://primer.style/react/ActionList) have been discovered during the [Primer React SelectPanel component](https://primer.style/react/SelectPanel) accessibility engineering review, and since the SelectPanel uses the component in the body.

This PR is to fix the focus and navigation issue in the [Primer React ActionList component](https://primer.style/react/ActionList).

- https://github.com/github/primer/issues/1045

### What approach did you choose and why?

Use [useFocusZone](https://primer.style/react/focusZone#usefocuszone-hook) hook in ActionList

### Screenshots

N/A

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
