### PR TITLE
Extend theme provider props to accept children

### DIFF
--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -18,6 +18,7 @@ export type ThemeProviderProps = {
   dayScheme?: string
   nightScheme?: string
   preventSSRMismatch?: boolean
+  children?: React.ReactNode
 }
 
 const ThemeContext = React.createContext<{


### PR DESCRIPTION
Added a functionality to extend the ThemeProviderProps type to accept children (React.ReactNode).

Closes #2194 

### Screenshots

![image](https://user-images.githubusercontent.com/43625217/181256056-7afffc8b-1130-42e2-8432-9486d4a2ff93.png)

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
