### PR TITLE
[UnderlineNav] : Keep selected item always visible

### DIFF
--- a/.changeset/lazy-lions-repair.md
+++ b/.changeset/lazy-lions-repair.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+UnderlineNav2: Introduce "keeping the selected item always visible" functionality

--- a/docs/content/drafts/UnderlineNav2.mdx
+++ b/docs/content/drafts/UnderlineNav2.mdx
@@ -34,7 +34,7 @@ import {UnderlineNav} from '@primer/react/drafts'
     Issues
   </UnderlineNav.Item>
   <UnderlineNav.Item icon={GitPullRequestIcon} counter={3}>
-    Pull requests
+    Pull Requests
   </UnderlineNav.Item>
   <UnderlineNav.Item icon={CommentDiscussionIcon}>Discussions</UnderlineNav.Item>
   <UnderlineNav.Item icon={EyeIcon} counter={9}>
@@ -61,7 +61,7 @@ When overflow occurs, the component first hides icons if present to optimize for
     Issues
   </UnderlineNav.Item>
   <UnderlineNav.Item icon={GitPullRequestIcon} counter={3}>
-    Pull requests
+    Pull Requests
   </UnderlineNav.Item>
   <UnderlineNav.Item icon={CommentDiscussionIcon}>Discussions</UnderlineNav.Item>
   <UnderlineNav.Item icon={PlayIcon} counter={9}>
@@ -91,7 +91,7 @@ If there is still overflow, the component will behave depending on the pointer.
     Issues
   </UnderlineNav.Item>
   <UnderlineNav.Item icon={GitPullRequestIcon} counter={3}>
-    Pull requests
+    Pull Requests
   </UnderlineNav.Item>
   <UnderlineNav.Item icon={CommentDiscussionIcon}>Discussions</UnderlineNav.Item>
   <UnderlineNav.Item icon={EyeIcon} counter={9}>

--- a/src/UnderlineNav2/UnderlineNav.test.tsx
+++ b/src/UnderlineNav2/UnderlineNav.test.tsx
@@ -1,4 +1,4 @@
-import React, {useLayoutEffect} from 'react'
+import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import {fireEvent, render} from '@testing-library/react'
 import {

--- a/src/UnderlineNav2/UnderlineNav.test.tsx
+++ b/src/UnderlineNav2/UnderlineNav.test.tsx
@@ -1,7 +1,16 @@
-import React from 'react'
+import React, {useLayoutEffect} from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import {fireEvent, render} from '@testing-library/react'
-import {CodeIcon, EyeIcon} from '@primer/octicons-react'
+import {
+  IconProps,
+  CodeIcon,
+  IssueOpenedIcon,
+  GitPullRequestIcon,
+  CommentDiscussionIcon,
+  ProjectIcon,
+  ShieldLockIcon,
+  GraphIcon
+} from '@primer/octicons-react'
 
 import {UnderlineNav} from '.'
 
@@ -25,46 +34,71 @@ Object.defineProperty(window.Element.prototype, 'scrollTo', {
   value: jest.fn(),
   writable: true
 })
+
+const ResponsiveUnderlineNav = ({
+  selectedItemText = 'Code',
+  loadingCounters = false
+}: {
+  selectedItemText?: string
+  loadingCounters?: boolean
+}) => {
+  useLayoutEffect(() => {
+    for (const listItem of document.querySelectorAll('li[class^="Box"]'))
+      Object.defineProperty(listItem, 'getBoundingClientRect', {
+        value: {
+          width: 100
+        },
+        writable: true
+      })
+  })
+
+  const items: {navigation: string; icon?: React.FC<IconProps>; counter?: number}[] = [
+    {navigation: 'Code', icon: CodeIcon},
+    {navigation: 'Issues', icon: IssueOpenedIcon, counter: 120},
+    {navigation: 'Pull Requests', icon: GitPullRequestIcon, counter: 13},
+    {navigation: 'Discussions', icon: CommentDiscussionIcon, counter: 5},
+    {navigation: 'Actions', counter: 4},
+    {navigation: 'Projects', icon: ProjectIcon, counter: 9},
+    {navigation: 'Insights', icon: GraphIcon},
+    {navigation: 'Settings', counter: 10},
+    {navigation: 'Security', icon: ShieldLockIcon}
+  ]
+  return (
+    <UnderlineNav label="Repository" loadingCounters={loadingCounters}>
+      {items.map(item => (
+        <UnderlineNav.Item
+          key={item.navigation}
+          icon={item.icon}
+          selected={item.navigation === selectedItemText}
+          counter={item.counter}
+        >
+          {item.navigation}
+        </UnderlineNav.Item>
+      ))}
+    </UnderlineNav>
+  )
+}
+
 describe('UnderlineNav', () => {
-  test('selected nav', () => {
-    const {getByText} = render(
-      <UnderlineNav label="Test nav">
-        <UnderlineNav.Item selected>Item 1</UnderlineNav.Item>
-        <UnderlineNav.Item>Item 2</UnderlineNav.Item>
-        <UnderlineNav.Item>Item 3</UnderlineNav.Item>
-      </UnderlineNav>
-    )
-    const selectedNavLink = getByText('Item 1').closest('a')
+  it('renders aria-current attribute to be pages when an item is selected', () => {
+    const {getByText} = render(<ResponsiveUnderlineNav />)
+    const selectedNavLink = getByText('Code').closest('a')
 
     expect(selectedNavLink?.getAttribute('aria-current')).toBe('page')
   })
-  test('basic nav functionality', () => {
-    const {container} = render(
-      <UnderlineNav label="Test nav">
-        <UnderlineNav.Item selected>Item 1</UnderlineNav.Item>
-        <UnderlineNav.Item>Item 2</UnderlineNav.Item>
-        <UnderlineNav.Item>Item 3</UnderlineNav.Item>
-      </UnderlineNav>
-    )
+  it('renders aria-label attribute correctly', () => {
+    const {container} = render(<ResponsiveUnderlineNav />)
     expect(container.getElementsByTagName('nav').length).toEqual(1)
     const nav = container.getElementsByTagName('nav')[0]
 
-    expect(nav.getAttribute('aria-label')).toBe('Test nav')
+    expect(nav.getAttribute('aria-label')).toBe('Repository')
   })
-  test('with icons', () => {
-    const {container} = render(
-      <UnderlineNav label="Test nav">
-        <UnderlineNav.Item icon={CodeIcon}>Code</UnderlineNav.Item>
-        <UnderlineNav.Item icon={EyeIcon} counter={6}>
-          Issues
-        </UnderlineNav.Item>
-        <UnderlineNav.Item>Pull Request</UnderlineNav.Item>
-      </UnderlineNav>
-    )
+  it('renders icons correctly', () => {
+    const {container} = render(<ResponsiveUnderlineNav />)
     const nav = container.getElementsByTagName('nav')[0]
-    expect(nav.getElementsByTagName('svg').length).toEqual(2)
+    expect(nav.getElementsByTagName('svg').length).toEqual(7)
   })
-  test('should fire onSelect on click and keypress', async () => {
+  it('fires onSelect on click and keypress', async () => {
     const onSelect = jest.fn()
     const {getByText} = render(
       <UnderlineNav label="Test nav">
@@ -79,34 +113,89 @@ describe('UnderlineNav', () => {
     fireEvent.keyPress(item, {key: 'Enter', code: 13, charCode: 13})
     expect(onSelect).toHaveBeenCalledTimes(2)
   })
-  test('respect counter prop', () => {
-    const {getByText} = render(
-      <UnderlineNav label="Test nav" align="right">
-        <UnderlineNav.Item counter={8} selected>
-          Item 1
-        </UnderlineNav.Item>
-        <UnderlineNav.Item>Item 2</UnderlineNav.Item>
-        <UnderlineNav.Item>Item 3</UnderlineNav.Item>
-      </UnderlineNav>
-    )
-    const item = getByText('Item 1').closest('a')
-    const counter = item?.getElementsByTagName('span')[2]
+  it('respects counter prop', () => {
+    const {getByText} = render(<ResponsiveUnderlineNav />)
+    const item = getByText('Issues').closest('a')
+    const counter = item?.getElementsByTagName('span')[3]
     expect(counter?.className).toContain('CounterLabel')
-    expect(counter?.textContent).toBe('8')
+    expect(counter?.textContent).toBe('120')
   })
-  test('respect loadingCounters prop', () => {
-    const {getByText} = render(
-      <UnderlineNav label="Test nav" loadingCounters={true}>
-        <UnderlineNav.Item selected counter={4}>
-          Item 1
-        </UnderlineNav.Item>
-        <UnderlineNav.Item>Item 2</UnderlineNav.Item>
-        <UnderlineNav.Item>Item 3</UnderlineNav.Item>
-      </UnderlineNav>
-    )
-    const item = getByText('Item 1').closest('a')
+  it('respects loadingCounters prop', () => {
+    const {getByText} = render(<ResponsiveUnderlineNav loadingCounters={true} />)
+    const item = getByText('Actions').closest('a')
     const loadingCounter = item?.getElementsByTagName('span')[2]
     expect(loadingCounter?.className).toContain('LoadingCounter')
     expect(loadingCounter?.textContent).toBe('')
+  })
+})
+
+describe.skip('UnderlineNav when overflow occurs on fine pointer devices', () => {
+  beforeAll(() => {
+    jest.spyOn(window.screen, 'width', 'get').mockReturnValue(800)
+  })
+
+  it("does not render icons where nav width is less than the sum of items' width (without icons)", () => {
+    const {getByText} = render(<ResponsiveUnderlineNav />)
+
+    const el = getByText('Code').closest('a')
+    const icon = el?.getElementsByTagName('span')[0]
+    expect(icon).not.toBeVisible()
+  })
+
+  it("renders More menu where nav width is less than the sum of items' width (without icons)", () => {
+    const {getByText} = render(<ResponsiveUnderlineNav />)
+
+    const el = getByText('More')
+    expect(el).toBeVisible()
+  })
+
+  it('moves the selected item out of the menu when it is selected and appends it to the list', () => {
+    const {container, getByText} = render(<ResponsiveUnderlineNav />)
+
+    const el = getByText('More')
+    fireEvent.click(el)
+
+    const menuItem = getByText('Settings')
+    fireEvent.click(menuItem)
+
+    const selectedEl = getByText('Settings').closest('a')
+    const selectedListItem = getByText('Settings').closest('li')
+    expect(selectedEl).toHaveAttribute('aria-current', 'page')
+    const list = container.getElementsByTagName('ul')[0]
+    // The last one is the More Btn
+    const secondLastItemIndex = list.childNodes.length - 2
+    expect(list.childNodes[secondLastItemIndex]).toBe(selectedListItem)
+  })
+
+  it('keeps the updated order when a naturally visible item is selected', () => {
+    const {container, getByText} = render(<ResponsiveUnderlineNav />)
+
+    const el = getByText('More')
+    fireEvent.click(el)
+
+    // select an item from the menu
+    const menuItem = getByText('Settings')
+    fireEvent.click(menuItem)
+    // the order is now updated and is different than the original children order.
+    // select an item that is naturally visible (meaning it does not fall under the menu when page first loaded or resized)
+    const naturallyVisibleItem = getByText('Code')
+    fireEvent.click(naturallyVisibleItem)
+    const selectedListItem = getByText('Settings').closest('li')
+    const list = container.getElementsByTagName('ul')[0]
+    // The last one is the More Btn
+    const secondLastItemIndex = list.childNodes.length - 2
+    // Settings should still be on the last position
+    expect(list.childNodes[secondLastItemIndex]).toBe(selectedListItem)
+  })
+
+  it('displays the selected item as the last child of the list if the selected item naturally falls under the menu when the page is loaded or resized', () => {
+    const {container, getByText} = render(<ResponsiveUnderlineNav selectedItemText="Settings" />)
+
+    const selectedEl = getByText('Settings').closest('a')
+    expect(selectedEl).toHaveAttribute('aria-current', 'page')
+    const selectedListItem = getByText('Settings').closest('li')
+    const list = container.getElementsByTagName('ul')[0]
+    const secondLastItemIndex = list.childNodes.length - 2
+    expect(list.childNodes[secondLastItemIndex]).toBe(selectedListItem)
   })
 })

--- a/src/UnderlineNav2/UnderlineNav.test.tsx
+++ b/src/UnderlineNav2/UnderlineNav.test.tsx
@@ -42,16 +42,6 @@ const ResponsiveUnderlineNav = ({
   selectedItemText?: string
   loadingCounters?: boolean
 }) => {
-  useLayoutEffect(() => {
-    for (const listItem of document.querySelectorAll('li[class^="Box"]'))
-      Object.defineProperty(listItem, 'getBoundingClientRect', {
-        value: {
-          width: 100
-        },
-        writable: true
-      })
-  })
-
   const items: {navigation: string; icon?: React.FC<IconProps>; counter?: number}[] = [
     {navigation: 'Code', icon: CodeIcon},
     {navigation: 'Issues', icon: IssueOpenedIcon, counter: 120},
@@ -126,76 +116,5 @@ describe('UnderlineNav', () => {
     const loadingCounter = item?.getElementsByTagName('span')[2]
     expect(loadingCounter?.className).toContain('LoadingCounter')
     expect(loadingCounter?.textContent).toBe('')
-  })
-})
-
-describe.skip('UnderlineNav when overflow occurs on fine pointer devices', () => {
-  beforeAll(() => {
-    jest.spyOn(window.screen, 'width', 'get').mockReturnValue(800)
-  })
-
-  it("does not render icons where nav width is less than the sum of items' width (without icons)", () => {
-    const {getByText} = render(<ResponsiveUnderlineNav />)
-
-    const el = getByText('Code').closest('a')
-    const icon = el?.getElementsByTagName('span')[0]
-    expect(icon).not.toBeVisible()
-  })
-
-  it("renders More menu where nav width is less than the sum of items' width (without icons)", () => {
-    const {getByText} = render(<ResponsiveUnderlineNav />)
-
-    const el = getByText('More')
-    expect(el).toBeVisible()
-  })
-
-  it('moves the selected item out of the menu when it is selected and appends it to the list', () => {
-    const {container, getByText} = render(<ResponsiveUnderlineNav />)
-
-    const el = getByText('More')
-    fireEvent.click(el)
-
-    const menuItem = getByText('Settings')
-    fireEvent.click(menuItem)
-
-    const selectedEl = getByText('Settings').closest('a')
-    const selectedListItem = getByText('Settings').closest('li')
-    expect(selectedEl).toHaveAttribute('aria-current', 'page')
-    const list = container.getElementsByTagName('ul')[0]
-    // The last one is the More Btn
-    const secondLastItemIndex = list.childNodes.length - 2
-    expect(list.childNodes[secondLastItemIndex]).toBe(selectedListItem)
-  })
-
-  it('keeps the updated order when a naturally visible item is selected', () => {
-    const {container, getByText} = render(<ResponsiveUnderlineNav />)
-
-    const el = getByText('More')
-    fireEvent.click(el)
-
-    // select an item from the menu
-    const menuItem = getByText('Settings')
-    fireEvent.click(menuItem)
-    // the order is now updated and is different than the original children order.
-    // select an item that is naturally visible (meaning it does not fall under the menu when page first loaded or resized)
-    const naturallyVisibleItem = getByText('Code')
-    fireEvent.click(naturallyVisibleItem)
-    const selectedListItem = getByText('Settings').closest('li')
-    const list = container.getElementsByTagName('ul')[0]
-    // The last one is the More Btn
-    const secondLastItemIndex = list.childNodes.length - 2
-    // Settings should still be on the last position
-    expect(list.childNodes[secondLastItemIndex]).toBe(selectedListItem)
-  })
-
-  it('displays the selected item as the last child of the list if the selected item naturally falls under the menu when the page is loaded or resized', () => {
-    const {container, getByText} = render(<ResponsiveUnderlineNav selectedItemText="Settings" />)
-
-    const selectedEl = getByText('Settings').closest('a')
-    expect(selectedEl).toHaveAttribute('aria-current', 'page')
-    const selectedListItem = getByText('Settings').closest('li')
-    const list = container.getElementsByTagName('ul')[0]
-    const secondLastItemIndex = list.childNodes.length - 2
-    expect(list.childNodes[secondLastItemIndex]).toBe(selectedListItem)
   })
 })

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -192,13 +192,12 @@ export const UnderlineNav = forwardRef(
       const updatedMenuItems = [...actions]
       // Add itemsToAddToMenu array's items to the menu at the index of the prospectiveListItem and remove 1 count of items (prospectiveListItem)
       updatedMenuItems.splice(indexOfProspectiveListItem, 1, ...itemsToAddToMenu)
-
+      setSelectedLinkText(prospectiveListItem.props.children)
       callback(
         {items: updatedItemList, actions: updatedMenuItems, overflowStyles: responsiveProps.overflowStyles},
         false
       )
     }
-
     // How many items do we need to pull in to the menu to make room for the selected menu item.
     function getBreakpointForItemSwapping(widthToFitIntoList: number, availableSpace: number) {
       let widthToSwap = 0
@@ -220,6 +219,10 @@ export const UnderlineNav = forwardRef(
     // selectedLinkText is needed to be able set the selected menu item as selectedLink.
     // This is needed because setSelectedLink only accepts ref but at the time of setting selected menu item as selectedLink, its ref as a list item is not available
     const [selectedLinkText, setSelectedLinkText] = useState<string>('')
+    // Capture the mouse/keyboard event when a menu item is selected so that we can use it to fire the onSelect callback after the menu item is swapped with the list item
+    const [selectEvent, setSelectEvent] = useState<
+      React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement> | null
+    >(null)
 
     const [iconsVisible, setIconsVisible] = useState<boolean>(true)
 
@@ -317,6 +320,7 @@ export const UnderlineNav = forwardRef(
           setSelectedLink,
           selectedLinkText,
           setSelectedLinkText,
+          selectEvent,
           afterSelect: afterSelectHandler,
           variant,
           loadingCounters,
@@ -355,8 +359,8 @@ export const UnderlineNav = forwardRef(
                           key={index}
                           {...actionElementProps}
                           onSelect={(event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
-                            setSelectedLinkText(action.props.children)
                             swapMenuItemWithListItem(action, index, event, updateListAndMenu)
+                            setSelectEvent(event)
                           }}
                         >
                           <Box as="span" sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -106,6 +106,11 @@ const overflowEffect = (
       for (const [index, child] of childArray.entries()) {
         if (index < numberOfItemsPossibleWithMoreMenu) {
           items.push(child)
+          // keeping selected item always visible.
+        } else if (child.props.selected) {
+          // If selected item's index couldn't make the list, we swap it with the last item in the list.
+          const propsectiveAction = items.splice(numberOfItemsPossibleWithMoreMenu - 1, 1, child)[0]
+          actions.push(propsectiveAction)
         } else {
           actions.push(child)
         }
@@ -363,7 +368,7 @@ export const UnderlineNav = forwardRef(
               <ActionMenu>
                 <ActionMenu.Button sx={moreBtnStyles}>More</ActionMenu.Button>
                 <ActionMenu.Overlay align="end">
-                  <ActionList>
+                  <ActionList selectionVariant="single">
                     {actions.map((action, index) => {
                       const {children: actionElementChildren, ...actionElementProps} = action.props
                       return (

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -12,7 +12,15 @@ import CounterLabel from '../CounterLabel'
 import {useTheme} from '../ThemeProvider'
 import {ChildWidthArray, ResponsiveProps, OnScrollWithButtonEventType} from './types'
 
-import {moreBtnStyles, getDividerStyle, getNavStyles, ulStyles, scrollStyles, moreMenuStyles} from './styles'
+import {
+  moreBtnStyles,
+  getDividerStyle,
+  getNavStyles,
+  ulStyles,
+  scrollStyles,
+  moreMenuStyles,
+  menuItemStyles
+} from './styles'
 import {LeftArrowButton, RightArrowButton} from './UnderlineNavArrowButton'
 import styled from 'styled-components'
 import {LoadingCounter} from './LoadingCounter'
@@ -346,11 +354,12 @@ export const UnderlineNav = forwardRef(
                 <ActionMenu>
                   <ActionMenu.Button sx={moreBtnStyles}>More</ActionMenu.Button>
                   <ActionMenu.Overlay align="end">
-                    <ActionList>
+                    <ActionList selectionVariant="single">
                       {actions.map((action, index) => {
                         const {children: actionElementChildren, ...actionElementProps} = action.props
                         return (
                           <ActionList.Item
+                            sx={menuItemStyles}
                             key={index}
                             {...actionElementProps}
                             onSelect={(event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -193,8 +193,6 @@ export const UnderlineNav = forwardRef(
       // Add itemsToAddToMenu array's items to the menu at the index of the prospectiveListItem and remove 1 count of items (prospectiveListItem)
       updatedMenuItems.splice(indexOfProspectiveListItem, 1, ...itemsToAddToMenu)
 
-      // This is to prevent calling the overflowEffect function again when the responsiveProps is being updated.
-      setIsSwapping(true)
       callback(
         {items: updatedItemList, actions: updatedMenuItems, overflowStyles: responsiveProps.overflowStyles},
         false
@@ -214,8 +212,6 @@ export const UnderlineNav = forwardRef(
       }
       return breakpoint
     }
-
-    const [isSwapping, setIsSwapping] = useState(false)
 
     const isCoarsePointer = useMedia('(pointer: coarse)')
 
@@ -280,39 +276,22 @@ export const UnderlineNav = forwardRef(
       })
     }, [])
 
-    // resizeObserver calls this function infinitely without a useCallback
-    const resizeObserverCallback = useCallback(
-      (resizeObserverEntries: ResizeObserverEntry[]) => {
-        const childArray = getValidChildren(children)
-        const navWidth = resizeObserverEntries[0].contentRect.width
-        const moreMenuWidth = moreMenuRef.current?.getBoundingClientRect().width ?? 0
+    useResizeObserver((resizeObserverEntries: ResizeObserverEntry[]) => {
+      const childArray = getValidChildren(children)
+      const navWidth = resizeObserverEntries[0].contentRect.width
+      const moreMenuWidth = moreMenuRef.current?.getBoundingClientRect().width ?? 0
 
-        if (!isSwapping) {
-          overflowEffect(
-            navWidth,
-            moreMenuWidth,
-            childArray,
-            childWidthArray,
-            noIconChildWidthArray,
-            isCoarsePointer,
-            updateListAndMenu
-          )
-        }
-        handleArrowBtnsVisibility(listRef, updateOffsetValues)
-      },
-      [
-        updateListAndMenu,
-        updateOffsetValues,
+      overflowEffect(
+        navWidth,
+        moreMenuWidth,
+        childArray,
         childWidthArray,
         noIconChildWidthArray,
-        children,
         isCoarsePointer,
-        moreMenuRef,
-        isSwapping
-      ]
-    )
-
-    useResizeObserver(resizeObserverCallback, navRef as RefObject<HTMLElement>)
+        updateListAndMenu
+      )
+      handleArrowBtnsVisibility(listRef, updateOffsetValues)
+    }, navRef as RefObject<HTMLElement>)
 
     useEffect(() => {
       const listEl = listRef.current

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -356,46 +356,48 @@ export const UnderlineNav = forwardRef(
 
           <NavigationList sx={merge<BetterSystemStyleObject>(responsiveProps.overflowStyles, ulStyles)} ref={listRef}>
             {responsiveProps.items}
+            {actions.length > 0 && (
+              <Box as="div" sx={{display: 'flex'}} ref={moreMenuRef}>
+                <Box sx={getDividerStyle(theme)}></Box>
+                <ActionMenu>
+                  <ActionMenu.Button sx={moreBtnStyles}>More</ActionMenu.Button>
+                  <ActionMenu.Overlay align="end">
+                    <ActionList selectionVariant="single">
+                      {actions.map((action, index) => {
+                        const {children: actionElementChildren, ...actionElementProps} = action.props
+                        return (
+                          <ActionList.Item
+                            key={index}
+                            {...actionElementProps}
+                            onSelect={(event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
+                              swapMenuItemWithListItem(action, index, event, updateListAndMenu)
+                              setSelectEvent(event)
+                            }}
+                          >
+                            <Box
+                              as="span"
+                              sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}
+                            >
+                              {actionElementChildren}
+
+                              {loadingCounters ? (
+                                <LoadingCounter />
+                              ) : (
+                                <CounterLabel>{actionElementProps.counter}</CounterLabel>
+                              )}
+                            </Box>
+                          </ActionList.Item>
+                        )
+                      })}
+                    </ActionList>
+                  </ActionMenu.Overlay>
+                </ActionMenu>
+              </Box>
+            )}
           </NavigationList>
 
           {isCoarsePointer && (
             <RightArrowButton show={scrollValues.scrollRight > 0} onScrollWithButton={onScrollWithButton} />
-          )}
-
-          {actions.length > 0 && (
-            <Box as="div" sx={{display: 'flex'}} ref={moreMenuRef}>
-              <Box sx={getDividerStyle(theme)}></Box>
-              <ActionMenu>
-                <ActionMenu.Button sx={moreBtnStyles}>More</ActionMenu.Button>
-                <ActionMenu.Overlay align="end">
-                  <ActionList selectionVariant="single">
-                    {actions.map((action, index) => {
-                      const {children: actionElementChildren, ...actionElementProps} = action.props
-                      return (
-                        <ActionList.Item
-                          key={index}
-                          {...actionElementProps}
-                          onSelect={(event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
-                            swapMenuItemWithListItem(action, index, event, updateListAndMenu)
-                            setSelectEvent(event)
-                          }}
-                        >
-                          <Box as="span" sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
-                            {actionElementChildren}
-
-                            {loadingCounters ? (
-                              <LoadingCounter />
-                            ) : (
-                              <CounterLabel>{actionElementProps.counter}</CounterLabel>
-                            )}
-                          </Box>
-                        </ActionList.Item>
-                      )
-                    })}
-                  </ActionList>
-                </ActionMenu.Overlay>
-              </ActionMenu>
-            </Box>
           )}
         </Box>
       </UnderlineNavContext.Provider>

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -67,7 +67,6 @@ const overflowEffect = (
 ) => {
   let iconsVisible = true
   let overflowStyles: BetterSystemStyleObject | null = {}
-
   if (childWidthArray.length === 0) {
     updateListAndMenu({items: childArray, actions: [], overflowStyles}, iconsVisible)
   }
@@ -304,11 +303,29 @@ export const UnderlineNav = forwardRef(
     }, [scrollOnList])
 
     useEffect(() => {
-      // scroll the selected link into the view
-      if (selectedLink && selectedLink.current && listRef.current) {
+      // scroll the selected link into the view (coarse pointer behaviour)
+      if (isCoarsePointer && selectedLink?.current && listRef.current) {
         scrollIntoView(selectedLink.current, listRef.current, underlineNavScrollMargins)
+        return
       }
-    }, [selectedLink])
+
+      const navWidth = navRef.current.getBoundingClientRect().width
+      if (childWidthArray.length !== 0 && noIconChildWidthArray.length !== 0 && navWidth !== 0) {
+        const childArray = getValidChildren(children)
+        const moreMenuWidth = moreMenuRef.current?.getBoundingClientRect().width ?? 0
+
+        // run overflowEffect when the selectedLink is changed
+        overflowEffect(
+          navWidth,
+          moreMenuWidth,
+          childArray,
+          childWidthArray,
+          noIconChildWidthArray,
+          isCoarsePointer,
+          updateListAndMenu
+        )
+      }
+    }, [selectedLink, isCoarsePointer, navRef, children, childWidthArray, noIconChildWidthArray, updateListAndMenu])
 
     return (
       <UnderlineNavContext.Provider

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -47,6 +47,10 @@ const NavigationList = styled.ul`
   ${sx};
 `
 
+const MoreMenuListItem = styled.li`
+  display: flex;
+`
+
 const handleArrowBtnsVisibility = (
   scrollableList: RefObject<HTMLUListElement>,
   callback: (scroll: {scrollLeft: number; scrollRight: number}) => void
@@ -157,7 +161,7 @@ export const UnderlineNav = forwardRef(
     const backupRef = useRef<HTMLElement>(null)
     const navRef = (forwardedRef ?? backupRef) as MutableRefObject<HTMLElement>
     const listRef = useRef<HTMLUListElement>(null)
-    const moreMenuRef = useRef<HTMLDivElement>(null)
+    const moreMenuRef = useRef<HTMLLIElement>(null)
 
     const {theme} = useTheme()
 
@@ -173,11 +177,9 @@ export const UnderlineNav = forwardRef(
     ) => {
       // get the selected menu item's width
       const widthToFitIntoList = getItemsWidth(prospectiveListItem.props.children)
-      // Check if there is any empty space on the right side of the more btn
+      // Check if there is any empty space on the right side of the list
       const availableSpace =
-        navRef.current.getBoundingClientRect().width -
-        (moreMenuRef.current?.getBoundingClientRect().width || 0) -
-        (listRef.current?.getBoundingClientRect().width || 0)
+        navRef.current.getBoundingClientRect().width - (listRef.current?.getBoundingClientRect().width || 0)
 
       // Calculate how many items need to be pulled in to the menu to make room for the selected menu item
       // I.e. if we need to pull 2 items in (index 0 and index 1), breakpoint (index) will return 1.
@@ -282,7 +284,6 @@ export const UnderlineNav = forwardRef(
       const childArray = getValidChildren(children)
       const navWidth = resizeObserverEntries[0].contentRect.width
       const moreMenuWidth = moreMenuRef.current?.getBoundingClientRect().width ?? 0
-
       overflowEffect(
         navWidth,
         moreMenuWidth,
@@ -308,24 +309,7 @@ export const UnderlineNav = forwardRef(
         scrollIntoView(selectedLink.current, listRef.current, underlineNavScrollMargins)
         return
       }
-
-      const navWidth = navRef.current.getBoundingClientRect().width
-      if (childWidthArray.length !== 0 && noIconChildWidthArray.length !== 0 && navWidth !== 0) {
-        const childArray = getValidChildren(children)
-        const moreMenuWidth = moreMenuRef.current?.getBoundingClientRect().width ?? 0
-
-        // run overflowEffect when the selectedLink is changed
-        overflowEffect(
-          navWidth,
-          moreMenuWidth,
-          childArray,
-          childWidthArray,
-          noIconChildWidthArray,
-          isCoarsePointer,
-          updateListAndMenu
-        )
-      }
-    }, [selectedLink, isCoarsePointer, navRef, children, childWidthArray, noIconChildWidthArray, updateListAndMenu])
+    }, [selectedLink, isCoarsePointer])
 
     return (
       <UnderlineNavContext.Provider
@@ -357,12 +341,12 @@ export const UnderlineNav = forwardRef(
           <NavigationList sx={merge<BetterSystemStyleObject>(responsiveProps.overflowStyles, ulStyles)} ref={listRef}>
             {responsiveProps.items}
             {actions.length > 0 && (
-              <Box as="div" sx={{display: 'flex'}} ref={moreMenuRef}>
+              <MoreMenuListItem ref={moreMenuRef}>
                 <Box sx={getDividerStyle(theme)}></Box>
                 <ActionMenu>
                   <ActionMenu.Button sx={moreBtnStyles}>More</ActionMenu.Button>
                   <ActionMenu.Overlay align="end">
-                    <ActionList selectionVariant="single">
+                    <ActionList>
                       {actions.map((action, index) => {
                         const {children: actionElementChildren, ...actionElementProps} = action.props
                         return (
@@ -392,7 +376,7 @@ export const UnderlineNav = forwardRef(
                     </ActionList>
                   </ActionMenu.Overlay>
                 </ActionMenu>
-              </Box>
+              </MoreMenuListItem>
             )}
           </NavigationList>
 

--- a/src/UnderlineNav2/UnderlineNavArrowButton.tsx
+++ b/src/UnderlineNav2/UnderlineNavArrowButton.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, {useContext} from 'react'
 import {IconButton} from '../Button/IconButton'
 import {ChevronLeftIcon, ChevronRightIcon} from '@primer/octicons-react'
 import {getLeftArrowHiddenBtn, getRightArrowHiddenBtn, getLeftArrowVisibleBtn, getRightArrowVisibleBtn} from './styles'
 import {OnScrollWithButtonEventType} from './types'
-import {useTheme} from '../ThemeProvider'
+import {UnderlineNavContext} from './UnderlineNavContext'
 
 const LeftArrowButton = ({
   show,
@@ -12,7 +12,7 @@ const LeftArrowButton = ({
   show: boolean
   onScrollWithButton: OnScrollWithButtonEventType
 }) => {
-  const {theme} = useTheme()
+  const {theme} = useContext(UnderlineNavContext)
   return (
     <IconButton
       aria-label="Scroll Left"
@@ -30,7 +30,7 @@ const RightArrowButton = ({
   show: boolean
   onScrollWithButton: OnScrollWithButtonEventType
 }) => {
-  const {theme} = useTheme()
+  const {theme} = useContext(UnderlineNavContext)
   return (
     <IconButton
       aria-label="Scroll Right"

--- a/src/UnderlineNav2/UnderlineNavContext.tsx
+++ b/src/UnderlineNav2/UnderlineNavContext.tsx
@@ -1,8 +1,8 @@
 import React, {createContext, RefObject} from 'react'
 
 export const UnderlineNavContext = createContext<{
-  setChildrenWidth: React.Dispatch<{width: number}>
-  setNoIconChildrenWidth: React.Dispatch<{width: number}>
+  setChildrenWidth: React.Dispatch<{text: string; width: number}>
+  setNoIconChildrenWidth: React.Dispatch<{text: string; width: number}>
   selectedLink: RefObject<HTMLElement> | undefined
   setSelectedLink: (ref: RefObject<HTMLElement>) => void
   afterSelect?: (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void

--- a/src/UnderlineNav2/UnderlineNavContext.tsx
+++ b/src/UnderlineNav2/UnderlineNavContext.tsx
@@ -1,19 +1,26 @@
 import React, {createContext, RefObject} from 'react'
+import {Theme} from '../ThemeProvider'
 
 export const UnderlineNavContext = createContext<{
+  theme: Theme | undefined
   setChildrenWidth: React.Dispatch<{text: string; width: number}>
   setNoIconChildrenWidth: React.Dispatch<{text: string; width: number}>
   selectedLink: RefObject<HTMLElement> | undefined
   setSelectedLink: (ref: RefObject<HTMLElement>) => void
+  selectedLinkText: string
+  setSelectedLinkText: React.Dispatch<React.SetStateAction<string>>
   afterSelect?: (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void
   variant: 'default' | 'small'
   loadingCounters: boolean
   iconsVisible: boolean
 }>({
+  theme: {},
   setChildrenWidth: () => null,
   setNoIconChildrenWidth: () => null,
   selectedLink: undefined,
   setSelectedLink: () => null,
+  selectedLinkText: '',
+  setSelectedLinkText: () => null,
   variant: 'default',
   loadingCounters: false,
   iconsVisible: true

--- a/src/UnderlineNav2/UnderlineNavContext.tsx
+++ b/src/UnderlineNav2/UnderlineNavContext.tsx
@@ -9,6 +9,7 @@ export const UnderlineNavContext = createContext<{
   setSelectedLink: (ref: RefObject<HTMLElement>) => void
   selectedLinkText: string
   setSelectedLinkText: React.Dispatch<React.SetStateAction<string>>
+  selectEvent: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement> | null
   afterSelect?: (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void
   variant: 'default' | 'small'
   loadingCounters: boolean
@@ -21,6 +22,7 @@ export const UnderlineNavContext = createContext<{
   setSelectedLink: () => null,
   selectedLinkText: '',
   setSelectedLinkText: () => null,
+  selectEvent: null,
   variant: 'default',
   loadingCounters: false,
   iconsVisible: true

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -71,6 +71,7 @@ export const UnderlineNavItem = forwardRef(
       setSelectedLink,
       selectedLinkText,
       setSelectedLinkText,
+      selectEvent,
       afterSelect,
       variant,
       loadingCounters,
@@ -99,10 +100,12 @@ export const UnderlineNavItem = forwardRef(
       setNoIconChildrenWidth({text, width: domRect.width - iconWidthWithMargin})
       preSelected && selectedLink === undefined && setSelectedLink(ref as RefObject<HTMLElement>)
 
+      // Only runs when a menu item is selected (swapping the menu item with the list item to keep it visible)
       if (selectedLinkText === text) {
         setSelectedLink(ref as RefObject<HTMLElement>)
+        if (typeof onSelect === 'function' && selectEvent !== null) onSelect(selectEvent)
+        setSelectedLinkText('')
       }
-      setSelectedLinkText('')
     }, [
       ref,
       preSelected,
@@ -111,7 +114,9 @@ export const UnderlineNavItem = forwardRef(
       setSelectedLinkText,
       setSelectedLink,
       setChildrenWidth,
-      setNoIconChildrenWidth
+      setNoIconChildrenWidth,
+      onSelect,
+      selectEvent
     ])
 
     const keyPressHandler = React.useCallback(

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -5,7 +5,6 @@ import {IconProps} from '@primer/octicons-react'
 import {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 import {UnderlineNavContext} from './UnderlineNavContext'
 import CounterLabel from '../CounterLabel'
-import {useTheme} from '../ThemeProvider'
 import {getLinkStyles, wrapperStyles, iconWrapStyles, counterStyles} from './styles'
 import {LoadingCounter} from './LoadingCounter'
 
@@ -65,16 +64,19 @@ export const UnderlineNavItem = forwardRef(
     const backupRef = useRef<HTMLElement>(null)
     const ref = (forwardedRef ?? backupRef) as RefObject<HTMLElement>
     const {
+      theme,
       setChildrenWidth,
       setNoIconChildrenWidth,
       selectedLink,
       setSelectedLink,
+      selectedLinkText,
+      setSelectedLinkText,
       afterSelect,
       variant,
       loadingCounters,
       iconsVisible
     } = useContext(UnderlineNavContext)
-    const {theme} = useTheme()
+
     useLayoutEffect(() => {
       const domRect = (ref as MutableRefObject<HTMLElement>).current.getBoundingClientRect()
 
@@ -96,7 +98,21 @@ export const UnderlineNavItem = forwardRef(
       setChildrenWidth({text, width: domRect.width})
       setNoIconChildrenWidth({text, width: domRect.width - iconWidthWithMargin})
       preSelected && selectedLink === undefined && setSelectedLink(ref as RefObject<HTMLElement>)
-    }, [ref, preSelected, selectedLink, setSelectedLink, setChildrenWidth, setNoIconChildrenWidth])
+
+      if (selectedLinkText === text) {
+        setSelectedLink(ref as RefObject<HTMLElement>)
+      }
+      setSelectedLinkText('')
+    }, [
+      ref,
+      preSelected,
+      selectedLink,
+      selectedLinkText,
+      setSelectedLinkText,
+      setSelectedLink,
+      setChildrenWidth,
+      setNoIconChildrenWidth
+    ])
 
     const keyPressHandler = React.useCallback(
       event => {

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -77,15 +77,24 @@ export const UnderlineNavItem = forwardRef(
     const {theme} = useTheme()
     useLayoutEffect(() => {
       const domRect = (ref as MutableRefObject<HTMLElement>).current.getBoundingClientRect()
-      // might want to select this better
-      const icon = (ref as MutableRefObject<HTMLElement>).current.children[0].children[0]
-      const iconWidthWithMargin =
-        icon.getBoundingClientRect().width +
-        Number(getComputedStyle(icon).marginRight.slice(0, -2)) +
-        Number(getComputedStyle(icon).marginLeft.slice(0, -2))
 
-      setChildrenWidth({width: domRect.width})
-      setNoIconChildrenWidth({width: domRect.width - iconWidthWithMargin})
+      const icon = Array.from((ref as MutableRefObject<HTMLElement>).current.children[0].children).find(
+        child => child.getAttribute('data-component') === 'icon'
+      )
+
+      const content = Array.from((ref as MutableRefObject<HTMLElement>).current.children[0].children).find(
+        child => child.getAttribute('data-component') === 'text'
+      ) as HTMLElement
+      const text = content.textContent as string
+
+      const iconWidthWithMargin = icon
+        ? icon.getBoundingClientRect().width +
+          Number(getComputedStyle(icon).marginRight.slice(0, -2)) +
+          Number(getComputedStyle(icon).marginLeft.slice(0, -2))
+        : 0
+
+      setChildrenWidth({text, width: domRect.width})
+      setNoIconChildrenWidth({text, width: domRect.width - iconWidthWithMargin})
       preSelected && selectedLink === undefined && setSelectedLink(ref as RefObject<HTMLElement>)
     }, [ref, preSelected, selectedLink, setSelectedLink, setChildrenWidth, setNoIconChildrenWidth])
 

--- a/src/UnderlineNav2/examples.stories.tsx
+++ b/src/UnderlineNav2/examples.stories.tsx
@@ -75,13 +75,14 @@ export const withCounterLabels = (args: UnderlineNavProps) => {
 const items: {navigation: string; icon: React.FC<IconProps>; counter?: number}[] = [
   {navigation: 'Code', icon: CodeIcon},
   {navigation: 'Issues', icon: IssueOpenedIcon, counter: 120},
-  {navigation: 'Pull Requests', icon: GitPullRequestIcon, counter: 13},
+
   {navigation: 'Discussions', icon: CommentDiscussionIcon, counter: 5},
   {navigation: 'Actions', icon: PlayIcon, counter: 4},
   {navigation: 'Projects', icon: ProjectIcon, counter: 9},
   {navigation: 'Insights', icon: GraphIcon},
   {navigation: 'Settings', icon: GearIcon, counter: 10},
-  {navigation: 'Security', icon: ShieldLockIcon}
+  {navigation: 'Security', icon: ShieldLockIcon},
+  {navigation: 'Pull Requests', icon: GitPullRequestIcon, counter: 13}
 ]
 
 export const InternalResponsiveNav = (args: UnderlineNavProps) => {

--- a/src/UnderlineNav2/examples.stories.tsx
+++ b/src/UnderlineNav2/examples.stories.tsx
@@ -75,14 +75,13 @@ export const withCounterLabels = (args: UnderlineNavProps) => {
 const items: {navigation: string; icon: React.FC<IconProps>; counter?: number}[] = [
   {navigation: 'Code', icon: CodeIcon},
   {navigation: 'Issues', icon: IssueOpenedIcon, counter: 120},
-
+  {navigation: 'Pull Requests', icon: GitPullRequestIcon, counter: 13},
   {navigation: 'Discussions', icon: CommentDiscussionIcon, counter: 5},
   {navigation: 'Actions', icon: PlayIcon, counter: 4},
   {navigation: 'Projects', icon: ProjectIcon, counter: 9},
   {navigation: 'Insights', icon: GraphIcon},
   {navigation: 'Settings', icon: GearIcon, counter: 10},
-  {navigation: 'Security', icon: ShieldLockIcon},
-  {navigation: 'Pull Requests', icon: GitPullRequestIcon, counter: 13}
+  {navigation: 'Security', icon: ShieldLockIcon}
 ]
 
 export const InternalResponsiveNav = (args: UnderlineNavProps) => {

--- a/src/UnderlineNav2/styles.ts
+++ b/src/UnderlineNav2/styles.ts
@@ -206,3 +206,10 @@ export const scrollStyles: BetterSystemStyleObject = {
 }
 
 export const moreMenuStyles: BetterSystemStyleObject = {whiteSpace: 'nowrap'}
+
+export const menuItemStyles = {
+  // This is needed to hide the selected check icon on the menu item. https://github.com/primer/react/blob/main/src/ActionList/Selection.tsx#L32
+  '& > span': {
+    display: 'none'
+  }
+}

--- a/src/UnderlineNav2/types.ts
+++ b/src/UnderlineNav2/types.ts
@@ -1,5 +1,5 @@
 import {BetterSystemStyleObject} from '../sx'
-export type ChildWidthArray = Array<{width: number}>
+export type ChildWidthArray = Array<{text: string; width: number}>
 export type ResponsiveProps = {
   items: Array<React.ReactElement>
   actions: Array<React.ReactElement>

--- a/src/hooks/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver.ts
@@ -22,7 +22,7 @@ export function useResizeObserver<T extends HTMLElement>(callback: ResizeObserve
     }
 
     const observer = new ResizeObserver(entries => {
-      savedCallback.current?.(entries)
+      savedCallback.current(entries)
     })
 
     observer.observe(targetEl)

--- a/src/hooks/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver.ts
@@ -1,4 +1,4 @@
-import {RefObject} from 'react'
+import {RefObject, useRef} from 'react'
 import useLayoutEffect from '../utils/useIsomorphicLayoutEffect'
 
 // https://gist.github.com/strothj/708afcf4f01dd04de8f49c92e88093c3
@@ -9,13 +9,26 @@ export interface ResizeObserverEntry {
 }
 
 export function useResizeObserver<T extends HTMLElement>(callback: ResizeObserverCallback, target?: RefObject<T>) {
+  const savedCallback = useRef(callback)
+
+  useLayoutEffect(() => {
+    savedCallback.current = callback
+  })
+
   useLayoutEffect(() => {
     const targetEl = target && 'current' in target ? target.current : document.documentElement
-    if (!targetEl) return () => {}
-    const observer = new window.ResizeObserver(entries => callback(entries))
+    if (!targetEl) {
+      return
+    }
+
+    const observer = new ResizeObserver(entries => {
+      savedCallback.current?.(entries)
+    })
+
     observer.observe(targetEl)
+
     return () => {
       observer.disconnect()
     }
-  }, [callback, target])
+  }, [target])
 }


### PR DESCRIPTION
Closes [#1296](https://github.com/github/primer/issues/1296)

Storybook link: https://primer-1475f2ddc1-13348165.drafts.github.io/storybook/?path=/story/components-underlinenav

This PR is for keeping UnderlineNav's selected link always visible. This means;

- [x] If an item selected and the window is resized or a when a page is loaded and the selected item stays out of the viewport, component always make sure to keep this item on the list and not be pulled in to the dropdown menu. It does it by interrupting the natural order of the list and appending this selected item to the list as the last item.
- [x] If an item from the dropdown menu is selected, component moves this item out of the menu, appends it to the list and pulls as many item as required into the menu to make room for the selected item. (Natural order is interrupted here as well)

### Screen Recordings

https://user-images.githubusercontent.com/1446503/193276303-b846fc80-d6bf-400c-bb07-385ccde4b16c.mov

Please provide before/after screenshots for any visual changes

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
