### PR TITLE
Add stickyTop prop to PageLayout.Pane

### DIFF
--- a/.changeset/fuzzy-windows-divide.md
+++ b/.changeset/fuzzy-windows-divide.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Add a `stickyTop` prop, the height of a sticky header, to the `PageLayout.Pane` to push the pane down for the sticky header when necessary.

--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -168,7 +168,7 @@ See [storybook](https://primer.style/react/storybook?path=/story/layout-pagelayo
 </Box>
 ```
 
-### With a stickyTop sticky pane
+### With a custom sticky header
 
 ```jsx live
 <Box sx={{height: 320, overflowY: 'auto', border: '1px solid', borderColor: 'border.default'}}>

--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -168,6 +168,36 @@ See [storybook](https://primer.style/react/storybook?path=/story/layout-pagelayo
 </Box>
 ```
 
+### With a stickyTop sticky pane
+
+```jsx live
+<Box sx={{height: '360px', overflowY: 'scroll', border: '1px solid', borderColor: 'border.default'}}>
+  <Box
+    height="100px"
+    width="100%"
+    borderBottom="1px solid"
+    borderColor="border.default"
+    sx={{position: 'sticky', top: '0', backgroundColor: 'canvas.subtle'}}
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+  >
+    <Heading>Sticky top content</Heading>
+  </Box>
+  <PageLayout>
+    <PageLayout.Content>
+      <Placeholder label="Content" height={240} />
+    </PageLayout.Content>
+    <PageLayout.Pane stickyTop={100} position="start" sticky>
+      <Placeholder label="Pane" height={240} />
+    </PageLayout.Pane>
+    <PageLayout.Footer>
+      <Placeholder label="Footer" height={64} />
+    </PageLayout.Footer>
+  </PageLayout>
+</Box>
+```
+
 ## Props
 
 ### PageLayout

--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -373,7 +373,7 @@ See [storybook](https://primer.style/react/storybook?path=/story/layout-pagelayo
     name="stickyTop"
     type="number | string"
     defaultValue="0"
-    description="Use stickyTop to push the sticky pane down to make room for a sticky header if necessary"
+    description="Use stickyTop to push the sticky pane down to make room for a sticky header if necessary. Use the type `string` to specify the height with a unit i.e. 5rem; otherwise the type `number` will be taken as px."
   />
   <PropsTableRow
     name="padding"

--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -173,16 +173,18 @@ See [storybook](https://primer.style/react/storybook?path=/story/layout-pagelayo
 ```jsx live
 <Box sx={{height: 320, overflowY: 'auto', border: '1px solid', borderColor: 'border.default'}}>
   <Box
-    height="64px"
-    width="100%"
-    borderBottom="1px solid"
-    borderColor="border.default"
-    sx={{position: 'sticky', top: '0', backgroundColor: 'canvas.subtle'}}
-    display="flex"
-    alignItems="center"
-    justifyContent="center"
+    sx={{
+      position: 'sticky',
+      top: 0,
+      height: 64,
+      display: 'grid',
+      placeItems: 'center',
+      backgroundColor: 'canvas.subtle',
+      borderBottom: '1px solid',
+      borderColor: 'border.default'
+    }}
   >
-    <Heading>Sticky top content</Heading>
+    Custom sticky header
   </Box>
   <PageLayout>
     <PageLayout.Content>

--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -171,9 +171,9 @@ See [storybook](https://primer.style/react/storybook?path=/story/layout-pagelayo
 ### With a stickyTop sticky pane
 
 ```jsx live
-<Box sx={{height: '360px', overflowY: 'scroll', border: '1px solid', borderColor: 'border.default'}}>
+<Box sx={{height: 320, overflowY: 'auto', border: '1px solid', borderColor: 'border.default'}}>
   <Box
-    height="100px"
+    height="64px"
     width="100%"
     borderBottom="1px solid"
     borderColor="border.default"
@@ -186,10 +186,10 @@ See [storybook](https://primer.style/react/storybook?path=/story/layout-pagelayo
   </Box>
   <PageLayout>
     <PageLayout.Content>
-      <Placeholder label="Content" height={240} />
+      <Placeholder label="Content" height={320} />
     </PageLayout.Content>
-    <PageLayout.Pane stickyTop={100} position="start" sticky>
-      <Placeholder label="Pane" height={240} />
+    <PageLayout.Pane position="start" stickyTop={64} sticky>
+      <Placeholder label="Pane" height={120} />
     </PageLayout.Pane>
     <PageLayout.Footer>
       <Placeholder label="Footer" height={64} />
@@ -367,6 +367,7 @@ See [storybook](https://primer.style/react/storybook?path=/story/layout-pagelayo
     defaultValue="false"
     description="Whether the pane should stick to the top of the screen while the content scrolls."
   />
+  <PropsTableRow name="stickyTop" type="number" defaultValue="0" description="The height of the sticky top element" />
   <PropsTableRow
     name="padding"
     type={`| 'none'

--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -367,7 +367,12 @@ See [storybook](https://primer.style/react/storybook?path=/story/layout-pagelayo
     defaultValue="false"
     description="Whether the pane should stick to the top of the screen while the content scrolls."
   />
-  <PropsTableRow name="stickyTop" type="number" defaultValue="0" description="The height of the sticky top element" />
+  <PropsTableRow
+    name="stickyTop"
+    type="number | string"
+    defaultValue="0"
+    description="Use stickyTop to push the sticky pane down to make room for a sticky header if necessary"
+  />
   <PropsTableRow
     name="padding"
     type={`| 'none'

--- a/docs/content/SplitPageLayout.mdx
+++ b/docs/content/SplitPageLayout.mdx
@@ -261,6 +261,7 @@ If you need a more flexible layout component, consider using the [PageLayout](/P
     </SplitPageLayout.Footer>
   </SplitPageLayout>
 </Box>
+```
 
 ## Props
 

--- a/docs/content/SplitPageLayout.mdx
+++ b/docs/content/SplitPageLayout.mdx
@@ -233,7 +233,7 @@ If you need a more flexible layout component, consider using the [PageLayout](/P
 
 ### With a custom sticky header
 
-```jsx live
+```jsx live drafts
 <Box sx={{height: 320, overflowY: 'auto', border: '1px solid', borderColor: 'border.default'}}>
   <Box
     sx={{
@@ -249,19 +249,18 @@ If you need a more flexible layout component, consider using the [PageLayout](/P
   >
     Custom sticky header
   </Box>
-  <PageLayout>
-    <PageLayout.Content>
+  <SplitPageLayout>
+    <SplitPageLayout.Content>
       <Placeholder label="Content" height={320} />
-    </PageLayout.Content>
-    <PageLayout.Pane position="start" stickyTop={64} sticky>
+    </SplitPageLayout.Content>
+    <SplitPageLayout.Pane stickyTop={64}>
       <Placeholder label="Pane" height={120} />
-    </PageLayout.Pane>
-    <PageLayout.Footer>
+    </SplitPageLayout.Pane>
+    <SplitPageLayout.Footer>
       <Placeholder label="Footer" height={64} />
-    </PageLayout.Footer>
-  </PageLayout>
+    </SplitPageLayout.Footer>
+  </SplitPageLayout>
 </Box>
-```
 
 ## Props
 

--- a/docs/content/SplitPageLayout.mdx
+++ b/docs/content/SplitPageLayout.mdx
@@ -231,6 +231,38 @@ If you need a more flexible layout component, consider using the [PageLayout](/P
 </Box>
 ```
 
+### With a custom sticky header
+
+```jsx live
+<Box sx={{height: 320, overflowY: 'auto', border: '1px solid', borderColor: 'border.default'}}>
+  <Box
+    sx={{
+      position: 'sticky',
+      top: 0,
+      height: 64,
+      display: 'grid',
+      placeItems: 'center',
+      backgroundColor: 'canvas.subtle',
+      borderBottom: '1px solid',
+      borderColor: 'border.default'
+    }}
+  >
+    Custom sticky header
+  </Box>
+  <PageLayout>
+    <PageLayout.Content>
+      <Placeholder label="Content" height={320} />
+    </PageLayout.Content>
+    <PageLayout.Pane position="start" stickyTop={64} sticky>
+      <Placeholder label="Pane" height={120} />
+    </PageLayout.Pane>
+    <PageLayout.Footer>
+      <Placeholder label="Footer" height={64} />
+    </PageLayout.Footer>
+  </PageLayout>
+</Box>
+```
+
 ## Props
 
 ### SplitPageLayout
@@ -349,6 +381,12 @@ If you need a more flexible layout component, consider using the [PageLayout](/P
     type="boolean"
     defaultValue="true"
     description="Whether the pane should stick to the top of the screen while the content scrolls."
+  />
+  <PropsTableRow
+    name="stickyTop"
+    type="number | string"
+    defaultValue="0"
+    description="Use stickyTop to push the sticky pane down to make room for a sticky header if necessary. Use the type `string` to specify the height with a unit i.e. 5rem; otherwise the type `number` will be taken as px."
   />
   <PropsTableRow
     name="padding"

--- a/src/PageLayout/PageLayout.stories.tsx
+++ b/src/PageLayout/PageLayout.stories.tsx
@@ -716,8 +716,8 @@ CustomStickyHeader.argTypes = {
     defaultValue: true
   },
   stickyTop: {
-    type: 'number',
-    defaultValue: 100
+    type: 'string',
+    defaultValue: '8rem'
   },
   numParagraphsInPane: {
     type: 'number',

--- a/src/PageLayout/PageLayout.stories.tsx
+++ b/src/PageLayout/PageLayout.stories.tsx
@@ -659,4 +659,72 @@ NestedScrollContainer.argTypes = {
   }
 }
 
+export const StickyPaneWithStickyTop: Story = args => (
+  // a box to create a sticky top element that will be on the consumer side and outside of the PageLayout component
+  <Box>
+    <Box
+      height={args.stickyTop}
+      width="100%"
+      border="1px solid"
+      borderColor="border.default"
+      sx={{position: 'sticky', top: '0', backgroundColor: 'canvas.subtle'}}
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Heading>Sticky top content</Heading>
+    </Box>
+    <PageLayout rowGap="none" columnGap="none" padding="none" containerWidth="full">
+      <PageLayout.Content padding="normal" width="large">
+        <Box sx={{display: 'grid', gap: 3}}>
+          {Array.from({length: args.numParagraphsInContent}).map((_, i) => (
+            <Box key={i} as="p" sx={{margin: 0}}>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam at enim id lorem tempus egestas a non ipsum.
+              Maecenas imperdiet ante quam, at varius lorem molestie vel. Sed at eros consequat, varius tellus et,
+              auctor felis. Donec pulvinar lacinia urna nec commodo. Phasellus at imperdiet risus. Donec sit amet massa
+              purus. Nunc sem lectus, bibendum a sapien nec, tristique tempus felis. Ut porttitor auctor tellus in
+              imperdiet. Ut blandit tincidunt augue, quis fringilla nunc tincidunt sed. Vestibulum auctor euismod nisi.
+              Nullam tincidunt est in mi tincidunt dictum. Sed consectetur aliquet velit ut ornare.
+            </Box>
+          ))}
+        </Box>
+      </PageLayout.Content>
+      <PageLayout.Pane position="start" padding="normal" divider="line" stickyTop={100} sticky>
+        <Box sx={{display: 'grid', gap: 3}}>
+          {Array.from({length: args.numParagraphsInPane}).map((_, i) => (
+            <Box key={i} as="p" sx={{margin: 0}}>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam at enim id lorem tempus egestas a non ipsum.
+              Maecenas imperdiet ante quam, at varius lorem molestie vel. Sed at eros consequat, varius tellus et,
+              auctor felis. Donec pulvinar lacinia urna nec commodo. Phasellus at imperdiet risus. Donec sit amet massa
+              purus.
+            </Box>
+          ))}
+        </Box>
+      </PageLayout.Pane>
+      <PageLayout.Footer padding="normal" divider="line">
+        <Placeholder label="Footer" height={64} />
+      </PageLayout.Footer>
+    </PageLayout>
+  </Box>
+)
+
+StickyPaneWithStickyTop.argTypes = {
+  sticky: {
+    type: 'boolean',
+    defaultValue: true
+  },
+  stickyTop: {
+    type: 'number',
+    defaultValue: 100
+  },
+  numParagraphsInPane: {
+    type: 'number',
+    defaultValue: 10
+  },
+  numParagraphsInContent: {
+    type: 'number',
+    defaultValue: 30
+  }
+}
+
 export default meta

--- a/src/PageLayout/PageLayout.stories.tsx
+++ b/src/PageLayout/PageLayout.stories.tsx
@@ -659,20 +659,22 @@ NestedScrollContainer.argTypes = {
   }
 }
 
-export const StickyPaneWithStickyTop: Story = args => (
+export const CustomStickyHeader: Story = args => (
   // a box to create a sticky top element that will be on the consumer side and outside of the PageLayout component
   <Box>
     <Box
-      height={args.stickyTop}
-      width="100%"
-      border="1px solid"
-      borderColor="border.default"
-      sx={{position: 'sticky', top: '0', backgroundColor: 'canvas.subtle'}}
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
+      sx={{
+        position: 'sticky',
+        top: 0,
+        height: args.stickyTop,
+        display: 'grid',
+        placeItems: 'center',
+        backgroundColor: 'canvas.subtle',
+        borderBottom: '1px solid',
+        borderColor: 'border.default'
+      }}
     >
-      <Heading>Sticky top content</Heading>
+      Custom sticky header
     </Box>
     <PageLayout rowGap="none" columnGap="none" padding="none" containerWidth="full">
       <PageLayout.Content padding="normal" width="large">
@@ -689,7 +691,7 @@ export const StickyPaneWithStickyTop: Story = args => (
           ))}
         </Box>
       </PageLayout.Content>
-      <PageLayout.Pane position="start" padding="normal" divider="line" stickyTop={100} sticky>
+      <PageLayout.Pane position="start" padding="normal" divider="line" sticky stickyTop={args.stickyTop}>
         <Box sx={{display: 'grid', gap: 3}}>
           {Array.from({length: args.numParagraphsInPane}).map((_, i) => (
             <Box key={i} as="p" sx={{margin: 0}}>
@@ -708,7 +710,7 @@ export const StickyPaneWithStickyTop: Story = args => (
   </Box>
 )
 
-StickyPaneWithStickyTop.argTypes = {
+CustomStickyHeader.argTypes = {
   sticky: {
     type: 'boolean',
     defaultValue: true

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -22,7 +22,7 @@ const PageLayoutContext = React.createContext<{
   padding: keyof typeof SPACING_MAP
   rowGap: keyof typeof SPACING_MAP
   columnGap: keyof typeof SPACING_MAP
-  enableStickyPane?: (stickyTopHeight: number) => void
+  enableStickyPane?: (top: number | string) => void
   disableStickyPane?: () => void
   contentTopRef?: (node?: Element | null | undefined) => void
   contentBottomRef?: (node?: Element | null | undefined) => void
@@ -362,7 +362,7 @@ export type PageLayoutPaneProps = {
    */
   dividerWhenNarrow?: 'inherit' | 'none' | 'line' | 'filled'
   sticky?: boolean
-  stickyTop?: number // the height of the sticky top element
+  stickyTop?: string | number
   hidden?: boolean | ResponsiveValue<boolean>
 } & SxProp
 

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -22,7 +22,7 @@ const PageLayoutContext = React.createContext<{
   padding: keyof typeof SPACING_MAP
   rowGap: keyof typeof SPACING_MAP
   columnGap: keyof typeof SPACING_MAP
-  enableStickyPane?: () => void
+  enableStickyPane?: (stickyTopHeight: number) => void
   disableStickyPane?: () => void
   contentTopRef?: (node?: Element | null | undefined) => void
   contentBottomRef?: (node?: Element | null | undefined) => void
@@ -362,6 +362,7 @@ export type PageLayoutPaneProps = {
    */
   dividerWhenNarrow?: 'inherit' | 'none' | 'line' | 'filled'
   sticky?: boolean
+  stickyTop?: number // the height of the sticky top element
   hidden?: boolean | ResponsiveValue<boolean>
 } & SxProp
 
@@ -384,6 +385,7 @@ const Pane: React.FC<React.PropsWithChildren<PageLayoutPaneProps>> = ({
   divider: responsiveDivider = 'none',
   dividerWhenNarrow = 'inherit',
   sticky = false,
+  stickyTop = 0,
   hidden: responsiveHidden = false,
   children,
   sx = {}
@@ -410,11 +412,11 @@ const Pane: React.FC<React.PropsWithChildren<PageLayoutPaneProps>> = ({
 
   React.useEffect(() => {
     if (sticky) {
-      enableStickyPane?.()
+      enableStickyPane?.(stickyTop)
     } else {
       disableStickyPane?.()
     }
-  }, [sticky, enableStickyPane, disableStickyPane])
+  }, [sticky, enableStickyPane, disableStickyPane, stickyTop])
 
   return (
     <Box
@@ -439,7 +441,9 @@ const Pane: React.FC<React.PropsWithChildren<PageLayoutPaneProps>> = ({
               ...(sticky
                 ? {
                     position: 'sticky',
-                    top: 0,
+                    // If stickyTop has value, it will stick the pane to the position where the sticky top ends
+                    // else top will be 0 as the default value of stickyTop
+                    top: stickyTop,
                     overflow: 'hidden',
                     maxHeight: 'var(--sticky-pane-height)'
                   }

--- a/src/PageLayout/useStickyPaneHeight.ts
+++ b/src/PageLayout/useStickyPaneHeight.ts
@@ -5,14 +5,12 @@ import {useInView} from 'react-intersection-observer'
  * Calculates the height of the sticky pane such that it always
  * fits into the viewport even when the header or footer are visible.
  */
-// TODO: Handle sticky header
 export function useStickyPaneHeight() {
   const rootRef = React.useRef<HTMLDivElement>(null)
 
   // Default the height to the viewport height
   const [height, setHeight] = React.useState('100vh')
-  // stickyTop state
-  const [stickyTopHeight, setStickyTopHeight] = React.useState(0)
+  const [stickyTop, setStickyTop] = React.useState<number | string>(0)
 
   // Create intersection observers to track the top and bottom of the content region
   const [contentTopRef, contentTopInView, contentTopEntry] = useInView()
@@ -46,11 +44,13 @@ export function useStickyPaneHeight() {
       // We need to account for this when calculating the offset.
       const overflowScroll = Math.max(window.scrollY + window.innerHeight - document.body.scrollHeight, 0)
 
-      calculatedHeight = `calc(100vh - ${Math.max(topOffset, stickyTopHeight) + bottomOffset - overflowScroll}px)`
+      const stickyTopWithUnits = typeof stickyTop === 'number' ? `${stickyTop}px` : stickyTop
+
+      calculatedHeight = `calc(100vh - (max(${topOffset}px, ${stickyTopWithUnits}) + ${bottomOffset}px - ${overflowScroll}px))`
     }
 
     setHeight(calculatedHeight)
-  }, [contentTopEntry, contentBottomEntry, stickyTopHeight])
+  }, [contentTopEntry, contentBottomEntry, stickyTop])
 
   // We only want to add scroll and resize listeners if the pane is sticky.
   // Since hooks can't be called conditionally, we need to use state to track
@@ -90,12 +90,14 @@ export function useStickyPaneHeight() {
     }
   }, [isEnabled, contentTopInView, contentBottomInView, calculateHeight])
 
-  const enableStickyPane = (stickyTop: number) => {
+  function enableStickyPane(top: string | number) {
     setIsEnabled(true)
-    setStickyTopHeight(stickyTop)
+    setStickyTop(top)
   }
 
-  const disableStickyPane = () => setIsEnabled(false)
+  function disableStickyPane() {
+    setIsEnabled(false)
+  }
 
   return {
     rootRef,

--- a/src/PageLayout/useStickyPaneHeight.ts
+++ b/src/PageLayout/useStickyPaneHeight.ts
@@ -11,6 +11,8 @@ export function useStickyPaneHeight() {
 
   // Default the height to the viewport height
   const [height, setHeight] = React.useState('100vh')
+  // stickyTop state
+  const [stickyTopHeight, setStickyTopHeight] = React.useState(0)
 
   // Create intersection observers to track the top and bottom of the content region
   const [contentTopRef, contentTopInView, contentTopEntry] = useInView()
@@ -44,11 +46,11 @@ export function useStickyPaneHeight() {
       // We need to account for this when calculating the offset.
       const overflowScroll = Math.max(window.scrollY + window.innerHeight - document.body.scrollHeight, 0)
 
-      calculatedHeight = `calc(100vh - ${topOffset + bottomOffset - overflowScroll}px)`
+      calculatedHeight = `calc(100vh - ${Math.max(topOffset, stickyTopHeight) + bottomOffset - overflowScroll}px)`
     }
 
     setHeight(calculatedHeight)
-  }, [contentTopEntry, contentBottomEntry])
+  }, [contentTopEntry, contentBottomEntry, stickyTopHeight])
 
   // We only want to add scroll and resize listeners if the pane is sticky.
   // Since hooks can't be called conditionally, we need to use state to track
@@ -88,10 +90,17 @@ export function useStickyPaneHeight() {
     }
   }, [isEnabled, contentTopInView, contentBottomInView, calculateHeight])
 
+  const enableStickyPane = (stickyTop: number) => {
+    setIsEnabled(true)
+    setStickyTopHeight(stickyTop)
+  }
+
+  const disableStickyPane = () => setIsEnabled(false)
+
   return {
     rootRef,
-    enableStickyPane: () => setIsEnabled(true),
-    disableStickyPane: () => setIsEnabled(false),
+    enableStickyPane,
+    disableStickyPane,
     contentTopRef,
     contentBottomRef,
     stickyPaneHeight: height


### PR DESCRIPTION
Closes [this issue ](https://github.com/github/primer/issues/1200) which lives in the internal repo. 

## Motivation

This PR adds a prop called stickyTop to the PageLayout.Pane to be able to push the pane down and make space for the top sticky element (which lives outside of the PageLayout component) and sticks the pane to a position where the top element ends.

```
<PageLayout>
  <PageLayout.Pane sticky stickyTop={100}>...</PageLayout.Pane>
  <PageLayout.Content>...</PageLayout.Content>
</PageLayout>
```

### Screen record


https://user-images.githubusercontent.com/1446503/184807222-7719ac67-6f7b-4457-a793-b0ab0a4e305b.mp4



### Merge checklist

- [ ] Added/updated tests
   - I'll work with @pksjce and @colebemis to write interaction tests for this case
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
