### PR TITLE
fix(TreeView): add hcm styles for aria-current in TreeView

### DIFF
--- a/.changeset/lemon-rabbits-move.md
+++ b/.changeset/lemon-rabbits-move.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Add support for aria-current styles in high contrast mode for TreeView

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -21,7 +21,7 @@ module.exports = {
     builder: {
       name: 'webpack5',
       options: {
-        // lazyCompilation: true,
+        lazyCompilation: true,
         fsCache: true
       }
     }

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -21,7 +21,7 @@ module.exports = {
     builder: {
       name: 'webpack5',
       options: {
-        lazyCompilation: true,
+        // lazyCompilation: true,
         fsCache: true
       }
     }

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -272,7 +272,10 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
                     height: '24px',
                     content: '""',
                     bg: 'accent.fg',
-                    borderRadius: 2
+                    borderRadius: 2,
+                    '@media (forced-colors: active)': {
+                      backgroundColor: 'SelectedItem'
+                    }
                   }
                 }
               },

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -224,7 +224,7 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
             '&:focus-visible > div': {
               boxShadow: (theme: Theme) => `inset 0 0 0 2px ${theme.colors.accent.emphasis}`,
               '@media (forced-colors: active)': {
-                outline: '2px solid SelectedItem',
+                outline: '2px solid HighlightText',
                 outlineOffset: -2
               }
             }
@@ -274,7 +274,7 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
                     bg: 'accent.fg',
                     borderRadius: 2,
                     '@media (forced-colors: active)': {
-                      backgroundColor: 'SelectedItem'
+                      backgroundColor: 'HighlightText'
                     }
                   }
                 }


### PR DESCRIPTION
This addresses the HCM feedback from: https://github.com/github/primer/issues/1114#issuecomment-1292865037

TreeView uses the `HighlightText` keyword for `aria-current` and focus styles


https://user-images.githubusercontent.com/3901764/199105960-865882e2-89dd-4e60-b1ba-9698725bb1a2.mov


