### PR TITLE
feat(Button): support as prop, add CustomButtonProps type

### DIFF
--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
 import {EyeClosedIcon, EyeIcon, SearchIcon, TriangleDownIcon, XIcon, TriangleRightIcon} from '@primer/octicons-react'
 import {Meta} from '@storybook/react'
 import React, {useState, forwardRef} from 'react'
-import {Button, ButtonProps, IconButton} from '.'
+import {Button, ButtonProps, IconButton, CustomButtonProps} from '.'
 import {BaseStyles, ThemeProvider} from '..'
 import Box from '../Box'
 
@@ -246,5 +246,16 @@ export const linkButton = ({...args}: ButtonProps) => {
         </Button>
       </Box>
     </>
+  )
+}
+
+export const customButton = () => {
+  function CustomButton(props: CustomButtonProps) {
+    return <Box as="button" {...props} />
+  }
+  return (
+    <Button as={CustomButton} variant="default">
+      Custom
+    </Button>
   )
 }

--- a/src/Button/ButtonBase.tsx
+++ b/src/Button/ButtonBase.tsx
@@ -8,7 +8,7 @@ import {getVariantStyles, getSizeStyles, getButtonStyles} from './styles'
 
 const ButtonBase = forwardRef<HTMLElement, ButtonProps>(
   ({children, as: Component = 'button', sx: sxProp = {}, ...props}, forwardedRef): JSX.Element => {
-    const {leadingIcon: LeadingIcon, trailingIcon: TrailingIcon, variant = 'default', size = 'medium'} = props
+    const {leadingIcon: LeadingIcon, trailingIcon: TrailingIcon, variant = 'default', size = 'medium', ...rest} = props
     const {theme} = useTheme()
     const iconWrapStyles = {
       display: 'inline-block'
@@ -17,7 +17,7 @@ const ButtonBase = forwardRef<HTMLElement, ButtonProps>(
       return merge.all([getButtonStyles(theme), getSizeStyles(size, variant, false), getVariantStyles(variant, theme)])
     }, [theme, size, variant])
     return (
-      <StyledButton as={Component} sx={merge(sxStyles, sxProp as SxProp)} {...props} ref={forwardedRef}>
+      <StyledButton as={Component} sx={merge(sxStyles, sxProp as SxProp)} {...rest} ref={forwardedRef}>
         {LeadingIcon && (
           <Box as="span" data-component="leadingIcon" sx={iconWrapStyles}>
             <LeadingIcon />

--- a/src/Button/index.ts
+++ b/src/Button/index.ts
@@ -2,7 +2,7 @@ import {ButtonComponent} from './Button'
 import {Counter} from './ButtonCounter'
 import {IconButton} from './IconButton'
 import {LinkButton} from './LinkButton'
-export type {ButtonProps, IconButtonProps} from './types'
+export type {ButtonProps, IconButtonProps, CustomButtonProps} from './types'
 export {IconButton, LinkButton}
 
 export const Button = Object.assign(ButtonComponent, {

--- a/src/Button/types.ts
+++ b/src/Button/types.ts
@@ -53,6 +53,10 @@ export type IconButtonProps = ButtonA11yProps & {
   icon: React.FunctionComponent<React.PropsWithChildren<IconProps>>
 } & ButtonBaseProps
 
+export type CustomButtonProps = {
+  children: React.ReactNode
+} & SxProp
+
 // adopted from React.AnchorHTMLAttributes
 export type LinkButtonProps = {
   underline?: boolean

--- a/src/__tests__/Button.test.tsx
+++ b/src/__tests__/Button.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import {IconButton, Button} from '../Button'
+import {IconButton, Button, ButtonProps, CustomButtonProps} from '../Button'
 import {behavesAsComponent} from '../utils/testing'
-import {render, fireEvent} from '@testing-library/react'
+import {render, fireEvent, screen} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import {SearchIcon} from '@primer/octicons-react'
 expect.extend(toHaveNoViolations)
@@ -94,9 +94,22 @@ describe('Button', () => {
     expect(IconOnlyButton).toHaveStyleRule('padding-right', '8px')
     expect(IconOnlyButton).toMatchSnapshot()
   })
+
   it('makes sure icon button has an aria-label', () => {
     const container = render(<IconButton icon={SearchIcon} aria-label="Search button" />)
     const IconOnlyButton = container.getByLabelText('Search button')
     expect(IconOnlyButton).toBeTruthy()
+  })
+
+  it('should support a custom component through the `as` prop', () => {
+    function CustomButton(props: CustomButtonProps) {
+      return <button data-testid="custom-component" {...props} />
+    }
+    render(
+      <Button as={CustomButton} variant="default">
+        test
+      </Button>
+    )
+    expect(screen.getByTestId('custom-component')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes https://github.com/primer/react/issues/2351

This PR grabs the extra values from props in `ButtonBase` and spreads them onto `StyledButton`.

One thing I noticed is that the props for this custom component would not align with `ButtonProps` and so I created a `CustomButtonProps` type to help out with this. I'd love feedback on if this would be the best way to support this, I wasn't quite sure what approach to take.

Something else I noticed is that the custom component through `as` must accept `sx` so I made sure the type intersects with `SxProp`.