### PR TITLE
Enable chromatic for all builds without approval (to see if we need to replace or upgrade)

### DIFF
--- a/.github/workflows/visual_testing.yml
+++ b/.github/workflows/visual_testing.yml
@@ -9,7 +9,6 @@ jobs:
   chromatic:
     name: Visual testing
     runs-on: ubuntu-latest
-    environment: ${{ github.ref == 'refs/heads/main' && 'Preview' || 'needs-approval' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Hi! 

Right now, to stay under the free tier usage limit, we only run chromatic after an approval step. 

I'm removing the approval step to see if we will bypass the free tier limit in a month, and ask the question if we should replace it with our own infrastructure or upgrade to a paid plan with higher limits.