### PR TITLE
[UnderlineNav2]: Introduce disclosure widget pattern

### DIFF
--- a/.changeset/curly-hornets-bathe.md
+++ b/.changeset/curly-hornets-bathe.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+UnderlineNav2: Introduce disclosure widget pattern

--- a/.changeset/moody-garlics-know.md
+++ b/.changeset/moody-garlics-know.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+UnderlineNav2: Always show at least two items in the overflow menu

--- a/.changeset/twelve-spoons-walk.md
+++ b/.changeset/twelve-spoons-walk.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+UnderlineNav2: Render a visually hidden heading for screen readers when aria-label is present

--- a/src/UnderlineNav2/UnderlineNav.test.tsx
+++ b/src/UnderlineNav2/UnderlineNav.test.tsx
@@ -112,4 +112,10 @@ describe('UnderlineNav', () => {
     expect(loadingCounter?.className).toContain('LoadingCounter')
     expect(loadingCounter?.textContent).toBe('')
   })
+  it('renders a visually hidden h2 heading for screen readers when aria-label is present', () => {
+    const {container} = render(<ResponsiveUnderlineNav />)
+    const heading = container.getElementsByTagName('h2')[0]
+    expect(heading.className).toContain('VisuallyHidden')
+    expect(heading.textContent).toBe('Repository navigation')
+  })
 })

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -68,23 +68,34 @@ const overflowEffect = (
   const items: Array<React.ReactElement> = []
   const actions: Array<React.ReactElement> = []
 
-  // For fine pointer devices, first we check if we can fit all the items with icons
+  // First, we check if we can fit all the items with their icons
   if (childArray.length <= numberOfItemsPossible) {
     items.push(...childArray)
   } else if (childArray.length <= numberOfItemsWithoutIconPossible) {
-    // if we can't fit all the items with icons, we check if we can fit all the items without icons
+    // if we can't fit all the items with their icons, we check if we can fit all the items without their icons
     iconsVisible = false
     items.push(...childArray)
   } else {
-    // if we can't fit all the items without icons, we keep the icons hidden and show the rest in the menu
+    // if we can't fit all the items without their icons, we keep the icons hidden and show the ones that doesn't fit into the list in the overflow menu
     iconsVisible = false
+
+    /* Below is an accessibiility requirement. Never show only one item in the overflow menu.
+     * If there is only one item left to display in the overflow menu according to the calculation,
+     * we need to pull another item from the list into the overflow menu.
+     */
+    const numberOfItemsInMenu = childArray.length - numberOfItemsPossibleWithMoreMenu
+    const numberOfListItems =
+      numberOfItemsInMenu === 1 ? numberOfItemsPossibleWithMoreMenu - 1 : numberOfItemsPossibleWithMoreMenu
+
     for (const [index, child] of childArray.entries()) {
-      if (index < numberOfItemsPossibleWithMoreMenu) {
+      if (index < numberOfListItems) {
         items.push(child)
-        // keeping selected item always visible.
+        // We need to make sure to keep the selected item always visible.
       } else if (child.props.selected) {
-        // If selected item's index couldn't make the list, we swap it with the last item in the list.
-        const propsectiveAction = items.splice(numberOfItemsPossibleWithMoreMenu - 1, 1, child)[0]
+        // If selected item can't make it to the list, we swap it with the last item in the list.
+        const indexToReplaceAt = numberOfListItems - 1 // because we are replacing the last item in the list
+        // splice method modifies the array by removing 1 item here at the given index and replace it with the "child" element then returns the removed item.
+        const propsectiveAction = items.splice(indexToReplaceAt, 1, child)[0]
         actions.push(propsectiveAction)
       } else {
         actions.push(child)

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -6,6 +6,7 @@ import {useResizeObserver, ResizeObserverEntry} from '../hooks/useResizeObserver
 import CounterLabel from '../CounterLabel'
 import {useTheme} from '../ThemeProvider'
 import {ChildWidthArray, ResponsiveProps} from './types'
+import VisuallyHidden from '../_VisuallyHidden'
 import {moreBtnStyles, getDividerStyle, getNavStyles, ulStyles, menuStyles, menuItemStyles, GAP} from './styles'
 import styled from 'styled-components'
 import {LoadingCounter} from './LoadingCounter'
@@ -307,6 +308,7 @@ export const UnderlineNav = forwardRef(
           iconsVisible
         }}
       >
+        {ariaLabel && <VisuallyHidden as="h2">{`${ariaLabel} navigation`}</VisuallyHidden>}
         <Box
           as={as}
           sx={merge<BetterSystemStyleObject>(getNavStyles(theme, {align}), sxProp)}

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -207,8 +207,6 @@ export const UnderlineNav = forwardRef(
       React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement> | null
     >(null)
 
-    const [asNavItem, setAsNavItem] = useState('a')
-
     const [iconsVisible, setIconsVisible] = useState<boolean>(true)
 
     const afterSelectHandler = (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
@@ -300,7 +298,6 @@ export const UnderlineNav = forwardRef(
           setSelectedLink,
           selectedLinkText,
           setSelectedLinkText,
-          setAsNavItem,
           selectEvent,
           afterSelect: afterSelectHandler,
           variant,
@@ -343,8 +340,8 @@ export const UnderlineNav = forwardRef(
                       <Box key={index} as="li">
                         <ActionList.Item
                           {...actionElementProps}
+                          as={action.props.as || 'a'}
                           sx={menuItemStyles}
-                          as={asNavItem}
                           onSelect={(event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
                             swapMenuItemWithListItem(action, index, event, updateListAndMenu)
                             setSelectEvent(event)

--- a/src/UnderlineNav2/UnderlineNavContext.tsx
+++ b/src/UnderlineNav2/UnderlineNavContext.tsx
@@ -10,7 +10,6 @@ export const UnderlineNavContext = createContext<{
   selectedLinkText: string
   setSelectedLinkText: React.Dispatch<React.SetStateAction<string>>
   selectEvent: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement> | null
-  setAsNavItem: React.Dispatch<React.SetStateAction<string>>
   afterSelect?: (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void
   variant: 'default' | 'small'
   loadingCounters: boolean
@@ -24,7 +23,6 @@ export const UnderlineNavContext = createContext<{
   selectedLinkText: '',
   setSelectedLinkText: () => null,
   selectEvent: null,
-  setAsNavItem: () => null,
   variant: 'default',
   loadingCounters: false,
   iconsVisible: true

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -72,7 +72,6 @@ export const UnderlineNavItem = forwardRef(
       selectedLinkText,
       setSelectedLinkText,
       selectEvent,
-      setAsNavItem,
       afterSelect,
       variant,
       loadingCounters,
@@ -107,7 +106,6 @@ export const UnderlineNavItem = forwardRef(
         if (typeof onSelect === 'function' && selectEvent !== null) onSelect(selectEvent)
         setSelectedLinkText('')
       }
-      setAsNavItem(Component)
     }, [
       ref,
       preSelected,
@@ -118,9 +116,7 @@ export const UnderlineNavItem = forwardRef(
       setChildrenWidth,
       setNoIconChildrenWidth,
       onSelect,
-      selectEvent,
-      setAsNavItem,
-      Component
+      selectEvent
     ])
 
     const keyPressHandler = React.useCallback(

--- a/src/UnderlineNav2/examples.stories.tsx
+++ b/src/UnderlineNav2/examples.stories.tsx
@@ -72,16 +72,16 @@ export const withCounterLabels = () => {
   )
 }
 
-const items: {navigation: string; icon: React.FC<IconProps>; counter?: number | string}[] = [
-  {navigation: 'Code', icon: CodeIcon},
-  {navigation: 'Issues', icon: IssueOpenedIcon, counter: '12K'},
-  {navigation: 'Pull Requests', icon: GitPullRequestIcon, counter: 13},
-  {navigation: 'Discussions', icon: CommentDiscussionIcon, counter: 5},
-  {navigation: 'Actions', icon: PlayIcon, counter: 4},
-  {navigation: 'Projects', icon: ProjectIcon, counter: 9},
-  {navigation: 'Insights', icon: GraphIcon, counter: '0'},
-  {navigation: 'Settings', icon: GearIcon, counter: 10},
-  {navigation: 'Security', icon: ShieldLockIcon}
+const items: {navigation: string; icon: React.FC<IconProps>; counter?: number | string; href?: string}[] = [
+  {navigation: 'Code', icon: CodeIcon, href: '#code'},
+  {navigation: 'Issues', icon: IssueOpenedIcon, counter: '12K', href: '#issues'},
+  {navigation: 'Pull Requests', icon: GitPullRequestIcon, counter: 13, href: '#pull-requests'},
+  {navigation: 'Discussions', icon: CommentDiscussionIcon, counter: 5, href: '#discussions'},
+  {navigation: 'Actions', icon: PlayIcon, counter: 4, href: '#actions'},
+  {navigation: 'Projects', icon: ProjectIcon, counter: 9, href: '#projects'},
+  {navigation: 'Insights', icon: GraphIcon, counter: '0', href: '#insights'},
+  {navigation: 'Settings', icon: GearIcon, counter: 10, href: '#settings'},
+  {navigation: 'Security', icon: ShieldLockIcon, href: '#security'}
 ]
 
 export const InternalResponsiveNav = () => {
@@ -96,6 +96,7 @@ export const InternalResponsiveNav = () => {
           selected={index === selectedIndex}
           onSelect={() => setSelectedIndex(index)}
           counter={item.counter}
+          href={item.href}
         >
           {item.navigation}
         </UnderlineNav.Item>

--- a/src/UnderlineNav2/styles.ts
+++ b/src/UnderlineNav2/styles.ts
@@ -39,8 +39,7 @@ export const getNavStyles = (theme?: Theme, props?: Partial<Pick<UnderlineNavPro
   borderBottom: '1px solid',
   borderBottomColor: `${theme?.colors.border.muted}`,
   align: 'row',
-  alignItems: 'center',
-  position: 'relative'
+  alignItems: 'center'
 })
 
 export const ulStyles = {
@@ -52,7 +51,8 @@ export const ulStyles = {
   margin: 0,
   marginBottom: '-1px',
   alignItems: 'center',
-  gap: `${GAP}px`
+  gap: `${GAP}px`,
+  position: 'relative'
 }
 
 export const getDividerStyle = (theme?: Theme) => ({
@@ -71,7 +71,10 @@ export const moreBtnStyles = {
   fontWeight: 'normal',
   boxShadow: 'none',
   paddingY: 1,
-  paddingX: 2
+  paddingX: 2,
+  '& > span[data-component="trailingIcon"]': {
+    marginLeft: 0
+  }
 }
 
 export const getLinkStyles = (
@@ -142,3 +145,17 @@ export const menuItemStyles = {
   // To reset the style when the menu items are rendered as react router links
   textDecoration: 'none'
 }
+
+export const getMenuStyles = (theme?: Theme, isWidgetOpen?: boolean) => ({
+  position: 'absolute',
+  top: '90%',
+  right: '0',
+  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24)',
+  borderRadius: '12px',
+  backgroundColor: `${theme?.colors.canvas.overlay}`,
+  listStyle: 'none',
+  // Values are from ActionMenu
+  minWidth: '192px',
+  maxWidth: '640px',
+  display: isWidgetOpen ? 'block' : 'none'
+})

--- a/src/UnderlineNav2/styles.ts
+++ b/src/UnderlineNav2/styles.ts
@@ -152,7 +152,7 @@ export const getMenuStyles = (theme?: Theme, isWidgetOpen?: boolean) => ({
   right: '0',
   boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24)',
   borderRadius: '12px',
-  backgroundColor: `${theme?.colors.canvas.overlay}`,
+backgroundColor: 'canvas.overlay'
   listStyle: 'none',
   // Values are from ActionMenu
   minWidth: '192px',

--- a/src/UnderlineNav2/styles.ts
+++ b/src/UnderlineNav2/styles.ts
@@ -146,16 +146,15 @@ export const menuItemStyles = {
   textDecoration: 'none'
 }
 
-export const getMenuStyles = (theme?: Theme, isWidgetOpen?: boolean) => ({
+export const menuStyles = {
   position: 'absolute',
   top: '90%',
   right: '0',
   boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24)',
   borderRadius: '12px',
-backgroundColor: 'canvas.overlay'
+  backgroundColor: 'canvas.overlay',
   listStyle: 'none',
   // Values are from ActionMenu
   minWidth: '192px',
-  maxWidth: '640px',
-  display: isWidgetOpen ? 'block' : 'none'
-})
+  maxWidth: '640px'
+}

--- a/src/hooks/useOnOutsideClick.tsx
+++ b/src/hooks/useOnOutsideClick.tsx
@@ -4,7 +4,7 @@ export type TouchOrMouseEvent = MouseEvent | TouchEvent
 type TouchOrMouseEventCallback = (event: TouchOrMouseEvent) => boolean | undefined
 
 export type UseOnOutsideClickSettings = {
-  containerRef: React.RefObject<HTMLDivElement>
+  containerRef: React.RefObject<HTMLDivElement> | React.RefObject<HTMLUListElement>
   ignoreClickRefs?: React.RefObject<HTMLElement>[]
   onClickOutside: (e: TouchOrMouseEvent) => void
 }


### PR DESCRIPTION
Following up the accessibility [sign-off review](https://github.com/github/primer/issues/1112) feedback (ref: [comment](https://github.com/github/primer/issues/1112#issuecomment-1281157150)), this PR discarding the `ActionMenu` and introduces a disclosure widget.

Storybook test link : https://primer-0a924a1192-13348165.drafts.github.io/storybook/iframe.html?args=&id=components-underlinenav--internal-responsive-nav&viewMode=story

The reasons for discarding the `ActionMenu` are

1. The `ActionMenu` is a portal which means it doesn't follow the button element (that toggles the menu) in the DOM hierarchy. Considering `aria-controls` attribute's [poor support](https://a11ysupport.io/tech/aria/aria-controls_attribute), we cannot rely on it therefore, the menu has to follow the button in the DOM order. 
2. Keyboard accessibility on the `ActionMenu` is not aligning with the disclosure pattern one. I.e focus trap or only arrow key navigation.

What did we introduce? (Disclosure widget pattern)

- We have a button that toggles a menu.
- Menu immediately follows the button element in the DOM hierarchy.
- Button has `aria-controls` and its value is the id of the menu.
- Button has `aria-expanded` attribute and conditionally have true / false value.
- Navigation items (both list and menu items) are navigable with arrow keys (both horizontal and vertical) and the tab key.
- Menu doesn't trap the focus.
- Menu can be closed with clicking outside and ESC. 

### Screenshots

There shouldn't be any visual differences between the `ActionMenu` version and the disclosure widget version. 

### Merge checklist

- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
