### PR TITLE
TreeView: Fix focus styles in styled-components v5.2+

### DIFF
--- a/.changeset/brown-bees-tap.md
+++ b/.changeset/brown-bees-tap.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+TreeView: Fix focus styles in styled-components v5.2+

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -89,7 +89,7 @@ const Item: React.FC<TreeViewItemProps> = ({
   onToggle,
   children
 }) => {
-  const {setActiveDescendant} = React.useContext(RootContext)
+  const {activeDescendant, setActiveDescendant} = React.useContext(RootContext)
   const itemId = useSSRSafeId()
   const labelId = useSSRSafeId()
   const itemRef = React.useRef<HTMLLIElement>(null)
@@ -182,8 +182,9 @@ const Item: React.FC<TreeViewItemProps> = ({
             '&:hover': {
               backgroundColor: 'actionListItem.default.hoverBg'
             },
-            [`[role=tree][aria-activedescendant="${itemId}"]:focus-visible &`]: {
-              boxShadow: (theme: Theme) => `0 0 0 2px ${theme.colors.accent.emphasis}`
+            [`[role=tree]:focus-visible &`]: {
+              boxShadow: (theme: Theme) =>
+                activeDescendant === itemId ? `0 0 0 2px ${theme.colors.accent.emphasis}` : undefined
             },
             '[role=treeitem][aria-current=true] > &': {
               bg: 'actionListItem.default.selectedBg',

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -182,6 +182,10 @@ const Item: React.FC<TreeViewItemProps> = ({
             '&:hover': {
               backgroundColor: 'actionListItem.default.hoverBg'
             },
+            // WARNING: styled-components v5.2 introduced a bug that changed
+            // how it expands `&` in CSS selectors. The following selectors
+            // are unnecessarily specific to work around that styled-components bug.
+            // Reference issue: https://github.com/styled-components/styled-components/issues/3265
             [`[role=tree][aria-activedescendant="${itemId}"]:focus-visible #${itemId} > &:is(div)`]: {
               boxShadow: (theme: Theme) => `0 0 0 2px ${theme.colors.accent.emphasis}`
             },

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -89,7 +89,7 @@ const Item: React.FC<TreeViewItemProps> = ({
   onToggle,
   children
 }) => {
-  const {activeDescendant, setActiveDescendant} = React.useContext(RootContext)
+  const {setActiveDescendant} = React.useContext(RootContext)
   const itemId = useSSRSafeId()
   const labelId = useSSRSafeId()
   const itemRef = React.useRef<HTMLLIElement>(null)
@@ -182,11 +182,10 @@ const Item: React.FC<TreeViewItemProps> = ({
             '&:hover': {
               backgroundColor: 'actionListItem.default.hoverBg'
             },
-            [`[role=tree]:focus-visible &`]: {
-              boxShadow: (theme: Theme) =>
-                activeDescendant === itemId ? `0 0 0 2px ${theme.colors.accent.emphasis}` : undefined
+            [`[role=tree][aria-activedescendant="${itemId}"]:focus-visible #${itemId} > &:is(div)`]: {
+              boxShadow: (theme: Theme) => `0 0 0 2px ${theme.colors.accent.emphasis}`
             },
-            '[role=treeitem][aria-current=true] > &': {
+            '[role=treeitem][aria-current=true] > &:is(div)': {
               bg: 'actionListItem.default.selectedBg',
               '&::after': {
                 position: 'absolute',


### PR DESCRIPTION
## Problem

styled-components v5.2 introduced a [bug](https://github.com/styled-components/styled-components/issues/3265) that changed how it expands `&` in CSS selectors.

This bug affected TreeView's current and focused styles (see "before" pictures). 

## Solution

I had to get creative with our CSS selectors to work around this bug.  

## Screenshots

| Before | After |
| --- | --- |
| ![CleanShot 2022-09-26 at 15 12 05](https://user-images.githubusercontent.com/4608155/192389825-e3debecd-7b71-423f-9aad-78bde8b1cf72.png) | ![CleanShot 2022-09-26 at 15 11 30](https://user-images.githubusercontent.com/4608155/192389760-0739b00d-5789-4307-a306-62350839b2bf.png) |
| ![CleanShot 2022-09-26 at 15 12 42](https://user-images.githubusercontent.com/4608155/192389906-efd80487-b48a-442e-b9d7-1d59cf6f93ca.png) | ![CleanShot 2022-09-26 at 15 13 13](https://user-images.githubusercontent.com/4608155/192389959-7811010f-9d8b-4faa-8b39-a6bea306e92b.png) |

Closes https://github.com/github/primer/issues/1312

### Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
