### PR TITLE
Expose input area via imperative handle

### DIFF
--- a/.changeset/silly-grapes-obey.md
+++ b/.changeset/silly-grapes-obey.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Exposes a reference to the MarkdownEditor's input.

--- a/src/drafts/MarkdownEditor/MarkdownEditor.test.tsx
+++ b/src/drafts/MarkdownEditor/MarkdownEditor.test.tsx
@@ -190,6 +190,13 @@ describe('MarkdownEditor', () => {
     expect(getInput()).toHaveFocus()
   })
 
+  it('exposes the input via imperative handle ref', async () => {
+    const ref: React.RefObject<MarkdownEditorHandle> = {current: null}
+    const {getInput} = await render(<UncontrolledEditor ref={ref} />)
+
+    expect(getInput()).toEqual(ref.current?.input())
+  })
+
   it('enables the textarea by default', async () => {
     const {getInput} = await render(<UncontrolledEditor />)
     expect(getInput()).not.toBeDisabled()

--- a/src/drafts/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/drafts/MarkdownEditor/MarkdownEditor.tsx
@@ -100,6 +100,8 @@ export type MarkdownEditorProps = SxProp & {
 const handleBrand = Symbol()
 
 export interface MarkdownEditorHandle {
+  /** A reference to the textarea */
+  input: () => HTMLTextAreaElement
   /** Focus on the markdown textarea (has no effect in preview mode). */
   focus: (options?: FocusOptions) => void
   /** Scroll to the editor. */
@@ -192,6 +194,7 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(
       ref,
       () =>
         ({
+          input: () => inputRef.current,
           focus: opts => inputRef.current?.focus(opts),
           scrollIntoView: opts => containerRef.current?.scrollIntoView(opts)
         } as MarkdownEditorHandle)


### PR DESCRIPTION
In order to properly insert suggestions, we need a reference to the textarea itself. 

I'm working on implementing a "suggest changes" button in the draft `MarkdownEditor`, and I think that still belongs outside of the `MarkdownEditor`. We should be able to use some of the existing behavior as long as we expose a reference to the textarea.

Since we're already using [`useImperativeHandle`](https://reactjs.org/docs/hooks-reference.html#useimperativehandle), I added another property.

I want to be able to test a canary version of this before going through the release process 😄, so if y'all have advice about the failing check I would appreciate it. 


### Screenshots

n/a

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
