### PR TITLE
Adapt deprecated ActionList (semantics & focus)

### DIFF
--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -5,7 +5,6 @@ import TextInput, {TextInputProps} from '../TextInput'
 import Box from '../Box'
 import {ActionList} from '../deprecated/ActionList'
 import Spinner from '../Spinner'
-import {useFocusZone} from '../hooks/useFocusZone'
 import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
 import styled from 'styled-components'
 import {get} from '../constants'
@@ -56,7 +55,6 @@ export function FilteredActionList({
   )
 
   const scrollContainerRef = useRef<HTMLDivElement>(null)
-  const listContainerRef = useRef<HTMLDivElement>(null)
   const inputRef = useProvidedRefOrCreate<HTMLInputElement>(providedInputRef)
   const activeDescendantRef = useRef<HTMLElement>()
   const listId = useSSRSafeId()
@@ -72,28 +70,6 @@ export function FilteredActionList({
       }
     },
     [activeDescendantRef]
-  )
-
-  useFocusZone(
-    {
-      containerRef: listContainerRef,
-      focusOutBehavior: 'wrap',
-      focusableElementFilter: element => {
-        return !(element instanceof HTMLInputElement)
-      },
-      activeDescendantFocus: inputRef,
-      onActiveDescendantChanged: (current, previous, directlyActivated) => {
-        activeDescendantRef.current = current
-
-        if (current && scrollContainerRef.current && directlyActivated) {
-          scrollIntoView(current, scrollContainerRef.current, menuScrollMargins)
-        }
-      }
-    },
-    [
-      // List ref isn't set while loading.  Need to re-bind focus zone when it changes
-      loading
-    ]
   )
 
   useEffect(() => {
@@ -128,7 +104,7 @@ export function FilteredActionList({
             <Spinner />
           </Box>
         ) : (
-          <ActionList ref={listContainerRef} items={items} {...listProps} role="listbox" id={listId} />
+          <ActionList items={items} {...listProps} role="listbox" id={listId} />
         )}
       </Box>
     </Box>

--- a/src/deprecated/ActionList/Item.tsx
+++ b/src/deprecated/ActionList/Item.tsx
@@ -97,7 +97,7 @@ export interface ItemProps extends SxProp {
   /**
    * Callback that will trigger both on click selection and keyboard selection.
    */
-  onAction?: (item: ItemProps, event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => void
+  onAction?: (item: ItemProps, event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void
 
   /**
    * An id associated with this item.  Should be unique between items
@@ -170,7 +170,7 @@ const MainContent = styled.div`
   flex-grow: 1;
 `
 
-const StyledItem = styled.div<
+const StyledItem = styled.li<
   {
     variant: ItemProps['variant']
     showDivider: ItemProps['showDivider']
@@ -476,6 +476,6 @@ export const Item = React.forwardRef((itemProps, ref) => {
       </DividedContent>
     </StyledItem>
   )
-}) as PolymorphicForwardRefComponent<'div', ItemProps>
+}) as PolymorphicForwardRefComponent<'li', ItemProps>
 
 Item.displayName = 'ActionList.Item'

--- a/src/deprecated/ActionList/List.tsx
+++ b/src/deprecated/ActionList/List.tsx
@@ -6,13 +6,14 @@ import {Divider} from './Divider'
 import styled from 'styled-components'
 import {get} from '../../constants'
 import {SystemCssProperties} from '@styled-system/css'
-import {hasActiveDescendantAttribute} from '@primer/behaviors'
+import {FocusKeys, hasActiveDescendantAttribute} from '@primer/behaviors'
 import {Merge} from '../../utils/types/Merge'
+import {useFocusZone} from '../../hooks/useFocusZone'
 
 type RenderItemFn = (props: ItemProps) => React.ReactElement
 
 export type ItemInput =
-  | Merge<React.ComponentPropsWithoutRef<'div'>, ItemProps>
+  | Merge<React.ComponentPropsWithoutRef<'li'>, ItemProps>
   | ((Partial<ItemProps> & {renderItem: RenderItemFn}) & {key?: Key})
 
 /**
@@ -100,7 +101,7 @@ function isGroupedListProps(props: ListProps): props is GroupedListProps {
  */
 export type ListProps = ListPropsBase | GroupedListProps
 
-const StyledList = styled.div`
+const ListBox = styled.ul`
   font-size: ${get('fontSizes.1')};
   /* 14px font-size * 1.428571429 = 20px line height
    *
@@ -108,6 +109,7 @@ const StyledList = styled.div`
    * hardcoded '20px'
    */
   line-height: 20px;
+  padding-inline-start: 0;
 
   &[${hasActiveDescendantAttribute}], &:focus-within {
     --item-hover-bg-override: none;
@@ -143,7 +145,7 @@ function useListVariant(variant: ListProps['variant'] = 'inset'): {
 /**
  * Lists `Item`s, either grouped or ungrouped, with a `Divider` between each `Group`.
  */
-export const List = React.forwardRef<HTMLDivElement, ListProps>((props, forwardedRef): JSX.Element => {
+export const List = React.forwardRef<HTMLUListElement, ListProps>((props, forwardedRef): JSX.Element => {
   // Get `sx` prop values for `List` children matching the given `List` style variation.
   const {firstGroupStyle, lastGroupStyle, headerStyle, itemStyle} = useListVariant(props.variant)
 
@@ -226,32 +228,36 @@ export const List = React.forwardRef<HTMLDivElement, ListProps>((props, forwarde
     groups = [...groupMap.values()]
   }
 
+  const {containerRef} = useFocusZone({bindKeys: FocusKeys.ArrowVertical | FocusKeys.HomeAndEnd})
+
   return (
-    <StyledList {...props} ref={forwardedRef}>
-      {groups.map(({header, ...groupProps}, index) => {
-        const hasFilledHeader = header?.variant === 'filled'
-        const shouldShowDivider = index > 0 && !hasFilledHeader
-        return (
-          <React.Fragment key={groupProps.groupId}>
-            {shouldShowDivider ? <Divider key={`${groupProps.groupId}-divider`} /> : null}
-            {renderGroup({
-              sx: {
-                ...(index === 0 && firstGroupStyle),
-                ...(index === groups.length - 1 && lastGroupStyle),
-                ...(index > 0 && !shouldShowDivider && {mt: 2})
-              },
-              ...(header && {
-                header: {
-                  ...header,
-                  sx: {...headerStyle, ...header.sx}
-                }
-              }),
-              ...groupProps
-            })}
-          </React.Fragment>
-        )
-      })}
-    </StyledList>
+    <div ref={containerRef as React.RefObject<HTMLDivElement>}>
+      <ListBox {...props} ref={forwardedRef}>
+        {groups.map(({header, ...groupProps}, index) => {
+          const hasFilledHeader = header?.variant === 'filled'
+          const shouldShowDivider = index > 0 && !hasFilledHeader
+          return (
+            <React.Fragment key={groupProps.groupId}>
+              {shouldShowDivider ? <Divider key={`${groupProps.groupId}-divider`} /> : null}
+              {renderGroup({
+                sx: {
+                  ...(index === 0 && firstGroupStyle),
+                  ...(index === groups.length - 1 && lastGroupStyle),
+                  ...(index > 0 && !shouldShowDivider && {mt: 2})
+                },
+                ...(header && {
+                  header: {
+                    ...header,
+                    sx: {...headerStyle, ...header.sx}
+                  }
+                }),
+                ...groupProps
+              })}
+            </React.Fragment>
+          )
+        })}
+      </ListBox>
+    </div>
   )
 })
 

--- a/src/deprecated/ActionMenu.tsx
+++ b/src/deprecated/ActionMenu.tsx
@@ -18,7 +18,7 @@ interface ActionMenuBaseProps extends Partial<Omit<GroupedListProps, keyof ListP
   /**
    * A callback that triggers both on clicks and keyboard events. This callback will be overridden by item level `onAction` callbacks.
    */
-  onAction?: (props: ItemProps, event?: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => void
+  onAction?: (props: ItemProps, event?: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void
 
   /**
    * If defined, will control the open/closed state of the overlay. Must be used in conjuction with `setOpen`.


### PR DESCRIPTION
### What are you trying to accomplish?

Some accessibility issues in the [deprecated Primer React ActionList component](https://primer.style/react/deprecated/ActionList/) have been discovered during the [Primer React SelectPanel component](https://primer.style/react/SelectPanel) accessibility engineering review, and since the SelectPanel uses the component in the body.

This PR is to fix the focus and semantics for the [deprecated Primer React ActionList component](https://primer.style/react/deprecated/ActionList/).

- https://github.com/github/primer/issues/1045

### What approach did you choose and why?

Use [useFocusZone](https://primer.style/react/focusZone#usefocuszone-hook) hook in [deprecated Primer React ActionList component](https://primer.style/react/deprecated/ActionList/)

### Screenshots

N/A

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
