### PR TITLE
test: update jest transformIgnorePatterns config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,10 @@ module.exports = {
     '<rootDir>/src/utils/test-helpers.tsx'
   ],
   testMatch: ['<rootDir>/(src|codemods)/**/*.test.[jt]s?(x)', '!**/*.types.test.[jt]s?(x)'],
-  transformIgnorePatterns: [
-    'node_modules/(?!@github/combobox-nav|@koddsson/textarea-caret|@github/markdown-toolbar-element)'
-  ]
+
+  // Note: this configuration option should not exclude any packages within
+  // `node_modules`. When excluding packages from `node_modules`, we have no way
+  // to test if this package is shipping with support for both ESM and CommonJS
+  // @see https://github.com/primer/react/issues/2275
+  transformIgnorePatterns: ['/node_modules/']
 }


### PR DESCRIPTION
Closes #2275

This PR updates our `transformIgnorePatterns` config in Jest to not exclude modules in `node_modules`. Typically, excluding packages through this field is an indicator that the package only ships with support for ESM. Using the default value for this field allows us to catch if a package is not shipping with support for ESM before we publish.

Note: the tests for this PR are expected to fail since we currently rely on packages that ship ESM-only bundles. These should be addressed before merging this PR in.