### PR TITLE
fix(Select): move selected from <option> to defaultValue on <select>

### DIFF
--- a/.changeset/moody-islands-impress.md
+++ b/.changeset/moody-islands-impress.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Remove selected from <option> and add defaultValue for <select> when placeholder is provided

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -87,10 +87,11 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
         disabled={disabled}
         aria-invalid={validationStatus === 'error' ? 'true' : 'false'}
         data-hasplaceholder={Boolean(placeholder)}
+        defaultValue={placeholder ?? undefined}
         {...rest}
       >
         {placeholder && (
-          <option value="" disabled={required} selected hidden={required}>
+          <option value="" disabled={required} hidden={required}>
             {placeholder}
           </option>
         )}


### PR DESCRIPTION
We currently set `selected` on the `<option>` within a `<select>` when `placeholder` is provided. When doing so, we receive the following error from `styled-components`:


```
Warning: Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>.
    at option
    at select
    at StyledComponent (/Users/joshblack/gh/primer/react/node_modules/styled-components/dist/styled-components.cjs.js:1950:5)
    at Select__StyledSelect
    at span
    at StyledComponent (/Users/joshblack/gh/primer/react/node_modules/styled-components/dist/styled-components.cjs.js:1950:5)
    at _TextInputWrapper__TextInputWrapper
    at block (/Users/joshblack/gh/primer/react/src/Select.tsx:67:5)
```

This PR removes the `selected` prop from `<option>` and instead optionally specifies the `defaultValue` if `placeholder` is present.

> **Note**
> When a consumer passes in `defaultValue`, it should continue to override whatever is provided since `{...rest}` is applied _after_ `defaultValue`