### PR TITLE
fix(TreeView): add outline transparent for visible focus indicators

### DIFF
--- a/.changeset/large-bulldogs-dance.md
+++ b/.changeset/large-bulldogs-dance.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Update TreeView hover and focus styles to work in Windows High Contrast Mode

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -216,7 +216,11 @@ const Item: React.FC<TreeViewItemProps> = ({
             borderRadius: 2,
             cursor: 'pointer',
             '&:hover': {
-              backgroundColor: 'actionListItem.default.hoverBg'
+              backgroundColor: 'actionListItem.default.hoverBg',
+              '@media (forced-colors: active)': {
+                outline: '2px solid transparent',
+                outlineOffset: -2
+              }
             },
             '@media (pointer: coarse)': {
               '--toggle-width': '1.5rem', // 24px
@@ -228,7 +232,10 @@ const Item: React.FC<TreeViewItemProps> = ({
             // Reference issue: https://github.com/styled-components/styled-components/issues/3265
             [`[role=tree][aria-activedescendant="${itemId}"]:focus-visible #${itemId} > &:is(div)`]: {
               boxShadow: (theme: Theme) => `inset 0 0 0 2px ${theme.colors.accent.emphasis}`,
-              outline: '2px solid transparent'
+              '@media (forced-colors: active)': {
+                outline: '2px solid SelectedItem',
+                outlineOffset: -2
+              }
             },
             '[role=treeitem][aria-current=true] > &:is(div)': {
               bg: 'actionListItem.default.selectedBg',

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -227,7 +227,8 @@ const Item: React.FC<TreeViewItemProps> = ({
             // are unnecessarily specific to work around that styled-components bug.
             // Reference issue: https://github.com/styled-components/styled-components/issues/3265
             [`[role=tree][aria-activedescendant="${itemId}"]:focus-visible #${itemId} > &:is(div)`]: {
-              boxShadow: (theme: Theme) => `inset 0 0 0 2px ${theme.colors.accent.emphasis}`
+              boxShadow: (theme: Theme) => `inset 0 0 0 2px ${theme.colors.accent.emphasis}`,
+              outline: '2px solid transparent'
             },
             '[role=treeitem][aria-current=true] > &:is(div)': {
               bg: 'actionListItem.default.selectedBg',


### PR DESCRIPTION
This PR updates TreeView based on feedback received for WHCM (Windows High Contrast Mode), specifically around focus and hover styles.

https://github.com/github/primer/issues/815#issuecomment-1273922579

By default, it uses a transparent outline in forced-colors: 'active' mode which will be visible in WHCM. For focus, it uses the `SelectedItem` keyword using the same technique.

Preview of changes: https://www.loom.com/share/3c518ae9c39f4ed7b015010dd03e37c2

**Before**

Hover

![Screen Shot 2022-10-14 at 11 11 30 AM](https://user-images.githubusercontent.com/3901764/195892752-457c95f7-5d58-4627-bb79-f6ff2c9961c5.png)

Focus

![Screen Shot 2022-10-14 at 11 11 38 AM](https://user-images.githubusercontent.com/3901764/195892766-1b406033-532b-4c1d-a22e-d5c762c1566f.png)

**After**

Hover

![Screen Shot 2022-10-14 at 11 11 46 AM](https://user-images.githubusercontent.com/3901764/195892834-48d10b38-e080-4d8c-a240-9b842ed25857.png)

Focus 

![Screen Shot 2022-10-14 at 11 11 51 AM](https://user-images.githubusercontent.com/3901764/195892846-c5ac0dff-03a5-4b36-a90e-c6c7e6f3f4eb.png)
