### PR TITLE
correct types for markdown viewer label react 18

### DIFF
--- a/.changeset/eleven-years-march.md
+++ b/.changeset/eleven-years-march.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+fix react 18 typing for MarkdownEditor.Label

--- a/src/drafts/MarkdownEditor/Label.tsx
+++ b/src/drafts/MarkdownEditor/Label.tsx
@@ -6,6 +6,7 @@ import {MarkdownEditorContext} from './_MarkdownEditorContext'
 
 type LabelProps = SxProp & {
   visuallyHidden?: boolean
+  children?: React.ReactNode
 }
 
 // ref is not forwarded because InputLabel does not (yet) support it


### PR DESCRIPTION
FC no longer has 'children' as implicit, so they must be defined separately. It seems that this was missed in review of the prs adding this component. 

It may be worth locally updating the React.FC types to remove implicit children, or use Eslint to force usage of React.VFC instead, until react 18 typings land (where this implicit type is removed)

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
