### PR TITLE
chore: narrow typescript range in consumer test

### DIFF
--- a/consumer-test/package.json
+++ b/consumer-test/package.json
@@ -4,6 +4,6 @@
   },
   "dependencies": {
     "@primer/react": "*",
-    "typescript": "^4.4.4"
+    "typescript": "~4.7.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/react",
-  "version": "35.7.0",
+  "version": "35.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/react",
-      "version": "35.7.0",
+      "version": "35.8.0",
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.1.5",
@@ -3116,14 +3116,14 @@
       "integrity": "sha512-dmG1PuppNKHnBBEcfylWDwj9SSxd/E/qd8mC1G/klQC3s7ps5q6JZ034mwkkG0LKfI+Y+UgEua/ROD776N400w=="
     },
     "node_modules/@github/markdown-toolbar-element": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@github/markdown-toolbar-element/-/markdown-toolbar-element-2.1.1.tgz",
-      "integrity": "sha512-J++rpd5H9baztabJQB82h26jtueOeBRSTqetk9Cri+Lj/s28ndu6Tovn0uHQaOKtBWDobFunk9b5pP5vcqt7cA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@github/markdown-toolbar-element/-/markdown-toolbar-element-2.1.0.tgz",
+      "integrity": "sha512-nYjuErjGl5enF6BiZsP9qL7fbH5YRIOebv0vFru7MJu6Yu/ayQjb0iRrm8zLKq/IELMUYQHw9+Uifl3qUyTKrA=="
     },
     "node_modules/@github/paste-markdown": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@github/paste-markdown/-/paste-markdown-1.3.3.tgz",
-      "integrity": "sha512-l/nlZ8cEWB/XlvvplA0GGF7lde7DNbgaNKTKwb7bvANMQXNb6YivLJiwNGxkrkdBNz45ZRbz3FIqZIiliNLtQg=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@github/paste-markdown/-/paste-markdown-1.3.1.tgz",
+      "integrity": "sha512-xew5uSUOPm+pD4dSvR0/qtq2USUNYQ6ehpOqxK550+UAO4FWSEnNHjR0PA2Tul9PGyGBKfB+LQ5yF9DZwbpwUw=="
     },
     "node_modules/@github/prettier-config": {
       "version": "0.0.4",
@@ -39635,14 +39635,14 @@
       "integrity": "sha512-dmG1PuppNKHnBBEcfylWDwj9SSxd/E/qd8mC1G/klQC3s7ps5q6JZ034mwkkG0LKfI+Y+UgEua/ROD776N400w=="
     },
     "@github/markdown-toolbar-element": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@github/markdown-toolbar-element/-/markdown-toolbar-element-2.1.1.tgz",
-      "integrity": "sha512-J++rpd5H9baztabJQB82h26jtueOeBRSTqetk9Cri+Lj/s28ndu6Tovn0uHQaOKtBWDobFunk9b5pP5vcqt7cA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@github/markdown-toolbar-element/-/markdown-toolbar-element-2.1.0.tgz",
+      "integrity": "sha512-nYjuErjGl5enF6BiZsP9qL7fbH5YRIOebv0vFru7MJu6Yu/ayQjb0iRrm8zLKq/IELMUYQHw9+Uifl3qUyTKrA=="
     },
     "@github/paste-markdown": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@github/paste-markdown/-/paste-markdown-1.3.3.tgz",
-      "integrity": "sha512-l/nlZ8cEWB/XlvvplA0GGF7lde7DNbgaNKTKwb7bvANMQXNb6YivLJiwNGxkrkdBNz45ZRbz3FIqZIiliNLtQg=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@github/paste-markdown/-/paste-markdown-1.3.1.tgz",
+      "integrity": "sha512-xew5uSUOPm+pD4dSvR0/qtq2USUNYQ6ehpOqxK550+UAO4FWSEnNHjR0PA2Tul9PGyGBKfB+LQ5yF9DZwbpwUw=="
     },
     "@github/prettier-config": {
       "version": "0.0.4",


### PR DESCRIPTION
This PR reduces the range for typescript from `^4.4.4` to `~4.7.2` as it appears that versions >= 4.8.2 cause an issue with `@types/styled-components`. The goal of this PR is to get the consumer-test back to green and then PR the fix in afterwards to support TS versions >= 4.8.2

In order to support TS >= 4.8.2, I believe we'll need to update `@types/styled-components` to >= 5.1.26 along with some other types in the project