### PR TITLE
PageLayout: Use width prop to caluculate default width of resizable pane

### DIFF
--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -518,7 +518,7 @@ const paneWidths = {
   large: ['100%', null, '256px', '320px', '336px']
 }
 
-const defaultPaneWidth = 256
+const defaultPaneWidth = {small: 256, medium: 296, large: 320}
 
 const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayoutPaneProps>>(
   (
@@ -569,7 +569,7 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
 
     const [paneWidth, setPaneWidth] = React.useState(() => {
       if (!canUseDOM) {
-        return defaultPaneWidth
+        return defaultPaneWidth[width]
       }
 
       let storedWidth
@@ -580,7 +580,7 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
         storedWidth = null
       }
 
-      return storedWidth && !isNaN(Number(storedWidth)) ? Number(storedWidth) : defaultPaneWidth
+      return storedWidth && !isNaN(Number(storedWidth)) ? Number(storedWidth) : defaultPaneWidth[width]
     })
 
     const updatePaneWidth = (width: number) => {
@@ -659,7 +659,7 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
             updatePaneWidth(paneRect.width)
           }}
           // Reset pane width on double click
-          onDoubleClick={() => updatePaneWidth(defaultPaneWidth)}
+          onDoubleClick={() => updatePaneWidth(defaultPaneWidth[width])}
         />
 
         <Box

--- a/src/PageLayout/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/PageLayout/__snapshots__/PageLayout.test.tsx.snap
@@ -224,7 +224,7 @@ exports[`PageLayout renders condensed layout 1`] = `
           />
           <div
             class="c11"
-            style="--pane-width: 256px;"
+            style="--pane-width: 296px;"
           >
             Pane
           </div>
@@ -517,7 +517,7 @@ exports[`PageLayout renders default layout 1`] = `
           />
           <div
             class="c11"
-            style="--pane-width: 256px;"
+            style="--pane-width: 296px;"
           >
             Pane
           </div>
@@ -810,7 +810,7 @@ exports[`PageLayout renders pane in different position when narrow 1`] = `
           />
           <div
             class="c11"
-            style="--pane-width: 256px;"
+            style="--pane-width: 296px;"
           >
             Pane
           </div>
@@ -1103,7 +1103,7 @@ exports[`PageLayout renders with dividers 1`] = `
           />
           <div
             class="c10"
-            style="--pane-width: 256px;"
+            style="--pane-width: 296px;"
           >
             Pane
           </div>

--- a/src/SplitPageLayout/__snapshots__/SplitPageLayout.test.tsx.snap
+++ b/src/SplitPageLayout/__snapshots__/SplitPageLayout.test.tsx.snap
@@ -259,7 +259,7 @@ exports[`SplitPageLayout renders default layout 1`] = `
           />
           <div
             class="c11"
-            style="--pane-width: 256px;"
+            style="--pane-width: 296px;"
           >
             Pane
           </div>


### PR DESCRIPTION
Updates the default width of a resizable pane depending on the value of the `width` prop.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
