### PR TITLE
docs(TreeView): remove navigation from label

### DIFF
--- a/docs/content/TreeView.mdx
+++ b/docs/content/TreeView.mdx
@@ -11,8 +11,8 @@ description: A hierarchical list of items where nested items can be expanded and
 
 ```jsx live drafts
 <Box sx={{maxWidth: 400}}>
-  <nav aria-label="File navigation">
-    <TreeView aria-label="File navigation">
+  <nav aria-label="Files">
+    <TreeView aria-label="Files">
       <TreeView.Item>
         <TreeView.LeadingVisual>
           <TreeView.DirectoryIcon />
@@ -57,8 +57,8 @@ description: A hierarchical list of items where nested items can be expanded and
 
 ```jsx live drafts
 <Box sx={{maxWidth: 400}}>
-  <nav aria-label="File navigation">
-    <TreeView aria-label="File navigation">
+  <nav aria-label="Files">
+    <TreeView aria-label="Files">
       <TreeView.LinkItem href="#">
         <TreeView.LeadingVisual>
           <TreeView.DirectoryIcon />
@@ -113,8 +113,8 @@ function ControlledTreeView() {
   return (
     <Box sx={{display: 'grid', gap: 2, maxWidth: 400}}>
       <Button onClick={() => setExpanded(!expanded)}>{expanded ? 'Collapse' : 'Expand'}</Button>
-      <nav aria-label="File navigation">
-        <TreeView aria-label="File navigation">
+      <nav aria-label="Files">
+        <TreeView aria-label="Files">
           <TreeView.Item expanded={expanded} onExpandedChange={setExpanded}>
             src
             <TreeView.SubTree>
@@ -139,8 +139,8 @@ To render stateful visuals, pass a render function to `TreeView.LeadingVisual` o
 
 ```jsx live drafts
 <Box sx={{maxWidth: 400}}>
-  <nav aria-label="File navigation">
-    <TreeView aria-label="File navigation">
+  <nav aria-label="Files">
+    <TreeView aria-label="Files">
       <TreeView.Item>
         <TreeView.LeadingVisual>
           {({isExpanded}) => (isExpanded ? <FileDirectoryOpenFillIcon /> : <FileDirectoryFillIcon />)}
@@ -162,8 +162,8 @@ Since stateful directory icons are a common use case for TreeView, we provide a 
 
 ```jsx live drafts
 <Box sx={{maxWidth: 400}}>
-  <nav aria-label="File navigation">
-    <TreeView aria-label="File navigation">
+  <nav aria-label="Files">
+    <TreeView aria-label="Files">
       <TreeView.Item>
         <TreeView.LeadingVisual>
           <TreeView.DirectoryIcon />

--- a/src/TreeView/TreeView.stories.tsx
+++ b/src/TreeView/TreeView.stories.tsx
@@ -19,8 +19,8 @@ const meta: Meta = {
 
 export const FileTreeWithDirectoryLinks: Story = () => (
   <Box sx={{p: 3, maxWidth: 400}}>
-    <nav aria-label="File navigation">
-      <TreeView aria-label="File navigation">
+    <nav aria-label="Files">
+      <TreeView aria-label="Files">
         <TreeView.LinkItem href="#src">
           <TreeView.LeadingVisual>
             <TreeView.DirectoryIcon />
@@ -99,8 +99,8 @@ export const FileTreeWithDirectoryLinks: Story = () => (
 export const FileTreeWithoutDirectoryLinks: Story = () => {
   return (
     <Box sx={{p: 3, maxWidth: 400}}>
-      <nav aria-label="File navigation">
-        <TreeView aria-label="File navigation">
+      <nav aria-label="Files">
+        <TreeView aria-label="Files">
           <TreeView.Item defaultExpanded>
             <TreeView.LeadingVisual>
               <TreeView.DirectoryIcon />
@@ -344,9 +344,9 @@ export const Controlled: Story = () => {
           </ActionMenu.Overlay>
         </ActionMenu>
       </Box>
-      <nav aria-label="File navigation">
+      <nav aria-label="Files">
         <CurrentPathContext.Provider value={{currentPath, setCurrentPath}}>
-          <TreeView aria-label="File navigation">
+          <TreeView aria-label="Files">
             {tree.map(item => (
               <TreeItem
                 key={item.data.name}
@@ -419,8 +419,8 @@ export const AsyncSuccess: Story = args => {
 
   return (
     <Box sx={{p: 3}}>
-      <nav aria-label="File navigation">
-        <TreeView aria-label="File navigation">
+      <nav aria-label="Files">
+        <TreeView aria-label="Files">
           <TreeView.Item
             onExpandedChange={async isExpanded => {
               if (asyncItems.length === 0 && isExpanded) {
@@ -473,8 +473,8 @@ export const AsyncWithCount: Story = args => {
 
   return (
     <Box sx={{p: 3}}>
-      <nav aria-label="File navigation">
-        <TreeView aria-label="File navigation">
+      <nav aria-label="Files">
+        <TreeView aria-label="Files">
           <TreeView.Item
             onExpandedChange={async isExpanded => {
               if (asyncItems.length === 0 && isExpanded) {
@@ -600,8 +600,8 @@ export const AsyncError: Story = args => {
 
   return (
     <Box sx={{p: 3}}>
-      <nav aria-label="File navigation">
-        <TreeView aria-label="File navigation">
+      <nav aria-label="Files">
+        <TreeView aria-label="Files">
           <TreeView.Item
             expanded={isExpanded}
             onExpandedChange={isExpanded => {


### PR DESCRIPTION
Reference: https://github.com/github/primer/issues/702

This PR renames the `File navigation` labels to `Files`.