### PR TITLE
Add UnderlineNav draft component to docs

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -161,6 +161,8 @@
       url: /drafts/MarkdownEditor
     - title: MarkdownViewer
       url: /drafts/MarkdownViewer
+    - title: UnderlineNav v2
+      url: /drafts/UnderlineNav2
 - title: Deprecated
   children:
     - title: ActionList (legacy)


### PR DESCRIPTION
Missed adding the draft component docs to nav.yml.

