### PR TITLE
Keep anchoredoverlay tabindex

### DIFF
--- a/.changeset/anchored-overlay-clever-mails-roll.md
+++ b/.changeset/anchored-overlay-clever-mails-roll.md
@@ -1,8 +1,5 @@
 ---
-"@primer/react": patch
+'@primer/react': patch
 ---
 
-AnchoredOverlay accessibility fixes
-- `aria-expanded` attribute is removed from anchor when overlay is not open
-- `tabIndex=0` is removed from anchor because it should only be used with interactive elements
-
+AnchoredOverlay: `aria-expanded` attribute is removed from anchor when overlay is not open

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -166,6 +166,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
           id: anchorId,
           'aria-haspopup': 'true',
           'aria-expanded': open ? 'true' : undefined,
+          tabIndex: 0,
           onClick: onAnchorClick,
           onKeyDown: onAnchorKeyDown
         })}


### PR DESCRIPTION
This was removed in https://github.com/primer/react/pull/2099/commits/e7f2d03df8d40364270c1af750b86f0941238dbe to fix https://github.com/github/primer/issues/989 but this causes tests a test in memex to fail: [table-focus-test.tsx#L365-L380](https://github.com/github/memex/blob/main/src/tests/components/react-table/table-focus-test.tsx#L365-L380)

The use case is a bit complicated and would probably need a change in memex as well. To unblock https://github.com/primer/react/pull/2131, I'm taking this commit out and reopening https://github.com/github/primer/issues/989