### PR TITLE
fix(bundle): remove inline @github deps

### DIFF
--- a/.changeset/pink-jokes-destroy.md
+++ b/.changeset/pink-jokes-destroy.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Update bundle to not inline @github dependencies

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "codemods",
     "dist",
     "lib",
-    "lib/node_modules",
     "lib-esm",
     "index.d.ts",
     "drafts/package.json",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,10 +46,10 @@ const baseConfig = {
       babelHelpers: 'inline',
       babelrc: false
     }),
+    commonjs(),
     resolve({
       extensions
-    }),
-    commonjs()
+    })
   ]
 }
 
@@ -69,11 +69,7 @@ export default [
   // CommonJS
   {
     ...baseConfig,
-    external: isExternal(
-      external.filter(id => {
-        return !id.startsWith('@github')
-      })
-    ),
+    external: isExternal(external),
     output: {
       dir: 'lib',
       format: 'commonjs',


### PR DESCRIPTION
This PR updates the rollup config to not inline `@github` dependencies in CommonJS. This is due to two problems when packaging:

- The `node_modules` folder when `lib` is ignored when publishing
- The `require()` statement within `_FormattingTools.tsx` is not being rewritten to the inlined dependency when enabled

To unblock 35.11, this PR reverts this change back to the existing behavior until we can resolve the two points above.