### PR TITLE
PageLayout.Pane: `stickyTop` bug fixes

### DIFF
--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -442,7 +442,7 @@ const Pane: React.FC<React.PropsWithChildren<PageLayoutPaneProps>> = ({
                     position: 'sticky',
                     // If stickyTop has value, it will stick the pane to the position where the sticky top ends
                     // else top will be 0 as the default value of stickyTop
-                    top: stickyTop,
+                    top: typeof stickyTop === 'number' ? `${stickyTop}px` : stickyTop,
                     overflow: 'hidden',
                     maxHeight: 'var(--sticky-pane-height)'
                   }

--- a/src/PageLayout/useStickyPaneHeight.ts
+++ b/src/PageLayout/useStickyPaneHeight.ts
@@ -29,13 +29,15 @@ export function useStickyPaneHeight() {
     const topRect = contentTopEntry?.target.getBoundingClientRect()
     const bottomRect = contentBottomEntry?.target.getBoundingClientRect()
 
+    const stickyTopWithUnits = typeof stickyTop === 'number' ? `${stickyTop}px` : stickyTop
+
     if (scrollContainer) {
       const scrollRect = scrollContainer.getBoundingClientRect()
 
       const topOffset = topRect ? Math.max(topRect.top - scrollRect.top, 0) : 0
       const bottomOffset = bottomRect ? Math.max(scrollRect.bottom - bottomRect.bottom, 0) : 0
 
-      calculatedHeight = `${scrollRect.height - (topOffset + bottomOffset)}px`
+      calculatedHeight = `calc(${scrollRect.height}px - (max(${topOffset}px, ${stickyTopWithUnits}) + ${bottomOffset}px))`
     } else {
       const topOffset = topRect ? Math.max(topRect.top, 0) : 0
       const bottomOffset = bottomRect ? Math.max(window.innerHeight - bottomRect.bottom, 0) : 0
@@ -43,8 +45,6 @@ export function useStickyPaneHeight() {
       // Safari's elastic scroll feature allows you to scroll beyond the scroll height of the page.
       // We need to account for this when calculating the offset.
       const overflowScroll = Math.max(window.scrollY + window.innerHeight - document.body.scrollHeight, 0)
-
-      const stickyTopWithUnits = typeof stickyTop === 'number' ? `${stickyTop}px` : stickyTop
 
       calculatedHeight = `calc(100vh - (max(${topOffset}px, ${stickyTopWithUnits}) + ${bottomOffset}px - ${overflowScroll}px))`
     }

--- a/src/SplitPageLayout/__snapshots__/SplitPageLayout.test.tsx.snap
+++ b/src/SplitPageLayout/__snapshots__/SplitPageLayout.test.tsx.snap
@@ -154,7 +154,7 @@ exports[`SplitPageLayout renders default layout 1`] = `
     margin-bottom: 0 !important;
     position: -webkit-sticky;
     position: sticky;
-    top: 0;
+    top: 0px;
     overflow: hidden;
     max-height: var(--sticky-pane-height);
     -webkit-flex-direction: row-reverse;


### PR DESCRIPTION
I noticed a couple minor bugs in `stickyTop` that I missed during my initial review. This PR fixes them.

**Bug 1**

Sometimes passing a number to `stickyProp` gives you an unexpected result. This happens because the `sx` prop treats the number as an index into our [spacing scale](https://github.com/primer/react/blob/main/src/theme-preval.js#L50) instead of a pixel value.

![CleanShot 2022-08-17 at 18 43 57@2x](https://user-images.githubusercontent.com/4608155/185273806-984d1f39-9f1b-42f5-8798-c3dbf60fb37b.png)


**Bug 2**

If PageLayout is nested inside a scroll container, the height of the pane doesn't account for the stickyTop prop. 

<img width="622" alt="CleanShot 2022-08-17 at 18 44 58@2x" src="https://user-images.githubusercontent.com/4608155/185273897-52833501-1dc7-4a96-83b6-be4d5467d425.png">
