### PR TITLE
Fix a bug in the useMnemonics hook to make it compatible with textareas

### DIFF
--- a/.changeset/mean-bees-ring.md
+++ b/.changeset/mean-bees-ring.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+useMnemonics hook ignores keydown events from textarea elements

--- a/src/__tests__/hooks/useMnemonics.test.tsx
+++ b/src/__tests__/hooks/useMnemonics.test.tsx
@@ -5,10 +5,12 @@ import {useMnemonics} from '../../hooks'
 const Fixture = ({
   onSelect = () => null,
   hasInput = false,
+  hasTextarea = false,
   refNotAttached = false
 }: {
   onSelect?: (event: React.KeyboardEvent<HTMLButtonElement>) => void
   hasInput?: boolean
+  hasTextarea?: boolean
   refNotAttached?: boolean
 }) => {
   const containerRef = React.createRef<HTMLDivElement>()
@@ -19,6 +21,7 @@ const Fixture = ({
       <div ref={refNotAttached ? undefined : containerRef} data-testid="container">
         {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
         {hasInput && <input autoFocus type="text" placeholder="Filter options" />}
+        {hasTextarea && <textarea autoFocus placeholder="Filter options" />}
         <button onKeyDown={onSelect}>button 1</button>
         <button onKeyDown={onSelect}>Button 2</button>
         <button onKeyDown={onSelect}>third button</button>
@@ -152,6 +155,17 @@ describe('useTypeaheadFocus', () => {
 
     fireEvent.keyDown(container, {key: 'b', code: 'b'})
     expect(input).toEqual(document.activeElement)
+  })
+
+  it('Text area: when a textarea has focus, typeahead should not do anything', async () => {
+    const {getByTestId, getByPlaceholderText} = render(<Fixture hasTextarea={true} />)
+    const container = getByTestId('container')
+
+    const textArea = getByPlaceholderText('Filter options')
+    expect(textArea).toEqual(document.activeElement)
+
+    fireEvent.keyDown(container, {key: 'b', code: 'b'})
+    expect(textArea).toEqual(document.activeElement)
   })
 
   it('Missing ref: when a ref is not attached, typeahead should break the component', async () => {

--- a/src/hooks/useMnemonics.ts
+++ b/src/hooks/useMnemonics.ts
@@ -37,7 +37,7 @@ export const useMnemonics = (open: boolean, providedRef?: React.RefObject<HTMLEl
       const handler = (event: KeyboardEvent) => {
         // skip if a TextInput has focus
         const activeElement = document.activeElement as HTMLElement
-        if (activeElement.tagName === 'INPUT') return
+        if (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA') return
 
         // skip if used with modifier to preserve shortcuts like ⌘ + F
         const hasModifier = event.ctrlKey || event.altKey || event.metaKey


### PR DESCRIPTION
Fix a bug in the useMnemonics hook that makes it incompatible with `textarea` elements. This bug manifested itself when I was trying to use a `MarkdownEditor` in an `ActionMenu`.

Closes #2316 

### Screenshots

No visual changes.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation (didn't seem necessary)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
