### PR TITLE
refactor(MarkdownEditor): guard web component imports

### DIFF
--- a/.changeset/moody-bats-invent.md
+++ b/.changeset/moody-bats-invent.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Refactor MarkdownEditor to import client-only dependencies outside of useEffect

--- a/babel.config.js
+++ b/babel.config.js
@@ -39,7 +39,12 @@ module.exports = {
     },
     test: {
       presets: makePresets('commonjs'),
-      plugins: [...sharedPlugins, ['@babel/plugin-transform-modules-commonjs'], replacementPlugin('test')]
+      plugins: [
+        ...sharedPlugins,
+        ['@babel/plugin-transform-modules-commonjs'],
+        replacementPlugin('test'),
+        'babel-plugin-dynamic-import-node'
+      ]
     }
   }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -39,12 +39,7 @@ module.exports = {
     },
     test: {
       presets: makePresets('commonjs'),
-      plugins: [
-        ...sharedPlugins,
-        ['@babel/plugin-transform-modules-commonjs'],
-        replacementPlugin('test'),
-        'babel-plugin-dynamic-import-node'
-      ]
+      plugins: [...sharedPlugins, ['@babel/plugin-transform-modules-commonjs'], replacementPlugin('test')]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     }
   },
   "typings": "lib/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "lib-esm/web-components/**/*.js",
+    "lib/web-components/**/*.js"
+  ],
   "scripts": {
     "setup": "./script/setup",
     "build": "./script/build",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
   },
   "typings": "lib/index.d.ts",
   "sideEffects": [
-    "lib-esm/web-components/**/*.js",
-    "lib/web-components/**/*.js"
+    "lib-esm/web-components/*",
+    "lib/web-components/*",
+    "src/web-components/*"
   ],
   "scripts": {
     "setup": "./script/setup",

--- a/src/drafts/MarkdownEditor/_FormattingTools.tsx
+++ b/src/drafts/MarkdownEditor/_FormattingTools.tsx
@@ -1,4 +1,5 @@
-import React, {forwardRef, useImperativeHandle, useRef, useEffect} from 'react'
+import '../../web-components/markdown-toolbar-element'
+import React, {forwardRef, useImperativeHandle, useRef} from 'react'
 
 export type FormattingTools = {
   header: () => void
@@ -14,8 +15,6 @@ export type FormattingTools = {
   reference: () => void
 }
 
-let hasRegisteredToolbarElement = false
-
 /**
  * Renders an invisible `markdown-toolbar-element` that provides formatting actions to the
  * editor. This is a hacky way of using the library, but it allows us to use the built-in
@@ -24,12 +23,6 @@ let hasRegisteredToolbarElement = false
  * buttons (ie, by keyboard shortcut).
  */
 export const FormattingTools = forwardRef<FormattingTools, {forInputId: string}>(({forInputId}, forwadedRef) => {
-  useEffect(() => {
-    // requiring this module will register the custom element; we don't want to do that until the component mounts in the DOM
-    if (!hasRegisteredToolbarElement) require('@github/markdown-toolbar-element')
-    hasRegisteredToolbarElement = true
-  }, [])
-
   const headerRef = useRef<HTMLElement>(null)
   const boldRef = useRef<HTMLElement>(null)
   const italicRef = useRef<HTMLElement>(null)

--- a/src/web-components/markdown-toolbar-element.ts
+++ b/src/web-components/markdown-toolbar-element.ts
@@ -2,6 +2,10 @@ import {canUseDOM} from '../utils/environment'
 
 if (canUseDOM) {
   if (typeof require === 'function') {
+    // Since require() is synchronous, we use Promise.resolve() to create a
+    // promise-chain to then run `require()` in order to emulate `import()`
+    // behavior
+    // eslint-disable-next-line github/no-then
     Promise.resolve().then(() => {
       require('@github/markdown-toolbar-element')
     })

--- a/src/web-components/markdown-toolbar-element.ts
+++ b/src/web-components/markdown-toolbar-element.ts
@@ -1,0 +1,5 @@
+import {canUseDOM} from '../utils/environment'
+
+if (canUseDOM) {
+  import('@github/markdown-toolbar-element')
+}

--- a/src/web-components/markdown-toolbar-element.ts
+++ b/src/web-components/markdown-toolbar-element.ts
@@ -1,5 +1,11 @@
 import {canUseDOM} from '../utils/environment'
 
 if (canUseDOM) {
-  import('@github/markdown-toolbar-element')
+  if (typeof require === 'function') {
+    Promise.resolve().then(() => {
+      require('@github/markdown-toolbar-element')
+    })
+  } else {
+    import('@github/markdown-toolbar-element')
+  }
 }


### PR DESCRIPTION
**Approach**

This PR proposes a convention for dependencies intending to run only on the client. For components looking to use these dependencies, they can use a bare import to a file under `src/web-components`. This file should include a check to see if the current runtime supports the DOM before using a dynamic `import()` to bring in the dependency.

```ts
// src/web-components/markdown-toolbar-element.ts
import { canUseDOM } from '../utils/environment';

if (canUseDOM) {
  import('@github/markdown-toolbar-element');
}

// src/path/to/component
import '../web-components/markdown-toolbar-element';
export default function ExampleComponent() {
  // ...
}
```

Files under `src/web-components/*` are treated as side effects to make sure that they are included in the bundle even if no imports are used.

**Caveats**

Dynamic import is not supported in environments like Jest until support lands for ESM in Node.js VMs[^1]. We can use `babel-plugin-dynamic-import-node` locally to polyfill this in Node.js environments. However, downstream teams may not be using this plugin and will run into an unexpected error if we ship with this change.

As a result, we have a couple of options:

- Create Node.js specific bundles which include this plugin
- Try and feature detect to determine if we should use `import()` or `require()`. This could potentially look like:

    ```ts
    import {canUseDOM} from '../utils/environment'
    
    if (canUseDOM) {
      if (typeof require === 'function') {
        Promise.resolve().then(() => {
          require('@github/markdown-toolbar-element')
        })
      } else {
        import('@github/markdown-toolbar-element')
      }
    }
    ```

[^1]: https://jestjs.io/docs/ecmascript-modules

**Looking forward**

One concern that is not implemented is if a component would like to listen to when the module is available _before_ rendering. If this scenario comes up, we could use a convention where each module exposes a `ready()` or `register()` function that returns a `Promise` that resolves when the module is loaded (or rejects if there is an error)