### PR TITLE
[UnderlineNav]: A11y improvements

### DIFF
--- a/.changeset/dry-camels-enjoy.md
+++ b/.changeset/dry-camels-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Underline2: accessibility improvments

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -258,39 +258,49 @@ export const UnderlineNav = forwardRef(
           ref={newRef}
         >
           {isCoarsePointer && (
-            <LeftArrowButton show={scrollValues.scrollLeft > 0} onScrollWithButton={onScrollWithButton} />
+            <LeftArrowButton
+              tabIndex={scrollValues.scrollLeft > 0 ? 0 : -1}
+              show={scrollValues.scrollLeft > 0}
+              onScrollWithButton={onScrollWithButton}
+            />
           )}
 
           <NavigationList sx={merge<BetterSystemStyleObject>(responsiveProps.overflowStyles, ulStyles)} ref={listRef}>
             {responsiveProps.items}
+            {actions.length > 0 && (
+              <Box as="div" sx={{display: 'flex'}} ref={moreMenuRef} role="listitem">
+                <Box sx={getDividerStyle(theme)}></Box>
+                <ActionMenu>
+                  <ActionMenu.Button sx={moreBtnStyles}>More</ActionMenu.Button>
+                  <ActionMenu.Overlay align="end">
+                    <ActionList>
+                      {actions.map((action, index) => {
+                        const {children: actionElementChildren, ...actionElementProps} = action.props
+                        return (
+                          <ActionList.Item key={index} {...actionElementProps}>
+                            <Box
+                              as="span"
+                              sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}
+                            >
+                              {actionElementChildren}
+                              <CounterLabel>{actionElementProps.counter}</CounterLabel>
+                            </Box>
+                          </ActionList.Item>
+                        )
+                      })}
+                    </ActionList>
+                  </ActionMenu.Overlay>
+                </ActionMenu>
+              </Box>
+            )}
           </NavigationList>
 
           {isCoarsePointer && (
-            <RightArrowButton show={scrollValues.scrollRight > 0} onScrollWithButton={onScrollWithButton} />
-          )}
-
-          {actions.length > 0 && (
-            <Box as="div" sx={{display: 'flex'}} ref={moreMenuRef}>
-              <Box sx={getDividerStyle(theme)}></Box>
-              <ActionMenu>
-                <ActionMenu.Button sx={moreBtnStyles}>More</ActionMenu.Button>
-                <ActionMenu.Overlay align="end">
-                  <ActionList>
-                    {actions.map((action, index) => {
-                      const {children: actionElementChildren, ...actionElementProps} = action.props
-                      return (
-                        <ActionList.Item key={index} {...actionElementProps}>
-                          <Box as="span" sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
-                            {actionElementChildren}
-                            <CounterLabel>{actionElementProps.counter}</CounterLabel>
-                          </Box>
-                        </ActionList.Item>
-                      )
-                    })}
-                  </ActionList>
-                </ActionMenu.Overlay>
-              </ActionMenu>
-            </Box>
+            <RightArrowButton
+              tabIndex={scrollValues.scrollRight > 0 ? 0 : -1}
+              show={scrollValues.scrollRight > 0}
+              onScrollWithButton={onScrollWithButton}
+            />
           )}
         </Box>
       </UnderlineNavContext.Provider>

--- a/src/UnderlineNav2/UnderlineNavArrowButton.tsx
+++ b/src/UnderlineNav2/UnderlineNavArrowButton.tsx
@@ -7,14 +7,17 @@ import {useTheme} from '../ThemeProvider'
 
 const LeftArrowButton = ({
   show,
-  onScrollWithButton
+  onScrollWithButton,
+  tabIndex
 }: {
   show: boolean
   onScrollWithButton: OnScrollWithButtonEventType
+  tabIndex?: number
 }) => {
   const {theme} = useTheme()
   return (
     <IconButton
+      tabIndex={tabIndex}
       aria-label="Scroll Left"
       onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => onScrollWithButton(e, -1)}
       icon={ChevronLeftIcon}
@@ -25,14 +28,17 @@ const LeftArrowButton = ({
 
 const RightArrowButton = ({
   show,
-  onScrollWithButton
+  onScrollWithButton,
+  tabIndex
 }: {
   show: boolean
   onScrollWithButton: OnScrollWithButtonEventType
+  tabIndex?: number
 }) => {
   const {theme} = useTheme()
   return (
     <IconButton
+      tabIndex={tabIndex}
       aria-label="Scroll Right"
       onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => onScrollWithButton(e, 1)}
       icon={ChevronRightIcon}


### PR DESCRIPTION
Just a few accessibility improvements while preparing UnderlineNav to accessibility review

- Move `More` button into the `ul` to make it a sibling to other `li` elements.
- Set arrow buttons' tabIndex to -1 when there are not visible.  


Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
