### PR TITLE
TreeView: Increase touch target size for coarse pointers

### DIFF
--- a/.changeset/orange-beds-rhyme.md
+++ b/.changeset/orange-beds-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+TreeView: Increase touch target size for coarse pointers

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -169,18 +169,23 @@ const Item: React.FC<TreeViewItemProps> = ({
             }
           }}
           sx={{
+            '--toggle-width': '1rem', // 16px
             position: 'relative',
             display: 'grid',
-            gridTemplateColumns: `calc(${level - 1} * 8px) 16px 1fr`,
+            gridTemplateColumns: `calc(${level - 1} * (var(--toggle-width) / 2)) var(--toggle-width) 1fr`,
             gridTemplateAreas: `"spacer toggle content"`,
             width: '100%',
-            height: 32,
+            height: '2rem', // 32px
             fontSize: 1,
             color: 'fg.default',
             borderRadius: 2,
             cursor: 'pointer',
             '&:hover': {
               backgroundColor: 'actionListItem.default.hoverBg'
+            },
+            '@media (pointer: coarse)': {
+              '--toggle-width': '1.5rem', // 24px
+              height: '2.75rem' // 44px
             },
             // WARNING: styled-components v5.2 introduced a bug that changed
             // how it expands `&` in CSS selectors. The following selectors

--- a/src/sx.ts
+++ b/src/sx.ts
@@ -11,7 +11,16 @@ export type BetterCssProperties = {
     : SystemCssProperties[K]
 }
 
-export type BetterSystemStyleObject = BetterCssProperties | SystemStyleObject
+// Support CSS custom properties in the `sx` prop
+type CSSCustomProperties = {
+  [key: `--${string}`]: string | number
+}
+
+type CSSSelectorObject = {
+  [cssSelector: string]: SystemStyleObject | CSSCustomProperties
+}
+
+export type BetterSystemStyleObject = BetterCssProperties | SystemStyleObject | CSSCustomProperties | CSSSelectorObject
 
 export interface SxProp {
   sx?: BetterSystemStyleObject


### PR DESCRIPTION
### Summary

Increases the touch target size of tree items when the device pointer has limited accuracy (example: touch screen devices).

### Screenshots

| `pointer:fine` | `pointer:coarse` |
| --- | --- |
| ![CleanShot 2022-09-26 at 17 16 46](https://user-images.githubusercontent.com/4608155/192402944-281236d8-c65f-4a62-9225-1ec67b5e0d94.png) | ![CleanShot 2022-09-26 at 17 16 20](https://user-images.githubusercontent.com/4608155/192402908-6f42622f-927d-4ffc-80df-a20b963556bf.png) |


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
