### PR TITLE
PageHeader API

### DIFF
--- a/docs/content/PageHeader.mdx
+++ b/docs/content/PageHeader.mdx
@@ -25,13 +25,13 @@ import {PageHeader} from '@primer/react'
     <PageHeader.Title>Branches</PageHeader.Title>
     <PageHeader.TitleActions>
       {/* Visible only in narrow viewport*/}
-      <WhenNarrow>
+      <Stack direction={{narrow: 'inline', regular: 'none'}}>
         <Button variant="primary">New Branch</Button>
-      </WhenNarrow>
+      </Stack>
       {/* Visible only in regular viewport*/}
-      <WhenRegular>
+      <Stack direction={{narrow: 'none', regular: 'inline'}}>
         <Button variant="primary">New</Button>
-      </WhenRegular>
+      </Stack>
       {/* Visible in all viewports */}
       <IconButton aria-label="More actions" icon={KebabHorizontalIcon} />
     </PageHeader.TitleActions>
@@ -89,11 +89,11 @@ import {PageHeader} from '@primer/react'
   <PageHeader.Description>
     <StateLabel status="issueOpened">Open</StateLabel>
     <Box sx={{display: 'inline-flex'}}>
-      <WhenRegular>
+      <Stack direction={{narrow: 'none', regular: 'inline'}}>
         <Box>
           <b>simurai</b> wants to merge 12 commits from
         </Box>
-      </WhenRegular>
+      </Stack>
       <Box>
         <Token>token-mode</Token>
         <ArrowRightIcon />

--- a/docs/content/PageHeader.mdx
+++ b/docs/content/PageHeader.mdx
@@ -18,7 +18,7 @@ import {PageHeader} from '@primer/react'
   {/* Visible only in narrow viewport*/}
   <PageHeader.ContextNav>
     {/* Always renders with a backbutton and is left aligned*/}
-    <PageHeader.ParentLink>Code</PageHeader.ParentLink>
+    <PageHeader.ParentLink href="/code">Code</PageHeader.ParentLink>
   </PageHeader.ContextNav>
   {/* Visible in all viewports */}
   <PageHeader.TitleArea>
@@ -45,7 +45,7 @@ import {PageHeader} from '@primer/react'
   {/* Visible only in narrow viewport only*/}
   <PageHeader.ContextNav>
     {/* Always renders with a backbutton and is left aligned*/}
-    <PageHeader.ParentLink>Files</PageHeader.ParentLink>
+    <PageHeader.ParentLink href="files">Files</PageHeader.ParentLink>
     {/* These are right aligned*/}
     <PageHeader.ContextNavActions>
       {/* Should these buttons be normal sized?*/}
@@ -75,7 +75,7 @@ import {PageHeader} from '@primer/react'
 
 <PageHeader>
   <PageHeader.ContextNav>
-    <PageHeader.ParentLink>Pull requests</PageHeader.ParentLink>
+    <PageHeader.ParentLink href="prs">Pull requests</PageHeader.ParentLink>
   </PageHeader.ContextNav>
   <PageHeader.TitleArea>
     <PageHeader.Title>PageLayout component/Layout beta + storybook</PageHeader.Title>

--- a/docs/content/PageHeader.mdx
+++ b/docs/content/PageHeader.mdx
@@ -1,0 +1,114 @@
+---
+title: PageHeader
+componentId: page_header
+status: Draft
+description: This component can be used independently or inside PageLayout.Header. It helps provide structure and responsive aspects to the Header component.
+# source: https://github.com/primer/react/tree/main/src/PageHeader
+# storybook: https://primer.style/react/storybook?path=/story/layout-pageheader--default
+---
+
+```js
+import {PageHeader} from '@primer/react'
+```
+
+### Default
+
+```jsx live
+<PageHeader>
+  {/* Visible only in narrow viewport*/}
+  <PageHeader.ContextNav>
+    {/* Always renders with a backbutton and is left aligned*/}
+    <PageHeader.ParentLink>Code</PageHeader.ParentLink>
+  </PageHeader.ContextNav>
+  {/* Visible in all viewports */}
+  <PageHeader.TitleArea>
+    <PageHeader.Title>Branches</PageHeader.Title>
+    <PageHeader.TitleActions>
+      {/* Visible only in narrow viewport*/}
+      <WhenNarrow>
+        <Button variant="primary">New Branch</Button>
+      </WhenNarrow>
+      {/* Visible only in regular viewport*/}
+      <WhenRegular>
+        <Button variant="primary">New</Button>
+      </WhenRegular>
+      {/* Visible in all viewports */}
+      <IconButton aria-label="More actions" icon={KebabHorizontalIcon} />
+    </PageHeader.TitleActions>
+  </PageHeader.TitleArea>
+</PageHeader>
+```
+
+### With Context Actions and Breadcrumbs
+
+<PageHeader>
+  {/* Visible only in narrow viewport only*/}
+  <PageHeader.ContextNav>
+    {/* Always renders with a backbutton and is left aligned*/}
+    <PageHeader.ParentLink>Files</PageHeader.ParentLink>
+    {/* These are right aligned*/}
+    <PageHeader.ContextNavActions>
+      {/* Should these buttons be normal sized?*/}
+      <Button size="small" leadingIcon={GitBranchIcon} trailingIcon={ChevronDownIcon} variant="outline">
+        main
+      </Button>
+      <IconButton size="small" aria-label="More actions" icon={KebabHorizontalIcon} />
+    </PageHeader.ContextNavActions>
+  </PageHeader.ContextNav>
+  {/* Visible only in all viewports */}
+  <PageHeader.TitleArea>
+    <PageHeader.Title>
+      <Breadcrumbs>
+        <Breadcrumbs.Item href="/">...</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="/primer">primer</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="/primer/react">react</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="/primer/react/PageHeader">PageHeader</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="/primer/react/PageHeader/index.ts" selected>
+          index.ts
+        </Breadcrumbs.Item>
+      </Breadcrumbs>
+    </PageHeader.Title>
+  </PageHeader.TitleArea>
+</PageHeader>
+
+### With a description and local navigation
+
+<PageHeader>
+  <PageHeader.ContextNav>
+    <PageHeader.ParentLink>Pull requests</PageHeader.ParentLink>
+  </PageHeader.ContextNav>
+  <PageHeader.TitleArea>
+    <PageHeader.Title>PageLayout component/Layout beta + storybook</PageHeader.Title>
+    <PageHeader.TitleActions>
+      <Button>Edit</Button>
+      <Button leadingIcon={CodeIcon} trailingIcon={ChevronDownIcon}>
+        Code
+      </Button>
+    </PageHeader.TitleActions>
+  </PageHeader.TitleArea>
+  <PageHeader.Description>
+    <StateLabel status="issueOpened">Open</StateLabel>
+    <Box sx={{display: 'inline-flex'}}>
+      <WhenRegular>
+        <Box>
+          <b>simurai</b> wants to merge 12 commits from
+        </Box>
+      </WhenRegular>
+      <Box>
+        <Token>token-mode</Token>
+        <ArrowRightIcon />
+        <Token>main</Token>
+      </Box>
+    </Box>
+  </PageHeader.Description>
+  <PageHeader.LocalNav>
+    <UnderlineNav>
+      <UnderlineNav.Link>Overview</UnderlineNav.Link>
+      <UnderlineNav.Link leadingIcon={CommentDiscussionIcon}>
+        Conversations
+        <CounterLabel sx={{ml: 2}}>42</CounterLabel>
+      </UnderlineNav.Link>
+      <UnderlineNav.Link leadingIcon={GitCommitIcon}>Commits</UnderlineNav.Link>
+    </UnderlineNav>
+  </PageHeader.LocalNav>
+</PageHeader>


### PR DESCRIPTION
This PR documents `PageHeader` proposed API. The implementation PR will be https://github.com/primer/react/pull/2265 where the goal is to get the same api as documented here working inside storybooks. I will modify implementation based on feedback here. This PR needs to be merged first before implementation PR.

Link to PageHeader API in figma - https://www.figma.com/file/Ee0OrXuOLXMDqUW83EnDHP/PageHeader-(FY23-Q1)?node-id=2%3A80694
This is the proposed anatomy that seems most complete to me
![image](https://user-images.githubusercontent.com/417268/186641338-79b23fdf-284d-4748-b066-a39dfee4248c.png)

Here are the corresponding figma shots for the three API examples. Together I think this gives us a decent look at the API.

### Default

![image](https://user-images.githubusercontent.com/417268/186641387-6838214a-3e8b-4c9d-a09b-f5ad2b887f86.png)

### With Context Actions and Breadcrumbs
![image](https://user-images.githubusercontent.com/417268/186641604-802eeda6-d074-46ac-97c1-11c00e52a92d.png)

### With a description and local navigation
![image](https://user-images.githubusercontent.com/417268/186641711-f5813558-0949-484f-b2c6-b2cbcedec210.png)


I'm looking for specific feedback on -
- API does not communicate that `PageHeader.ContextNav` will only be visible in narrow mode.
- The ADR on responsive design proposes a `Stack` component. I feel like my usecase needs this component. It's not developed yet. I'm planning on making it. WDYT?
- Naming of components and the depth of the component tree (is it too much?)
