### PR TITLE
Release checklist: Add after merge step for permalink

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -25,4 +25,8 @@ Please ensure these items are checked before merging.
 - [ ] No noticeable regressions have not been introduced as a result of changes in this release
 - [ ] Release notes accurately describe the changes made
 
+### 🚢 After merge
+
+- [ ] Add the preview deployment's link to releases as a way of permalinking to old version's docs. [Example](https://github.com/primer/react/releases/tag/v35.9.0)
+
 Please also leave any testing notes as a comment on this pull request. In particular, describing any issues encountered during your testing. This is helpful in providing historical context to maintainers.


### PR DESCRIPTION
Today, we don't have a quick way to see the docs for an older version of primer/react that an application might be using. This [comes up](https://github.com/github/planning-tracking/discussions/1429#discussioncomment-3627233) [quite often](https://github.com/primer/react/issues/2160). 

As a bandaid, we should add the permalink of preview deployment for Release Tracking PR to the release notes after merge. (I added it for the [last 5 releases](https://github.com/primer/react/releases), [example](https://github.com/primer/react/releases/tag/v35.9.0#:~:text=Permalink%20to%20documentation))

Would be nice to automate it, if possible? cc @rezrah  



<img width="597" alt="release notes with a link to the documentation" src="https://user-images.githubusercontent.com/1863771/189858638-2ff43568-c9fb-48d6-93dc-62f3ade8dbab.png">
