### PR TITLE
Use useFocusZone hook in ActionList

### DIFF
--- a/.changeset/perfect-llamas-refuse.md
+++ b/.changeset/perfect-llamas-refuse.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Add useFocusZone hook to the [Primer React SelectPanel component](https://primer.style/react/SelectPanel).

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -255,6 +255,16 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
 
     const ItemWrapper = _PrivateItemWrapper || React.Fragment
 
+    // 'aria-selected' is not allowed when using role === 'menuitemcheckbox' || role === 'menuitemradio'
+    // 'aria-selected' is not allowed at the same time as 'aria-checked'
+    let ariaSelectionAttribute = 'aria-selected'
+    if (selectionAttribute) {
+      ariaSelectionAttribute = selectionAttribute
+    }
+    if (props.hasOwnProperty('aria-checked') || role === 'menuitemcheckbox' || role === 'menuitemradio') {
+      ariaSelectionAttribute = 'aria-checked'
+    }
+
     return (
       <Slots context={{variant, disabled, inlineDescriptionId, blockDescriptionId}}>
         {slots => (
@@ -264,11 +274,11 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
             onClick={clickHandler}
             onKeyPress={keyPressHandler}
             aria-disabled={disabled ? true : undefined}
-            tabIndex={disabled || _PrivateItemWrapper ? undefined : 0}
+            tabIndex={-1} // Since we're using the useFocus hook for the whole ActionList, all non-iteractive ActionListItem need to have tabindex="-1" (See iterate-focusable-elements.ts in primer/behavior)
             aria-labelledby={`${labelId} ${slots.InlineDescription ? inlineDescriptionId : ''}`}
             aria-describedby={slots.BlockDescription ? blockDescriptionId : undefined}
             role={role || itemRole}
-            {...(selectionAttribute && {[selectionAttribute]: selected})}
+            {...{[ariaSelectionAttribute]: selected}}
             {...props}
           >
             <ItemWrapper>

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -48,10 +48,7 @@ export const List = React.forwardRef<HTMLUListElement, ActionListProps>(
       selectionVariant: containerSelectionVariant // TODO: Remove after DropdownMenu2 deprecation
     } = React.useContext(ActionListContainerContext)
 
-    const {containerRef} = useFocusZone({
-      focusOutBehavior: 'wrap',
-      bindKeys: FocusKeys.ArrowVertical | FocusKeys.HomeAndEnd | FocusKeys.PageUpDown
-    })
+    const {containerRef} = useFocusZone({bindKeys: FocusKeys.ArrowVertical | FocusKeys.HomeAndEnd})
 
     return (
       <div ref={containerRef as React.RefObject<HTMLDivElement>}>

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
 import {ForwardRefComponent as PolymorphicForwardRefComponent} from '@radix-ui/react-polymorphic'
+import React from 'react'
 import styled from 'styled-components'
-import sx, {SxProp, merge} from '../sx'
+import {FocusKeys, useFocusZone} from '../hooks/useFocusZone'
+import sx, {merge, SxProp} from '../sx'
 import {AriaRole} from '../utils/types'
 import {ActionListContainerContext} from './ActionListContainerContext'
 
@@ -47,25 +48,32 @@ export const List = React.forwardRef<HTMLUListElement, ActionListProps>(
       selectionVariant: containerSelectionVariant // TODO: Remove after DropdownMenu2 deprecation
     } = React.useContext(ActionListContainerContext)
 
+    const {containerRef} = useFocusZone({
+      focusOutBehavior: 'wrap',
+      bindKeys: FocusKeys.ArrowVertical | FocusKeys.HomeAndEnd | FocusKeys.PageUpDown
+    })
+
     return (
-      <ListBox
-        sx={merge(styles, sxProp as SxProp)}
-        role={role || listRole}
-        aria-labelledby={listLabelledBy}
-        {...props}
-        ref={forwardedRef}
-      >
-        <ListContext.Provider
-          value={{
-            variant,
-            selectionVariant: selectionVariant || containerSelectionVariant,
-            showDividers,
-            role: role || listRole
-          }}
+      <div ref={containerRef as React.RefObject<HTMLDivElement>}>
+        <ListBox
+          sx={merge(styles, sxProp as SxProp)}
+          role={role || listRole}
+          aria-labelledby={listLabelledBy}
+          {...props}
+          ref={forwardedRef}
         >
-          {props.children}
-        </ListContext.Provider>
-      </ListBox>
+          <ListContext.Provider
+            value={{
+              variant,
+              selectionVariant: selectionVariant || containerSelectionVariant,
+              showDividers,
+              role: role || listRole
+            }}
+          >
+            {props.children}
+          </ListContext.Provider>
+        </ListBox>
+      </div>
     )
   }
 ) as PolymorphicForwardRefComponent<'ul', ActionListProps>

--- a/src/NavList/__snapshots__/NavList.test.tsx.snap
+++ b/src/NavList/__snapshots__/NavList.test.tsx.snap
@@ -297,74 +297,82 @@ exports[`NavList renders a simple list 1`] = `
   <nav
     class=""
   >
-    <ul
-      class="c0"
-    >
-      <li
-        aria-labelledby="react-aria-1 "
-        class="c1 c2"
+    <div>
+      <ul
+        class="c0"
       >
-        <a
-          aria-current="page"
-          class="c3"
-          href="/"
+        <li
+          aria-labelledby="react-aria-1 "
+          class="c1 c2"
+          tabindex="0"
         >
-          <div
-            class="c4"
-            data-component="ActionList.Item--DividerContainer"
+          <a
+            aria-current="page"
+            class="c3"
+            href="/"
+            tabindex="-1"
           >
-            <span
-              class="c5"
-              id="react-aria-1"
+            <div
+              class="c4"
+              data-component="ActionList.Item--DividerContainer"
             >
-              Home
-            </span>
-          </div>
-        </a>
-      </li>
-      <li
-        aria-labelledby="react-aria-4 "
-        class="c1 c6"
-      >
-        <a
-          class="c3"
-          href="/about"
+              <span
+                class="c5"
+                id="react-aria-1"
+              >
+                Home
+              </span>
+            </div>
+          </a>
+        </li>
+        <li
+          aria-labelledby="react-aria-4 "
+          class="c1 c6"
+          tabindex="-1"
         >
-          <div
-            class="c4"
-            data-component="ActionList.Item--DividerContainer"
+          <a
+            class="c3"
+            href="/about"
+            tabindex="-1"
           >
-            <span
-              class="c5"
-              id="react-aria-4"
+            <div
+              class="c4"
+              data-component="ActionList.Item--DividerContainer"
             >
-              About
-            </span>
-          </div>
-        </a>
-      </li>
-      <li
-        aria-labelledby="react-aria-7 "
-        class="c1 c6"
-      >
-        <a
-          class="c3"
-          href="/contact"
+              <span
+                class="c5"
+                id="react-aria-4"
+              >
+                About
+              </span>
+            </div>
+          </a>
+        </li>
+        <li
+          aria-labelledby="react-aria-7 "
+          class="c1 c6"
+          tabindex="-1"
         >
-          <div
-            class="c4"
-            data-component="ActionList.Item--DividerContainer"
+          <a
+            class="c3"
+            href="/contact"
+            tabindex="-1"
           >
-            <span
-              class="c5"
-              id="react-aria-7"
+            <div
+              class="c4"
+              data-component="ActionList.Item--DividerContainer"
             >
-              Contact
-            </span>
-          </div>
-        </a>
-      </li>
-    </ul>
+              <span
+                class="c5"
+                id="react-aria-7"
+              >
+                Contact
+              </span>
+            </div>
+          </a>
+        </li>
+      </ul>
+    </div>
   </nav>
 </div>
 `;
@@ -700,103 +708,109 @@ exports[`NavList renders with groups 1`] = `
   <nav
     class=""
   >
-    <ul
-      class="c0"
-    >
-      <li
-        aria-hidden="true"
-        class="c1"
-        data-component="ActionList.Divider"
-      />
-      <li
-        class="c2"
+    <div>
+      <ul
+        class="c0"
       >
-        <div
+        <li
           aria-hidden="true"
-          class="c3"
-          role="presentation"
+          class="c1"
+          data-component="ActionList.Divider"
+        />
+        <li
+          class="c2"
         >
-          <span
-            id="react-aria-1"
+          <div
+            aria-hidden="true"
+            class="c3"
+            role="presentation"
           >
-            Overview
-          </span>
-        </div>
-        <ul
-          aria-labelledby="react-aria-1"
-          class="c4"
-        >
-          <li
-            aria-labelledby="react-aria-2 "
-            class="c5 c6"
-          >
-            <a
-              aria-current="page"
-              class="c7"
-              href="/getting-started"
+            <span
+              id="react-aria-1"
             >
-              <div
-                class="c8"
-                data-component="ActionList.Item--DividerContainer"
+              Overview
+            </span>
+          </div>
+          <ul
+            aria-labelledby="react-aria-1"
+            class="c4"
+          >
+            <li
+              aria-labelledby="react-aria-2 "
+              class="c5 c6"
+              tabindex="0"
+            >
+              <a
+                aria-current="page"
+                class="c7"
+                href="/getting-started"
+                tabindex="-1"
               >
-                <span
-                  class="c9"
-                  id="react-aria-2"
+                <div
+                  class="c8"
+                  data-component="ActionList.Item--DividerContainer"
                 >
-                  Getting started
-                </span>
-              </div>
-            </a>
-          </li>
-        </ul>
-      </li>
-      <li
-        aria-hidden="true"
-        class="c1"
-        data-component="ActionList.Divider"
-      />
-      <li
-        class="c2"
-      >
-        <div
+                  <span
+                    class="c9"
+                    id="react-aria-2"
+                  >
+                    Getting started
+                  </span>
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li
           aria-hidden="true"
-          class="c3"
-          role="presentation"
+          class="c1"
+          data-component="ActionList.Divider"
+        />
+        <li
+          class="c2"
         >
-          <span
-            id="react-aria-5"
+          <div
+            aria-hidden="true"
+            class="c3"
+            role="presentation"
           >
-            Components
-          </span>
-        </div>
-        <ul
-          aria-labelledby="react-aria-5"
-          class="c4"
-        >
-          <li
-            aria-labelledby="react-aria-6 "
-            class="c5 c10"
-          >
-            <a
-              class="c7"
-              href="/Avatar"
+            <span
+              id="react-aria-5"
             >
-              <div
-                class="c8"
-                data-component="ActionList.Item--DividerContainer"
+              Components
+            </span>
+          </div>
+          <ul
+            aria-labelledby="react-aria-5"
+            class="c4"
+          >
+            <li
+              aria-labelledby="react-aria-6 "
+              class="c5 c10"
+              tabindex="-1"
+            >
+              <a
+                class="c7"
+                href="/Avatar"
+                tabindex="-1"
               >
-                <span
-                  class="c9"
-                  id="react-aria-6"
+                <div
+                  class="c8"
+                  data-component="ActionList.Item--DividerContainer"
                 >
-                  Avatar
-                </span>
-              </div>
-            </a>
-          </li>
-        </ul>
-      </li>
-    </ul>
+                  <span
+                    class="c9"
+                    id="react-aria-6"
+                  >
+                    Avatar
+                  </span>
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
   </nav>
 </div>
 `;
@@ -1186,87 +1200,90 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
   <nav
     class=""
   >
-    <ul
-      class="c0"
-    >
-      <li
-        aria-labelledby="react-aria-1"
-        class="c1"
+    <div>
+      <ul
+        class="c0"
       >
-        <button
-          aria-controls="react-aria-2"
-          aria-expanded="true"
-          aria-labelledby="react-aria-1 "
-          class="c2 c3"
-          tabindex="0"
+        <li
+          aria-labelledby="react-aria-1"
+          class="c1"
         >
-          <div
-            class="c4"
-            data-component="ActionList.Item--DividerContainer"
+          <button
+            aria-controls="react-aria-2"
+            aria-expanded="true"
+            aria-labelledby="react-aria-1 "
+            class="c2 c3"
+            tabindex="0"
           >
             <div
-              class="c5"
+              class="c4"
+              data-component="ActionList.Item--DividerContainer"
             >
-              <span
-                class="c6"
-                id="react-aria-1"
+              <div
+                class="c5"
               >
-                Item
-              </span>
-              <span
-                class="c7"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c8"
-                  fill="currentColor"
-                  height="16"
-                  role="img"
-                  style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
-                  viewBox="0 0 16 16"
-                  width="16"
+                <span
+                  class="c6"
+                  id="react-aria-1"
                 >
-                  <path
-                    d="M12.78 6.22a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.28a.75.75 0 011.06-1.06L8 9.94l3.72-3.72a.75.75 0 011.06 0z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-            </div>
-          </div>
-        </button>
-        <div>
-          <ul
-            aria-labelledby="react-aria-1"
-            class="c9"
-            id="react-aria-2"
-          >
-            <li
-              aria-labelledby="react-aria-3 "
-              class="c2 c10"
-            >
-              <a
-                aria-current="page"
-                class="c11"
-                href="#"
-              >
-                <div
-                  class="c4"
-                  data-component="ActionList.Item--DividerContainer"
+                  Item
+                </span>
+                <span
+                  class="c7"
                 >
-                  <span
-                    class="c6"
-                    id="react-aria-3"
+                  <svg
+                    aria-hidden="true"
+                    class="c8"
+                    fill="currentColor"
+                    height="16"
+                    role="img"
+                    style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+                    viewBox="0 0 16 16"
+                    width="16"
                   >
-                    Sub Item
-                  </span>
-                </div>
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-    </ul>
+                    <path
+                      d="M12.78 6.22a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.28a.75.75 0 011.06-1.06L8 9.94l3.72-3.72a.75.75 0 011.06 0z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+          </button>
+          <div>
+            <ul
+              aria-labelledby="react-aria-1"
+              class="c9"
+              id="react-aria-2"
+            >
+              <li
+                aria-labelledby="react-aria-3 "
+                class="c2 c10"
+                tabindex="-1"
+              >
+                <a
+                  aria-current="page"
+                  class="c11"
+                  href="#"
+                >
+                  <div
+                    class="c4"
+                    data-component="ActionList.Item--DividerContainer"
+                  >
+                    <span
+                      class="c6"
+                      id="react-aria-3"
+                    >
+                      Sub Item
+                    </span>
+                  </div>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </div>
   </nav>
 </div>
 `;
@@ -1668,87 +1685,90 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
   <nav
     class=""
   >
-    <ul
-      class="c0"
-    >
-      <li
-        aria-labelledby="react-aria-1"
-        class="c1"
+    <div>
+      <ul
+        class="c0"
       >
-        <button
-          aria-controls="react-aria-2"
-          aria-expanded="false"
-          aria-labelledby="react-aria-1 "
-          class="c2 c3"
-          tabindex="0"
+        <li
+          aria-labelledby="react-aria-1"
+          class="c1"
         >
-          <div
-            class="c4"
-            data-component="ActionList.Item--DividerContainer"
+          <button
+            aria-controls="react-aria-2"
+            aria-expanded="false"
+            aria-labelledby="react-aria-1 "
+            class="c2 c3"
+            tabindex="0"
           >
             <div
-              class="c5"
+              class="c4"
+              data-component="ActionList.Item--DividerContainer"
             >
-              <span
-                class="c6"
-                id="react-aria-1"
+              <div
+                class="c5"
               >
-                Item
-              </span>
-              <span
-                class="c7"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c8"
-                  fill="currentColor"
-                  height="16"
-                  role="img"
-                  style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
-                  viewBox="0 0 16 16"
-                  width="16"
+                <span
+                  class="c6"
+                  id="react-aria-1"
                 >
-                  <path
-                    d="M12.78 6.22a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.28a.75.75 0 011.06-1.06L8 9.94l3.72-3.72a.75.75 0 011.06 0z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-            </div>
-          </div>
-        </button>
-        <div>
-          <ul
-            aria-labelledby="react-aria-1"
-            class="c9"
-            id="react-aria-2"
-          >
-            <li
-              aria-labelledby="react-aria-3 "
-              class="c2 c10"
-            >
-              <a
-                aria-current="page"
-                class="c11"
-                href="#"
-              >
-                <div
-                  class="c4"
-                  data-component="ActionList.Item--DividerContainer"
+                  Item
+                </span>
+                <span
+                  class="c7"
                 >
-                  <span
-                    class="c6"
-                    id="react-aria-3"
+                  <svg
+                    aria-hidden="true"
+                    class="c8"
+                    fill="currentColor"
+                    height="16"
+                    role="img"
+                    style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+                    viewBox="0 0 16 16"
+                    width="16"
                   >
-                    Sub Item
-                  </span>
-                </div>
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-    </ul>
+                    <path
+                      d="M12.78 6.22a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.28a.75.75 0 011.06-1.06L8 9.94l3.72-3.72a.75.75 0 011.06 0z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+          </button>
+          <div>
+            <ul
+              aria-labelledby="react-aria-1"
+              class="c9"
+              id="react-aria-2"
+            >
+              <li
+                aria-labelledby="react-aria-3 "
+                class="c2 c10"
+                tabindex="-1"
+              >
+                <a
+                  aria-current="page"
+                  class="c11"
+                  href="#"
+                >
+                  <div
+                    class="c4"
+                    data-component="ActionList.Item--DividerContainer"
+                  >
+                    <span
+                      class="c6"
+                      id="react-aria-3"
+                    >
+                      Sub Item
+                    </span>
+                  </div>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </div>
   </nav>
 </div>
 `;

--- a/src/__tests__/__snapshots__/ActionList.test.tsx.snap
+++ b/src/__tests__/__snapshots__/ActionList.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`ActionList renders consistently 1`] = `
   padding-bottom: 8px;
 }
 
-<ul
-  className="c0"
-/>
+<div>
+  <ul
+    className="c0"
+  />
+</div>
 `;


### PR DESCRIPTION
### What are you trying to accomplish?

Some accessibility issues in the [Primer React ActionList component](https://primer.style/react/ActionList) have been discovered during the [Primer React SelectPanel component](https://primer.style/react/SelectPanel) accessibility engineering review, and since the SelectPanel uses the component in the body.

This PR is to fix the focus and navigation issue in the [Primer React ActionList component](https://primer.style/react/ActionList).

- https://github.com/github/primer/issues/1045

### What approach did you choose and why?

Use [useFocusZone](https://primer.style/react/focusZone#usefocuszone-hook) hook in ActionList

```
const {containerRef} = useFocusZone({bindKeys: FocusKeys.ArrowVertical | FocusKeys.HomeAndEnd})
```

Now the ActionList is one single tab stop and the user will navigate the elements using `up/down arrows` or `home/end keys`

### Screenshots

N/A

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
