### PR TITLE
restore contributor stats to docs footer

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -16,6 +16,8 @@ jobs:
       contents: read
       pages: write
       id-token: write
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:
       node_version: 14
       install: npm ci && cd docs && npm ci && cd ..

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -37,6 +37,8 @@ jobs:
     needs: [guard]
     if: ${{ needs.guard.outputs.should_deploy == 'true' }}
     uses: primer/.github/.github/workflows/deploy.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:
       node_version: 14
       install: npm ci && cd docs && npm ci && cd ..


### PR DESCRIPTION
Describe your changes here.

Restores contributor stats to docs 👇 

![docs footer](https://user-images.githubusercontent.com/13340707/182613207-49a9a32a-3433-491b-8843-8e158b726323.png)


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
