### PR TITLE
TreeView: Fix unexpected scrolling

### DIFF
--- a/.changeset/violet-plants-sip.md
+++ b/.changeset/violet-plants-sip.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+TreeView: Fix unexpected scrolling when focusing child items

--- a/src/TreeView/TreeView.stories.tsx
+++ b/src/TreeView/TreeView.stories.tsx
@@ -678,6 +678,7 @@ export const NestedScrollContainer: Story = () => {
             Directory {i}
             <TreeView.SubTree>
               {Array.from({length: 10}).map((_, j) => (
+                // eslint-disable-next-line no-console
                 <TreeView.Item key={j} onSelect={() => console.log(`Directory ${i}/File ${j}`)}>
                   <TreeView.LeadingVisual>
                     <FileIcon />

--- a/src/TreeView/TreeView.stories.tsx
+++ b/src/TreeView/TreeView.stories.tsx
@@ -670,19 +670,19 @@ export const NestedScrollContainer: Story = () => {
   return (
     <Box sx={{p: 3, maxWidth: 400, maxHeight: '50vh', overflow: 'auto'}}>
       <TreeView aria-label="Files">
-        {Array.from({length: 100}).map((_, index) => (
-          <TreeView.Item key={index}>
+        {Array.from({length: 100}).map((_, i) => (
+          <TreeView.Item key={i}>
             <TreeView.LeadingVisual>
               <TreeView.DirectoryIcon />
             </TreeView.LeadingVisual>
-            Directory {index}
+            Directory {i}
             <TreeView.SubTree>
-              {Array.from({length: 10}).map((_, index) => (
-                <TreeView.Item key={index}>
+              {Array.from({length: 10}).map((_, j) => (
+                <TreeView.Item key={j} onSelect={() => console.log(`Directory ${i}/File ${j}`)}>
                   <TreeView.LeadingVisual>
                     <FileIcon />
                   </TreeView.LeadingVisual>
-                  File {index}
+                  File {j}
                 </TreeView.Item>
               ))}
             </TreeView.SubTree>

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -218,6 +218,9 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
           onFocus={event => {
             // Scroll the first child into view when the item receives focus
             event.currentTarget.firstElementChild?.scrollIntoView({block: 'nearest', inline: 'nearest'})
+
+            // Prevent focus event from bubbling up to parent items
+            event.stopPropagation()
           }}
           sx={{
             outline: 'none',


### PR DESCRIPTION
## Before

Focusing/clicking a child item would unexpectedly scroll the parent item into view:


https://user-images.githubusercontent.com/4608155/199579350-5113f0bc-9953-4517-b436-d5ece4a17b5e.mp4

## After

The TreeView doesn't scroll unexpectedly when focusing/clicking child items:


https://user-images.githubusercontent.com/4608155/199579427-86fa3d03-0756-4ff2-a4a1-bd601acff5d1.mp4



Closes  https://github.com/primer/react/issues/2505

### Merge checklist

- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
