### PR TITLE
[Storybook] ButtonGroup Stories

### DIFF
--- a/docs/content/Button.mdx
+++ b/docs/content/Button.mdx
@@ -3,7 +3,7 @@ componentId: button
 title: Button
 status: Alpha
 source: https://github.com/primer/react/tree/main/src/Button
-storybook: '/react/storybook?path=/story/components-button'
+storybook: '/react/storybook?path=/story/components-button-default'
 description: Use button for the main actions on a page or form.
 ---
 

--- a/docs/content/ButtonGroup.mdx
+++ b/docs/content/ButtonGroup.mdx
@@ -3,6 +3,7 @@ title: ButtonGroup
 componentId: button_group
 status: Alpha
 source: https://github.com/primer/react/tree/main/src/ButtonGroup
+storybook: '/react/storybook?path=/story/components-buttongroup--default'
 ---
 
 ```js

--- a/docs/content/deprecated/Buttons.mdx
+++ b/docs/content/deprecated/Buttons.mdx
@@ -9,9 +9,6 @@ storybook: '/react/storybook?path=/story/components-button--default-button'
 
 Use [Button](/Button) instead.
 
-For more info on the changes, have a look at the migration guide.
-[Button migration guide](/migration-guide/Button)
-
 `Button` is used for actions, like in forms, while `Link` is used for destinations, or moving from one page to another.
 
 In special cases where you'd like to use a `<a>` styled like a Button, use `<Button as='a'>` and provide an `href`.

--- a/src/stories/ButtonGroup.stories.tsx
+++ b/src/stories/ButtonGroup.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import {DashIcon, PlusIcon} from '@primer/octicons-react'
+import {Meta} from '@storybook/react'
+
+import ButtonGroup from '../ButtonGroup'
+import {Button, ButtonProps, IconButton} from '../Button'
+
+export default {
+  title: 'Components/ButtonGroup',
+  argTypes: {
+    size: {
+      control: {
+        type: 'radio'
+      },
+      options: ['small', 'medium', 'large']
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+        default: false
+      }
+    }
+  }
+} as Meta
+
+export const defaultButtonGroup = (args: ButtonProps) => (
+  <ButtonGroup>
+    <Button {...args}>Button 1</Button>
+    <Button {...args}>Button 2</Button>
+    <Button {...args}>Button 3</Button>
+  </ButtonGroup>
+)
+
+export const iconButtonGroup = (args: ButtonProps) => (
+  <ButtonGroup>
+    <IconButton {...args} aria-label="Zoom out" icon={DashIcon} />
+    <IconButton {...args} aria-label="Zoom in" icon={PlusIcon} />
+  </ButtonGroup>
+)

--- a/src/stories/ButtonGroup.stories.tsx
+++ b/src/stories/ButtonGroup.stories.tsx
@@ -23,7 +23,7 @@ export default {
   }
 } as Meta
 
-export const defaultButtonGroup = (args: ButtonProps) => (
+export const Default = (args: ButtonProps) => (
   <ButtonGroup>
     <Button {...args}>Button 1</Button>
     <Button {...args}>Button 2</Button>
@@ -31,7 +31,7 @@ export const defaultButtonGroup = (args: ButtonProps) => (
   </ButtonGroup>
 )
 
-export const iconButtonGroup = (args: ButtonProps) => (
+export const WithIcons = (args: ButtonProps) => (
   <ButtonGroup>
     <IconButton {...args} aria-label="Zoom out" icon={DashIcon} />
     <IconButton {...args} aria-label="Zoom in" icon={PlusIcon} />

--- a/src/stories/deprecated/Button.stories.tsx
+++ b/src/stories/deprecated/Button.stories.tsx
@@ -10,7 +10,6 @@ import {
   ButtonPrimary,
   ButtonTableList
 } from '../../deprecated'
-import {ButtonGroup} from '../..'
 import {ButtonStyleProps} from 'styled-system'
 import {ButtonBaseProps} from '../../deprecated/Button/ButtonBase'
 type StrictButtonStyleProps = ButtonStyleProps & {variant: ButtonBaseProps['variant']}
@@ -53,13 +52,6 @@ export const invisibleButton = (args: StrictButtonStyleProps) => (
 export const closeButton = (args: ButtonStyleProps) => (
   <ButtonClose {...args} onClick={() => alert('button clicked.')} />
 )
-export const buttonGroup = (args: StrictButtonStyleProps) => (
-  <ButtonGroup>
-    <Button {...args}>Button 1</Button>
-    <Button {...args}>Button 2</Button>
-    <Button {...args}>Button 3</Button>
-  </ButtonGroup>
-)
 export const buttonTableList = (args: ButtonStyleProps) => (
   <ButtonTableList {...args}>Button Table List</ButtonTableList>
 )
@@ -74,5 +66,4 @@ outlineButton.args = {variant: 'medium'}
 primaryButton.args = {variant: 'medium'}
 invisibleButton.args = {variant: 'medium'}
 closeButton.args = {variant: 'medium'}
-buttonGroup.args = {variant: 'medium'}
 buttonTableList.args = {variant: 'medium'}


### PR DESCRIPTION
Describe your changes here.

- [x] Remove ButtonGroup from deprecated stories
- [x] New ButtonGroup stories (default, icon)
- [x] Add the new `storybook` link to the documentation
- [x] Removed broken migration link in Button

Related work to support documentation IA as part of https://github.com/github/primer/issues/1488. cc @langermank 

### Screenshots

<img width="1840" alt="Screenshot 2022-11-07 at 11 08 03" src="https://user-images.githubusercontent.com/912236/200283746-a38577f5-2be3-43c0-a820-a25c8ebdcdb6.png">


### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
