### PR TITLE
fix(SelectPanel): .includes repacle with .find to avoid wrong checks …

### DIFF
--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -123,7 +123,7 @@ export function SelectPanel({
       return {
         ...item,
         role: 'option',
-        selected: 'selected' in item && item.selected === undefined ? undefined : finalItemsSelected.includes(item),
+        selected: 'selected' in item && item.selected === undefined ? undefined : !!finalItemsSelected.find(el => el.id === item.id),
         onAction: (itemFromAction, event) => {
           item.onAction?.(itemFromAction, event)
 


### PR DESCRIPTION
The problem is that the object reference may change due to external filters and therefore the .includes will not work correctly. The .find solves this problem.  

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
