### PR TITLE
Use import for `focus-visible` instead of require

### DIFF
--- a/.changeset/rude-buckets-fold.md
+++ b/.changeset/rude-buckets-fold.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Converted commonjs `require` of `focus-visible` to an esm `import`

--- a/@types/focus-visible/index.d.ts
+++ b/@types/focus-visible/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'focus-visible'

--- a/src/BaseStyles.tsx
+++ b/src/BaseStyles.tsx
@@ -4,6 +4,9 @@ import {COMMON, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from './co
 import {useTheme} from './ThemeProvider'
 import {ComponentProps} from './utils/types'
 
+// load polyfill for :focus-visible
+import 'focus-visible'
+
 const GlobalStyle = createGlobalStyle<{colorScheme?: 'light' | 'dark'}>`
   * { box-sizing: border-box; }
   body { margin: 0; }
@@ -35,9 +38,6 @@ export type BaseStylesProps = ComponentProps<typeof Base>
 function BaseStyles(props: BaseStylesProps) {
   const {children, ...rest} = props
   const {colorScheme} = useTheme()
-
-  // load polyfill for :focus-visible
-  require('focus-visible')
 
   return (
     <Base {...rest} data-portal-root>


### PR DESCRIPTION
In #1157, we added a new import for `focus-visible` but did so using `require`.  Unfortunately this does not translate well to ESM with our current build setup, so it will break in environments that aren't able to handle commonjs.

To fix this, I've switched the `require` to an `import` and moved it to the top of the file.  This means we will apply this polyfill in _all cases_, even if BaseStyles isn't used.  Are we ok with that?

Closes #1207 

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
