### PR TITLE
Add Storybook Storysource addon

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,11 +1,11 @@
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
+    {name: '@storybook/addon-essentials', options: {backgrounds: false}},
+    '@storybook/addon-storysource',
+    '@storybook/addon-interactions',
     '@storybook/addon-a11y',
     '@storybook/addon-links',
-    '@storybook/addon-interactions',
-    '@storybook/addon-storysource',
-    {name: '@storybook/addon-essentials', options: {backgrounds: false}},
     'storybook-addon-performance/register',
     {name: 'storybook-addon-turbo-build', options: {optimizationLevel: 2}},
     ...(process.env.NODE_ENV === 'production' && process.env.GITHUB_JOB !== 'chromatic'

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,6 +4,7 @@ module.exports = {
     '@storybook/addon-a11y',
     '@storybook/addon-links',
     '@storybook/addon-interactions',
+    '@storybook/addon-storysource',
     {name: '@storybook/addon-essentials', options: {backgrounds: false}},
     'storybook-addon-performance/register',
     {name: 'storybook-addon-turbo-build', options: {optimizationLevel: 2}},

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@storybook/addon-essentials": "6.5.9",
         "@storybook/addon-interactions": "6.5.9",
         "@storybook/addon-links": "^6.5.9",
+        "@storybook/addon-storysource": "6.5.12",
         "@storybook/jest": "0.0.10",
         "@storybook/react": "6.5.9",
         "@storybook/test-runner": "0.7.0",
@@ -7461,6 +7462,271 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@storybook/addon-storysource": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-storysource/-/addon-storysource-6.5.12.tgz",
+      "integrity": "sha512-FpqEbBET2buZ3tzf0I902zokf0zhbeUWmkq8wUxygn4SKhog8yVbvzTIjG7l0kh53t+y/udirzjjAt66LgR2hA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.5.12",
+        "@storybook/api": "6.5.12",
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/components": "6.5.12",
+        "@storybook/router": "6.5.12",
+        "@storybook/source-loader": "6.5.12",
+        "@storybook/theming": "6.5.12",
+        "core-js": "^3.8.2",
+        "estraverse": "^5.2.0",
+        "loader-utils": "^2.0.0",
+        "prop-types": "^15.7.2",
+        "react-syntax-highlighter": "^15.4.5",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/addons": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.5.12.tgz",
+      "integrity": "sha512-y3cgxZq41YGnuIlBJEuJjSFdMsm8wnvlNOGUP9Q+Er2dgfx8rJz4Q22o4hPjpvpaj4XdBtxCJXI2NeFpN59+Cw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/api": "6.5.12",
+        "@storybook/channels": "6.5.12",
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/core-events": "6.5.12",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/router": "6.5.12",
+        "@storybook/theming": "6.5.12",
+        "@types/webpack-env": "^1.16.0",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/api": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.5.12.tgz",
+      "integrity": "sha512-DuUZmMlQxkFNU9Vgkp9aNfCkAongU76VVmygvCuSpMVDI9HQ2lG0ydL+ppL4XKoSMCCoXTY6+rg4hJANnH+1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "6.5.12",
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/core-events": "6.5.12",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/router": "6.5.12",
+        "@storybook/semver": "^7.3.2",
+        "@storybook/theming": "6.5.12",
+        "core-js": "^3.8.2",
+        "fast-deep-equal": "^3.1.3",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "regenerator-runtime": "^0.13.7",
+        "store2": "^2.12.0",
+        "telejson": "^6.0.8",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/channels": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.5.12.tgz",
+      "integrity": "sha512-X5XaKbe4b7LXJ4sUakBo00x6pXnW78JkOonHoaKoWsccHLlEzwfBZpVVekhVZnqtCoLT23dB8wjKgA71RYWoiw==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/client-logger": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.5.12.tgz",
+      "integrity": "sha512-IrkMr5KZcudX935/C2balFbxLHhkvQnJ78rbVThHDVckQ7l3oIXTh66IMzldeOabVFDZEMiW8AWuGEYof+JtLw==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "global": "^4.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/components": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.5.12.tgz",
+      "integrity": "sha512-NAAGl5PDXaHdVLd6hA+ttmLwH3zAVGXeUmEubzKZ9bJzb+duhFKxDa9blM4YEkI+palumvgAMm0UgS7ou680Ig==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/theming": "6.5.12",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/core-events": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.5.12.tgz",
+      "integrity": "sha512-0AMyMM19R/lHsYRfWqM8zZTXthasTAK2ExkSRzYi2GkIaVMxRKtM33YRwxKIpJ6KmIKIs8Ru3QCXu1mfCmGzNg==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/router": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.5.12.tgz",
+      "integrity": "sha512-xHubde9YnBbpkDY5+zGO4Pr6VPxP8H9J2v4OTF3H82uaxCIKR0PKG0utS9pFKIsEiP3aM62Hb9qB8nU+v1nj3w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.12",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/source-loader": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-6.5.12.tgz",
+      "integrity": "sha512-4iuILFsKNV70sEyjzIkOqgzgQx7CJ8kTEFz590vkmWXQNKz7YQzjgISIwL7GBw/myJgeb04bl5psVgY0cbG5vg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.5.12",
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "core-js": "^3.8.2",
+        "estraverse": "^5.2.0",
+        "global": "^4.4.0",
+        "loader-utils": "^2.0.0",
+        "lodash": "^4.17.21",
+        "prettier": ">=2.2.1 <=2.3.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/theming": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.12.tgz",
+      "integrity": "sha512-uWOo84qMQ2R6c1C0faZ4Q0nY01uNaX7nXoJKieoiJ6ZqY9PSYxJl1kZLi3uPYnrxLZjzjVyXX8MgdxzbppYItA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.12",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/loader-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/@storybook/addon-toolbars": {
@@ -46514,6 +46780,185 @@
         "global": "^4.4.0",
         "regenerator-runtime": "^0.13.7",
         "ts-dedent": "^2.0.0"
+      }
+    },
+    "@storybook/addon-storysource": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-storysource/-/addon-storysource-6.5.12.tgz",
+      "integrity": "sha512-FpqEbBET2buZ3tzf0I902zokf0zhbeUWmkq8wUxygn4SKhog8yVbvzTIjG7l0kh53t+y/udirzjjAt66LgR2hA==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "6.5.12",
+        "@storybook/api": "6.5.12",
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/components": "6.5.12",
+        "@storybook/router": "6.5.12",
+        "@storybook/source-loader": "6.5.12",
+        "@storybook/theming": "6.5.12",
+        "core-js": "^3.8.2",
+        "estraverse": "^5.2.0",
+        "loader-utils": "^2.0.0",
+        "prop-types": "^15.7.2",
+        "react-syntax-highlighter": "^15.4.5",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.5.12.tgz",
+          "integrity": "sha512-y3cgxZq41YGnuIlBJEuJjSFdMsm8wnvlNOGUP9Q+Er2dgfx8rJz4Q22o4hPjpvpaj4XdBtxCJXI2NeFpN59+Cw==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.5.12",
+            "@storybook/channels": "6.5.12",
+            "@storybook/client-logger": "6.5.12",
+            "@storybook/core-events": "6.5.12",
+            "@storybook/csf": "0.0.2--canary.4566f4d.1",
+            "@storybook/router": "6.5.12",
+            "@storybook/theming": "6.5.12",
+            "@types/webpack-env": "^1.16.0",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.5.12.tgz",
+          "integrity": "sha512-DuUZmMlQxkFNU9Vgkp9aNfCkAongU76VVmygvCuSpMVDI9HQ2lG0ydL+ppL4XKoSMCCoXTY6+rg4hJANnH+1AQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "6.5.12",
+            "@storybook/client-logger": "6.5.12",
+            "@storybook/core-events": "6.5.12",
+            "@storybook/csf": "0.0.2--canary.4566f4d.1",
+            "@storybook/router": "6.5.12",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.5.12",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^6.0.8",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.5.12.tgz",
+          "integrity": "sha512-X5XaKbe4b7LXJ4sUakBo00x6pXnW78JkOonHoaKoWsccHLlEzwfBZpVVekhVZnqtCoLT23dB8wjKgA71RYWoiw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.5.12.tgz",
+          "integrity": "sha512-IrkMr5KZcudX935/C2balFbxLHhkvQnJ78rbVThHDVckQ7l3oIXTh66IMzldeOabVFDZEMiW8AWuGEYof+JtLw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.5.12.tgz",
+          "integrity": "sha512-NAAGl5PDXaHdVLd6hA+ttmLwH3zAVGXeUmEubzKZ9bJzb+duhFKxDa9blM4YEkI+palumvgAMm0UgS7ou680Ig==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "6.5.12",
+            "@storybook/csf": "0.0.2--canary.4566f4d.1",
+            "@storybook/theming": "6.5.12",
+            "core-js": "^3.8.2",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.5.12.tgz",
+          "integrity": "sha512-0AMyMM19R/lHsYRfWqM8zZTXthasTAK2ExkSRzYi2GkIaVMxRKtM33YRwxKIpJ6KmIKIs8Ru3QCXu1mfCmGzNg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.5.12.tgz",
+          "integrity": "sha512-xHubde9YnBbpkDY5+zGO4Pr6VPxP8H9J2v4OTF3H82uaxCIKR0PKG0utS9pFKIsEiP3aM62Hb9qB8nU+v1nj3w==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "6.5.12",
+            "core-js": "^3.8.2",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/source-loader": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-6.5.12.tgz",
+          "integrity": "sha512-4iuILFsKNV70sEyjzIkOqgzgQx7CJ8kTEFz590vkmWXQNKz7YQzjgISIwL7GBw/myJgeb04bl5psVgY0cbG5vg==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.5.12",
+            "@storybook/client-logger": "6.5.12",
+            "@storybook/csf": "0.0.2--canary.4566f4d.1",
+            "core-js": "^3.8.2",
+            "estraverse": "^5.2.0",
+            "global": "^4.4.0",
+            "loader-utils": "^2.0.0",
+            "lodash": "^4.17.21",
+            "prettier": ">=2.2.1 <=2.3.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.12.tgz",
+          "integrity": "sha512-uWOo84qMQ2R6c1C0faZ4Q0nY01uNaX7nXoJKieoiJ6ZqY9PSYxJl1kZLi3uPYnrxLZjzjVyXX8MgdxzbppYItA==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "6.5.12",
+            "core-js": "^3.8.2",
+            "memoizerific": "^1.11.3",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "prettier": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+          "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+          "dev": true
+        }
       }
     },
     "@storybook/addon-toolbars": {

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@storybook/addon-essentials": "6.5.9",
     "@storybook/addon-interactions": "6.5.9",
     "@storybook/addon-links": "^6.5.9",
+    "@storybook/addon-storysource": "6.5.12",
     "@storybook/jest": "0.0.10",
     "@storybook/react": "6.5.9",
     "@storybook/test-runner": "0.7.0",

--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -2,23 +2,10 @@ import {EyeClosedIcon, EyeIcon, SearchIcon, TriangleDownIcon, XIcon, TriangleRig
 import {Meta} from '@storybook/react'
 import React, {useState, forwardRef} from 'react'
 import {Button, ButtonProps, IconButton} from '.'
-import {BaseStyles, ThemeProvider} from '..'
 import Box from '../Box'
 
 export default {
   title: 'Components/Button',
-
-  decorators: [
-    Story => {
-      return (
-        <ThemeProvider>
-          <BaseStyles>
-            <Story />
-          </BaseStyles>
-        </ThemeProvider>
-      )
-    }
-  ],
   argTypes: {
     size: {
       control: {

--- a/src/stories/Overlay.stories.tsx
+++ b/src/stories/Overlay.stories.tsx
@@ -3,11 +3,9 @@ import {Meta} from '@storybook/react'
 import styled from 'styled-components'
 import {TriangleDownIcon, PlusIcon, IssueDraftIcon} from '@primer/octicons-react'
 import {
-  BaseStyles,
   Overlay,
   ButtonGroup,
   Text,
-  ThemeProvider,
   Box,
   StyledOcticon,
   Checkbox,
@@ -26,17 +24,6 @@ import {ItemInput} from '../deprecated/ActionList/List'
 export default {
   title: 'Private components/Overlay',
   component: Overlay,
-  decorators: [
-    Story => {
-      return (
-        <ThemeProvider>
-          <BaseStyles>
-            <Story />
-          </BaseStyles>
-        </ThemeProvider>
-      )
-    }
-  ],
   argTypes: {
     anchorSide: {
       defaultValue: 'inside-top',

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {Meta} from '@storybook/react'
 
-import {BaseStyles, Select, ThemeProvider, FormControl, Box} from '..'
+import {Select, FormControl, Box} from '..'
 import {SelectProps} from '../Select'
 import {
   FormControlArgs,
@@ -13,17 +13,6 @@ import {
 export default {
   title: 'Components/Forms/Select',
   component: Select,
-  decorators: [
-    Story => {
-      return (
-        <ThemeProvider>
-          <BaseStyles>
-            <Story />
-          </BaseStyles>
-        </ThemeProvider>
-      )
-    }
-  ],
   argTypes: {
     required: {
       defaultValue: false,

--- a/src/stories/deprecated/Button.stories.tsx
+++ b/src/stories/deprecated/Button.stories.tsx
@@ -10,25 +10,13 @@ import {
   ButtonPrimary,
   ButtonTableList
 } from '../../deprecated'
-import {BaseStyles, ButtonGroup, ThemeProvider} from '../..'
+import {ButtonGroup} from '../..'
 import {ButtonStyleProps} from 'styled-system'
 import {ButtonBaseProps} from '../../deprecated/Button/ButtonBase'
 type StrictButtonStyleProps = ButtonStyleProps & {variant: ButtonBaseProps['variant']}
 
 export default {
   title: 'Deprecated components/Button',
-
-  decorators: [
-    Story => {
-      return (
-        <ThemeProvider>
-          <BaseStyles>
-            <Story />
-          </BaseStyles>
-        </ThemeProvider>
-      )
-    }
-  ],
   argTypes: {
     as: {
       table: {


### PR DESCRIPTION
[Storysource](https://storybook.js.org/addons/@storybook/addon-storysource) adds a panel with a code snippet of the story "source" code for easy copy/paste. The source code view depends on the format of the story, and unfortunately isn't compatible with `template.bind()` syntax. However, if we treat "Feature" stories as code snippets and allow the Playground story to use controls, we kind of get the best of both worlds. We might consider investing in our own source code addon that is more consistent.

Closes https://github.com/github/primer/issues/1385

### Screenshots

It will generally look something like this:

<img width="505" alt="Storybook addons panel showing the source panel active, which renders a code snippet of the story" src="https://user-images.githubusercontent.com/18661030/194445125-ecd7fbcd-5cb3-4a83-af06-8e499689e017.png">

I also fixed the duplicate theme decorator in some stories, which improves the docs view:

Before:
<img width="1044" alt="Storybook docs page with a code snippet showing base Storybook code instead of component markup" src="https://user-images.githubusercontent.com/18661030/194445264-5305f67b-6f34-4afb-8592-0d4a02620000.png">

After:
<img width="1056" alt="Storybook docs page with a code snippet showing component markup" src="https://user-images.githubusercontent.com/18661030/194445211-30b4bffd-c1de-4bd0-8d1e-2900d5a43957.png">


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
