### PR TITLE
Disable TreeView `StressTest` story  snapshot in Chromatic

### DIFF
--- a/src/TreeView/TreeView.stories.tsx
+++ b/src/TreeView/TreeView.stories.tsx
@@ -622,6 +622,11 @@ export const StressTest: Story = () => {
   )
 }
 
+StressTest.parameters = {
+  // disables Chromatic's snapshotting on a story level
+  chromatic: {disableSnapshot: true}
+}
+
 export const EmptyDirectory: Story = () => {
   const [state, setState] = React.useState<SubTreeState>('loading')
   const timeoutId = React.useRef<ReturnType<typeof setTimeout> | null>(null)


### PR DESCRIPTION
TreeView StressTest story exceeds the chromatic snapshot limit and makes CI failed. This PR ignores Chromatic to take snapshot of the story.

### Screenshots

<img width="1036" alt="Screen Shot 2022-11-04 at 8 17 16 am" src="https://user-images.githubusercontent.com/1446503/199844971-baf7b580-b47c-4c84-a1db-753b58a28a8d.png">


<img width="651" alt="Screen Shot 2022-11-04 at 8 17 08 am" src="https://user-images.githubusercontent.com/1446503/199844960-c382c317-e474-4693-8d09-fafcb573114e.png">


Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
