### PR TITLE
docs(PageLayout): update custom sticky header to <header>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/react",
-  "version": "35.8.0",
+  "version": "35.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/react",
-      "version": "35.8.0",
+      "version": "35.9.0",
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.1.5",

--- a/src/PageLayout/PageLayout.stories.tsx
+++ b/src/PageLayout/PageLayout.stories.tsx
@@ -602,6 +602,7 @@ export const CustomStickyHeader: Story = args => (
   // a box to create a sticky top element that will be on the consumer side and outside of the PageLayout component
   <Box data-testid="story-window">
     <Box
+      as="header"
       data-testid="sticky-header"
       sx={{
         position: 'sticky',


### PR DESCRIPTION
This is a quick follow-up to: https://github.com/github/primer/issues/1113 which updates our custom sticky header example to use a `<header>` element.