### PR TITLE
Add isolate: isolation to AvatarStack

### DIFF
--- a/src/AvatarStack.tsx
+++ b/src/AvatarStack.tsx
@@ -12,6 +12,7 @@ type StyledAvatarStackWrapperProps = {
 const AvatarStackWrapper = styled.span<StyledAvatarStackWrapperProps>`
   display: flex;
   position: relative;
+  isolation: isolate;
   height: 20px;
   min-width: ${props => (props.count === 1 ? '20px' : props.count === 2 ? '30px' : '38px')};
 

--- a/src/stories/AvatarStack.stories.tsx
+++ b/src/stories/AvatarStack.stories.tsx
@@ -1,8 +1,9 @@
 import AvatarStack from '../AvatarStack'
 import Avatar from '../Avatar'
+import {Dialog} from '../Dialog/Dialog'
 import {Meta} from '@storybook/react'
-import React from 'react'
-import {ThemeProvider} from '..'
+import React, {useState} from 'react'
+import {Button, ThemeProvider} from '..'
 import BaseStyles from '../BaseStyles'
 
 const meta: Meta = {
@@ -26,13 +27,26 @@ const meta: Meta = {
 export default meta
 
 export function AvatarStackStory(): JSX.Element {
+  const [dialogOpen, setDialogOpen] = useState(false)
+
   return (
-    <AvatarStack>
-      <Avatar alt="Primer logo" src="https://avatars.githubusercontent.com/primer" />
-      <Avatar alt="GitHub logo" src="https://avatars.githubusercontent.com/github" />
-      <Avatar alt="Atom logo" src="https://avatars.githubusercontent.com/atom" />
-      <Avatar alt="GitHub Desktop logo" src="https://avatars.githubusercontent.com/desktop" />
-    </AvatarStack>
+    <div>
+      <p>Avatar stacks should gray out when the dialog is displayed, and they should show behind the dialog.</p>
+      <AvatarStack>
+        <Avatar alt="Primer logo" src="https://avatars.githubusercontent.com/primer" />
+        <Avatar alt="GitHub logo" src="https://avatars.githubusercontent.com/github" />
+        <Avatar alt="Atom logo" src="https://avatars.githubusercontent.com/atom" />
+        <Avatar alt="GitHub Desktop logo" src="https://avatars.githubusercontent.com/desktop" />
+      </AvatarStack>
+      <Button onClick={() => setDialogOpen(!dialogOpen)} sx={{my: 4}}>
+        Show dialog
+      </Button>
+      {dialogOpen && (
+        <Dialog title="Test dialog" width="xlarge" onClose={() => setDialogOpen(false)}>
+          Content
+        </Dialog>
+      )}
+    </div>
   )
 }
 AvatarStackStory.storyName = 'AvatarStack'


### PR DESCRIPTION
Prevent AvatarStack to overlap Dialog or other portal components.
AvatarStack uses `z-index` that leak to other components, specially Dialog or other portals. Adding `isolation` it won't leak.

I've updated the storybook to make visible this scenario, but if you think it's too specific, I can either split into a separate story, or just drop the storybook changes. I'm open to suggestions, it's my first time contributing here 🤓 

### Screenshots

#### Before

<img width="621" alt="image" src="https://user-images.githubusercontent.com/579705/191920865-180d16bb-fa15-474d-94f8-a6ed9d67daff.png">

#### After

<img width="678" alt="image" src="https://user-images.githubusercontent.com/579705/191920948-5a6503da-925f-4f09-ba12-9cb4865c9d45.png">

### Merge checklist

- [x] Added/updated tests: updated storybook to showing this scenario
- [ ] Added/updated documentation: no need
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
