### PR TITLE
Missing quotation mark on the mdx and remove broken component docs link

### DIFF
--- a/docs/content/drafts/UnderlineNav2.mdx
+++ b/docs/content/drafts/UnderlineNav2.mdx
@@ -4,7 +4,7 @@ componentId: underline_nav_2
 status: Draft
 description: Use an underlined nav to allow tab like navigation with overflow behaviour in your UI.
 source: https://github.com/primer/react/tree/main/src/UnderlineNav2
-storybook: '/react/storybook/?path=/story/components-underlinenav
+storybook: '/react/storybook/?path=/story/components-underlinenav'
 ---
 
 ```js

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -156,8 +156,6 @@
   children:
     - title: Dialog v2
       url: /drafts/Dialog
-    - title: Hidden
-      url: /Hidden
     - title: InlineAutocomplete
       url: /drafts/InlineAutocomplete
     - title: MarkdownEditor


### PR DESCRIPTION
I don't know why [the PR](https://github.com/primer/react/pull/2507) didn't warned me about this although it warned me for other missing quotation marks.  Also removes broken `Hidden` component docs link