### PR TITLE
fix(PageLayout): add maxWidth to container

### DIFF
--- a/.changeset/angry-wombats-burn.md
+++ b/.changeset/angry-wombats-burn.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Add maxWidth to container of PageLayout.{Pane, Content}

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -98,7 +98,7 @@ const Root: React.FC<React.PropsWithChildren<PageLayoutProps>> = ({
               return (
                 <>
                   {slots.Header}
-                  <Box sx={{display: 'flex', flex: '1 1 100%', flexWrap: 'wrap'}}>{children}</Box>
+                  <Box sx={{display: 'flex', flex: '1 1 100%', flexWrap: 'wrap', maxWidth: '100%'}}>{children}</Box>
                   {slots.Footer}
                 </>
               )

--- a/src/PageLayout/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/PageLayout/__snapshots__/PageLayout.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`PageLayout renders condensed layout 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .c6 {
@@ -265,6 +266,7 @@ exports[`PageLayout renders default layout 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .c6 {
@@ -547,6 +549,7 @@ exports[`PageLayout renders pane in different position when narrow 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .c6 {
@@ -829,6 +832,7 @@ exports[`PageLayout renders with dividers 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .c6 {

--- a/src/SplitPageLayout/__snapshots__/SplitPageLayout.test.tsx.snap
+++ b/src/SplitPageLayout/__snapshots__/SplitPageLayout.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`SplitPageLayout renders default layout 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .c6 {


### PR DESCRIPTION
This PR updates the container used to wrap `PageLayout.Pane` and `PageLayout.Content` to match their previous parent element which set `max-width: 100%`.

Without this property, the `PageLayout.Content` pane would extend passed the edge of the page and trigger overflow. This lead to issues as described [here](https://github.slack.com/archives/C01L618AEP9/p1666969818414279) where the `position: sticky` was triggered due to the overflow.

To reproduce this issue, you can visit the reivew lab from that Slack thread and reduce the size of the browser to where the symbol pane overlaps the code area. Adding in `max-width: 100%` to the container of the `main` and Pane addresses the issue.