### PR TITLE
Fix storybook urls and improve docs

### DIFF
--- a/docs/content/Autocomplete.mdx
+++ b/docs/content/Autocomplete.mdx
@@ -4,7 +4,7 @@ title: Autocomplete
 status: Alpha
 description: Used to render a text input that allows a user to quickly filter through a list of options to pick one or more values.
 source: https://github.com/primer/react/tree/main/src/Autocomplete
-storybook: '/react/storybook?path=/story/form-controls-autocomplete--default'
+storybook: '/react/storybook?path=/story/forms-form-controls-autocomplete'
 ---
 
 import {Autocomplete} from '@primer/react'

--- a/docs/content/Checkbox.mdx
+++ b/docs/content/Checkbox.mdx
@@ -3,7 +3,7 @@ title: Checkbox
 description: Use checkboxes to toggle between checked and unchecked states in a list or as a standalone form field
 status: Alpha
 source: https://github.com/primer/react/blob/main/src/Checkbox.tsx
-storybook: '/react/storybook?path=/story/form-controls-checkbox--default'
+storybook: '/react/storybook?path=/story/forms-form-controls-checkbox'
 componentId: checkbox
 ---
 

--- a/docs/content/CheckboxGroup.mdx
+++ b/docs/content/CheckboxGroup.mdx
@@ -4,7 +4,7 @@ componentId: checkbox_group
 description: Renders a set of checkboxes to let users make one or more selections from a short list of options
 status: Alpha
 source: https://github.com/primer/react/blob/main/src/CheckboxGroup/CheckboxGroup.tsx
-storybook: '/react/storybook/?path=/story/forms-checkboxgroup-examples--basic'
+storybook: '/react/storybook/?path=/story/forms-checkboxgroup-examples'
 ---
 
 import {CheckboxGroup, Checkbox, Box} from '@primer/components'

--- a/docs/content/FilteredSearch.md
+++ b/docs/content/FilteredSearch.md
@@ -4,9 +4,9 @@ title: FilteredSearch
 status: Alpha
 ---
 
-The FilteredSearch component helps style a Dropdown and a TextInput side-by-side.
+The FilteredSearch component helps style an ActionMenu and a TextInput side-by-side.
 
-**Note:** You _must_ use a `TextInput` and `Dropdown` (or native `<details>` and `<summary>`) in order for this component to work properly.
+**Note:** You _must_ use a `TextInput` and `ActionMenu` (or native `<details>` and `<summary>`) in order for this component to work properly.
 
 ## Default example
 
@@ -30,7 +30,7 @@ The FilteredSearch component helps style a Dropdown and a TextInput side-by-side
 
 #### FilteredSearch.Children
 
-| Name     | Type              | Default | Description                                                                                              |
-| :------- | :---------------- | :-----: | :------------------------------------------------------------------------------------------------------- |
-| children |                   |         | FilteredSearch is expected to contain a [`Dropdown`](/Dropdown) followed by a [`TextInput`](/TextInput). |
-| sx       | SystemStyleObject |   {}    | Style to be applied to the component                                                                     |
+| Name     | Type              | Default | Description                                                                                                   |
+| :------- | :---------------- | :-----: | :------------------------------------------------------------------------------------------------------------ |
+| children |                   |         | FilteredSearch is expected to contain an [`ActionMenu`](/ActionMenu) followed by a [`TextInput`](/TextInput). |
+| sx       | SystemStyleObject |   {}    | Style to be applied to the component                                                                          |

--- a/docs/content/IconButton.mdx
+++ b/docs/content/IconButton.mdx
@@ -3,7 +3,7 @@ title: IconButton
 componentId: icon_button
 status: Alpha
 source: https://github.com/primer/react/tree/main/src/Button
-storybook: '/react/storybook?path=/story/composite-components-button'
+storybook: '/react/storybook?path=/story/composite-components-button--icon-button'
 description: An accessible button component with no text and only icon.
 ---
 

--- a/docs/content/Label.mdx
+++ b/docs/content/Label.mdx
@@ -3,7 +3,7 @@ title: Label
 componentId: label
 status: Alpha
 source: https://github.com/primer/react/tree/main/src/Label
-storybook: '/react/storybook?path=story/labels-label--label'
+storybook: '/react/storybook?path=/story/labels-label--label'
 description: Use Label components to add contextual metadata to a design.
 ---
 

--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -15,7 +15,7 @@ import {PageLayout} from '@primer/react'
 
 <Note>
 
-See [storybook](https://primer.style/react/storybook?path=/story/layout-pagelayout--playground) for fullscreen examples.
+See [storybook](https://primer.style/react/storybook?path=/story/layout-pagelayout) for fullscreen examples.
 
 </Note>
 


### PR DESCRIPTION
There were a couple of storybook links broken, I fixed them also improved the FilteredSearch docs as the Dropdown that can be used as a child is [deprecated](https://primer.style/react/deprecated/Dropdown#deprecation) now.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
