### PR TITLE
ConfirmationDialog: Remove header landmark

### DIFF
--- a/.changeset/gold-rabbits-allow.md
+++ b/.changeset/gold-rabbits-allow.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+ConfirmationDialog: Remove header landmark to improve accessibility 

--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -40,7 +40,7 @@ export interface ConfirmationDialogProps {
   confirmButtonType?: 'normal' | 'primary' | 'danger'
 }
 
-const StyledConfirmationHeader = styled.header`
+const StyledConfirmationHeader = styled.div`
   padding: ${get('space.2')};
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
As requested by @jscholes in the [TreeView a11y sign-off review](https://github.com/github/primer/issues/1114#issuecomment-1292397344), this PR removes the banner/header landmark region from ConfirmationDialog.

> Not directly related to tree view, but the dialog displayed when async loading fails has a banner/header landmark region wrapping the "Error" h1 and "Close" button. This should be removed; landmarks are very rarely needed in modal dialogs.

### Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
