### PR TITLE
[UnderlineNav2]: Add visually hidden heading where `aria-label` is present

### DIFF
--- a/.changeset/twelve-spoons-walk.md
+++ b/.changeset/twelve-spoons-walk.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+UnderlineNav2: Render a visually hidden heading for screen readers when aria-label is present

--- a/src/UnderlineNav2/UnderlineNav.test.tsx
+++ b/src/UnderlineNav2/UnderlineNav.test.tsx
@@ -112,4 +112,10 @@ describe('UnderlineNav', () => {
     expect(loadingCounter?.className).toContain('LoadingCounter')
     expect(loadingCounter?.textContent).toBe('')
   })
+  it('renders a visually hidden h2 heading for screen readers when aria-label is present', () => {
+    const {container} = render(<ResponsiveUnderlineNav />)
+    const heading = container.getElementsByTagName('h2')[0]
+    expect(heading.className).toContain('VisuallyHidden')
+    expect(heading.textContent).toBe('Repository')
+  })
 })

--- a/src/UnderlineNav2/UnderlineNav.test.tsx
+++ b/src/UnderlineNav2/UnderlineNav.test.tsx
@@ -116,6 +116,6 @@ describe('UnderlineNav', () => {
     const {container} = render(<ResponsiveUnderlineNav />)
     const heading = container.getElementsByTagName('h2')[0]
     expect(heading.className).toContain('VisuallyHidden')
-    expect(heading.textContent).toBe('Repository')
+    expect(heading.textContent).toBe('Repository navigation')
   })
 })

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -6,6 +6,7 @@ import {useResizeObserver, ResizeObserverEntry} from '../hooks/useResizeObserver
 import CounterLabel from '../CounterLabel'
 import {useTheme} from '../ThemeProvider'
 import {ChildWidthArray, ResponsiveProps} from './types'
+import VisuallyHidden from '../_VisuallyHidden'
 import {moreBtnStyles, getDividerStyle, getNavStyles, ulStyles, menuStyles, menuItemStyles, GAP} from './styles'
 import styled from 'styled-components'
 import {LoadingCounter} from './LoadingCounter'
@@ -296,6 +297,7 @@ export const UnderlineNav = forwardRef(
           iconsVisible
         }}
       >
+        {ariaLabel && <VisuallyHidden as="h2">{ariaLabel}</VisuallyHidden>}
         <Box
           as={as}
           sx={merge<BetterSystemStyleObject>(getNavStyles(theme, {align}), sxProp)}

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -297,7 +297,7 @@ export const UnderlineNav = forwardRef(
           iconsVisible
         }}
       >
-        {ariaLabel && <VisuallyHidden as="h2">{ariaLabel}</VisuallyHidden>}
+        {ariaLabel && <VisuallyHidden as="h2">{`${ariaLabel} navigation`}</VisuallyHidden>}
         <Box
           as={as}
           sx={merge<BetterSystemStyleObject>(getNavStyles(theme, {align}), sxProp)}


### PR DESCRIPTION
Following up the accessibility [sign-off review](https://github.com/github/primer/issues/1112) feedback (ref: [comment](https://github.com/primer/react/pull/2447#issuecomment-1282755318)), this PR adds a visually hidden heading where aria-label is present

Story book link: https://primer-a937bd5bd7-13348165.drafts.github.io/storybook/?path=/story/components-underlinenav--default-nav

### Screenshots

<img width="737" alt="A screenshot of the DOM that shows a visually hidden h2 heading as a sibling to the nav landmark" src="https://user-images.githubusercontent.com/1446503/197437913-7c23378d-5e50-46cf-88b8-1a03ce9bdfc1.png">

### Merge checklist

- [x] Added/updated tests
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
