### PR TITLE
Don't crash when building docs

### DIFF
--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef, useImperativeHandle, useRef, useEffect} from 'react'
+import React, {forwardRef, useImperativeHandle, useRef} from 'react'
 
 export type FormattingTools = {
   header: () => void
@@ -48,12 +48,7 @@ export const FormattingTools = forwardRef<FormattingTools, {forInputId: string}>
     reference: () => referenceRef.current?.click()
   }))
 
-  useEffect(() => {
-    // eslint-disable-next-line prettier/prettier
-    (async function () {
-      await import('@github/markdown-toolbar-element')
-    })()
-  })
+  require('@github/markdown-toolbar-element')
 
   return (
     <markdown-toolbar for={forInputId} style={{display: 'none'}}>

--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -1,5 +1,4 @@
 import React, {forwardRef, useImperativeHandle, useRef, useEffect} from 'react'
-import '@github/markdown-toolbar-element'
 
 export type FormattingTools = {
   header: () => void
@@ -50,6 +49,8 @@ export const FormattingTools = forwardRef<FormattingTools, {forInputId: string}>
     mention: () => mentionRef.current?.click(),
     reference: () => referenceRef.current?.click()
   }))
+
+  require('@github/markdown-toolbar-element')
 
   return (
     <markdown-toolbar for={forInputId} style={{display: 'none'}}>

--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef, useImperativeHandle, useRef} from 'react'
+import React, {forwardRef, useImperativeHandle, useRef, useEffect} from 'react'
 
 export type FormattingTools = {
   header: () => void
@@ -48,7 +48,11 @@ export const FormattingTools = forwardRef<FormattingTools, {forInputId: string}>
     reference: () => referenceRef.current?.click()
   }))
 
-  require('@github/markdown-toolbar-element')
+  useEffect(() => {
+    ;(async function () {
+      await import('@github/markdown-toolbar-element')
+    })()
+  })
 
   return (
     <markdown-toolbar for={forInputId} style={{display: 'none'}}>

--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -50,7 +50,7 @@ export const FormattingTools = forwardRef<FormattingTools, {forInputId: string}>
 
   useEffect(() => {
     require('@github/markdown-toolbar-element')
-  })
+  }, [])
 
   return (
     <markdown-toolbar for={forInputId} style={{display: 'none'}}>

--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef, useImperativeHandle, useRef} from 'react'
+import React, {forwardRef, useImperativeHandle, useRef, useEffect} from 'react'
 
 export type FormattingTools = {
   header: () => void
@@ -48,7 +48,9 @@ export const FormattingTools = forwardRef<FormattingTools, {forInputId: string}>
     reference: () => referenceRef.current?.click()
   }))
 
-  require('@github/markdown-toolbar-element')
+  useEffect(() => {
+    require('@github/markdown-toolbar-element')
+  })
 
   return (
     <markdown-toolbar for={forInputId} style={{display: 'none'}}>

--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -1,5 +1,4 @@
 import React, {forwardRef, useImperativeHandle, useRef} from 'react'
-import '@github/markdown-toolbar-element'
 
 export type FormattingTools = {
   header: () => void

--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -49,7 +49,8 @@ export const FormattingTools = forwardRef<FormattingTools, {forInputId: string}>
   }))
 
   useEffect(() => {
-    ;(async function () {
+    // eslint-disable-next-line prettier/prettier
+    (async function () {
       await import('@github/markdown-toolbar-element')
     })()
   })


### PR DESCRIPTION
I moved the `@github/markdown-toolbar-element` import into the render function like suggested in https://www.gatsbyjs.com/docs/debugging-html-builds/

Closes https://github.com/github/markdown-toolbar-element/issues/68

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
- [ ] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

cc/ @keithamus 