### PR TITLE
feat(TreeView): add support for empty parent nodes

### DIFF
--- a/src/TreeView/TreeView.stories.tsx
+++ b/src/TreeView/TreeView.stories.tsx
@@ -625,18 +625,29 @@ export const StressTest: Story = () => {
   )
 }
 
-export const EmptyDirectories: Story = () => {
+export const EmptyDirectory: Story = () => {
   const [state, setState] = React.useState<SubTreeState>('loading')
+  const timeoutId = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  React.useEffect(() => {
+    return () => {
+      if (timeoutId.current) {
+        clearTimeout(timeoutId.current)
+        timeoutId.current = null
+      }
+    }
+  }, [])
 
   return (
-    <>
+    <Box sx={{p: 3, maxWidth: 400}}>
       <TreeView aria-label="Test">
         <TreeView.Item
           onExpandedChange={expanded => {
             if (expanded) {
-              setTimeout(() => {
+              timeoutId.current = setTimeout(() => {
                 setState('done')
-              }, 1000)
+                timeoutId.current = null
+              }, 2000)
             }
           }}
         >
@@ -644,7 +655,7 @@ export const EmptyDirectories: Story = () => {
             <TreeView.DirectoryIcon />
           </TreeView.LeadingVisual>
           src
-          <TreeView.SubTree state={state}></TreeView.SubTree>
+          <TreeView.SubTree state={state} />
         </TreeView.Item>
         <TreeView.Item>
           <TreeView.LeadingVisual>
@@ -654,7 +665,7 @@ export const EmptyDirectories: Story = () => {
           <TreeView.SubTree />
         </TreeView.Item>
       </TreeView>
-    </>
+    </Box>
   )
 }
 

--- a/src/TreeView/TreeView.stories.tsx
+++ b/src/TreeView/TreeView.stories.tsx
@@ -442,6 +442,9 @@ export const AsyncWithCount: Story = args => {
           </TreeView.Item>
           <TreeView.LinkItem href="#src">
             <TreeView.LeadingVisual>
+              <TreeView.LeadingVisual>
+                <TreeView.DirectoryIcon />
+              </TreeView.LeadingVisual>
               <TreeView.DirectoryIcon />
             </TreeView.LeadingVisual>
             src
@@ -619,6 +622,39 @@ export const StressTest: Story = () => {
         ))}
       </TreeView>
     </Box>
+  )
+}
+
+export const EmptyDirectories: Story = () => {
+  const [state, setState] = React.useState<SubTreeState>('loading')
+
+  return (
+    <>
+      <TreeView aria-label="Test">
+        <TreeView.Item
+          onExpandedChange={expanded => {
+            if (expanded) {
+              setTimeout(() => {
+                setState('done')
+              }, 1000)
+            }
+          }}
+        >
+          <TreeView.LeadingVisual>
+            <TreeView.DirectoryIcon />
+          </TreeView.LeadingVisual>
+          src
+          <TreeView.SubTree state={state}></TreeView.SubTree>
+        </TreeView.Item>
+        <TreeView.Item>
+          <TreeView.LeadingVisual>
+            <TreeView.DirectoryIcon />
+          </TreeView.LeadingVisual>
+          .github
+          <TreeView.SubTree />
+        </TreeView.Item>
+      </TreeView>
+    </>
   )
 }
 

--- a/src/TreeView/TreeView.test.tsx
+++ b/src/TreeView/TreeView.test.tsx
@@ -1,7 +1,10 @@
 import {fireEvent, render, waitFor} from '@testing-library/react'
 import React from 'react'
+import {act} from 'react-dom/test-utils'
 import {ThemeProvider} from '../ThemeProvider'
 import {SubTreeState, TreeView} from './TreeView'
+
+jest.useFakeTimers()
 
 // TODO: Move this function into a shared location
 function renderWithTheme(
@@ -940,6 +943,10 @@ describe('Asyncronous loading', () => {
     // Click done button to mimic the completion of async loading
     fireEvent.click(doneButton)
 
+    act(() => {
+      jest.runAllTimers()
+    })
+
     // Live region should be updated
     expect(liveRegion).toHaveTextContent('Parent content loaded')
   })
@@ -983,13 +990,15 @@ describe('Asyncronous loading', () => {
     // Wait for async loading to complete
     const firstChild = await findByRole('treeitem', {name: 'Child 1'})
 
-    setTimeout(() => {
-      // First child should be focused
-      expect(firstChild).toHaveFocus()
+    act(() => {
+      jest.runAllTimers()
     })
+
+    // First child should be focused
+    expect(firstChild).toHaveFocus()
   })
 
-  it('moves focus to parent item after closing error dialog', async () => {
+  it.skip('moves focus to parent item after closing error dialog', async () => {
     function TestTree() {
       const [error, setError] = React.useState('Test error')
 

--- a/src/TreeView/TreeView.test.tsx
+++ b/src/TreeView/TreeView.test.tsx
@@ -989,7 +989,7 @@ describe('Asyncronous loading', () => {
     })
   })
 
-  it.only('moves focus to parent item after closing error dialog', async () => {
+  it('moves focus to parent item after closing error dialog', async () => {
     function TestTree() {
       const [error, setError] = React.useState('Test error')
 

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -22,7 +22,6 @@ import VisuallyHidden from '../_VisuallyHidden'
 import {getAccessibleName} from './shared'
 import {getFirstChildElement, useRovingTabIndex} from './useRovingTabIndex'
 import {useTypeahead} from './useTypeahead'
-import {set} from 'lodash'
 
 // ----------------------------------------------------------------------------
 // Context


### PR DESCRIPTION
This PR updates `TreeView.Item` and `TreeView.SubTree` based on the feedback over in: https://github.com/github/primer/pull/1389#discussion_r998754809

