### PR TITLE
Minor fixes for `SelectPanel`

### DIFF
--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -205,7 +205,13 @@ export function SelectPanel({
       open={open}
       onOpen={onOpen}
       onClose={onCloseOverlay}
-      overlayProps={{...overlayProps, onKeyPress: overlayKeyPressHandler, role: 'dialog', 'aria-labelledby': titleId}}
+      overlayProps={{
+        ...overlayProps,
+        onKeyPress: overlayKeyPressHandler,
+        role: 'dialog',
+        'aria-labelledby': titleId,
+        'aria-modal': true
+      }}
       focusTrapSettings={focusTrapSettings}
       focusZoneSettings={focusZoneSettings}
     >

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -242,7 +242,7 @@ export function SelectPanel({
           alignItems="center"
           justifyContent="flex-end"
           gridGap="8px"
-          padding="12px"
+          p={2}
           borderTopColor="border.default"
           borderTopWidth={1}
           borderTopStyle="solid"

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -218,7 +218,7 @@ export function SelectPanel({
             ? 'No matching items'
             : `${items.length} matching ${items.length === 1 ? 'item' : 'items'}`}
         </VisuallyHidden>
-        <Box display="flex" alignItems="center" justifyContent="space-between" pl={3} pr={2} pt={2}>
+        <Box display="flex" alignItems="center" justifyContent="space-between" pl={3} pr={2} pt={2} as="header">
           <Heading as="h1" id={titleId} sx={{fontSize: 1}}>
             {title}
           </Heading>
@@ -246,6 +246,7 @@ export function SelectPanel({
           borderTopColor="border.default"
           borderTopWidth={1}
           borderTopStyle="solid"
+          as="footer"
         >
           <Button size="small" onClick={onCloseClickHandler}>
             Cancel


### PR DESCRIPTION
This is a few minor fixes for the `SelectPanel` component:

1. Change the header and footer sections to use semantic `header` and `footer` elements. These elements will now get the `HeaderAsNonLandmark` and `FooterAsNonLandmark` roles, meaning that they are semantically the header and footer of the dialog without being the header and footer of the entire page.
2. Add `aria-modal="true"` to the `SelectPanel` dialog. When open, the dialog is the only thing on the page that can be interacted with. Clicking outside causes the dialog to close. Thus, it is a `modal`.
3. Make the `SelectPanel` footer padding consistent with the header padding. This not only looks better (items align to a grid), it also saves a tiny bit of vertical space.

### Screenshots

#### Before

<img width="330" alt="Screenshot of the selectpanel before. The footer padding is much larger than the header padding." src="https://user-images.githubusercontent.com/2294248/189744239-1da0f290-7664-4567-8416-a400f0347ffc.png">


#### After
<img width="330" alt="Screenshot of the selectpanel after the change. The footer padding is consistent with the header padding." src="https://user-images.githubusercontent.com/2294248/189744121-734123b1-4be4-4248-9001-0122c8527167.png">


### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
