### PR TITLE
Fix new select panel issues

### DIFF
--- a/docs/content/SelectPanel.mdx
+++ b/docs/content/SelectPanel.mdx
@@ -44,11 +44,7 @@ function DemoComponent() {
 
   return (
     <SelectPanel
-      renderAnchor={({children, 'aria-labelledby': ariaLabelledBy, ...anchorProps}) => (
-        <Button trailingIcon={TriangleDownIcon} aria-labelledby={` ${ariaLabelledBy}`} {...anchorProps}>
-          {children || 'Select Labels'}
-        </Button>
-      )}
+      renderAnchor={({...anchorProps}) => <DropdownButton {...anchorProps}>Select Labels</DropdownButton>}
       title="Select Items"
       inputLabel="Select Items"
       open={open}

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -167,13 +167,18 @@ export function SelectPanel({
     onClose('selection')
   }, [finalItemsSelected, onSelectedChange, onClose, selected])
 
-  const onCancelClickHandler = React.useCallback(
+  const onCloseOverlay = React.useCallback(
     (gesture?: 'anchor-click' | 'click-outside' | 'escape') => {
       setFinalItemsSelected(selectedItems)
       onClose(gesture ?? 'escape')
     },
     [onClose, selectedItems]
   )
+
+  const onCloseClickHandler = React.useCallback(() => {
+    setFinalItemsSelected(selectedItems)
+    onClose('escape')
+  }, [onClose, selectedItems])
 
   const inputRef = React.useRef<HTMLInputElement>(null)
   const titleId = useSSRSafeId()
@@ -207,7 +212,7 @@ export function SelectPanel({
       anchorRef={anchorRef}
       open={open}
       onOpen={onOpen}
-      onClose={onCancelClickHandler}
+      onClose={onCloseOverlay}
       overlayProps={{...overlayProps, onKeyPress: overlayKeyPressHandler, role: 'dialog', 'aria-labelledby': titleId}}
       focusTrapSettings={focusTrapSettings}
       focusZoneSettings={focusZoneSettings}
@@ -222,8 +227,10 @@ export function SelectPanel({
             : `${items.length} matching ${items.length === 1 ? 'item' : 'items'}`}
         </SrOnly>
         <Box display="flex" alignItems="center" justifyContent="space-between" pl={3} pr={2} pt={2}>
-          <Heading as="h1" id={titleId} sx={{fontSize: 1}}>{title}</Heading>
-          <IconButton icon={XIcon} aria-label="Close" variant="invisible" onClick={onCancelClickHandler} />
+          <Heading as="h1" id={titleId} sx={{fontSize: 1}}>
+            {title}
+          </Heading>
+          <IconButton icon={XIcon} aria-label="Close" variant="invisible" onClick={onCloseClickHandler} />
         </Box>
         <FilteredActionList
           filterValue={filterValue}
@@ -248,7 +255,7 @@ export function SelectPanel({
           borderTopWidth={1}
           borderTopStyle="solid"
         >
-          <Button onClick={onCancelClickHandler}>Cancel</Button>
+          <Button onClick={onCloseClickHandler}>Cancel</Button>
           <Button variant="primary" onClick={onSaveClickHandler}>
             Save
           </Button>

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -100,6 +100,7 @@ export function SelectPanel({
   )
 
   const [finalItemsSelected, setFinalItemsSelected] = useState(selectedItems)
+  React.useEffect(() => setFinalItemsSelected(selectedItems), [selectedItems])
 
   const anchorRef = useProvidedRefOrCreate(externalAnchorRef)
   const onOpen: AnchoredOverlayProps['onOpen'] = useCallback(gesture => onOpenChange(true, gesture), [onOpenChange])


### PR DESCRIPTION
@bolonio @hectahertz While integrating with our app, I found a couple of issues that should be addressed.

1. The internal selected state does not synchronize the selected props that are passed in. So, if the selected state changes asynchronously after the `SelectPanel` has already started rendering, then the selected state does not appear as expected. Adding an effect to ensure that the internal selection state stays synchronized if the external selections change makes this work as expected.
2. The click handlers being passed to the close/cancel buttons were passing events as the first argument instead of a gesture string as expected. Creating two separate handlers, one for the `AnchoredOverlay`, and one for the close/cancel buttons ensures that we always pass the gesture string correctly.