### PR TITLE
Support ReactNode in ActionMenu.Overlay

### DIFF
--- a/.changeset/shiny-hairs-wait.md
+++ b/.changeset/shiny-hairs-wait.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Support React.ReactNode as child type in ActionMenu.Overlay

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -342,7 +342,7 @@ render(
 ### ActionMenu.Overlay
 
 <PropsTable>
-  <PropsTableRow name="children" required type="React.ReactElement | React.ReactElement[]" />
+  <PropsTableRow name="children" required type="React.ReactNode" />
   <PropsTableRow name="align" type="start | center | end" defaultValue="start" />
   <PropsTablePassthroughPropsRow
     elementName="Overlay"

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -100,7 +100,7 @@ type MenuOverlayProps = Partial<OverlayProps> &
     /**
      * Recommended: `ActionList`
      */
-     children: React.ReactNode
+    children: React.ReactNode
   }
 const Overlay: React.FC<MenuOverlayProps> = ({children, align = 'start', ...overlayProps}) => {
   // we typecast anchorRef as required instead of optional

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -100,7 +100,7 @@ type MenuOverlayProps = Partial<OverlayProps> &
     /**
      * Recommended: `ActionList`
      */
-    children: React.ReactElement[] | React.ReactElement
+     children: React.ReactNode
   }
 const Overlay: React.FC<MenuOverlayProps> = ({children, align = 'start', ...overlayProps}) => {
   // we typecast anchorRef as required instead of optional


### PR DESCRIPTION
Describe your changes here.

Add support for ReactNode as the child type in ActionMenu.Overlay so that conditional children can be rendered within an overlay.
Closes #2067 

### Screenshots

No visual changes

### Merge checklist

- [ ] Added/updated tests - current testing doesn't seem granular enough to warrant testing every possible prop type, I can add a test if it seems necessary though.
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
