### PR TITLE
Codemod for react 18 children types

### DIFF
--- a/.changeset/cyan-frogs-pump.md
+++ b/.changeset/cyan-frogs-pump.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+update types to allow children for react 18

--- a/src/ActionList/Description.tsx
+++ b/src/ActionList/Description.tsx
@@ -14,7 +14,11 @@ export type ActionListDescriptionProps = {
   variant?: 'inline' | 'block'
 } & SxProp
 
-export const Description: React.FC<React.PropsWithChildren<ActionListDescriptionProps>> = ({variant = 'inline', sx = {}, ...props}) => {
+export const Description: React.FC<React.PropsWithChildren<ActionListDescriptionProps>> = ({
+  variant = 'inline',
+  sx = {},
+  ...props
+}) => {
   const styles = {
     fontSize: 0,
     lineHeight: '16px',

--- a/src/ActionList/Description.tsx
+++ b/src/ActionList/Description.tsx
@@ -14,7 +14,7 @@ export type ActionListDescriptionProps = {
   variant?: 'inline' | 'block'
 } & SxProp
 
-export const Description: React.FC<ActionListDescriptionProps> = ({variant = 'inline', sx = {}, ...props}) => {
+export const Description: React.FC<React.PropsWithChildren<ActionListDescriptionProps>> = ({variant = 'inline', sx = {}, ...props}) => {
   const styles = {
     fontSize: 0,
     lineHeight: '16px',

--- a/src/ActionList/Divider.tsx
+++ b/src/ActionList/Divider.tsx
@@ -9,7 +9,7 @@ export type ActionListDividerProps = SxProp
 /**
  * Visually separates `Item`s or `Group`s in an `ActionList`.
  */
-export const Divider: React.FC<ActionListDividerProps> = ({sx = {}}) => {
+export const Divider: React.FC<React.PropsWithChildren<ActionListDividerProps>> = ({sx = {}}) => {
   return (
     <Box
       as="li"

--- a/src/ActionList/Group.tsx
+++ b/src/ActionList/Group.tsx
@@ -35,7 +35,7 @@ export type ActionListGroupProps = {
 type ContextProps = Pick<ActionListGroupProps, 'selectionVariant'>
 export const GroupContext = React.createContext<ContextProps>({})
 
-export const Group: React.FC<ActionListGroupProps> = ({
+export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
   title,
   variant = 'subtle',
   auxiliaryText,
@@ -82,7 +82,7 @@ export type HeaderProps = Pick<ActionListGroupProps, 'variant' | 'title' | 'auxi
  *
  * For visual presentation only. It's hidden from screen readers.
  */
-const Header: React.FC<HeaderProps> = ({variant, title, auxiliaryText, labelId, ...props}) => {
+const Header: React.FC<React.PropsWithChildren<HeaderProps>> = ({variant, title, auxiliaryText, labelId, ...props}) => {
   const {variant: listVariant} = React.useContext(ListContext)
 
   const styles = {

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -81,7 +81,7 @@ export type ActionListItemProps = {
   /**
    * Private API for use internally only. Used by LinkItem to wrap contents in an anchor
    */
-  _PrivateItemWrapper?: React.FC
+  _PrivateItemWrapper?: React.FC<React.PropsWithChildren<unknown>>
 } & SxProp
 
 const {Slots, Slot} = createSlots(['LeadingVisual', 'InlineDescription', 'BlockDescription', 'TrailingVisual'])
@@ -302,7 +302,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
 
 Item.displayName = 'ActionList.Item'
 
-const ConditionalBox: React.FC<{if: boolean} & BoxProps> = props => {
+const ConditionalBox: React.FC<React.PropsWithChildren<{if: boolean} & BoxProps>> = props => {
   const {if: condition, ...rest} = props
 
   if (condition) return <Box {...rest}>{props.children}</Box>

--- a/src/ActionList/Selection.tsx
+++ b/src/ActionList/Selection.tsx
@@ -6,7 +6,7 @@ import {ActionListItemProps} from './Item'
 import {LeadingVisualContainer} from './Visuals'
 
 type SelectionProps = Pick<ActionListItemProps, 'selected'>
-export const Selection: React.FC<SelectionProps> = ({selected}) => {
+export const Selection: React.FC<React.PropsWithChildren<SelectionProps>> = ({selected}) => {
   const {selectionVariant: listSelectionVariant} = React.useContext(ListContext)
   const {selectionVariant: groupSelectionVariant} = React.useContext(GroupContext)
 

--- a/src/ActionList/Visuals.tsx
+++ b/src/ActionList/Visuals.tsx
@@ -6,7 +6,7 @@ import {getVariantStyles, Slot, ItemContext, TEXT_ROW_HEIGHT} from './Item'
 
 type VisualProps = SxProp & React.HTMLAttributes<HTMLSpanElement>
 
-export const LeadingVisualContainer: React.FC<VisualProps> = ({sx = {}, ...props}) => {
+export const LeadingVisualContainer: React.FC<React.PropsWithChildren<VisualProps>> = ({sx = {}, ...props}) => {
   return (
     <Box
       as="span"
@@ -29,7 +29,7 @@ export const LeadingVisualContainer: React.FC<VisualProps> = ({sx = {}, ...props
 }
 
 export type ActionListLeadingVisualProps = VisualProps
-export const LeadingVisual: React.FC<VisualProps> = ({sx = {}, ...props}) => {
+export const LeadingVisual: React.FC<React.PropsWithChildren<VisualProps>> = ({sx = {}, ...props}) => {
   return (
     <Slot name="LeadingVisual">
       {({variant, disabled}: ItemContext) => (
@@ -51,7 +51,7 @@ export const LeadingVisual: React.FC<VisualProps> = ({sx = {}, ...props}) => {
 }
 
 export type ActionListTrailingVisualProps = VisualProps
-export const TrailingVisual: React.FC<VisualProps> = ({sx = {}, ...props}) => {
+export const TrailingVisual: React.FC<React.PropsWithChildren<VisualProps>> = ({sx = {}, ...props}) => {
   return (
     <Slot name="TrailingVisual">
       {({variant, disabled}: ItemContext) => (

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -33,7 +33,7 @@ export type ActionMenuProps = {
   onOpenChange?: (s: boolean) => void
 } & Pick<AnchoredOverlayProps, 'anchorRef'>
 
-const Menu: React.FC<ActionMenuProps> = ({
+const Menu: React.FC<React.PropsWithChildren<ActionMenuProps>> = ({
   anchorRef: externalAnchorRef,
   open,
   onOpenChange,
@@ -102,7 +102,7 @@ type MenuOverlayProps = Partial<OverlayProps> &
      */
     children: React.ReactElement[] | React.ReactElement
   }
-const Overlay: React.FC<MenuOverlayProps> = ({children, align = 'start', ...overlayProps}) => {
+const Overlay: React.FC<React.PropsWithChildren<MenuOverlayProps>> = ({children, align = 'start', ...overlayProps}) => {
   // we typecast anchorRef as required instead of optional
   // because we know that we're setting it in context in Menu
   const {anchorRef, renderAnchor, anchorId, open, onOpen, onClose} = React.useContext(MenuContext) as MandateProps<

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -86,7 +86,7 @@ export type AnchoredOverlayProps = AnchoredOverlayBaseProps &
  * An `AnchoredOverlay` provides an anchor that will open a floating overlay positioned relative to the anchor.
  * The overlay can be opened and navigated using keyboard or mouse.
  */
-export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
+export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayProps>> = ({
   renderAnchor,
   anchorRef: externalAnchorRef,
   anchorId: externalAnchorId,

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -45,7 +45,7 @@ const reducer = (state: State, action: Action) => {
   }
 }
 
-const Autocomplete: React.FC<{id?: string}> = ({children, id: idProp}) => {
+const Autocomplete: React.FC<React.PropsWithChildren<{id?: string}>> = ({children, id: idProp}) => {
   const activeDescendantRef = useRef<HTMLElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)

--- a/src/Autocomplete/AutocompleteInput.tsx
+++ b/src/Autocomplete/AutocompleteInput.tsx
@@ -16,7 +16,7 @@ import {ComponentProps} from '../utils/types'
 
 type InternalAutocompleteInputProps = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  as?: React.ComponentType<any>
+  as?: React.ComponentType<React.PropsWithChildren<any>>
 }
 
 const AutocompleteInput = React.forwardRef(

--- a/src/Button/types.ts
+++ b/src/Button/types.ts
@@ -41,16 +41,16 @@ export type ButtonProps = {
   /**
    * The leading icon comes before button content
    */
-  leadingIcon?: React.FunctionComponent<IconProps>
+  leadingIcon?: React.FunctionComponent<React.PropsWithChildren<IconProps>>
   /**
    * The trailing icon comes after button content
    */
-  trailingIcon?: React.FunctionComponent<IconProps>
+  trailingIcon?: React.FunctionComponent<React.PropsWithChildren<IconProps>>
   children: React.ReactNode
 } & ButtonBaseProps
 
 export type IconButtonProps = ButtonA11yProps & {
-  icon: React.FunctionComponent<IconProps>
+  icon: React.FunctionComponent<React.PropsWithChildren<IconProps>>
 } & ButtonBaseProps
 
 // adopted from React.AnchorHTMLAttributes

--- a/src/CheckboxGroup.tsx
+++ b/src/CheckboxGroup.tsx
@@ -20,7 +20,7 @@ export const CheckboxGroupContext = createContext<{
   onChange?: ChangeEventHandler<HTMLInputElement>
 }>({})
 
-const CheckboxGroup: FC<CheckboxGroupProps> = ({children, disabled, onChange, ...rest}) => {
+const CheckboxGroup: FC<React.PropsWithChildren<CheckboxGroupProps>> = ({children, disabled, onChange, ...rest}) => {
   const formControlComponentChildren = React.Children.toArray(children)
     .filter(child => React.isValidElement(child) && child.type === FormControl)
     .map(formControlComponent =>

--- a/src/CircleOcticon.tsx
+++ b/src/CircleOcticon.tsx
@@ -5,7 +5,7 @@ import Box, {BoxProps} from './Box'
 export type CircleOcticonProps = {
   as?: React.ElementType
   size?: number
-  icon: React.ComponentType<{size?: IconProps['size']}>
+  icon: React.ComponentType<React.PropsWithChildren<{size?: IconProps['size']}>>
 } & BoxProps
 
 function CircleOcticon(props: CircleOcticonProps) {

--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -52,7 +52,7 @@ const StyledTitle = styled(Box).attrs({as: 'h1'})`
   flex-grow: 1;
   margin: 0; /* override default margin */
 `
-const ConfirmationHeader: React.FC<DialogHeaderProps> = ({title, onClose, dialogLabelId}) => {
+const ConfirmationHeader: React.FC<React.PropsWithChildren<DialogHeaderProps>> = ({title, onClose, dialogLabelId}) => {
   const onCloseClick = useCallback(() => {
     onClose('close-button')
   }, [onClose])
@@ -69,7 +69,7 @@ const StyledConfirmationBody = styled(Box)`
   color: ${get('colors.fg.muted')};
   flex-grow: 1;
 `
-const ConfirmationBody: React.FC<DialogProps> = ({children}) => {
+const ConfirmationBody: React.FC<React.PropsWithChildren<DialogProps>> = ({children}) => {
   return <StyledConfirmationBody>{children}</StyledConfirmationBody>
 }
 const StyledConfirmationFooter = styled(Box)`
@@ -81,7 +81,7 @@ const StyledConfirmationFooter = styled(Box)`
   justify-content: end;
   padding: ${get('space.1')} ${get('space.3')} ${get('space.3')};
 `
-const ConfirmationFooter: React.FC<DialogProps> = ({footerButtons}) => {
+const ConfirmationFooter: React.FC<React.PropsWithChildren<DialogProps>> = ({footerButtons}) => {
   const {containerRef: footerRef} = useFocusZone({
     bindKeys: FocusKeys.ArrowHorizontal | FocusKeys.Tab,
     focusInStrategy: 'closest'
@@ -100,7 +100,7 @@ const ConfirmationFooter: React.FC<DialogProps> = ({footerButtons}) => {
  * two buttons: one to cancel the action and one to confirm it. No custom
  * rendering capabilities are provided for ConfirmationDialog.
  */
-export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = props => {
+export const ConfirmationDialog: React.FC<React.PropsWithChildren<ConfirmationDialogProps>> = props => {
   const {
     onClose,
     title,

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -213,7 +213,13 @@ const StyledDialog = styled.div<StyledDialogProps>`
   ${sx};
 `
 
-const DefaultHeader: React.FC<React.PropsWithChildren<DialogHeaderProps>> = ({dialogLabelId, title, subtitle, dialogDescriptionId, onClose}) => {
+const DefaultHeader: React.FC<React.PropsWithChildren<DialogHeaderProps>> = ({
+  dialogLabelId,
+  title,
+  subtitle,
+  dialogDescriptionId,
+  onClose
+}) => {
   const onCloseClick = useCallback(() => {
     onClose('close-button')
   }, [onClose])

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -67,7 +67,7 @@ export interface DialogProps {
    *
    * Warning: using a custom renderer may violate Primer UX principles.
    */
-  renderHeader?: React.FunctionComponent<DialogHeaderProps>
+  renderHeader?: React.FunctionComponent<React.PropsWithChildren<DialogHeaderProps>>
 
   /**
    * Provide a custom render function for the dialog body. This content is
@@ -76,7 +76,7 @@ export interface DialogProps {
    *
    * Warning: using a custom renderer may violate Primer UX principles.
    */
-  renderBody?: React.FunctionComponent<DialogProps>
+  renderBody?: React.FunctionComponent<React.PropsWithChildren<DialogProps>>
 
   /**
    * Provide a custom render function for the dialog footer. This content is
@@ -85,7 +85,7 @@ export interface DialogProps {
    *
    * Warning: using a custom renderer may violate Primer UX principles.
    */
-  renderFooter?: React.FunctionComponent<DialogProps>
+  renderFooter?: React.FunctionComponent<React.PropsWithChildren<DialogProps>>
 
   /**
    * Specifies the buttons to be rendered in the Dialog footer.
@@ -213,7 +213,7 @@ const StyledDialog = styled.div<StyledDialogProps>`
   ${sx};
 `
 
-const DefaultHeader: React.FC<DialogHeaderProps> = ({dialogLabelId, title, subtitle, dialogDescriptionId, onClose}) => {
+const DefaultHeader: React.FC<React.PropsWithChildren<DialogHeaderProps>> = ({dialogLabelId, title, subtitle, dialogDescriptionId, onClose}) => {
   const onCloseClick = useCallback(() => {
     onClose('close-button')
   }, [onClose])
@@ -229,10 +229,10 @@ const DefaultHeader: React.FC<DialogHeaderProps> = ({dialogLabelId, title, subti
     </Dialog.Header>
   )
 }
-const DefaultBody: React.FC<DialogProps> = ({children}) => {
+const DefaultBody: React.FC<React.PropsWithChildren<DialogProps>> = ({children}) => {
   return <Dialog.Body>{children}</Dialog.Body>
 }
-const DefaultFooter: React.FC<DialogProps> = ({footerButtons}) => {
+const DefaultFooter: React.FC<React.PropsWithChildren<DialogProps>> = ({footerButtons}) => {
   const {containerRef: footerRef} = useFocusZone({
     bindKeys: FocusKeys.ArrowHorizontal | FocusKeys.Tab,
     focusInStrategy: 'closest'
@@ -362,7 +362,7 @@ const buttonTypes = {
   primary: ButtonPrimary,
   danger: ButtonDanger
 }
-const Buttons: React.FC<{buttons: DialogButtonProps[]}> = ({buttons}) => {
+const Buttons: React.FC<React.PropsWithChildren<{buttons: DialogButtonProps[]}>> = ({buttons}) => {
   const autoFocusRef = useProvidedRefOrCreate<HTMLButtonElement>(buttons.find(button => button.autoFocus)?.ref)
   let autoFocusCount = 0
   const [hasRendered, setHasRendered] = useState(0)
@@ -405,7 +405,7 @@ const DialogCloseButton = styled(Button)`
   line-height: normal;
   box-shadow: none;
 `
-const CloseButton: React.FC<{onClose: () => void}> = ({onClose}) => {
+const CloseButton: React.FC<React.PropsWithChildren<{onClose: () => void}>> = ({onClose}) => {
   return (
     <DialogCloseButton aria-label="Close" onClick={onClose}>
       <StyledOcticon icon={XIcon} />

--- a/src/FilteredActionList/FilteredActionList.stories.tsx
+++ b/src/FilteredActionList/FilteredActionList.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta = {
   title: 'Composite components/FilteredActionList',
   component: FilteredActionList,
   decorators: [
-    (Story: React.ComponentType): JSX.Element => (
+    (Story: React.ComponentType<React.PropsWithChildren<unknown>>): JSX.Element => (
       <ThemeProvider>
         <BaseStyles>
           <Story />

--- a/src/FormControl/_FormControlCaption.tsx
+++ b/src/FormControl/_FormControlCaption.tsx
@@ -4,7 +4,7 @@ import InputCaption from '../_InputCaption'
 import {FormControlContext} from './FormControl'
 import {Slot} from './slots'
 
-const FormControlCaption: React.FC<{id?: string} & SxProp> = ({children, sx, id}) => (
+const FormControlCaption: React.FC<React.PropsWithChildren<{id?: string} & SxProp>> = ({children, sx, id}) => (
   <Slot name="Caption">
     {({captionId, disabled}: FormControlContext) => (
       <InputCaption id={id || captionId} disabled={disabled} sx={sx}>

--- a/src/FormControl/_FormControlLabel.tsx
+++ b/src/FormControl/_FormControlLabel.tsx
@@ -11,7 +11,7 @@ export type Props = {
   visuallyHidden?: boolean
 } & SxProp
 
-const FormControlLabel: React.FC<{htmlFor?: string; id?: string} & Props> = ({
+const FormControlLabel: React.FC<React.PropsWithChildren<{htmlFor?: string; id?: string} & Props>> = ({
   children,
   htmlFor,
   id,

--- a/src/FormControl/_FormControlLeadingVisual.tsx
+++ b/src/FormControl/_FormControlLeadingVisual.tsx
@@ -5,7 +5,7 @@ import {SxProp} from '../sx'
 import {FormControlContext} from './FormControl'
 import {Slot} from './slots'
 
-const FormControlLeadingVisual: React.FC<SxProp> = ({children, sx}) => (
+const FormControlLeadingVisual: React.FC<React.PropsWithChildren<SxProp>> = ({children, sx}) => (
   <Slot name="LeadingVisual">
     {({disabled, captionId}: FormControlContext) => (
       <Box

--- a/src/FormControl/_FormControlValidation.tsx
+++ b/src/FormControl/_FormControlValidation.tsx
@@ -10,7 +10,12 @@ export type FormControlValidationProps = {
   id?: string
 } & SxProp
 
-const FormControlValidation: React.FC<React.PropsWithChildren<FormControlValidationProps>> = ({children, variant, sx, id}) => (
+const FormControlValidation: React.FC<React.PropsWithChildren<FormControlValidationProps>> = ({
+  children,
+  variant,
+  sx,
+  id
+}) => (
   <Slot name="Validation">
     {({validationMessageId}: FormControlContext) => (
       <InputValidation validationStatus={variant} id={id || validationMessageId} sx={sx}>

--- a/src/FormControl/_FormControlValidation.tsx
+++ b/src/FormControl/_FormControlValidation.tsx
@@ -10,7 +10,7 @@ export type FormControlValidationProps = {
   id?: string
 } & SxProp
 
-const FormControlValidation: React.FC<FormControlValidationProps> = ({children, variant, sx, id}) => (
+const FormControlValidation: React.FC<React.PropsWithChildren<FormControlValidationProps>> = ({children, variant, sx, id}) => (
   <Slot name="Validation">
     {({validationMessageId}: FormControlContext) => (
       <InputValidation validationStatus={variant} id={id || validationMessageId} sx={sx}>

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -47,7 +47,7 @@ const containerWidths = {
 }
 
 // TODO: refs
-const Root: React.FC<PageLayoutProps> = ({
+const Root: React.FC<React.PropsWithChildren<PageLayoutProps>> = ({
   containerWidth = 'xlarge',
   padding = 'normal',
   rowGap = 'normal',
@@ -111,7 +111,7 @@ function negateSpacingValue(value: number | null | Array<number | null>) {
   return value === null ? null : -value
 }
 
-const HorizontalDivider: React.FC<DividerProps> = ({variant = 'none', variantWhenNarrow = 'inherit', sx = {}}) => {
+const HorizontalDivider: React.FC<React.PropsWithChildren<DividerProps>> = ({variant = 'none', variantWhenNarrow = 'inherit', sx = {}}) => {
   const {padding} = React.useContext(PageLayoutContext)
   return (
     <Box
@@ -153,7 +153,7 @@ const verticalDividerVariants = {
   }
 }
 
-const VerticalDivider: React.FC<DividerProps> = ({variant = 'none', variantWhenNarrow = 'inherit', sx = {}}) => {
+const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps>> = ({variant = 'none', variantWhenNarrow = 'inherit', sx = {}}) => {
   return (
     <Box
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -182,7 +182,7 @@ export type PageLayoutHeaderProps = {
   hidden?: boolean | ResponsiveValue<boolean>
 } & SxProp
 
-const Header: React.FC<PageLayoutHeaderProps> = ({
+const Header: React.FC<React.PropsWithChildren<PageLayoutHeaderProps>> = ({
   divider = 'none',
   dividerWhenNarrow = 'inherit',
   hidden = false,
@@ -232,7 +232,7 @@ const contentWidths = {
   xlarge: '1280px'
 }
 
-const Content: React.FC<PageLayoutContentProps> = ({width = 'full', hidden = false, children, sx = {}}) => {
+const Content: React.FC<React.PropsWithChildren<PageLayoutContentProps>> = ({width = 'full', hidden = false, children, sx = {}}) => {
   const isHidden = useResponsiveValue(hidden, false)
   return (
     <Box
@@ -282,7 +282,7 @@ const paneWidths = {
   large: ['100%', null, '256px', '320px', '336px']
 }
 
-const Pane: React.FC<PageLayoutPaneProps> = ({
+const Pane: React.FC<React.PropsWithChildren<PageLayoutPaneProps>> = ({
   position = 'end',
   positionWhenNarrow = 'inherit',
   width = 'medium',
@@ -349,7 +349,7 @@ export type PageLayoutFooterProps = {
   hidden?: boolean | ResponsiveValue<boolean>
 } & SxProp
 
-const Footer: React.FC<PageLayoutFooterProps> = ({
+const Footer: React.FC<React.PropsWithChildren<PageLayoutFooterProps>> = ({
   divider = 'none',
   dividerWhenNarrow = 'inherit',
   hidden = false,

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -111,7 +111,11 @@ function negateSpacingValue(value: number | null | Array<number | null>) {
   return value === null ? null : -value
 }
 
-const HorizontalDivider: React.FC<React.PropsWithChildren<DividerProps>> = ({variant = 'none', variantWhenNarrow = 'inherit', sx = {}}) => {
+const HorizontalDivider: React.FC<React.PropsWithChildren<DividerProps>> = ({
+  variant = 'none',
+  variantWhenNarrow = 'inherit',
+  sx = {}
+}) => {
   const {padding} = React.useContext(PageLayoutContext)
   return (
     <Box
@@ -153,7 +157,11 @@ const verticalDividerVariants = {
   }
 }
 
-const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps>> = ({variant = 'none', variantWhenNarrow = 'inherit', sx = {}}) => {
+const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps>> = ({
+  variant = 'none',
+  variantWhenNarrow = 'inherit',
+  sx = {}
+}) => {
   return (
     <Box
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -232,7 +240,12 @@ const contentWidths = {
   xlarge: '1280px'
 }
 
-const Content: React.FC<React.PropsWithChildren<PageLayoutContentProps>> = ({width = 'full', hidden = false, children, sx = {}}) => {
+const Content: React.FC<React.PropsWithChildren<PageLayoutContentProps>> = ({
+  width = 'full',
+  hidden = false,
+  children,
+  sx = {}
+}) => {
   const isHidden = useResponsiveValue(hidden, false)
   return (
     <Box

--- a/src/Placeholder.tsx
+++ b/src/Placeholder.tsx
@@ -2,11 +2,11 @@ import {Box} from '.'
 import React from 'react'
 
 /** Private component used to render placeholders in storybook and documentation examples  */
-export const Placeholder: React.FC<{
+export const Placeholder: React.FC<React.PropsWithChildren<{
   width?: number | string
   height: number | string
   label?: string
-}> = ({width, height, label}) => {
+}>> = ({width, height, label}) => {
   return (
     <Box
       sx={{

--- a/src/Placeholder.tsx
+++ b/src/Placeholder.tsx
@@ -2,11 +2,13 @@ import {Box} from '.'
 import React from 'react'
 
 /** Private component used to render placeholders in storybook and documentation examples  */
-export const Placeholder: React.FC<React.PropsWithChildren<{
-  width?: number | string
-  height: number | string
-  label?: string
-}>> = ({width, height, label}) => {
+export const Placeholder: React.FC<
+  React.PropsWithChildren<{
+    width?: number | string
+    height: number | string
+    label?: string
+  }>
+> = ({width, height, label}) => {
   return (
     <Box
       sx={{

--- a/src/Portal/Portal.tsx
+++ b/src/Portal/Portal.tsx
@@ -60,7 +60,11 @@ export interface PortalProps {
  * Creates a React Portal, placing all children in a separate physical DOM root node.
  * @see https://reactjs.org/docs/portals.html
  */
-export const Portal: React.FC<React.PropsWithChildren<PortalProps>> = ({children, onMount, containerName: _containerName}) => {
+export const Portal: React.FC<React.PropsWithChildren<PortalProps>> = ({
+  children,
+  onMount,
+  containerName: _containerName
+}) => {
   const hostElement = document.createElement('div')
 
   // Portaled content should get their own stacking context so they don't interfere

--- a/src/Portal/Portal.tsx
+++ b/src/Portal/Portal.tsx
@@ -60,7 +60,7 @@ export interface PortalProps {
  * Creates a React Portal, placing all children in a separate physical DOM root node.
  * @see https://reactjs.org/docs/portals.html
  */
-export const Portal: React.FC<PortalProps> = ({children, onMount, containerName: _containerName}) => {
+export const Portal: React.FC<React.PropsWithChildren<PortalProps>> = ({children, onMount, containerName: _containerName}) => {
   const hostElement = document.createElement('div')
 
   // Portaled content should get their own stacking context so they don't interfere

--- a/src/RadioGroup.tsx
+++ b/src/RadioGroup.tsx
@@ -24,7 +24,7 @@ export const RadioGroupContext = createContext<{
   name: string
 } | null>(null)
 
-const RadioGroup: FC<RadioGroupProps> = ({children, disabled, onChange, name, ...rest}) => {
+const RadioGroup: FC<React.PropsWithChildren<RadioGroupProps>> = ({children, disabled, onChange, name, ...rest}) => {
   const [selectedRadioValue, setSelectedRadioValue] = useRenderForcingRef<string | null>(null)
 
   const updateSelectedCheckboxes: ChangeEventHandler<HTMLInputElement> = e => {

--- a/src/SegmentedControl/SegmentedControl.tsx
+++ b/src/SegmentedControl/SegmentedControl.tsx
@@ -31,7 +31,7 @@ const getSegmentedControlStyles = (props?: SegmentedControlProps) => ({
   height: '32px' // TODO: use primitive `control.medium.size` when it is available
 })
 
-const Root: React.FC<SegmentedControlProps> = ({
+const Root: React.FC<React.PropsWithChildren<SegmentedControlProps>> = ({
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledby,
   children,

--- a/src/SegmentedControl/SegmentedControlButton.tsx
+++ b/src/SegmentedControl/SegmentedControlButton.tsx
@@ -11,7 +11,7 @@ export type SegmentedControlButtonProps = {
   /** Whether the segment is selected */
   selected?: boolean
   /** The leading icon comes before item label */
-  leadingIcon?: React.FunctionComponent<IconProps>
+  leadingIcon?: React.FunctionComponent<React.PropsWithChildren<IconProps>>
 } & SxProp &
   HTMLAttributes<HTMLButtonElement | HTMLLIElement>
 
@@ -19,7 +19,7 @@ const SegmentedControlButtonStyled = styled.button`
   ${sx};
 `
 
-const SegmentedControlButton: React.FC<SegmentedControlButtonProps> = ({
+const SegmentedControlButton: React.FC<React.PropsWithChildren<SegmentedControlButtonProps>> = ({
   children,
   leadingIcon: LeadingIcon,
   selected,

--- a/src/SegmentedControl/SegmentedControlIconButton.tsx
+++ b/src/SegmentedControl/SegmentedControlIconButton.tsx
@@ -12,7 +12,7 @@ import Tooltip from '../Tooltip'
 export type SegmentedControlIconButtonProps = {
   'aria-label': string
   /** The icon that represents the segmented control item */
-  icon: React.FunctionComponent<IconProps>
+  icon: React.FunctionComponent<React.PropsWithChildren<IconProps>>
   /** Whether the segment is selected */
   selected?: boolean
 } & SxProp &
@@ -28,7 +28,7 @@ const SegmentedControlIconButtonStyled = styled.button`
 //
 // See Slack thread: https://github.slack.com/archives/C02NUUQ9C30/p1656444474509599
 //
-export const SegmentedControlIconButton: React.FC<SegmentedControlIconButtonProps> = ({
+export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<SegmentedControlIconButtonProps>> = ({
   'aria-label': ariaLabel,
   icon: Icon,
   selected,

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -101,9 +101,13 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   )
 )
 
-const Option: React.FC<React.PropsWithChildren<React.HTMLProps<HTMLOptionElement> & {value: string}>> = props => <option {...props} />
+const Option: React.FC<React.PropsWithChildren<React.HTMLProps<HTMLOptionElement> & {value: string}>> = props => (
+  <option {...props} />
+)
 
-const OptGroup: React.FC<React.PropsWithChildren<React.HTMLProps<HTMLOptGroupElement>>> = props => <optgroup {...props} />
+const OptGroup: React.FC<React.PropsWithChildren<React.HTMLProps<HTMLOptGroupElement>>> = props => (
+  <optgroup {...props} />
+)
 
 export default Object.assign(Select, {
   Option,

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -49,7 +49,7 @@ const StyledSelect = styled.select`
   }
 `
 
-const ArrowIndicatorSVG: React.FC<{className?: string}> = ({className}) => (
+const ArrowIndicatorSVG: React.FC<React.PropsWithChildren<{className?: string}>> = ({className}) => (
   <svg width="16" height="16" fill="currentColor" xmlns="http://www.w3.org/2000/svg" className={className}>
     <path d="m4.074 9.427 3.396 3.396a.25.25 0 0 0 .354 0l3.396-3.396A.25.25 0 0 0 11.043 9H4.251a.25.25 0 0 0-.177.427ZM4.074 7.47 7.47 4.073a.25.25 0 0 1 .354 0L11.22 7.47a.25.25 0 0 1-.177.426H4.251a.25.25 0 0 1-.177-.426Z" />
   </svg>
@@ -101,9 +101,9 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   )
 )
 
-const Option: React.FC<React.HTMLProps<HTMLOptionElement> & {value: string}> = props => <option {...props} />
+const Option: React.FC<React.PropsWithChildren<React.HTMLProps<HTMLOptionElement> & {value: string}>> = props => <option {...props} />
 
-const OptGroup: React.FC<React.HTMLProps<HTMLOptGroupElement>> = props => <optgroup {...props} />
+const OptGroup: React.FC<React.PropsWithChildren<React.HTMLProps<HTMLOptGroupElement>>> = props => <optgroup {...props} />
 
 export default Object.assign(Select, {
   Option,

--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -11,7 +11,7 @@ import TextInputAction from './_TextInputInnerAction'
 
 export type TextInputNonPassthroughProps = {
   /** @deprecated Use `leadingVisual` or `trailingVisual` prop instead */
-  icon?: React.ComponentType<{className?: string}>
+  icon?: React.ComponentType<React.PropsWithChildren<{className?: string}>>
   /** Whether the to show a loading indicator in the input */
   loading?: boolean
   /**
@@ -24,11 +24,11 @@ export type TextInputNonPassthroughProps = {
   /**
    * A visual that renders inside the input before the typing area
    */
-  leadingVisual?: string | React.ComponentType<{className?: string}>
+  leadingVisual?: string | React.ComponentType<React.PropsWithChildren<{className?: string}>>
   /**
    * A visual that renders inside the input after the typing area
    */
-  trailingVisual?: string | React.ComponentType<{className?: string}>
+  trailingVisual?: string | React.ComponentType<React.PropsWithChildren<{className?: string}>>
   /**
    * A visual that renders inside the input after the typing area
    */

--- a/src/TextInputWithTokens.tsx
+++ b/src/TextInputWithTokens.tsx
@@ -23,7 +23,9 @@ export type TextInputWithTokensProps<TokenComponentType extends AnyReactComponen
   /**
    * The array of tokens to render
    */
-  tokens: TokenComponentType extends React.ComponentType<React.PropsWithChildren<infer TokenProps>> ? TokenProps[] : never
+  tokens: TokenComponentType extends React.ComponentType<React.PropsWithChildren<infer TokenProps>>
+    ? TokenProps[]
+    : never
   /**
    * The function that gets called when a token is removed
    */

--- a/src/TextInputWithTokens.tsx
+++ b/src/TextInputWithTokens.tsx
@@ -15,7 +15,7 @@ import TextInputWrapper, {textInputHorizPadding, TextInputSizes} from './_TextIn
 import UnstyledTextInput from './_UnstyledTextInput'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyReactComponent = React.ComponentType<any>
+type AnyReactComponent = React.ComponentType<React.PropsWithChildren<any>>
 
 // NOTE: if these props or their JSDoc comments are updated, be sure to also update
 // the prop table in docs/content/TextInputTokens.mdx
@@ -23,7 +23,7 @@ export type TextInputWithTokensProps<TokenComponentType extends AnyReactComponen
   /**
    * The array of tokens to render
    */
-  tokens: TokenComponentType extends React.ComponentType<infer TokenProps> ? TokenProps[] : never
+  tokens: TokenComponentType extends React.ComponentType<React.PropsWithChildren<infer TokenProps>> ? TokenProps[] : never
   /**
    * The function that gets called when a token is removed
    */

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -48,7 +48,7 @@ const getServerHandoff = () => {
   return {}
 }
 
-export const ThemeProvider: React.FC<ThemeProviderProps> = ({children, ...props}) => {
+export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>> = ({children, ...props}) => {
   // Get fallback values from parent ThemeProvider (if exists)
   const {
     theme: fallbackTheme,

--- a/src/ToggleSwitch.tsx
+++ b/src/ToggleSwitch.tsx
@@ -53,7 +53,7 @@ type SwitchButtonProps = {
 
 type InnerIconProps = {size?: SwitchProps['size']}
 
-const CircleIcon: React.FC<InnerIconProps> = ({size}) => (
+const CircleIcon: React.FC<React.PropsWithChildren<InnerIconProps>> = ({size}) => (
   <svg
     width={size === 'small' ? '12' : '16'}
     height={size === 'small' ? '12' : '16'}
@@ -64,7 +64,7 @@ const CircleIcon: React.FC<InnerIconProps> = ({size}) => (
     <path fillRule="evenodd" d="M8 12.5a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9ZM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12Z" />
   </svg>
 )
-const LineIcon: React.FC<InnerIconProps> = ({size}) => (
+const LineIcon: React.FC<React.PropsWithChildren<InnerIconProps>> = ({size}) => (
   <svg
     width={size === 'small' ? '12' : '16'}
     height={size === 'small' ? '12' : '16'}
@@ -209,7 +209,7 @@ const hiddenTextStyles: BetterSystemStyleObject = {
   height: 0
 }
 
-const Switch: React.FC<SwitchProps> = ({
+const Switch: React.FC<React.PropsWithChildren<SwitchProps>> = ({
   'aria-labelledby': ariaLabelledby,
   'aria-describedby': ariaDescribedby,
   defaultChecked,

--- a/src/Token/Token.tsx
+++ b/src/Token/Token.tsx
@@ -10,12 +10,12 @@ export interface TokenProps extends TokenBaseProps {
    * A function that renders a component before the token text
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  leadingVisual?: React.ComponentType<any>
+  leadingVisual?: React.ComponentType<React.PropsWithChildren<any>>
 }
 
 const tokenBorderWidthPx = 1
 
-const LeadingVisualContainer: React.FC<Pick<TokenBaseProps, 'size'>> = ({children, size}) => (
+const LeadingVisualContainer: React.FC<React.PropsWithChildren<Pick<TokenBaseProps, 'size'>>> = ({children, size}) => (
   <Box
     sx={{
       flexShrink: 0,

--- a/src/Token/_RemoveTokenButton.tsx
+++ b/src/Token/_RemoveTokenButton.tsx
@@ -89,7 +89,7 @@ const StyledTokenButton = styled.span<TokenButtonProps & SxProp>`
   ${sx}
 `
 
-const RemoveTokenButton: React.FC<ComponentProps<typeof StyledTokenButton>> = ({
+const RemoveTokenButton: React.FC<React.PropsWithChildren<ComponentProps<typeof StyledTokenButton>>> = ({
   'aria-label': ariaLabel,
   isParentInteractive,
   size,

--- a/src/_CheckboxOrRadioGroup/CheckboxOrRadioGroup.tsx
+++ b/src/_CheckboxOrRadioGroup/CheckboxOrRadioGroup.tsx
@@ -48,7 +48,7 @@ const Body = styled.div`
   }
 `
 
-const CheckboxOrRadioGroup: React.FC<CheckboxOrRadioGroupProps> = ({
+const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGroupProps>> = ({
   'aria-labelledby': ariaLabelledby,
   children,
   disabled,

--- a/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupCaption.tsx
+++ b/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupCaption.tsx
@@ -4,7 +4,7 @@ import {SxProp} from '../sx'
 import {CheckboxOrRadioGroupContext} from './CheckboxOrRadioGroup'
 import {Slot} from './slots'
 
-const CheckboxOrRadioGroupCaption: React.FC<SxProp> = ({children, sx}) => (
+const CheckboxOrRadioGroupCaption: React.FC<React.PropsWithChildren<SxProp>> = ({children, sx}) => (
   <Slot name="Caption">
     {({disabled, captionId}: CheckboxOrRadioGroupContext) => (
       <Text color={disabled ? 'fg.muted' : 'fg.subtle'} fontSize={1} id={captionId} sx={sx}>

--- a/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupLabel.tsx
+++ b/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupLabel.tsx
@@ -12,7 +12,7 @@ export type CheckboxOrRadioGroupLabelProps = {
   visuallyHidden?: boolean
 } & SxProp
 
-const CheckboxOrRadioGroupLabel: React.FC<CheckboxOrRadioGroupLabelProps> = ({children, visuallyHidden, sx}) => (
+const CheckboxOrRadioGroupLabel: React.FC<React.PropsWithChildren<CheckboxOrRadioGroupLabelProps>> = ({children, visuallyHidden, sx}) => (
   <Slot name="Label">
     {({required, disabled}: CheckboxOrRadioGroupContext) => (
       <VisuallyHidden

--- a/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupLabel.tsx
+++ b/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupLabel.tsx
@@ -12,7 +12,11 @@ export type CheckboxOrRadioGroupLabelProps = {
   visuallyHidden?: boolean
 } & SxProp
 
-const CheckboxOrRadioGroupLabel: React.FC<React.PropsWithChildren<CheckboxOrRadioGroupLabelProps>> = ({children, visuallyHidden, sx}) => (
+const CheckboxOrRadioGroupLabel: React.FC<React.PropsWithChildren<CheckboxOrRadioGroupLabelProps>> = ({
+  children,
+  visuallyHidden,
+  sx
+}) => (
   <Slot name="Label">
     {({required, disabled}: CheckboxOrRadioGroupContext) => (
       <VisuallyHidden

--- a/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupValidation.tsx
+++ b/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupValidation.tsx
@@ -10,7 +10,11 @@ export type CheckboxOrRadioGroupValidationProps = {
   variant: FormValidationStatus
 } & SxProp
 
-const CheckboxOrRadioGroupValidation: React.FC<React.PropsWithChildren<CheckboxOrRadioGroupValidationProps>> = ({children, variant, sx}) => (
+const CheckboxOrRadioGroupValidation: React.FC<React.PropsWithChildren<CheckboxOrRadioGroupValidationProps>> = ({
+  children,
+  variant,
+  sx
+}) => (
   <Slot name="Validation">
     {({validationMessageId = ''}: CheckboxOrRadioGroupContext) => (
       <InputValidation validationStatus={variant} id={validationMessageId} sx={sx}>

--- a/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupValidation.tsx
+++ b/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupValidation.tsx
@@ -10,7 +10,7 @@ export type CheckboxOrRadioGroupValidationProps = {
   variant: FormValidationStatus
 } & SxProp
 
-const CheckboxOrRadioGroupValidation: React.FC<CheckboxOrRadioGroupValidationProps> = ({children, variant, sx}) => (
+const CheckboxOrRadioGroupValidation: React.FC<React.PropsWithChildren<CheckboxOrRadioGroupValidationProps>> = ({children, variant, sx}) => (
   <Slot name="Validation">
     {({validationMessageId = ''}: CheckboxOrRadioGroupContext) => (
       <InputValidation validationStatus={variant} id={validationMessageId} sx={sx}>

--- a/src/_InputCaption.tsx
+++ b/src/_InputCaption.tsx
@@ -13,7 +13,7 @@ type Props = {
   disabled?: boolean
 } & SxProp
 
-const InputCaption: React.FC<Props> = ({children, disabled, id, sx}) => (
+const InputCaption: React.FC<React.PropsWithChildren<Props>> = ({children, disabled, id, sx}) => (
   <Text color={disabled ? 'fg.subtle' : 'fg.muted'} display="block" fontSize={0} id={id} sx={sx}>
     {children}
   </Text>

--- a/src/_InputLabel.tsx
+++ b/src/_InputLabel.tsx
@@ -9,7 +9,15 @@ interface Props extends React.HTMLProps<HTMLLabelElement> {
   visuallyHidden?: boolean
 }
 
-const InputLabel: React.FC<React.PropsWithChildren<Props & SxProp>> = ({children, disabled, htmlFor, id, required, visuallyHidden, sx}) => {
+const InputLabel: React.FC<React.PropsWithChildren<Props & SxProp>> = ({
+  children,
+  disabled,
+  htmlFor,
+  id,
+  required,
+  visuallyHidden,
+  sx
+}) => {
   return (
     <VisuallyHidden
       isVisible={!visuallyHidden}

--- a/src/_InputLabel.tsx
+++ b/src/_InputLabel.tsx
@@ -9,7 +9,7 @@ interface Props extends React.HTMLProps<HTMLLabelElement> {
   visuallyHidden?: boolean
 }
 
-const InputLabel: React.FC<Props & SxProp> = ({children, disabled, htmlFor, id, required, visuallyHidden, sx}) => {
+const InputLabel: React.FC<React.PropsWithChildren<Props & SxProp>> = ({children, disabled, htmlFor, id, required, visuallyHidden, sx}) => {
   return (
     <VisuallyHidden
       isVisible={!visuallyHidden}

--- a/src/_InputValidation.tsx
+++ b/src/_InputValidation.tsx
@@ -9,7 +9,7 @@ type Props = {
   validationStatus?: FormValidationStatus
 } & SxProp
 
-const validationIconMap: Record<NonNullable<Props['validationStatus']>, React.ComponentType<IconProps>> = {
+const validationIconMap: Record<NonNullable<Props['validationStatus']>, React.ComponentType<React.PropsWithChildren<IconProps>>> = {
   success: CheckCircleFillIcon,
   error: AlertFillIcon,
   warning: AlertFillIcon
@@ -21,7 +21,7 @@ const validationColorMap: Record<NonNullable<Props['validationStatus']>, string>
   warning: 'attention.fg'
 }
 
-const InputValidation: React.FC<Props> = ({children, id, validationStatus, sx}) => {
+const InputValidation: React.FC<React.PropsWithChildren<Props>> = ({children, id, validationStatus, sx}) => {
   const IconComponent = validationStatus ? validationIconMap[validationStatus] : undefined
   const fgColor = validationStatus ? validationColorMap[validationStatus] : undefined
 

--- a/src/_InputValidation.tsx
+++ b/src/_InputValidation.tsx
@@ -9,7 +9,10 @@ type Props = {
   validationStatus?: FormValidationStatus
 } & SxProp
 
-const validationIconMap: Record<NonNullable<Props['validationStatus']>, React.ComponentType<React.PropsWithChildren<IconProps>>> = {
+const validationIconMap: Record<
+  NonNullable<Props['validationStatus']>,
+  React.ComponentType<React.PropsWithChildren<IconProps>>
+> = {
   success: CheckCircleFillIcon,
   error: AlertFillIcon,
   warning: AlertFillIcon

--- a/src/_TextInputInnerAction.tsx
+++ b/src/_TextInputInnerAction.tsx
@@ -39,10 +39,12 @@ const invisibleButtonStyleOverrides = {
   }
 }
 
-const ConditionalTooltip: React.FC<React.PropsWithChildren<{
-  ['aria-label']?: string
-  children: React.ReactNode
-}>> = ({'aria-label': ariaLabel, children}) => (
+const ConditionalTooltip: React.FC<
+  React.PropsWithChildren<{
+    ['aria-label']?: string
+    children: React.ReactNode
+  }>
+> = ({'aria-label': ariaLabel, children}) => (
   <>
     {ariaLabel ? (
       <Tooltip

--- a/src/_TextInputInnerAction.tsx
+++ b/src/_TextInputInnerAction.tsx
@@ -10,7 +10,7 @@ type TextInputActionProps = Omit<React.HTMLProps<HTMLButtonElement>, 'aria-label
   /** Text that appears in a tooltip. If an icon is passed, this is also used as the label used by assistive technologies. */
   ['aria-label']?: string
   /** The icon to render inside the button */
-  icon?: React.FunctionComponent<IconProps>
+  icon?: React.FunctionComponent<React.PropsWithChildren<IconProps>>
   /**
    * @deprecated Text input action buttons should only use the 'invisible' button variant
    * Determine's the styles on a button one of 'default' | 'primary' | 'invisible' | 'danger'
@@ -39,10 +39,10 @@ const invisibleButtonStyleOverrides = {
   }
 }
 
-const ConditionalTooltip: React.FC<{
+const ConditionalTooltip: React.FC<React.PropsWithChildren<{
   ['aria-label']?: string
   children: React.ReactNode
-}> = ({'aria-label': ariaLabel, children}) => (
+}>> = ({'aria-label': ariaLabel, children}) => (
   <>
     {ariaLabel ? (
       <Tooltip

--- a/src/_TextInputInnerVisualSlot.tsx
+++ b/src/_TextInputInnerVisualSlot.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 import {Box, Spinner} from '.'
 import {TextInputNonPassthroughProps} from './TextInput'
 
-const TextInputInnerVisualSlot: React.FC<{
+const TextInputInnerVisualSlot: React.FC<React.PropsWithChildren<{
   /** Whether the input is expected to ever show a loading indicator */
   hasLoadingIndicator: boolean
   /** Whether the to show the loading indicator */
   showLoadingIndicator: TextInputNonPassthroughProps['loading']
   /** Which side of this visual is being rendered */
   visualPosition: 'leading' | 'trailing'
-}> = ({children, hasLoadingIndicator, showLoadingIndicator, visualPosition}) => {
+}>> = ({children, hasLoadingIndicator, showLoadingIndicator, visualPosition}) => {
   if ((!children && !hasLoadingIndicator) || (visualPosition === 'leading' && !children && !showLoadingIndicator)) {
     return null
   }

--- a/src/_TextInputInnerVisualSlot.tsx
+++ b/src/_TextInputInnerVisualSlot.tsx
@@ -2,14 +2,16 @@ import React from 'react'
 import {Box, Spinner} from '.'
 import {TextInputNonPassthroughProps} from './TextInput'
 
-const TextInputInnerVisualSlot: React.FC<React.PropsWithChildren<{
-  /** Whether the input is expected to ever show a loading indicator */
-  hasLoadingIndicator: boolean
-  /** Whether the to show the loading indicator */
-  showLoadingIndicator: TextInputNonPassthroughProps['loading']
-  /** Which side of this visual is being rendered */
-  visualPosition: 'leading' | 'trailing'
-}>> = ({children, hasLoadingIndicator, showLoadingIndicator, visualPosition}) => {
+const TextInputInnerVisualSlot: React.FC<
+  React.PropsWithChildren<{
+    /** Whether the input is expected to ever show a loading indicator */
+    hasLoadingIndicator: boolean
+    /** Whether the to show the loading indicator */
+    showLoadingIndicator: TextInputNonPassthroughProps['loading']
+    /** Which side of this visual is being rendered */
+    visualPosition: 'leading' | 'trailing'
+  }>
+> = ({children, hasLoadingIndicator, showLoadingIndicator, visualPosition}) => {
   if ((!children && !hasLoadingIndicator) || (visualPosition === 'leading' && !children && !showLoadingIndicator)) {
     return null
   }

--- a/src/_ValidationAnimationContainer.tsx
+++ b/src/_ValidationAnimationContainer.tsx
@@ -20,7 +20,7 @@ const fadeIn = keyframes`
 const AnimatedElement = styled.div<Props>`
   animation: ${props => props.show && css`170ms ${fadeIn} cubic-bezier(0.44, 0.74, 0.36, 1);`};
 `
-const ValidationAnimationContainer: React.FC<Props> = ({show, children}) => {
+const ValidationAnimationContainer: React.FC<React.PropsWithChildren<Props>> = ({show, children}) => {
   const [shouldRender, setRender] = useState(show)
 
   useEffect(() => {

--- a/src/__tests__/.eslintrc.json
+++ b/src/__tests__/.eslintrc.json
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "plugin:jest/recommended"
-  ],
+  "extends": ["plugin:jest/recommended"],
   "parserOptions": {
     "project": "../../tsconfig.json"
   },

--- a/src/__tests__/TextInputWithTokens.test.tsx
+++ b/src/__tests__/TextInputWithTokens.test.tsx
@@ -20,7 +20,7 @@ const mockTokens = [
   {text: 'seven', id: 7}
 ]
 
-const LabelledTextInputWithTokens: React.FC<TextInputWithTokensProps> = ({onTokenRemove, tokens, ...rest}) => (
+const LabelledTextInputWithTokens: React.FC<React.PropsWithChildren<TextInputWithTokensProps>> = ({onTokenRemove, tokens, ...rest}) => (
   <>
     {/* eslint-disable-next-line jsx-a11y/label-has-for */}
     <label htmlFor="tokenInput" id="tokenLabel">

--- a/src/__tests__/TextInputWithTokens.test.tsx
+++ b/src/__tests__/TextInputWithTokens.test.tsx
@@ -20,7 +20,11 @@ const mockTokens = [
   {text: 'seven', id: 7}
 ]
 
-const LabelledTextInputWithTokens: React.FC<React.PropsWithChildren<TextInputWithTokensProps>> = ({onTokenRemove, tokens, ...rest}) => (
+const LabelledTextInputWithTokens: React.FC<React.PropsWithChildren<TextInputWithTokensProps>> = ({
+  onTokenRemove,
+  tokens,
+  ...rest
+}) => (
   <>
     {/* eslint-disable-next-line jsx-a11y/label-has-for */}
     <label htmlFor="tokenInput" id="tokenLabel">

--- a/src/__tests__/Token.test.tsx
+++ b/src/__tests__/Token.test.tsx
@@ -10,7 +10,7 @@ import {AvatarTokenProps} from '../Token/AvatarToken'
 expect.extend(toHaveNoViolations)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const testTokenComponent = (Component: React.ComponentType<any>) => {
+const testTokenComponent = (Component: React.ComponentType<React.PropsWithChildren<any>>) => {
   behavesAsComponent({Component: Token})
 
   it('renders a <span>', () => {

--- a/src/__tests__/deprecated/ChoiceFieldset.test.tsx
+++ b/src/__tests__/deprecated/ChoiceFieldset.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event'
 import ChoiceFieldset, {Item, ChoiceFieldsetProps} from '../../deprecated/ChoiceFieldset'
 import {ChoiceFieldsetListProps} from '../../deprecated/ChoiceFieldset/ChoiceFieldsetList'
 
-const SelectableChoicelistFieldset: React.FC<ChoiceFieldsetProps & ChoiceFieldsetListProps> = ({
+const SelectableChoicelistFieldset: React.FC<React.PropsWithChildren<ChoiceFieldsetProps & ChoiceFieldsetListProps>> = ({
   onSelect,
   selectionVariant,
   selected = []

--- a/src/__tests__/deprecated/ChoiceFieldset.test.tsx
+++ b/src/__tests__/deprecated/ChoiceFieldset.test.tsx
@@ -7,34 +7,31 @@ import userEvent from '@testing-library/user-event'
 import ChoiceFieldset, {Item, ChoiceFieldsetProps} from '../../deprecated/ChoiceFieldset'
 import {ChoiceFieldsetListProps} from '../../deprecated/ChoiceFieldset/ChoiceFieldsetList'
 
-const SelectableChoicelistFieldset: React.FC<React.PropsWithChildren<ChoiceFieldsetProps & ChoiceFieldsetListProps>> = ({
-  onSelect,
-  selectionVariant,
-  selected = []
-}) => {
-  const [selectionVals, setSelectionVals] = React.useState<string[]>(selected)
+const SelectableChoicelistFieldset: React.FC<React.PropsWithChildren<ChoiceFieldsetProps & ChoiceFieldsetListProps>> =
+  ({onSelect, selectionVariant, selected = []}) => {
+    const [selectionVals, setSelectionVals] = React.useState<string[]>(selected)
 
-  React.useEffect(() => {
-    onSelect && onSelect(selectionVals)
-  }, [onSelect, selectionVals])
+    React.useEffect(() => {
+      onSelect && onSelect(selectionVals)
+    }, [onSelect, selectionVals])
 
-  return (
-    <SSRProvider>
-      <ChoiceFieldset
-        onSelect={selectedVals => {
-          setSelectionVals(selectedVals)
-        }}
-        selected={selectionVals}
-      >
-        <ChoiceFieldset.Legend>Legend</ChoiceFieldset.Legend>
-        <ChoiceFieldset.List selectionVariant={selectionVariant}>
-          <ChoiceFieldset.Item value="labelOne">Label one</ChoiceFieldset.Item>
-          <ChoiceFieldset.Item value="labelTwo">Label two</ChoiceFieldset.Item>
-        </ChoiceFieldset.List>
-      </ChoiceFieldset>
-    </SSRProvider>
-  )
-}
+    return (
+      <SSRProvider>
+        <ChoiceFieldset
+          onSelect={selectedVals => {
+            setSelectionVals(selectedVals)
+          }}
+          selected={selectionVals}
+        >
+          <ChoiceFieldset.Legend>Legend</ChoiceFieldset.Legend>
+          <ChoiceFieldset.List selectionVariant={selectionVariant}>
+            <ChoiceFieldset.Item value="labelOne">Label one</ChoiceFieldset.Item>
+            <ChoiceFieldset.Item value="labelTwo">Label two</ChoiceFieldset.Item>
+          </ChoiceFieldset.List>
+        </ChoiceFieldset>
+      </SSRProvider>
+    )
+  }
 
 describe('ChoiceFieldset', () => {
   it('renders default', () => {

--- a/src/__tests__/utils/createSlots.test.tsx
+++ b/src/__tests__/utils/createSlots.test.tsx
@@ -7,7 +7,7 @@ import createSlots from '../../utils/create-slots'
 const {Slots, Slot} = createSlots(['One', 'Two', 'Three'])
 type ContextTypes = {salutation?: string}
 
-const ComponentWithSlots: React.FC<ContextTypes> = ({salutation, children}) => {
+const ComponentWithSlots: React.FC<React.PropsWithChildren<ContextTypes>> = ({salutation, children}) => {
   return (
     <Slots context={{salutation}}>
       {slots => (
@@ -21,9 +21,9 @@ const ComponentWithSlots: React.FC<ContextTypes> = ({salutation, children}) => {
     </Slots>
   )
 }
-const SlotItem1: React.FC = ({children}) => <Slot name="One">{children}</Slot>
-const SlotItem2: React.FC = ({children}) => <Slot name="Two">{children}</Slot>
-const SlotItem3: React.FC = ({children}) => (
+const SlotItem1: React.FC<React.PropsWithChildren<unknown>> = ({children}) => <Slot name="One">{children}</Slot>
+const SlotItem2: React.FC<React.PropsWithChildren<unknown>> = ({children}) => <Slot name="Two">{children}</Slot>
+const SlotItem3: React.FC<React.PropsWithChildren<unknown>> = ({children}) => (
   <Slot name="Three">
     {(context: ContextTypes) => (
       <>

--- a/src/deprecated/ActionList/Item.tsx
+++ b/src/deprecated/ActionList/Item.tsx
@@ -42,13 +42,13 @@ export interface ItemProps extends SxProp {
   /**
    * Icon (or similar) positioned before `Item` text.
    */
-  leadingVisual?: React.FunctionComponent<IconProps>
+  leadingVisual?: React.FunctionComponent<React.PropsWithChildren<IconProps>>
 
   /**
    * @deprecated Use `trailingVisual` instead
    * Icon (or similar) positioned after `Item` text.
    */
-  trailingIcon?: React.FunctionComponent<IconProps>
+  trailingIcon?: React.FunctionComponent<React.PropsWithChildren<IconProps>>
 
   /**
    * @deprecated Use `trailingVisual` instead

--- a/src/deprecated/Button/ButtonBase.tsx
+++ b/src/deprecated/Button/ButtonBase.tsx
@@ -20,7 +20,7 @@ const variants = variant({
 })
 
 type StyledButtonBaseProps = {
-  as?: 'button' | 'a' | 'summary' | 'input' | string | React.ReactType
+  as?: 'button' | 'a' | 'summary' | 'input' | string | React.ElementType
   variant?: 'small' | 'medium' | 'large'
 }
 

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldCaption.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldCaption.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import ChoiceInputField from '../ChoiceInputField'
 
-const ChoiceFieldCaption: React.FC<React.PropsWithChildren<unknown>> = ({children}) => <ChoiceInputField.Caption>{children}</ChoiceInputField.Caption>
+const ChoiceFieldCaption: React.FC<React.PropsWithChildren<unknown>> = ({children}) => (
+  <ChoiceInputField.Caption>{children}</ChoiceInputField.Caption>
+)
 
 export default ChoiceFieldCaption

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldCaption.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldCaption.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ChoiceInputField from '../ChoiceInputField'
 
-const ChoiceFieldCaption: React.FC = ({children}) => <ChoiceInputField.Caption>{children}</ChoiceInputField.Caption>
+const ChoiceFieldCaption: React.FC<React.PropsWithChildren<unknown>> = ({children}) => <ChoiceInputField.Caption>{children}</ChoiceInputField.Caption>
 
 export default ChoiceFieldCaption

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldLabel.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldLabel.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import ChoiceInputField from '../ChoiceInputField'
 
-const ChoiceFieldLabel: React.FC<React.PropsWithChildren<unknown>> = ({children}) => <ChoiceInputField.Label>{children}</ChoiceInputField.Label>
+const ChoiceFieldLabel: React.FC<React.PropsWithChildren<unknown>> = ({children}) => (
+  <ChoiceInputField.Label>{children}</ChoiceInputField.Label>
+)
 
 export default ChoiceFieldLabel

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldLabel.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldLabel.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ChoiceInputField from '../ChoiceInputField'
 
-const ChoiceFieldLabel: React.FC = ({children}) => <ChoiceInputField.Label>{children}</ChoiceInputField.Label>
+const ChoiceFieldLabel: React.FC<React.PropsWithChildren<unknown>> = ({children}) => <ChoiceInputField.Label>{children}</ChoiceInputField.Label>
 
 export default ChoiceFieldLabel

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldsetDescription.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldsetDescription.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import {Text} from '../..'
 import {ChoiceFieldsetContext, Slot} from './ChoiceFieldset'
 
-const ChoiceFieldsetDescription: React.FC = ({children}) => (
+const ChoiceFieldsetDescription: React.FC<React.PropsWithChildren<unknown>> = ({children}) => (
   <Slot name="Description">
     {({disabled}: ChoiceFieldsetContext) => (
       <Text color={disabled ? 'fg.muted' : 'fg.default'} fontSize={1}>

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldsetLegend.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldsetLegend.tsx
@@ -10,7 +10,10 @@ export interface ChoiceFieldsetLegendProps {
   visuallyHidden?: boolean
 }
 
-const ChoiceFieldsetLegend: React.FC<React.PropsWithChildren<ChoiceFieldsetLegendProps>> = ({children, visuallyHidden}) => (
+const ChoiceFieldsetLegend: React.FC<React.PropsWithChildren<ChoiceFieldsetLegendProps>> = ({
+  children,
+  visuallyHidden
+}) => (
   <Slot name="Legend">
     {({required, disabled}: ChoiceFieldsetContext) => (
       <VisuallyHidden

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldsetLegend.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldsetLegend.tsx
@@ -10,7 +10,7 @@ export interface ChoiceFieldsetLegendProps {
   visuallyHidden?: boolean
 }
 
-const ChoiceFieldsetLegend: React.FC<ChoiceFieldsetLegendProps> = ({children, visuallyHidden}) => (
+const ChoiceFieldsetLegend: React.FC<React.PropsWithChildren<ChoiceFieldsetLegendProps>> = ({children, visuallyHidden}) => (
   <Slot name="Legend">
     {({required, disabled}: ChoiceFieldsetContext) => (
       <VisuallyHidden

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldsetList.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldsetList.tsx
@@ -37,7 +37,7 @@ const getSelectedCheckboxes = (
   return selectedValues.filter(selectedValue => selectedValue !== value)
 }
 
-const ChoiceFieldsetList: React.FC<ChoiceFieldsetListProps> = ({selectionVariant, children}) => {
+const ChoiceFieldsetList: React.FC<React.PropsWithChildren<ChoiceFieldsetListProps>> = ({selectionVariant, children}) => {
   const ssrSafeUniqueName = useSSRSafeId()
 
   return (

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldsetList.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldsetList.tsx
@@ -37,7 +37,10 @@ const getSelectedCheckboxes = (
   return selectedValues.filter(selectedValue => selectedValue !== value)
 }
 
-const ChoiceFieldsetList: React.FC<React.PropsWithChildren<ChoiceFieldsetListProps>> = ({selectionVariant, children}) => {
+const ChoiceFieldsetList: React.FC<React.PropsWithChildren<ChoiceFieldsetListProps>> = ({
+  selectionVariant,
+  children
+}) => {
   const ssrSafeUniqueName = useSSRSafeId()
 
   return (

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldsetListItem.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldsetListItem.tsx
@@ -23,7 +23,7 @@ export interface ChoiceFieldProps {
   value: string
 }
 
-const ChoiceFieldsetListItem: React.FC<ChoiceFieldProps> = ({children, id, disabled: disabledProp, value}) => {
+const ChoiceFieldsetListItem: React.FC<React.PropsWithChildren<ChoiceFieldProps>> = ({children, id, disabled: disabledProp, value}) => {
   const choiceFieldsetListContext = useContext(ChoiceFieldsetListContext)
   if (choiceFieldsetListContext === null) {
     throw new Error('ChoiceFieldsetListContext returned null')

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldsetListItem.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldsetListItem.tsx
@@ -23,7 +23,12 @@ export interface ChoiceFieldProps {
   value: string
 }
 
-const ChoiceFieldsetListItem: React.FC<React.PropsWithChildren<ChoiceFieldProps>> = ({children, id, disabled: disabledProp, value}) => {
+const ChoiceFieldsetListItem: React.FC<React.PropsWithChildren<ChoiceFieldProps>> = ({
+  children,
+  id,
+  disabled: disabledProp,
+  value
+}) => {
   const choiceFieldsetListContext = useContext(ChoiceFieldsetListContext)
   if (choiceFieldsetListContext === null) {
     throw new Error('ChoiceFieldsetListContext returned null')

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldsetValidation.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldsetValidation.tsx
@@ -4,6 +4,6 @@ export interface ChoiceFieldsetValidationProps {
   validationKey: string
 }
 
-const ChoiceFieldsetValidation: React.FC<ChoiceFieldsetValidationProps> = ({children}) => <>{children}</>
+const ChoiceFieldsetValidation: React.FC<React.PropsWithChildren<ChoiceFieldsetValidationProps>> = ({children}) => <>{children}</>
 
 export default ChoiceFieldsetValidation

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldsetValidation.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldsetValidation.tsx
@@ -4,6 +4,8 @@ export interface ChoiceFieldsetValidationProps {
   validationKey: string
 }
 
-const ChoiceFieldsetValidation: React.FC<React.PropsWithChildren<ChoiceFieldsetValidationProps>> = ({children}) => <>{children}</>
+const ChoiceFieldsetValidation: React.FC<React.PropsWithChildren<ChoiceFieldsetValidationProps>> = ({children}) => (
+  <>{children}</>
+)
 
 export default ChoiceFieldsetValidation

--- a/src/deprecated/ChoiceInputField.tsx
+++ b/src/deprecated/ChoiceInputField.tsx
@@ -25,7 +25,7 @@ const getInputToRender = (inputType: 'radio' | 'checkbox', children?: React.Reac
   )
 }
 
-const ChoiceInputField: React.FC<Props> = ({children, disabled, id: idProp, validationStatus}) => {
+const ChoiceInputField: React.FC<React.PropsWithChildren<Props>> = ({children, disabled, id: idProp, validationStatus}) => {
   const id = useSSRSafeId(idProp)
   const captionChildren: React.ReactElement[] | undefined | null = React.Children.map(children, child =>
     React.isValidElement(child) && child.type === InputFieldCaption ? child : null
@@ -125,7 +125,7 @@ const ChoiceInputField: React.FC<Props> = ({children, disabled, id: idProp, vali
   )
 }
 
-const Label: React.FC = ({children}) => <InputField.Label>{children}</InputField.Label>
+const Label: React.FC<React.PropsWithChildren<unknown>> = ({children}) => <InputField.Label>{children}</InputField.Label>
 
 /**
  * @deprecated Use `FormControl` instead. See https://primer.style/react/FormControl for more info

--- a/src/deprecated/ChoiceInputField.tsx
+++ b/src/deprecated/ChoiceInputField.tsx
@@ -25,7 +25,12 @@ const getInputToRender = (inputType: 'radio' | 'checkbox', children?: React.Reac
   )
 }
 
-const ChoiceInputField: React.FC<React.PropsWithChildren<Props>> = ({children, disabled, id: idProp, validationStatus}) => {
+const ChoiceInputField: React.FC<React.PropsWithChildren<Props>> = ({
+  children,
+  disabled,
+  id: idProp,
+  validationStatus
+}) => {
   const id = useSSRSafeId(idProp)
   const captionChildren: React.ReactElement[] | undefined | null = React.Children.map(children, child =>
     React.isValidElement(child) && child.type === InputFieldCaption ? child : null
@@ -125,7 +130,9 @@ const ChoiceInputField: React.FC<React.PropsWithChildren<Props>> = ({children, d
   )
 }
 
-const Label: React.FC<React.PropsWithChildren<unknown>> = ({children}) => <InputField.Label>{children}</InputField.Label>
+const Label: React.FC<React.PropsWithChildren<unknown>> = ({children}) => (
+  <InputField.Label>{children}</InputField.Label>
+)
 
 /**
  * @deprecated Use `FormControl` instead. See https://primer.style/react/FormControl for more info

--- a/src/deprecated/InputField/_InputFieldCaption.tsx
+++ b/src/deprecated/InputField/_InputFieldCaption.tsx
@@ -3,7 +3,7 @@ import InputCaption from '../../_InputCaption'
 import {InputFieldContext} from './InputField'
 import {Slot} from './slots'
 
-const InputFieldCaption: React.FC = ({children}) => (
+const InputFieldCaption: React.FC<React.PropsWithChildren<unknown>> = ({children}) => (
   <Slot name="Caption">
     {({captionId, disabled}: InputFieldContext) => (
       <InputCaption id={captionId} disabled={disabled}>

--- a/src/deprecated/InputField/_InputFieldLabel.tsx
+++ b/src/deprecated/InputField/_InputFieldLabel.tsx
@@ -10,7 +10,7 @@ export interface Props {
   visuallyHidden?: boolean
 }
 
-const InputFieldLabel: React.FC<Props> = ({children, visuallyHidden}) => (
+const InputFieldLabel: React.FC<React.PropsWithChildren<Props>> = ({children, visuallyHidden}) => (
   <Slot name="Label">
     {({disabled, id, required}: InputFieldContext) => (
       <InputLabel htmlFor={id} visuallyHidden={visuallyHidden} required={required} disabled={disabled}>

--- a/src/deprecated/InputField/_InputFieldValidation.tsx
+++ b/src/deprecated/InputField/_InputFieldValidation.tsx
@@ -3,6 +3,8 @@ export interface InputFieldValidationProps {
   validationKey: string
 }
 
-const InputFieldValidation: React.FC<React.PropsWithChildren<InputFieldValidationProps>> = ({children}) => <>{children}</>
+const InputFieldValidation: React.FC<React.PropsWithChildren<InputFieldValidationProps>> = ({children}) => (
+  <>{children}</>
+)
 
 export default InputFieldValidation

--- a/src/deprecated/InputField/_InputFieldValidation.tsx
+++ b/src/deprecated/InputField/_InputFieldValidation.tsx
@@ -3,6 +3,6 @@ export interface InputFieldValidationProps {
   validationKey: string
 }
 
-const InputFieldValidation: React.FC<InputFieldValidationProps> = ({children}) => <>{children}</>
+const InputFieldValidation: React.FC<React.PropsWithChildren<InputFieldValidationProps>> = ({children}) => <>{children}</>
 
 export default InputFieldValidation

--- a/src/deprecated/_ChoiceInputLeadingVisual.tsx
+++ b/src/deprecated/_ChoiceInputLeadingVisual.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import {Slot} from '../deprecated/InputField/slots'
 
-const ChoiceInputLeadingVisual: React.FC<React.PropsWithChildren<unknown>> = ({children}) => <Slot name="LeadingVisual">{children}</Slot>
+const ChoiceInputLeadingVisual: React.FC<React.PropsWithChildren<unknown>> = ({children}) => (
+  <Slot name="LeadingVisual">{children}</Slot>
+)
 
 export default ChoiceInputLeadingVisual

--- a/src/deprecated/_ChoiceInputLeadingVisual.tsx
+++ b/src/deprecated/_ChoiceInputLeadingVisual.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Slot} from '../deprecated/InputField/slots'
 
-const ChoiceInputLeadingVisual: React.FC = ({children}) => <Slot name="LeadingVisual">{children}</Slot>
+const ChoiceInputLeadingVisual: React.FC<React.PropsWithChildren<unknown>> = ({children}) => <Slot name="LeadingVisual">{children}</Slot>
 
 export default ChoiceInputLeadingVisual

--- a/src/stories/ActionList/examples.stories.tsx
+++ b/src/stories/ActionList/examples.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta = {
   title: 'Composite components/ActionList/examples',
   component: ActionList,
   decorators: [
-    (Story: React.ComponentType): JSX.Element => (
+    (Story: React.ComponentType<React.PropsWithChildren<unknown>>): JSX.Element => (
       <ThemeProvider>
         <BaseStyles>
           <Story />

--- a/src/stories/ActionList/fixtures.stories.tsx
+++ b/src/stories/ActionList/fixtures.stories.tsx
@@ -39,7 +39,7 @@ const meta: Meta = {
   title: 'Composite components/ActionList/fixtures',
   component: ActionList,
   decorators: [
-    (Story: React.ComponentType): JSX.Element => (
+    (Story: React.ComponentType<React.PropsWithChildren<unknown>>): JSX.Element => (
       <ThemeProvider>
         <BaseStyles>
           <Story />
@@ -158,7 +158,7 @@ const labels = [
   {name: 'good first issue', color: '#7057ff', description: 'Good for newcomers'}
 ]
 
-const LabelColor: React.FC<{color: string}> = ({color}) => (
+const LabelColor: React.FC<React.PropsWithChildren<{color: string}>> = ({color}) => (
   <Box sx={{backgroundColor: color, width: '14px', height: '14px', borderRadius: 3}} />
 )
 
@@ -810,7 +810,7 @@ export function ChildWithInternalState(): JSX.Element {
 }
 ChildWithInternalState.storyName = 'Child with internal state'
 
-const StatefulChild: React.FC = props => {
+const StatefulChild: React.FC<React.PropsWithChildren<unknown>> = props => {
   const [nameVisible, setNameVisibility] = React.useState(false)
   const toggle = () => {
     setNameVisibility(!nameVisible)
@@ -992,7 +992,7 @@ type SortableItemProps = {
   onSelect: ActionListItemProps['onSelect']
   reorder: ({optionToMove, moveAfterOption}: {optionToMove: Option; moveAfterOption: Option}) => void
 }
-const SortableItem: React.FC<SortableItemProps> = ({option, role, onSelect, reorder}) => {
+const SortableItem: React.FC<React.PropsWithChildren<SortableItemProps>> = ({option, role, onSelect, reorder}) => {
   const [{isDragging}, dragRef] = useDrag(() => ({
     type: 'ITEM',
     item: option,

--- a/src/stories/ActionMenu/examples.stories.tsx
+++ b/src/stories/ActionMenu/examples.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta = {
   title: 'Composite components/ActionMenu/examples',
   component: ActionMenu,
   decorators: [
-    (Story: React.ComponentType): JSX.Element => (
+    (Story: React.ComponentType<React.PropsWithChildren<unknown>>): JSX.Element => (
       <ThemeProvider>
         <BaseStyles>
           <Story />

--- a/src/stories/ActionMenu/fixtures.stories.tsx
+++ b/src/stories/ActionMenu/fixtures.stories.tsx
@@ -39,7 +39,7 @@ const meta: Meta = {
   title: 'Composite components/ActionMenu/fixtures',
   component: ActionMenu,
   decorators: [
-    (Story: React.ComponentType): JSX.Element => (
+    (Story: React.ComponentType<React.PropsWithChildren<unknown>>): JSX.Element => (
       <ThemeProvider>
         <BaseStyles>
           <Story />
@@ -310,7 +310,7 @@ const LayoutToggleItem = ({
 }: {
   selected: boolean
   children: React.ReactNode
-  Icon: React.ComponentType<IconProps>
+  Icon: React.ComponentType<React.PropsWithChildren<IconProps>>
 }) => {
   return (
     <FormControl

--- a/src/stories/AvatarStack.stories.tsx
+++ b/src/stories/AvatarStack.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta = {
   title: 'Composite components/AvatarStack',
   component: AvatarStack,
   decorators: [
-    (Story: React.ComponentType): JSX.Element => (
+    (Story: React.ComponentType<React.PropsWithChildren<unknown>>): JSX.Element => (
       <ThemeProvider>
         <BaseStyles>
           <Story />

--- a/src/stories/IssueLabelToken.stories.tsx
+++ b/src/stories/IssueLabelToken.stories.tsx
@@ -37,7 +37,7 @@ export default {
 
 const excludedControlKeys = ['id', 'as', 'tabIndex', 'onRemove']
 
-const SingleExampleContainer: React.FC<{label?: string}> = ({children, label}) => (
+const SingleExampleContainer: React.FC<React.PropsWithChildren<{label?: string}>> = ({children, label}) => (
   <Box
     display="flex"
     sx={{
@@ -55,7 +55,7 @@ const SingleExampleContainer: React.FC<{label?: string}> = ({children, label}) =
   </Box>
 )
 
-const ExampleCollectionContainer: React.FC = ({children}) => (
+const ExampleCollectionContainer: React.FC<React.PropsWithChildren<unknown>> = ({children}) => (
   <Box
     display="flex"
     sx={{

--- a/src/stories/Portal.stories.tsx
+++ b/src/stories/Portal.stories.tsx
@@ -48,7 +48,7 @@ export const customPortalRootById = () => (
   </>
 )
 
-export const CustomPortalRootByRegistration: React.FC<Record<string, never>> = () => {
+export const CustomPortalRootByRegistration: React.FC<React.PropsWithChildren<Record<string, never>>> = () => {
   const outerContainerRef = React.useRef<HTMLDivElement>(null)
   const [mounted, setMounted] = React.useState(false)
   React.useEffect(() => {
@@ -75,7 +75,7 @@ export const CustomPortalRootByRegistration: React.FC<Record<string, never>> = (
   )
 }
 
-export const MultiplePortalRoots: React.FC<Record<string, never>> = () => {
+export const MultiplePortalRoots: React.FC<React.PropsWithChildren<Record<string, never>>> = () => {
   const outerContainerRef = React.useRef<HTMLDivElement>(null)
   const innerContainerRef = React.useRef<HTMLDivElement>(null)
   const [mounted, setMounted] = React.useState(false)

--- a/src/stories/ProfileToken.stories.tsx
+++ b/src/stories/ProfileToken.stories.tsx
@@ -34,7 +34,7 @@ export default {
 
 const excludedControlKeys = ['id', 'as', 'tabIndex', 'onRemove']
 
-const SingleExampleContainer: React.FC<{label?: string}> = ({children, label}) => (
+const SingleExampleContainer: React.FC<React.PropsWithChildren<{label?: string}>> = ({children, label}) => (
   <Box
     display="flex"
     sx={{
@@ -52,7 +52,7 @@ const SingleExampleContainer: React.FC<{label?: string}> = ({children, label}) =
   </Box>
 )
 
-const ExampleCollectionContainer: React.FC = ({children}) => (
+const ExampleCollectionContainer: React.FC<React.PropsWithChildren<unknown>> = ({children}) => (
   <Box
     display="flex"
     sx={{

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta = {
   title: 'Composite components/SelectPanel',
   component: SelectPanel,
   decorators: [
-    (Story: React.ComponentType): JSX.Element => {
+    (Story: React.ComponentType<React.PropsWithChildren<unknown>>): JSX.Element => {
       return (
         <ThemeProvider theme={theme}>
           <BaseStyles>

--- a/src/stories/Token.stories.tsx
+++ b/src/stories/Token.stories.tsx
@@ -39,7 +39,7 @@ export default {
 
 const excludedControlKeys = ['id', 'as', 'tabIndex', 'onRemove', 'leadingVisual']
 
-const SingleExampleContainer: React.FC<{label?: string}> = ({children, label}) => (
+const SingleExampleContainer: React.FC<React.PropsWithChildren<{label?: string}>> = ({children, label}) => (
   <Box
     display="flex"
     sx={{
@@ -57,7 +57,7 @@ const SingleExampleContainer: React.FC<{label?: string}> = ({children, label}) =
   </Box>
 )
 
-const ExampleCollectionContainer: React.FC = ({children}) => (
+const ExampleCollectionContainer: React.FC<React.PropsWithChildren<unknown>> = ({children}) => (
   <Box
     display="flex"
     sx={{

--- a/src/stories/deprecated/ActionList.stories.tsx
+++ b/src/stories/deprecated/ActionList.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta = {
   title: 'Deprecated components/ActionList',
   component: ActionList,
   decorators: [
-    (Story: React.ComponentType): JSX.Element => (
+    (Story: React.ComponentType<React.PropsWithChildren<unknown>>): JSX.Element => (
       <ThemeProvider>
         <BaseStyles>
           <Story />

--- a/src/stories/deprecated/ActionMenu.stories.tsx
+++ b/src/stories/deprecated/ActionMenu.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta = {
   title: 'Deprecated components/ActionMenu',
   component: ActionMenu,
   decorators: [
-    (Story: React.ComponentType): JSX.Element => (
+    (Story: React.ComponentType<React.PropsWithChildren<unknown>>): JSX.Element => (
       <ThemeProvider>
         <BaseStyles>
           <Story />

--- a/src/stories/deprecated/DropdownMenu.stories.tsx
+++ b/src/stories/deprecated/DropdownMenu.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta = {
   title: 'Deprecated components/DropdownMenu',
   component: DropdownMenu,
   decorators: [
-    (Story: React.ComponentType): JSX.Element => {
+    (Story: React.ComponentType<React.PropsWithChildren<unknown>>): JSX.Element => {
       return (
         <ThemeProvider theme={theme}>
           <BaseStyles>

--- a/src/utils/create-slots.tsx
+++ b/src/utils/create-slots.tsx
@@ -27,10 +27,12 @@ const createSlots = <SlotNames extends string>(slotNames: SlotNames[]) => {
    *  When all the children have mounted = registered themselves in slot,
    *  we re-render the parent component to render with slots
    */
-  const Slots: React.FC<React.PropsWithChildren<{
-    context?: ContextProps['context']
-    children: (slots: Slots) => React.ReactNode
-  }>> = ({context = {}, children}) => {
+  const Slots: React.FC<
+    React.PropsWithChildren<{
+      context?: ContextProps['context']
+      children: (slots: Slots) => React.ReactNode
+    }>
+  > = ({context = {}, children}) => {
     // initialise slots
     const slotsDefinition: Slots = {}
     slotNames.map(name => (slotsDefinition[name] = null))
@@ -76,10 +78,12 @@ const createSlots = <SlotNames extends string>(slotNames: SlotNames[]) => {
     )
   }
 
-  const Slot: React.FC<React.PropsWithChildren<{
-    name: SlotNames
-    children: React.ReactNode
-  }>> = ({name, children}) => {
+  const Slot: React.FC<
+    React.PropsWithChildren<{
+      name: SlotNames
+      children: React.ReactNode
+    }>
+  > = ({name, children}) => {
     const {registerSlot, unregisterSlot, context} = React.useContext(SlotsContext)
 
     React.useEffect(() => {

--- a/src/utils/create-slots.tsx
+++ b/src/utils/create-slots.tsx
@@ -27,10 +27,10 @@ const createSlots = <SlotNames extends string>(slotNames: SlotNames[]) => {
    *  When all the children have mounted = registered themselves in slot,
    *  we re-render the parent component to render with slots
    */
-  const Slots: React.FC<{
+  const Slots: React.FC<React.PropsWithChildren<{
     context?: ContextProps['context']
     children: (slots: Slots) => React.ReactNode
-  }> = ({context = {}, children}) => {
+  }>> = ({context = {}, children}) => {
     // initialise slots
     const slotsDefinition: Slots = {}
     slotNames.map(name => (slotsDefinition[name] = null))
@@ -76,10 +76,10 @@ const createSlots = <SlotNames extends string>(slotNames: SlotNames[]) => {
     )
   }
 
-  const Slot: React.FC<{
+  const Slot: React.FC<React.PropsWithChildren<{
     name: SlotNames
     children: React.ReactNode
-  }> = ({name, children}) => {
+  }>> = ({name, children}) => {
     const {registerSlot, unregisterSlot, context} = React.useContext(SlotsContext)
 
     React.useEffect(() => {

--- a/src/utils/story-helpers.tsx
+++ b/src/utils/story-helpers.tsx
@@ -51,7 +51,7 @@ const GlobalStyleMultiTheme = createGlobalStyle`
   }
 `
 
-export const withThemeProvider = (Story: React.FC<StoryContext>, context: StoryContext) => {
+export const withThemeProvider = (Story: React.FC<React.PropsWithChildren<StoryContext>>, context: StoryContext) => {
   // used for testing ThemeProvider.stories.tsx
   if (context.parameters.disableThemeDecorator) return <Story {...context} />
 

--- a/src/utils/testing.tsx
+++ b/src/utils/testing.tsx
@@ -171,7 +171,7 @@ export function getClassName(node: React.ReactElement) {
 
 export function getClasses(node: React.ReactElement) {
   const className = getClassName(node)
-  return className ? className.trim().split(/ +/) : [];
+  return className ? className.trim().split(/ +/) : []
 }
 
 export async function loadCSS(path: string) {

--- a/src/utils/testing.tsx
+++ b/src/utils/testing.tsx
@@ -171,7 +171,7 @@ export function getClassName(node: React.ReactElement) {
 
 export function getClasses(node: React.ReactElement) {
   const className = getClassName(node)
-  return className ? className.trim().split(/ +/) : []
+  return className ? className.trim().split(/ +/) : [];
 }
 
 export async function loadCSS(path: string) {
@@ -202,7 +202,7 @@ interface Options {
 
 interface BehavesAsComponent {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Component: React.ComponentType<any>
+  Component: React.ComponentType<React.PropsWithChildren<any>>
   toRender?: () => React.ReactElement
   options?: Options
 }

--- a/src/utils/types/ComponentProps.ts
+++ b/src/utils/types/ComponentProps.ts
@@ -5,7 +5,7 @@
  *
  * @example ComponentProps<typeof MyComponent>
  */
-export type ComponentProps<T> = T extends React.ComponentType<infer Props>
+export type ComponentProps<T> = T extends React.ComponentType<React.PropsWithChildren<infer Props>>
   ? // eslint-disable-next-line @typescript-eslint/ban-types
     Props extends object
     ? Props


### PR DESCRIPTION
Describe your changes here.

Closes https://github.com/primer/react/issues/2065
Closes https://github.com/primer/react/issues/2194

Uses https://github.com/eps1lon/types-react-codemod to update types to react-18 compat. apis for children

Background: 

https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions

React 18 typings for `React.FC` and `React.FunctionComponent` no longer include implicit children props. In order to properly use these in typescript, a backward compatible codemod needs to be applied, wrapping props types that accept children in `React.PropsWithChildren` explicitly.

how I put together this PR: 

```sh
npx types-react-codemod preset-18 ./src

# select `implicit-children`
# run codemod
npx prettier --write ./src
```

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
