### PR TITLE
Replace `require` with `import` in `MarkdownEditor`'s `FormattingTools` component

### DIFF
--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -25,9 +25,15 @@ let hasRegisteredToolbarElement = false
  */
 export const FormattingTools = forwardRef<FormattingTools, {forInputId: string}>(({forInputId}, forwadedRef) => {
   useEffect(() => {
-    // requiring this module will register the custom element; we don't want to do that until the component mounts in the DOM
-    if (!hasRegisteredToolbarElement) require('@github/markdown-toolbar-element')
-    hasRegisteredToolbarElement = true
+    if (hasRegisteredToolbarElement) return
+    const fn = async () => {
+      // To prevent potential async race conditions, check again
+      if (hasRegisteredToolbarElement) return
+      // requiring this module will register the custom element; we don't want to do that until the component mounts in the DOM
+      await import('@github/markdown-toolbar-element')
+      hasRegisteredToolbarElement = true
+    }
+    fn()
   }, [])
 
   const headerRef = useRef<HTMLElement>(null)

--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -25,13 +25,12 @@ let hasRegisteredToolbarElement = false
  */
 export const FormattingTools = forwardRef<FormattingTools, {forInputId: string}>(({forInputId}, forwadedRef) => {
   useEffect(() => {
-    if (hasRegisteredToolbarElement) return
     const fn = async () => {
-      // To prevent potential async race conditions, check again
       if (hasRegisteredToolbarElement) return
+      // To prevent double-registering while the promise is pending, set it before importing
+      hasRegisteredToolbarElement = true
       // requiring this module will register the custom element; we don't want to do that until the component mounts in the DOM
       await import('@github/markdown-toolbar-element')
-      hasRegisteredToolbarElement = true
     }
     fn()
   }, [])


### PR DESCRIPTION
The `FormattingTools` component (owned by `MarkdownEditor`) depends on the [`markdown-toolbar-element`](https://github.com/github/markdown-toolbar-element). This library performs DOM-based side-effects on render, so it cannot be imported at the top level of the file - it must be imported in an effect.

I originally tried to use `import()` inside a `useEffect` for this but ran into problems so I used `require()` instead. Now, we've started running into problems with the mix of `require` and `import` in a file and I'd like to revisit trying to use `import`.

It seems to be working fine so far - Storybook, Gatsby docs, and tests all build alright. I think that the issue I was running into before was likely not due to the use of `import` but rather that I had forgotten to `await` the `import` because I didn't realize that it was aynchronous. If that is the case, then it should be fine to switch the strategy and I think it will solve a lot of complications.

