### PR TITLE
move markdown-toolbar-element into unconditional render

### DIFF
--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -1,5 +1,4 @@
-import React, {forwardRef, useImperativeHandle, useRef} from 'react'
-import '@github/markdown-toolbar-element'
+import React, {forwardRef, useImperativeHandle, useRef, useEffect} from 'react'
 
 export type FormattingTools = {
   header: () => void
@@ -48,6 +47,10 @@ export const FormattingTools = forwardRef<FormattingTools, {forInputId: string}>
     mention: () => mentionRef.current?.click(),
     reference: () => referenceRef.current?.click()
   }))
+
+  useEffect(() => {
+    require('@github/markdown-toolbar-element')
+  }, [])
 
   return (
     <markdown-toolbar for={forInputId} style={{display: 'none'}}>

--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef, useImperativeHandle, useRef, useEffect} from 'react'
+import React, {forwardRef, useImperativeHandle, useRef} from 'react'
 import '@github/markdown-toolbar-element'
 
 export type FormattingTools = {
@@ -14,8 +14,6 @@ export type FormattingTools = {
   mention: () => void
   reference: () => void
 }
-
-let hasRegisteredToolbarElement = false
 
 /**
  * Renders an invisible `markdown-toolbar-element` that provides formatting actions to the

--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -1,4 +1,5 @@
 import React, {forwardRef, useImperativeHandle, useRef, useEffect} from 'react'
+import '@github/markdown-toolbar-element'
 
 export type FormattingTools = {
   header: () => void
@@ -24,12 +25,6 @@ let hasRegisteredToolbarElement = false
  * buttons (ie, by keyboard shortcut).
  */
 export const FormattingTools = forwardRef<FormattingTools, {forInputId: string}>(({forInputId}, forwadedRef) => {
-  useEffect(() => {
-    // requiring this module will register the custom element; we don't want to do that until the component mounts in the DOM
-    if (!hasRegisteredToolbarElement) require('@github/markdown-toolbar-element')
-    hasRegisteredToolbarElement = true
-  }, [])
-
   const headerRef = useRef<HTMLElement>(null)
   const boldRef = useRef<HTMLElement>(null)
   const italicRef = useRef<HTMLElement>(null)


### PR DESCRIPTION
This moves the import of `markdown-toolbar-element` out of a conditional, which seems to be causing SegFaults due to poor support of ESM modules in various tools like Jest. Moving the import out of the conditional allows these tools to pick up the import which resolves segfaults.

We may want to move all web component definitions to a central file; `github/github` could de-duplicate these imports as it already imports them via PVC or via direct imports.

Closes #2339, refs #2334

### Merge checklist

- [x] Added/updated tests (N/A)
- [x] Added/updated documentation (N/A)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
