### PR TITLE
[UnderlineNav] : Final implementation and UI fixes & docs improvement

### DIFF
--- a/docs/content/drafts/UnderlineNav2.mdx
+++ b/docs/content/drafts/UnderlineNav2.mdx
@@ -153,16 +153,23 @@ render(<Navigation />)
 ### With React Router
 
 ```jsx
-import {Link} from 'react-router-dom'
+import {Link, useNavigate} from 'react-router-dom'
 import {UnderlineNav} from '@primer/react/drafts'
 
 const Navigation = () => {
+  const navigate = useNavigate()
   return (
     <UnderlineNav aria-label="Repository">
       <UnderlineNav.Item as={Link} to="code" counter={4} selected>
         Code
       </UnderlineNav.Item>
-      <UnderlineNav.Item counter={44} as={Link} to="issues">
+      <UnderlineNav.Item
+        counter={44}
+        as={Link}
+        onSelect={() => {
+          navigate('issues')
+        }}
+      >
         Issues
       </UnderlineNav.Item>
       <UnderlineNav.Item as={Link} to="pulls">
@@ -173,15 +180,24 @@ const Navigation = () => {
 }
 ```
 
+<Note>
+  You can bind the routing with both 'to' and 'onSelect' prop here. However; please note that if an 'href' prop is
+  passed, it will be ignored here.
+</Note>
+
 ## Props
 
 ### UnderlineNav
 
 <PropsTable>
+  <PropsTableRow name="children" required type="UnderlineNav.Item[]" />
   <PropsTableRow
     name="aria-label"
     type="string"
-    description="A unique name for the rendered 'nav' landmark. It will also be used to label the arrow buttons that control the scroll behaviour on coarse pointer devices. (I.e. 'Scroll ${aria-label} left/right')"
+    description="A unique name for the rendered 'nav' landmark. It will also be used to label the arrow
+        buttons that control the scroll behaviour on coarse pointer devices. (I.e.
+        'Scroll ${aria-label} left/right')
+     "
   />
   <PropsTableRow
     name="loadingCounters"
@@ -200,18 +216,23 @@ const Navigation = () => {
 ### UnderlineNav.Item
 
 <PropsTable>
+  <PropsTableRow
+    name="href"
+    type="string"
+    description="The URL that the item navigates to. 'href' is passed to the underlying '<a>' element. If 'as' is specified, the component may need different props and 'href' is ignored. (Required prop for the react router is 'to' for example)"
+  />
   <PropsTableRow name="icon" type="Component" description="The leading icon comes before item label" />
   <PropsTableRow name="selected" type="boolean" description="Whether the link is selected" />
   <PropsTableRow
     name="onSelect"
     type="(event) => void"
-    description="The handler that gets called when a nav link is selected"
+    description="The handler that gets called when a nav link is selected. For example, a manual route binding can be done here(I.e. 'navigate(href)' for the react router.)"
   />
   <PropsTableRow
     name="as"
-    type="string | Component"
+    type="string | React.ElementType"
     defaultValue="a"
-    description="What kind of component needs to be rendered"
+    description="The underlying element to render — either a HTML element name or a React component."
   />
   <PropsTableSxRow />
 </PropsTable>

--- a/docs/content/drafts/UnderlineNav2.mdx
+++ b/docs/content/drafts/UnderlineNav2.mdx
@@ -17,9 +17,9 @@ import {UnderlineNav} from '@primer/react/drafts'
 
 ```jsx live drafts
 <UnderlineNav aria-label="Repository">
-  <UnderlineNav.Item selected>Item 1</UnderlineNav.Item>
-  <UnderlineNav.Item>Item 2</UnderlineNav.Item>
-  <UnderlineNav.Item>Item 3</UnderlineNav.Item>
+  <UnderlineNav.Item selected>Code</UnderlineNav.Item>
+  <UnderlineNav.Item>Issues</UnderlineNav.Item>
+  <UnderlineNav.Item>Pull Requests</UnderlineNav.Item>
 </UnderlineNav>
 ```
 
@@ -48,79 +48,129 @@ import {UnderlineNav} from '@primer/react/drafts'
 
 ### Overflow Behaviour
 
-When overflow occurs, the component first hides icons if present to optimize for space and show as many items as possible. (Only for fine pointer devices)
+Component behaves depending on the pointer type in case of an overflow.
 
-#### Items Without Icons
+#### Fine Pointer Devices
 
-```jsx live drafts
-<UnderlineNav aria-label="Repository">
-  <UnderlineNav.Item selected icon={CodeIcon}>
-    Code
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={IssueOpenedIcon} counter={30}>
-    Issues
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={GitPullRequestIcon} counter={3}>
-    Pull Requests
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={CommentDiscussionIcon}>Discussions</UnderlineNav.Item>
-  <UnderlineNav.Item icon={PlayIcon} counter={9}>
-    Actions
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={ProjectIcon} counter={7}>
-    Projects
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={ShieldLockIcon}>Security</UnderlineNav.Item>
-  <UnderlineNav.Item icon={GraphIcon}>Insights</UnderlineNav.Item>
-  <UnderlineNav.Item icon={GearIcon} counter={1}>
-    Settings
-  </UnderlineNav.Item>
-</UnderlineNav>
+Component first hides icons if they present to optimize for space and show as many items as possible. If there is still an overflow, it will display the items that don't fit in the `More` menu.
+
+```javascript noinline live drafts
+const Navigation = () => {
+  const items = [
+    {navigation: 'Code', icon: CodeIcon},
+    {navigation: 'Issues', icon: IssueOpenedIcon, counter: 120},
+    {navigation: 'Pull Requests', icon: GitPullRequestIcon, counter: 13},
+    {navigation: 'Discussions', icon: CommentDiscussionIcon, counter: 5},
+    {navigation: 'Actions', icon: PlayIcon, counter: 4},
+    {navigation: 'Projects', icon: ProjectIcon, counter: 9},
+    {navigation: 'Insights', icon: GraphIcon},
+    {navigation: 'Settings', icon: GearIcon, counter: 10},
+    {navigation: 'Security', icon: ShieldLockIcon}
+  ]
+  const [selectedIndex, setSelectedIndex] = React.useState(0)
+  return (
+    <MatchMedia features={{'(pointer: coarse)': false}}>
+      <Box sx={{width: 750, border: '1px solid', borderBottom: 0, borderColor: 'border.default'}}>
+        <UnderlineNav aria-label="Repository">
+          {items.map((item, index) => (
+            <UnderlineNav.Item
+              key={item.navigation}
+              icon={item.icon}
+              selected={index === selectedIndex}
+              onSelect={e => {
+                setSelectedIndex(index)
+                e.preventDefault()
+              }}
+              counter={item.counter}
+            >
+              {item.navigation}
+            </UnderlineNav.Item>
+          ))}
+        </UnderlineNav>
+      </Box>
+    </MatchMedia>
+  )
+}
+
+render(<Navigation />)
 ```
 
-#### Display `More` Menu
+#### Coarse Pointer Devices
 
-If there is still overflow, the component will behave depending on the pointer.
+```javascript noinline live drafts
+const items = [
+  {navigation: 'Code', icon: CodeIcon},
+  {navigation: 'Issues', icon: IssueOpenedIcon, counter: 120},
+  {navigation: 'Pull Requests', icon: GitPullRequestIcon, counter: 13},
+  {navigation: 'Discussions', icon: CommentDiscussionIcon, counter: 5},
+  {navigation: 'Actions', icon: PlayIcon, counter: 4},
+  {navigation: 'Projects', icon: ProjectIcon, counter: 9},
+  {navigation: 'Insights', icon: GraphIcon},
+  {navigation: 'Settings', icon: GearIcon, counter: 10},
+  {navigation: 'Security', icon: ShieldLockIcon}
+]
+const Navigation = () => {
+  const [selectedIndex, setSelectedIndex] = React.useState(0)
+  return (
+    <MatchMedia features={{'(pointer: coarse)': true}}>
+      <Box sx={{width: 450, border: '1px solid', borderBottom: 0, borderColor: 'border.default'}}>
+        <UnderlineNav aria-label="Repository">
+          {items.map((item, index) => (
+            <UnderlineNav.Item
+              key={item.navigation}
+              icon={item.icon}
+              selected={index === selectedIndex}
+              onSelect={e => {
+                setSelectedIndex(index)
+                e.preventDefault()
+              }}
+              counter={item.counter}
+            >
+              {item.navigation}
+            </UnderlineNav.Item>
+          ))}
+        </UnderlineNav>
+      </Box>
+    </MatchMedia>
+  )
+}
 
-```jsx live drafts
-<UnderlineNav aria-label="Repository">
-  <UnderlineNav.Item selected icon={CodeIcon}>
-    Code
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={IssueOpenedIcon} counter={30}>
-    Issues
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={GitPullRequestIcon} counter={3}>
-    Pull Requests
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={CommentDiscussionIcon}>Discussions</UnderlineNav.Item>
-  <UnderlineNav.Item icon={EyeIcon} counter={9}>
-    Actions
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={EyeIcon} counter={7}>
-    Projects
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={EyeIcon}>Security</UnderlineNav.Item>
-  <UnderlineNav.Item icon={EyeIcon} counter={14}>
-    Insights
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={EyeIcon} counter={1}>
-    Settings
-  </UnderlineNav.Item>
-  <UnderlineNav.Item icon={EyeIcon}>Wiki</UnderlineNav.Item>
-</UnderlineNav>
+render(<Navigation />)
 ```
 
-### Loading state for counters
+### Loading State For Counters
 
 ```jsx live drafts
 <UnderlineNav aria-label="Repository" loadingCounters={true}>
   <UnderlineNav.Item counter={4} selected>
-    Item 1
+    Code
   </UnderlineNav.Item>
-  <UnderlineNav.Item counter={44}>Item 2</UnderlineNav.Item>
-  <UnderlineNav.Item>Item 3</UnderlineNav.Item>
+  <UnderlineNav.Item counter={44}>Issues</UnderlineNav.Item>
+  <UnderlineNav.Item>Pull Requests</UnderlineNav.Item>
 </UnderlineNav>
+```
+
+### With React Router
+
+```jsx
+import {Link} from 'react-router-dom'
+import {UnderlineNav} from '@primer/react/drafts'
+
+const Navigation = () => {
+  return (
+    <UnderlineNav aria-label="Repository">
+      <UnderlineNav.Item as={Link} to="code" counter={4} selected>
+        Code
+      </UnderlineNav.Item>
+      <UnderlineNav.Item counter={44} as={Link} to="issues">
+        Issues
+      </UnderlineNav.Item>
+      <UnderlineNav.Item as={Link} to="pulls">
+        Pull Requests
+      </UnderlineNav.Item>
+    </UnderlineNav>
+  )
+}
 ```
 
 ## Props

--- a/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
@@ -4,6 +4,7 @@ import * as primerComponents from '@primer/react'
 import * as drafts from '@primer/react/drafts'
 import * as deprecated from '@primer/react/deprecated'
 import {Placeholder} from '@primer/react/Placeholder'
+import {MatchMedia} from '@primer/react/hooks/useMedia'
 import React from 'react'
 import State from '../../../components/State'
 
@@ -24,6 +25,7 @@ export default function resolveScope(metastring) {
     ...(metastring.includes('deprecated') ? deprecated : {}),
     ReactRouterLink,
     State,
+    MatchMedia,
     Placeholder
   }
 }

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -19,7 +19,8 @@ import {
   ulStyles,
   scrollStyles,
   moreMenuStyles,
-  menuItemStyles
+  menuItemStyles,
+  GAP
 } from './styles'
 import {ArrowButton} from './UnderlineNavArrowButton'
 import styled from 'styled-components'
@@ -146,7 +147,8 @@ const calculatePossibleItems = (childWidthArray: ChildWidthArray, navWidth: numb
       breakpoint = index - 1
       break
     } else {
-      sumsOfChildWidth = sumsOfChildWidth + childWidth.width
+      // The the gap between items into account when calculating the number of items possible
+      sumsOfChildWidth = sumsOfChildWidth + childWidth.width + GAP
     }
   }
 

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -12,7 +12,15 @@ import CounterLabel from '../CounterLabel'
 import {useTheme} from '../ThemeProvider'
 import {ChildWidthArray, ResponsiveProps, OnScrollWithButtonEventType} from './types'
 
-import {moreBtnStyles, getDividerStyle, getNavStyles, ulStyles, scrollStyles, moreMenuStyles} from './styles'
+import {
+  moreBtnStyles,
+  getDividerStyle,
+  getNavStyles,
+  ulStyles,
+  scrollStyles,
+  moreMenuStyles,
+  menuItemStyles
+} from './styles'
 import {ArrowButton} from './UnderlineNavArrowButton'
 import styled from 'styled-components'
 import {LoadingCounter} from './LoadingCounter'
@@ -216,6 +224,8 @@ export const UnderlineNav = forwardRef(
 
     const isCoarsePointer = useMedia('(pointer: coarse)')
 
+    const [asNavItem, setAsNavItem] = useState('a')
+
     const [selectedLink, setSelectedLink] = useState<RefObject<HTMLElement> | undefined>(undefined)
 
     const [focusedLink, setFocusedLink] = useState<RefObject<HTMLElement> | null>(null)
@@ -339,6 +349,7 @@ export const UnderlineNav = forwardRef(
           selectedLinkText,
           setSelectedLinkText,
           setFocusedLink,
+          setAsNavItem,
           selectEvent,
           afterSelect: afterSelectHandler,
           variant,
@@ -375,29 +386,32 @@ export const UnderlineNav = forwardRef(
                         {actions.map((action, index) => {
                           const {children: actionElementChildren, ...actionElementProps} = action.props
                           return (
-                            <ActionList.Item
-                              key={index}
-                              {...actionElementProps}
-                              onSelect={(
-                                event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>
-                              ) => {
-                                swapMenuItemWithListItem(action, index, event, updateListAndMenu)
-                                setSelectEvent(event)
-                              }}
-                            >
-                              <Box
-                                as="span"
-                                sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}
+                            <Box key={index} as="li">
+                              <ActionList.Item
+                                as={asNavItem}
+                                sx={menuItemStyles}
+                                {...actionElementProps}
+                                onSelect={(
+                                  event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>
+                                ) => {
+                                  swapMenuItemWithListItem(action, index, event, updateListAndMenu)
+                                  setSelectEvent(event)
+                                }}
                               >
-                                {actionElementChildren}
+                                <Box
+                                  as="span"
+                                  sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}
+                                >
+                                  {actionElementChildren}
 
-                                {loadingCounters ? (
-                                  <LoadingCounter />
-                                ) : (
-                                  <CounterLabel>{actionElementProps.counter}</CounterLabel>
-                                )}
-                              </Box>
-                            </ActionList.Item>
+                                  {loadingCounters ? (
+                                    <LoadingCounter />
+                                  ) : (
+                                    <CounterLabel>{actionElementProps.counter}</CounterLabel>
+                                  )}
+                                </Box>
+                              </ActionList.Item>
+                            </Box>
                           )
                         })}
                       </ActionList>

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -407,7 +407,9 @@ export const UnderlineNav = forwardRef(
                                   {loadingCounters ? (
                                     <LoadingCounter />
                                   ) : (
-                                    <CounterLabel>{actionElementProps.counter}</CounterLabel>
+                                    actionElementProps.counter !== undefined && (
+                                      <CounterLabel>{actionElementProps.counter}</CounterLabel>
+                                    )
                                   )}
                                 </Box>
                               </ActionList.Item>

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -12,15 +12,7 @@ import CounterLabel from '../CounterLabel'
 import {useTheme} from '../ThemeProvider'
 import {ChildWidthArray, ResponsiveProps, OnScrollWithButtonEventType} from './types'
 
-import {
-  moreBtnStyles,
-  getDividerStyle,
-  getNavStyles,
-  ulStyles,
-  scrollStyles,
-  moreMenuStyles,
-  menuItemStyles
-} from './styles'
+import {moreBtnStyles, getDividerStyle, getNavStyles, ulStyles, scrollStyles, moreMenuStyles} from './styles'
 import {ArrowButton} from './UnderlineNavArrowButton'
 import styled from 'styled-components'
 import {LoadingCounter} from './LoadingCounter'
@@ -354,74 +346,77 @@ export const UnderlineNav = forwardRef(
           iconsVisible
         }}
       >
-        <Box
-          as={as}
-          sx={merge<BetterSystemStyleObject>(getNavStyles(theme, {align}), sxProp)}
-          aria-label={ariaLabel}
-          ref={navRef}
-        >
-          {isCoarsePointer && (
-            <ArrowButton
-              scrollValue={scrollValues.scrollLeft}
-              type="left"
-              show={scrollValues.scrollLeft > 0}
-              onScrollWithButton={onScrollWithButton}
-              aria-label={ariaLabel}
-            />
-          )}
-
-          <NavigationList sx={merge<BetterSystemStyleObject>(responsiveProps.overflowStyles, ulStyles)} ref={listRef}>
-            {responsiveProps.items}
-            {actions.length > 0 && (
-              <MoreMenuListItem ref={moreMenuRef}>
-                <Box sx={getDividerStyle(theme)}></Box>
-                <ActionMenu>
-                  <ActionMenu.Button sx={moreBtnStyles}>More</ActionMenu.Button>
-                  <ActionMenu.Overlay align="end">
-                    <ActionList selectionVariant="single">
-                      {actions.map((action, index) => {
-                        const {children: actionElementChildren, ...actionElementProps} = action.props
-                        return (
-                          <ActionList.Item
-                            sx={menuItemStyles}
-                            key={index}
-                            {...actionElementProps}
-                            onSelect={(event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
-                              swapMenuItemWithListItem(action, index, event, updateListAndMenu)
-                              setSelectEvent(event)
-                            }}
-                          >
-                            <Box
-                              as="span"
-                              sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}
-                            >
-                              {actionElementChildren}
-
-                              {loadingCounters ? (
-                                <LoadingCounter />
-                              ) : (
-                                <CounterLabel>{actionElementProps.counter}</CounterLabel>
-                              )}
-                            </Box>
-                          </ActionList.Item>
-                        )
-                      })}
-                    </ActionList>
-                  </ActionMenu.Overlay>
-                </ActionMenu>
-              </MoreMenuListItem>
+        <Box sx={{overflow: 'hidden'}}>
+          <Box
+            as={as}
+            sx={merge<BetterSystemStyleObject>(getNavStyles(theme, {align}), sxProp)}
+            aria-label={ariaLabel}
+            ref={navRef}
+          >
+            {isCoarsePointer && (
+              <ArrowButton
+                scrollValue={scrollValues.scrollLeft}
+                type="left"
+                show={scrollValues.scrollLeft > 0}
+                onScrollWithButton={onScrollWithButton}
+                aria-label={ariaLabel}
+              />
             )}
-          </NavigationList>
 
-          {isCoarsePointer && (
-            <ArrowButton
-              scrollValue={scrollValues.scrollRight}
-              type="right"
-              show={scrollValues.scrollRight > 0}
-              onScrollWithButton={onScrollWithButton}
-              aria-label={ariaLabel}
-            />
-          )}
+            <NavigationList sx={merge<BetterSystemStyleObject>(responsiveProps.overflowStyles, ulStyles)} ref={listRef}>
+              {responsiveProps.items}
+              {actions.length > 0 && (
+                <MoreMenuListItem ref={moreMenuRef}>
+                  <Box sx={getDividerStyle(theme)}></Box>
+                  <ActionMenu>
+                    <ActionMenu.Button sx={moreBtnStyles}>More</ActionMenu.Button>
+                    <ActionMenu.Overlay align="end">
+                      <ActionList selectionVariant="single">
+                        {actions.map((action, index) => {
+                          const {children: actionElementChildren, ...actionElementProps} = action.props
+                          return (
+                            <ActionList.Item
+                              key={index}
+                              {...actionElementProps}
+                              onSelect={(
+                                event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>
+                              ) => {
+                                swapMenuItemWithListItem(action, index, event, updateListAndMenu)
+                                setSelectEvent(event)
+                              }}
+                            >
+                              <Box
+                                as="span"
+                                sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}
+                              >
+                                {actionElementChildren}
+
+                                {loadingCounters ? (
+                                  <LoadingCounter />
+                                ) : (
+                                  <CounterLabel>{actionElementProps.counter}</CounterLabel>
+                                )}
+                              </Box>
+                            </ActionList.Item>
+                          )
+                        })}
+                      </ActionList>
+                    </ActionMenu.Overlay>
+                  </ActionMenu>
+                </MoreMenuListItem>
+              )}
+            </NavigationList>
+
+            {isCoarsePointer && (
+              <ArrowButton
+                scrollValue={scrollValues.scrollRight}
+                type="right"
+                show={scrollValues.scrollRight > 0}
+                onScrollWithButton={onScrollWithButton}
+                aria-label={ariaLabel}
+              />
+            )}
+          </Box>
         </Box>
       </UnderlineNavContext.Provider>
     )

--- a/src/UnderlineNav2/UnderlineNavArrowButton.tsx
+++ b/src/UnderlineNav2/UnderlineNavArrowButton.tsx
@@ -56,7 +56,7 @@ const ArrowButton = ({
         aria-label={`Scroll ${ariaLabel} navigation ${type}`}
         onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => onScrollWithButton(e, direction)}
         icon={type === 'left' ? ChevronLeftIcon : ChevronRightIcon}
-        sx={getArrowBtnStyles(theme, type)}
+        sx={getArrowBtnStyles(theme)}
         aria-disabled={!show}
       />
     </Box>

--- a/src/UnderlineNav2/UnderlineNavContext.tsx
+++ b/src/UnderlineNav2/UnderlineNavContext.tsx
@@ -10,6 +10,7 @@ export const UnderlineNavContext = createContext<{
   selectedLinkText: string
   setSelectedLinkText: React.Dispatch<React.SetStateAction<string>>
   setFocusedLink: React.Dispatch<React.SetStateAction<RefObject<HTMLElement> | null>>
+  setAsNavItem: React.Dispatch<React.SetStateAction<string>>
   selectEvent: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement> | null
   afterSelect?: (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void
   variant: 'default' | 'small'
@@ -24,6 +25,7 @@ export const UnderlineNavContext = createContext<{
   selectedLinkText: '',
   setSelectedLinkText: () => null,
   setFocusedLink: () => null,
+  setAsNavItem: () => null,
   selectEvent: null,
   variant: 'default',
   loadingCounters: false,

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -175,9 +175,18 @@ export const UnderlineNavItem = forwardRef(
                 {children}
               </Box>
             )}
-            <Box as="span" data-component="counter" sx={counterStyles}>
-              {loadingCounters ? <LoadingCounter /> : counter !== undefined && <CounterLabel>{counter}</CounterLabel>}
-            </Box>
+
+            {loadingCounters ? (
+              <Box as="span" data-component="counter" sx={counterStyles}>
+                <LoadingCounter />
+              </Box>
+            ) : (
+              counter !== undefined && (
+                <Box as="span" data-component="counter" sx={counterStyles}>
+                  <CounterLabel>{counter}</CounterLabel>
+                </Box>
+              )
+            )}
           </Box>
         </Box>
       </Box>

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -127,7 +127,6 @@ export const UnderlineNavItem = forwardRef(
           if (typeof afterSelect === 'function') afterSelect(event)
         }
         setSelectedLink(ref as RefObject<HTMLElement>)
-        event.preventDefault()
       },
       [onSelect, afterSelect, ref, setSelectedLink]
     )
@@ -138,7 +137,6 @@ export const UnderlineNavItem = forwardRef(
           if (typeof afterSelect === 'function') afterSelect(event)
         }
         setSelectedLink(ref as RefObject<HTMLElement>)
-        event.preventDefault()
       },
       [onSelect, afterSelect, ref, setSelectedLink]
     )

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -42,7 +42,7 @@ export type UnderlineNavItemProps = {
   /**
    * Counter
    */
-  counter?: number
+  counter?: number | string
 } & SxProp &
   LinkProps
 
@@ -175,11 +175,9 @@ export const UnderlineNavItem = forwardRef(
                 {children}
               </Box>
             )}
-            {counter && (
-              <Box as="span" data-component="counter" sx={counterStyles}>
-                {loadingCounters ? <LoadingCounter /> : <CounterLabel>{counter}</CounterLabel>}
-              </Box>
-            )}
+            <Box as="span" data-component="counter" sx={counterStyles}>
+              {loadingCounters ? <LoadingCounter /> : counter !== undefined && <CounterLabel>{counter}</CounterLabel>}
+            </Box>
           </Box>
         </Box>
       </Box>

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -72,6 +72,7 @@ export const UnderlineNavItem = forwardRef(
       selectedLinkText,
       setSelectedLinkText,
       setFocusedLink,
+      setAsNavItem,
       selectEvent,
       afterSelect,
       variant,
@@ -107,6 +108,8 @@ export const UnderlineNavItem = forwardRef(
         if (typeof onSelect === 'function' && selectEvent !== null) onSelect(selectEvent)
         setSelectedLinkText('')
       }
+
+      setAsNavItem(Component)
     }, [
       ref,
       preSelected,
@@ -117,7 +120,9 @@ export const UnderlineNavItem = forwardRef(
       setChildrenWidth,
       setNoIconChildrenWidth,
       onSelect,
-      selectEvent
+      selectEvent,
+      Component,
+      setAsNavItem
     ])
 
     const keyPressHandler = React.useCallback(

--- a/src/UnderlineNav2/examples.stories.tsx
+++ b/src/UnderlineNav2/examples.stories.tsx
@@ -72,10 +72,10 @@ export const withCounterLabels = () => {
   )
 }
 
-const items: {navigation: string; icon: React.FC<IconProps>; counter?: number}[] = [
+const items: {navigation: string; icon: React.FC<IconProps>; counter?: number | string}[] = [
   {navigation: 'Code', icon: CodeIcon},
-  {navigation: 'Issues', icon: IssueOpenedIcon, counter: 120},
-  {navigation: 'Pull Requests', icon: GitPullRequestIcon, counter: 13},
+  {navigation: 'Issues', icon: IssueOpenedIcon, counter: 0},
+  {navigation: 'Pull Requests', icon: GitPullRequestIcon, counter: '12K'},
   {navigation: 'Discussions', icon: CommentDiscussionIcon, counter: 5},
   {navigation: 'Actions', icon: PlayIcon, counter: 4},
   {navigation: 'Projects', icon: ProjectIcon, counter: 9},

--- a/src/UnderlineNav2/styles.ts
+++ b/src/UnderlineNav2/styles.ts
@@ -32,19 +32,20 @@ export const counterStyles = {
 
 export const getNavStyles = (theme?: Theme, props?: Partial<Pick<UnderlineNavProps, 'align'>>) => ({
   display: 'flex',
-  paddingX: 2,
   justifyContent: props?.align === 'right' ? 'flex-end' : 'flex-start',
   borderBottom: '1px solid',
   borderBottomColor: `${theme?.colors.border.muted}`,
   align: 'row',
   alignItems: 'center',
-  position: 'relative'
+  position: 'relative',
+  paddingX: 3
 })
 
 export const ulStyles = {
   display: 'flex',
   listStyle: 'none',
-  padding: '0',
+  paddingY: 0,
+  paddingX: 0,
   margin: '0',
   marginBottom: '-1px',
   alignItems: 'center'
@@ -82,6 +83,8 @@ export const btnWrapperStyles = (
   bottom: 0,
   left: direction === 'left' ? 0 : 'auto',
   right: direction === 'right' ? 0 : 'auto',
+  // Min touch target size
+  width: '44px',
   alignItems: 'center',
   background: show
     ? `linear-gradient(to ${direction} ,#fff0, ${theme?.colors.canvas.default} 14px, ${theme?.colors.canvas.default} 100%)`
@@ -90,33 +93,28 @@ export const btnWrapperStyles = (
   display: `${display}`
 })
 
-export const getArrowBtnStyles = (theme?: Theme, direction = 'left') => ({
-  fontWeight: 'normal',
+export const getArrowBtnStyles = (theme?: Theme) => ({
   boxShadow: 'none',
-  margin: 0,
   border: 0,
-  borderRadius: 2,
-  paddingX: '14px',
-  paddingY: 0,
   background: 'transparent',
-  height: '60%',
-
+  width: '100%',
+  height: '100%',
+  // to reset the hover styles of the button
   '&:hover:not([disabled]), &:focus-visible': {
-    background: theme?.colors.canvas.default
+    background: 'transparent'
   },
+  // To reset global focus styles because it doesn't support safari right now.
   '&:focus:not(:disabled)': {
     outline: 0,
-    boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`,
-    background: `linear-gradient(to ${direction} ,#fff0, ${theme?.colors.canvas.default} 14px, ${theme?.colors.canvas.default} 100%)`
+    boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`
   },
   // where focus-visible is supported, remove the focus box-shadow
   '&:not(:focus-visible)': {
-    boxShadow: 'none',
-    background: `linear-gradient(to ${direction} ,#fff0, ${theme?.colors.canvas.default} 14px, ${theme?.colors.canvas.default} 100%)`
+    boxShadow: 'none'
   },
   '&:focus-visible:not(:disabled)': {
-    boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`,
-    background: `linear-gradient(to ${direction} ,#fff0, ${theme?.colors.canvas.default} 14px, ${theme?.colors.canvas.default} 100%)`
+    outline: 0,
+    boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`
   }
 })
 
@@ -200,5 +198,7 @@ export const menuItemStyles = {
   // This is needed to hide the selected check icon on the menu item. https://github.com/primer/react/blob/main/src/ActionList/Selection.tsx#L32
   '& > span': {
     display: 'none'
-  }
+  },
+  // To reset the style when the menu items are rendered as react router links
+  textDecoration: 'none'
 }

--- a/src/UnderlineNav2/styles.ts
+++ b/src/UnderlineNav2/styles.ts
@@ -2,6 +2,13 @@ import {Theme} from '../ThemeProvider'
 import {BetterSystemStyleObject} from '../sx'
 import {UnderlineNavProps} from './UnderlineNav'
 
+// The gap between the list items. It is a constant because the gap is used to calculate the possible number of items that can fit in the container.
+export const GAP = 8
+
+const focusRing = (theme?: Theme): BetterSystemStyleObject => ({
+  boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`
+})
+
 export const iconWrapStyles = {
   alignItems: 'center',
   display: 'inline-flex',
@@ -48,7 +55,8 @@ export const ulStyles = {
   paddingX: 0,
   margin: '0',
   marginBottom: '-1px',
-  alignItems: 'center'
+  alignItems: 'center',
+  gap: `${GAP}px`
 }
 
 export const getDividerStyle = (theme?: Theme) => ({
@@ -106,15 +114,14 @@ export const getArrowBtnStyles = (theme?: Theme) => ({
   // To reset global focus styles because it doesn't support safari right now.
   '&:focus:not(:disabled)': {
     outline: 0,
-    boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`
+    ...focusRing(theme)
   },
   // where focus-visible is supported, remove the focus box-shadow
   '&:not(:focus-visible)': {
     boxShadow: 'none'
   },
   '&:focus-visible:not(:disabled)': {
-    outline: 0,
-    boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`
+    ...focusRing(theme)
   }
 })
 
@@ -129,7 +136,6 @@ export const getLinkStyles = (
   color: 'fg.default',
   textAlign: 'center',
   textDecoration: 'none',
-  paddingX: 1,
   ...(props?.variant === 'small' ? smallVariantLinkStyles : defaultVariantLinkStyles),
   '@media (hover:hover)': {
     '&:hover > div[data-component="wrapper"] ': {
@@ -140,7 +146,7 @@ export const getLinkStyles = (
   '&:focus': {
     outline: 0,
     '& > div[data-component="wrapper"]': {
-      boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`
+      ...focusRing(theme)
     },
     // where focus-visible is supported, remove the focus box-shadow
     '&:not(:focus-visible) > div[data-component="wrapper"]': {
@@ -148,7 +154,7 @@ export const getLinkStyles = (
     }
   },
   '&:focus-visible > div[data-component="wrapper"]': {
-    boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`
+    ...focusRing(theme)
   },
   // renders a visibly hidden "copy" of the label in bold, reserving box space for when label becomes bold on selected
   '& span[data-content]::before': {
@@ -164,7 +170,7 @@ export const getLinkStyles = (
     position: 'absolute',
     right: '50%',
     bottom: 0,
-    width: `calc(100% - 8px)`,
+    width: '100%',
     height: 2,
     content: '""',
     bg: selectedLink === ref ? theme?.colors.primer.border.active : 'transparent',


### PR DESCRIPTION
TLDR: This PR addresses a couple of implementation issues, UI fixes as well as some documentation improvement. 

---

Storybook link: https://primer-7f80a98c95-13348165.drafts.github.io/storybook/?path=/story/components-underlinenav--internal-responsive-nav
Docs link: https://primer-7f80a98c95-13348165.drafts.github.io/drafts/UnderlineNav2

---

### Issues addressed in this PR:
- Render menu items as the given `as` prop to the UnderlineNav
- Wrap the `nav` with a container that `overflow: hidden` to prevent arrow buttons showing up when they are supposed to be hidden. 
- Display loading counters for all nav items.
- Add `string` type to `counter` prop to support cases like `12K`
- Remove `event.preventDefault()` from click and keypress handlers as UnderlineNav should support with `href` along with react routing configuration. When react routing is configured, it ignores the `href`
- Take the `4px` left and right padding off from the link items and add `8px` as a `gap` between the list items to align with design specs and take that gap value into account when calculating the possible number of items that can fit in the screen.
- UI fixes to align with design specs.

### Improvements in this PR:
- Add responsive behaviour example to the documentation (Scroll behaviour for the course pointer devices)
- Add React router example to the documentation
- Some docs update in general

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
