### PR TITLE
TreeView: Add aria-atomic attribute to live region

### DIFF
--- a/.changeset/brave-melons-leave.md
+++ b/.changeset/brave-melons-leave.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+TreeView: Add aria-atomic attribute to live region

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -81,7 +81,7 @@ const Root: React.FC<TreeViewProps> = ({'aria-label': ariaLabel, 'aria-labelledb
   return (
     <RootContext.Provider value={{announceUpdate}}>
       <>
-        <VisuallyHidden role="status" aria-live="polite">
+        <VisuallyHidden role="status" aria-live="polite" aria-atomic="true">
           {ariaLiveMessage}
         </VisuallyHidden>
         <UlBox


### PR DESCRIPTION
Adds `aria-atomic="true"` to TreeView live region based on [accessibility feedback](https://github.com/github/primer/pull/1389#discussion_r998750245).
