### PR TITLE
test(Textarea): update controlled test to provide onChange

### DIFF
--- a/src/__tests__/Textarea.test.tsx
+++ b/src/__tests__/Textarea.test.tsx
@@ -94,7 +94,8 @@ describe('Textarea', () => {
 
   it('renders a value in the textarea', () => {
     const mockValue = 'mock value'
-    const {getByRole} = render(<Textarea value={mockValue} />)
+    const onChange = jest.fn()
+    const {getByRole} = render(<Textarea onChange={onChange} value={mockValue} />)
 
     const textareaElement = getByRole('textbox') as HTMLTextAreaElement
 


### PR DESCRIPTION
Update the `Textarea` test to include `onChange` when `value` is provided. This helps to address the following error that shows up in Jest:

```
Warning: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.
    at textarea
    at StyledComponent (/Users/joshblack/gh/primer/react/node_modules/styled-components/dist/styled-components.cjs.js:1950:5)
    at Textarea__StyledTextarea
    at span
    at StyledComponent (/Users/joshblack/gh/primer/react/node_modules/styled-components/dist/styled-components.cjs.js:1950:5)
    at _TextInputWrapper__TextInputBaseWrapper
    at value (/Users/joshblack/gh/primer/react/src/Textarea.tsx:67:7)
```
