### PR TITLE
Fix small bugs in `InlineAutocomplete`

### DIFF
--- a/.changeset/slow-rice-fold.md
+++ b/.changeset/slow-rice-fold.md
@@ -1,0 +1,6 @@
+---
+"@primer/react": patch
+---
+
+- Fix `InlineAutocomplete` accessibility hint affecting page layout outside of the suggestions
+- Fix suggestion icons not being visible in `InlineAutocomplete` items

--- a/src/drafts/InlineAutocomplete/InlineAutocomplete.tsx
+++ b/src/drafts/InlineAutocomplete/InlineAutocomplete.tsx
@@ -207,7 +207,7 @@ const InlineAutocomplete = ({
       <Portal>
         {/* This should NOT be linked to the input with aria-describedby or screen readers may not read the live updates.
         The assertive live attribute ensures the suggestions are read instead of the input label, which voiceover will try to re-read when the role changes. */}
-        <span aria-live="assertive" aria-atomic style={{clipPath: 'circle(0)'}}>
+        <span aria-live="assertive" aria-atomic style={{clipPath: 'circle(0)', position: 'absolute'}}>
           {suggestionsDescription}
         </span>
       </Portal>

--- a/src/drafts/MarkdownEditor/suggestions/_useEmojiSuggestions.tsx
+++ b/src/drafts/MarkdownEditor/suggestions/_useEmojiSuggestions.tsx
@@ -19,7 +19,7 @@ const emojiToSugggestion = (emoji: Emoji): Suggestion => ({
   value: emoji.character,
   key: emoji.name, // emoji characters may not be unique - ie haircut and haircut_man both have the same emoji codepoint. But names are guarunteed to be unique.
   render: props => (
-    <ActionList.Item {...props} sx={{...props.sx, '& > span:first-child': {display: 'none'}}}>
+    <ActionList.Item {...props}>
       <ActionList.LeadingVisual>{emoji.character}</ActionList.LeadingVisual>
       {emoji.name}
     </ActionList.Item>

--- a/src/drafts/MarkdownEditor/suggestions/_useMentionSuggestions.tsx
+++ b/src/drafts/MarkdownEditor/suggestions/_useMentionSuggestions.tsx
@@ -19,7 +19,7 @@ const trigger: Trigger = {
 const mentionableToSuggestion = (mentionable: Mentionable): Suggestion => ({
   value: mentionable.identifier,
   render: props => (
-    <ActionList.Item {...props} sx={{...props.sx, '& > span': {display: 'none'}}}>
+    <ActionList.Item {...props}>
       <Text sx={{fontWeight: 'bold'}}>{mentionable.identifier}</Text>{' '}
       <ActionList.Description>{mentionable.description}</ActionList.Description>
     </ActionList.Item>

--- a/src/drafts/MarkdownEditor/suggestions/_useReferenceSuggestions.tsx
+++ b/src/drafts/MarkdownEditor/suggestions/_useReferenceSuggestions.tsx
@@ -20,7 +20,7 @@ const trigger: Trigger = {
 const referenceToSuggestion = (reference: Reference): Suggestion => ({
   value: reference.id,
   render: props => (
-    <ActionList.Item {...props} sx={{...props.sx, '& > span:first-child': {display: 'none'}}}>
+    <ActionList.Item {...props}>
       {reference.iconHtml && (
         <ActionList.LeadingVisual>
           <span dangerouslySetInnerHTML={{__html: reference.iconHtml}} />


### PR DESCRIPTION
1. The `aria-live` hint text for screen readers related to the `InlineAutocomplete` component is visually hidden with `clip-path: circle(0)`, but this doesn't remove it from the layout of the page. It's inside a `Portal` component so it renders into the `primerPortalRoot` portal. Because the hint text element is only visually hidden, it could cause the portal root to push page content around unintentionally. To fix this, I have added `position: absolute` to the element to remove it from the page flow.
2. Recent changes seem to have removed the leading element from `ActionList` items when there is no selecting enabled. A previous hack to hide that element so it wouldn't indent items is now breaking the leading icons in `InlineAutocomplete` suggestions, preventing the emojis and other icons from appearing. The simple fix for this is to remove the styling hack.
