### PR TITLE
PageLayout: Fix containerWidth default value in docs

### DIFF
--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -158,7 +158,7 @@ See [storybook](https://primer.style/react/storybook?path=/story/layout-pagelayo
 | 'medium'
 | 'large'
 | 'xlarge'`}
-    defaultValue="'full'"
+    defaultValue="'xlarge'"
     description="The maximum width of the page container."
   />
   <PropsTableRow


### PR DESCRIPTION
The default value for the `containerWidth` prop is `xlarge`, but the docs incorrectly say it's `full`.
