### PR TITLE
fix(Button): memoize call to merge.all

### DIFF
--- a/src/Button/ButtonBase.tsx
+++ b/src/Button/ButtonBase.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentPropsWithRef, forwardRef} from 'react'
+import React, {ComponentPropsWithRef, forwardRef, useMemo} from 'react'
 import {ForwardRefComponent as PolymorphicForwardRefComponent} from '@radix-ui/react-polymorphic'
 import Box from '../Box'
 import {merge, SxProp} from '../sx'
@@ -7,18 +7,20 @@ import {ButtonProps, StyledButton} from './types'
 import {getVariantStyles, getSizeStyles, getButtonStyles} from './styles'
 
 const ButtonBase = forwardRef<HTMLElement, ButtonProps>(
-  ({children, as: Component = 'button', sx: sxProp = {}, ...props}, forwardedRef): JSX.Element => {
+  ({children, as: Component = 'button', sx: sxProp, ...props}, forwardedRef): JSX.Element => {
     const {leadingIcon: LeadingIcon, trailingIcon: TrailingIcon, variant = 'default', size = 'medium'} = props
     const {theme} = useTheme()
     const iconWrapStyles = {
       display: 'inline-block'
     }
-    const sxStyles = merge.all([
-      getButtonStyles(theme),
-      getSizeStyles(size, variant, false),
-      getVariantStyles(variant, theme),
-      sxProp as SxProp
-    ])
+    const sxStyles = useMemo(() => {
+      return merge.all([
+        getButtonStyles(theme),
+        getSizeStyles(size, variant, false),
+        getVariantStyles(variant, theme),
+        (sxProp ?? {}) as SxProp
+      ])
+    }, [theme, size, variant, sxProp])
     return (
       <StyledButton as={Component} sx={sxStyles} {...props} ref={forwardedRef}>
         {LeadingIcon && (


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/1191

This PR updates `ButtonBase` to memoize the call to `merge.all` with `useMemo`. This seemed like the best next step when I was taking a look at the issue, let me know if I misunderstood the approach!

A quick aside, I removed the default value of `sx` so that `useMemo` wouldn't be called each render. The fallback value has been moved to the `merge.all` call

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
