### PR TITLE
fix(bundle): add lib/node_modulels to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "codemods",
     "dist",
     "lib",
+    "lib/node_modules",
     "lib-esm",
     "index.d.ts",
     "drafts/package.json",


### PR DESCRIPTION
This PR adds `lib/node_modules` to the `files` array in `package.json`. By default, folders named `node_modules` are (understandably) not included during publish. This folder is now explicitly included. A quick test with `npm publish --dry-run` lists this folder and its files in the package tarball

![image](https://user-images.githubusercontent.com/3901764/193365439-e4346e5c-a595-4d47-bccd-c05d11b39078.png)

**Context**

The `node_modules` folder here is present for dependencies which are ESM-only. This is a current trade-off to allow the CommonJS bundle to work until PRC is able to move to an ESM-only package.