### PR TITLE
Dialog: Remove landmark elements

### DIFF
--- a/.changeset/chatty-kangaroos-reply.md
+++ b/.changeset/chatty-kangaroos-reply.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Dialog: Remove landmark elements to improve accessibility

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -313,7 +313,7 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
 })
 _Dialog.displayName = 'Dialog'
 
-const Header = styled.div.attrs<SxProp>({as: 'header'})`
+const Header = styled.div<SxProp>`
   box-shadow: 0 1px 0 ${get('colors.border.default')};
   padding: ${get('space.2')};
   z-index: 1;
@@ -344,7 +344,7 @@ const Body = styled.div<SxProp>`
   ${sx};
 `
 
-const Footer = styled.div.attrs<SxProp>({as: 'footer'})`
+const Footer = styled.div<SxProp>`
   box-shadow: 0 -1px 0 ${get('colors.border.default')};
   padding: ${get('space.3')};
   display: flex;


### PR DESCRIPTION
Remove landmark elements from Dialog based on accessibility feedback from @kendallgassner: https://github.com/primer/react/pull/2352#issuecomment-1261173654

> Will you remove the banner and footer landmark semantics on the dialog component. These landmarks should not be in a dialog since they are not a standalone page.
