### PR TITLE
Fixes sx prop on the SegmentedControl buttons

### DIFF
--- a/.changeset/clever-hotels-kneel.md
+++ b/.changeset/clever-hotels-kneel.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fixes the sx prop on the SegmentedControl buttons by properly merging the sx prop when cloning button children.

--- a/src/SegmentedControl/SegmentedControl.tsx
+++ b/src/SegmentedControl/SegmentedControl.tsx
@@ -162,8 +162,9 @@ const Root: React.FC<React.PropsWithChildren<SegmentedControlProps>> = ({
           selected: index === selectedIndex,
           sx: {
             '--separator-color':
-              index === selectedIndex || index === selectedIndex - 1 ? 'transparent' : theme?.colors.border.default
-          } as React.CSSProperties
+              index === selectedIndex || index === selectedIndex - 1 ? 'transparent' : theme?.colors.border.default,
+            ...child.props.sx
+          }
         }
 
         // Render the 'hideLabels' variant of the SegmentedControlButton


### PR DESCRIPTION
Properly merges the `sx` prop when cloning button children.

Closes https://github.com/primer/react/issues/2286
