### PR TITLE
Fix label colors for border and text

### DIFF
--- a/.changeset/rude-bats-appear.md
+++ b/.changeset/rude-bats-appear.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+fixes colors for done and sponsors label

--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -56,12 +56,12 @@ export const variants: Record<LabelColorOptions, BetterSystemStyleObject> = {
     color: 'danger.fg'
   },
   done: {
-    borderColor: 'done.fg',
-    color: 'done.emphasis'
+    borderColor: 'done.emphasis',
+    color: 'done.fg'
   },
   sponsors: {
-    borderColor: 'sponsors.fg',
-    color: 'sponsors.emphasis'
+    borderColor: 'sponsors.emphasis',
+    color: 'sponsors.fg'
   }
 }
 


### PR DESCRIPTION
Label colors for border and text were mixed up for variants `done` and `sponsors`. 

This leads to an a11y issue were text colors don't pass.