### PR TITLE
ci: split ci workflow into distinct jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,12 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  ci:
-    name: CI
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -24,18 +27,59 @@ jobs:
       - name: Lint
         run: npm run lint
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Build
         run: npm run build
 
       - name: Test
         run: npm run test -- --coverage
 
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Type check
         run: npm run test:type-check
 
-      - name: Install dependencies for examples
-        working-directory: examples/nextjs
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install dependencies
         run: npm ci
+
+      - name: Build
+        run: npm run build
 
       - name: Build examples
         working-directory: examples/nextjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Install examples dependencies
+        working-directory: examples/nextjs
+        run: npm ci
+
       - name: Build examples
         working-directory: examples/nextjs
         run: npm run build


### PR DESCRIPTION
**Background**

The current CI workflow and CI job is made up of several stages, specifically: linting, testing, type checking, and building examples. This job is a required status check in order to be merged.

This PR breaks up these stages into discrete jobs to reduce the total time spent in CI. It also isolates the stages in to jobs which can independently report status for contributors to better understand any issues present in CI.

<details>
<summary>Job time information</summary>

| Workflow | Job | Time | 
| :------- | :-- | :--- |
| CI       | CI  | 7m   |
| CI       | lint | 2m  |
| CI       | test | 6m  |
| CI       | type-check | 2m  |
| CI       | examples | 2m  |

</details>

#### Changelog

**New**

**Changed**

- Update `ci.yml` workflow to use distinct jobs instead of one `ci` job, specifically: `lint`, `test`, `type-check`, `examples`
- Update `ci.yml` to include `concurrency` key to cancel any existing jobs when a new commit is pushed

**Removed**