### PR TITLE
Selected tab doesn't need to be <a> tag

### DIFF
--- a/.changeset/thick-pets-shop.md
+++ b/.changeset/thick-pets-shop.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fixes issue when tabs are not links

--- a/src/TabNav.tsx
+++ b/src/TabNav.tsx
@@ -32,7 +32,9 @@ function TabNav({children, 'aria-label': ariaLabel, ...rest}: TabNavProps) {
   const customContainerRef = useRef<HTMLElement>(null)
   const customStrategy = React.useCallback(() => {
     if (customContainerRef.current) {
-      const tabs = Array.from(customContainerRef.current.querySelectorAll<HTMLElement>('a[aria-selected=true]'))
+      const tabs = Array.from(
+        customContainerRef.current.querySelectorAll<HTMLElement>('[role=tab][aria-selected=true]')
+      )
       return tabs[0]
     }
   }, [customContainerRef])
@@ -60,7 +62,8 @@ const TabNavLink = styled.a.attrs<StyledTabNavLinkProps>(props => ({
   activeClassName: typeof props.to === 'string' ? 'selected' : '',
   className: classnames(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
   role: 'tab',
-  'aria-selected': !!props.selected
+  'aria-selected': !!props.selected,
+  tabIndex: -1
 }))<StyledTabNavLinkProps>`
   padding: 8px 12px;
   font-size: ${get('fontSizes.1')};

--- a/src/__tests__/TabNav.test.tsx
+++ b/src/__tests__/TabNav.test.tsx
@@ -13,7 +13,7 @@ describe('TabNav', () => {
   const tabNavMarkup = (
     <Box>
       <TabNav>
-        <TabNav.Link id="first" href="#">
+        <TabNav.Link id="first" href="#" as="div">
           First
         </TabNav.Link>
         <TabNav.Link id="middle" href="#" selected>

--- a/src/__tests__/__snapshots__/TabNav.test.tsx.snap
+++ b/src/__tests__/__snapshots__/TabNav.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`TabNav TabNav.Link renders consistently 1`] = `
   aria-selected={false}
   className="c0 TabNav-item"
   role="tab"
+  tabIndex={-1}
 />
 `;
 


### PR DESCRIPTION
After testing memex against the new TabNav it became clear that my TypeScript was skipping the case where the tab is changed from the default `<a>` to a `<div>` - this change should fix that issue.

I also noticed that `wrap` seems to be broken on the memex side but I cannot replicate that here so I'm going to use the build from the PR to do some more digging.  EDIT: Confirmed that `wrap` appears to work correctly once the issue was resolved.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
