### PR TITLE
Reduce amount of chromatic tests

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -16,5 +16,7 @@ export const parameters = {
   html: {
     root: '#html-addon-root',
     removeEmptyComments: true
-  }
+  },
+  // disables snapshotting on a global level
+  chromatic: {disableSnapshot: true}
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -18,5 +18,5 @@ export const parameters = {
     removeEmptyComments: true
   },
   // disables snapshotting on a global level
-  chromatic: {disableSnapshot: true}
+  chromatic: {disable: true}
 }

--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -35,7 +35,7 @@ export default {
   },
   parameters: {
     chromatic: {
-      disableSnapshot: false
+      disable: false
     }
   }
 } as Meta

--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -32,6 +32,11 @@ export default {
         default: false
       }
     }
+  },
+  parameters: {
+    chromatic: {
+      disableSnapshot: false
+    }
   }
 } as Meta
 


### PR DESCRIPTION
We run visual regressions on a bunch of interactive components in their closed state. Reducing the amount of snapshots.