### PR TITLE
Only run replaceChildren with htmlContainer change

### DIFF
--- a/.changeset/weak-hotels-shout.md
+++ b/.changeset/weak-hotels-shout.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+MarkdownViewer bug fix: Only run `replaceChildren` when `htmlContainer` changes

--- a/src/drafts/MarkdownViewer/MarkdownViewer.tsx
+++ b/src/drafts/MarkdownViewer/MarkdownViewer.tsx
@@ -107,7 +107,7 @@ const MarkdownViewer = ({
   // If we were to inject the `...htmlContainer.children` instead of the container element itself,
   // those children elements would be moved from the `htmlContainer` to the `outputContainer`. Then if
   // other effects use `htmlContainer.querySelectorAll`, they wouldn't find any elements to affect
-  useEffect(() => outputContainerRef.current?.replaceChildren(htmlContainer))
+  useEffect(() => outputContainerRef.current?.replaceChildren(htmlContainer), [htmlContainer])
 
   return loading ? (
     <Box sx={{display: 'flex', justifyContent: 'space-around', p: 2}}>


### PR DESCRIPTION
Upstreams a fix applied in https://github.com/github/memex/pull/12104

Setting the dependency of `htmlContainer` to the MarkdownViewer `useEffect` prevents `replaceChildren` from running unnecessarily (prevents removing and then immediately adding the element and triggering a bug in the selector-observer library).

### Screenshots

See referenced PR for screenshots

### Merge checklist

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~
- [X] Tested in Chrome
- [X] Tested in Firefox
- [X] Tested in Safari
- ~~[ ] Tested in Edge~~

