### PR TITLE
Improves keyboard navigation for the SegmentedControl

### DIFF
--- a/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/SegmentedControl/SegmentedControl.test.tsx
@@ -1,26 +1,34 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import {render} from '@testing-library/react'
+import {fireEvent, render} from '@testing-library/react'
 import {EyeIcon, FileCodeIcon, PeopleIcon} from '@primer/octicons-react'
 import userEvent from '@testing-library/user-event'
 import {behavesAsComponent, checkExports, checkStoriesForAxeViolations} from '../utils/testing'
 import {SegmentedControl} from '.' // TODO: update import when we move this to the global index
 
 const segmentData = [
-  {label: 'Preview', iconLabel: 'EyeIcon', icon: () => <EyeIcon aria-label="EyeIcon" />},
-  {label: 'Raw', iconLabel: 'FileCodeIcon', icon: () => <FileCodeIcon aria-label="FileCodeIcon" />},
-  {label: 'Blame', iconLabel: 'PeopleIcon', icon: () => <PeopleIcon aria-label="PeopleIcon" />}
+  {label: 'Preview', id: 'preview', iconLabel: 'EyeIcon', icon: () => <EyeIcon aria-label="EyeIcon" />},
+  {label: 'Raw', id: 'raw', iconLabel: 'FileCodeIcon', icon: () => <FileCodeIcon aria-label="FileCodeIcon" />},
+  {label: 'Blame', id: 'blame', iconLabel: 'PeopleIcon', icon: () => <PeopleIcon aria-label="PeopleIcon" />}
 ]
 
 // TODO: improve test coverage
 describe('SegmentedControl', () => {
+  const mockWarningFn = jest.fn()
+
+  beforeAll(() => {
+    jest.spyOn(global.console, 'warn').mockImplementation(mockWarningFn)
+  })
+
   behavesAsComponent({
     Component: SegmentedControl,
     toRender: () => (
       <SegmentedControl aria-label="File view">
-        <SegmentedControl.Button selected>Preview</SegmentedControl.Button>
-        <SegmentedControl.Button>Raw</SegmentedControl.Button>
-        <SegmentedControl.Button>Blame</SegmentedControl.Button>
+        {segmentData.map(({label}, index) => (
+          <SegmentedControl.Button selected={index === 0} key={label}>
+            {label}
+          </SegmentedControl.Button>
+        ))}
       </SegmentedControl>
     )
   })
@@ -132,6 +140,85 @@ describe('SegmentedControl', () => {
       userEvent.click(buttonToClick)
     }
     expect(handleClick).toHaveBeenCalled()
+  })
+
+  it('focuses the selected button first', () => {
+    const {getByRole} = render(
+      <>
+        <button>Before</button>
+        <SegmentedControl aria-label="File view">
+          {segmentData.map(({label, id}, index) => (
+            <SegmentedControl.Button selected={index === 1} key={label} id={id}>
+              {label}
+            </SegmentedControl.Button>
+          ))}
+        </SegmentedControl>
+      </>
+    )
+    const initialFocusButtonNode = getByRole('button', {name: segmentData[1].label})
+
+    expect(document.activeElement?.id).not.toEqual(initialFocusButtonNode.id)
+
+    userEvent.tab()
+    userEvent.tab()
+
+    expect(document.activeElement?.id).toEqual(initialFocusButtonNode.id)
+  })
+
+  it('focuses the next button when keying ArrowRight', () => {
+    const {getByRole} = render(
+      <SegmentedControl aria-label="File view">
+        {segmentData.map(({label, id}, index) => (
+          <SegmentedControl.Button selected={index === 0} key={label} id={id}>
+            {label}
+          </SegmentedControl.Button>
+        ))}
+      </SegmentedControl>
+    )
+    const initialFocusButtonNode = getByRole('button', {name: segmentData[1].label})
+    const nextFocusButtonNode = getByRole('button', {name: segmentData[2].label})
+
+    expect(document.activeElement?.id).not.toEqual(nextFocusButtonNode.id)
+
+    fireEvent.focus(initialFocusButtonNode)
+    fireEvent.keyDown(initialFocusButtonNode, {key: 'ArrowRight'})
+
+    expect(document.activeElement?.id).toEqual(nextFocusButtonNode.id)
+  })
+
+  it('focuses the next button when keying ArrowLeft', () => {
+    const {getByRole} = render(
+      <SegmentedControl aria-label="File view">
+        {segmentData.map(({label, id}, index) => (
+          <SegmentedControl.Button selected={index === 0} key={label} id={id}>
+            {label}
+          </SegmentedControl.Button>
+        ))}
+      </SegmentedControl>
+    )
+    const initialFocusButtonNode = getByRole('button', {name: segmentData[1].label})
+    const nextFocusButtonNode = getByRole('button', {name: segmentData[0].label})
+
+    expect(document.activeElement?.id).not.toEqual(nextFocusButtonNode.id)
+
+    fireEvent.focus(initialFocusButtonNode)
+    fireEvent.keyDown(initialFocusButtonNode, {key: 'ArrowLeft'})
+
+    expect(document.activeElement?.id).toEqual(nextFocusButtonNode.id)
+  })
+
+  it('should warn the user if they neglect to specify a label for the segmented control', () => {
+    render(
+      <SegmentedControl>
+        {segmentData.map(({label, id}) => (
+          <SegmentedControl.Button id={id} key={label}>
+            {label}
+          </SegmentedControl.Button>
+        ))}
+      </SegmentedControl>
+    )
+
+    expect(mockWarningFn).toHaveBeenCalled()
   })
 })
 

--- a/src/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -86,6 +86,10 @@ exports[`SegmentedControl renders consistently 1`] = `
   width: 1px;
 }
 
+.c1:focus:focus-visible:not(:last-child):after {
+  width: 0;
+}
+
 .c1 .segmentedControl-text:after {
   content: "Preview";
   display: block;
@@ -180,6 +184,10 @@ exports[`SegmentedControl renders consistently 1`] = `
   width: 1px;
 }
 
+.c2:focus:focus-visible:not(:last-child):after {
+  width: 0;
+}
+
 .c2 .segmentedControl-text:after {
   content: "Raw";
   display: block;
@@ -272,6 +280,10 @@ exports[`SegmentedControl renders consistently 1`] = `
   top: 8px;
   bottom: 8px;
   width: 1px;
+}
+
+.c3:focus:focus-visible:not(:last-child):after {
+  width: 0;
 }
 
 .c3 .segmentedControl-text:after {

--- a/src/SegmentedControl/examples.stories.tsx
+++ b/src/SegmentedControl/examples.stories.tsx
@@ -50,7 +50,7 @@ export const Default = (args: Args) => (
 )
 
 export const Controlled = (args: Args) => {
-  const [selectedIndex, setSelectedIndex] = useState(1)
+  const [selectedIndex, setSelectedIndex] = useState(0)
   const handleChange = (i: number) => {
     setSelectedIndex(i)
   }

--- a/src/SegmentedControl/getSegmentedControlStyles.ts
+++ b/src/SegmentedControl/getSegmentedControlStyles.ts
@@ -75,6 +75,11 @@ const getSegmentedControlButtonStyles = (props?: SegmentedControlButtonProps & {
     }
   },
 
+  // fixes an issue where the focus outline shows over the pseudo-element
+  ':focus:focus-visible:not(:last-child):after': {
+    width: 0
+  },
+
   '.segmentedControl-text': {
     ':after': {
       content: `"${props?.children}"`,


### PR DESCRIPTION
Implements keyboard navigation behavior described in the a11y design review ([comment](https://github.com/github/primer/issues/762#issuecomment-1145538220)).

### Screenshots

https://user-images.githubusercontent.com/2313998/175668068-a14a8be8-0fcf-4b3b-9962-163b8deb29d2.mp4

### Merge checklist

- [x] Added/updated tests
- [n/a] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
