### PR TITLE
UnderlineNav2: Make selected prop redundant and expose aria-current to the API

### DIFF
--- a/src/UnderlineNav2/UnderlineNav.test.tsx
+++ b/src/UnderlineNav2/UnderlineNav.test.tsx
@@ -54,7 +54,7 @@ const ResponsiveUnderlineNav = ({
         <UnderlineNav.Item
           key={item.navigation}
           icon={item.icon}
-          selected={item.navigation === selectedItemText}
+          aria-current={item.navigation === selectedItemText ? 'page' : undefined}
           counter={item.counter}
         >
           {item.navigation}

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -92,7 +92,7 @@ const overflowEffect = (
       if (index < numberOfListItems) {
         items.push(child)
         // We need to make sure to keep the selected item always visible.
-      } else if (child.props.selected) {
+      } else if (child.props.ariaCurrent === 'page') {
         // If selected item can't make it to the list, we swap it with the last item in the list.
         const indexToReplaceAt = numberOfListItems - 1 // because we are replacing the last item in the list
         // splice method modifies the array by removing 1 item here at the given index and replace it with the "child" element then returns the removed item.

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -31,9 +31,9 @@ export type UnderlineNavItemProps = {
    */
   onSelect?: (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void
   /**
-   * Is the `Link` is currently selected?
+   * Is the `Link` current page?
    */
-  selected?: boolean
+  'aria-current'?: 'page' | undefined
   /**
    *  Icon before the text
    */
@@ -55,7 +55,7 @@ export const UnderlineNavItem = forwardRef(
       children,
       counter,
       onSelect,
-      selected: preSelected = false,
+      'aria-current': ariaCurrent,
       icon: Icon,
       ...props
     },
@@ -98,7 +98,14 @@ export const UnderlineNavItem = forwardRef(
 
       setChildrenWidth({text, width: domRect.width})
       setNoIconChildrenWidth({text, width: domRect.width - iconWidthWithMargin})
-      preSelected && selectedLink === undefined && setSelectedLink(ref as RefObject<HTMLElement>)
+
+      if (
+        selectedLink === undefined &&
+        ariaCurrent !== undefined &&
+        ref.current?.getAttribute('aria-current') !== 'false'
+      ) {
+        setSelectedLink(ref as RefObject<HTMLElement>)
+      }
 
       // Only runs when a menu item is selected (swapping the menu item with the list item to keep it visible)
       if (selectedLinkText === text) {
@@ -108,7 +115,6 @@ export const UnderlineNavItem = forwardRef(
       }
     }, [
       ref,
-      preSelected,
       selectedLink,
       selectedLinkText,
       setSelectedLinkText,
@@ -116,7 +122,8 @@ export const UnderlineNavItem = forwardRef(
       setChildrenWidth,
       setNoIconChildrenWidth,
       onSelect,
-      selectEvent
+      selectEvent,
+      ariaCurrent
     ])
 
     const keyPressHandler = React.useCallback(
@@ -139,7 +146,6 @@ export const UnderlineNavItem = forwardRef(
       },
       [onSelect, afterSelect, ref, setSelectedLink]
     )
-
     return (
       <Box as="li" sx={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
         <Box
@@ -149,8 +155,8 @@ export const UnderlineNavItem = forwardRef(
           onClick={clickHandler}
           {...(selectedLink === ref ? {'aria-current': 'page'} : {})}
           sx={merge(getLinkStyles(theme, {variant}, selectedLink, ref), sxProp as SxProp)}
-          {...props}
           ref={ref}
+          {...props}
         >
           <Box as="div" data-component="wrapper" sx={wrapperStyles}>
             {iconsVisible && Icon && (

--- a/src/UnderlineNav2/examples.stories.tsx
+++ b/src/UnderlineNav2/examples.stories.tsx
@@ -34,7 +34,7 @@ export default {
 export const DefaultNav = () => {
   return (
     <UnderlineNav aria-label="Repository">
-      <UnderlineNav.Item selected>Code</UnderlineNav.Item>
+      <UnderlineNav.Item aria-current="page">Code</UnderlineNav.Item>
       <UnderlineNav.Item>Issues</UnderlineNav.Item>
       <UnderlineNav.Item>Pull Requests</UnderlineNav.Item>
     </UnderlineNav>
@@ -48,7 +48,7 @@ export const withIcons = () => {
       <UnderlineNav.Item icon={EyeIcon} counter={6}>
         Issues
       </UnderlineNav.Item>
-      <UnderlineNav.Item selected icon={GitPullRequestIcon}>
+      <UnderlineNav.Item aria-current="page" icon={GitPullRequestIcon}>
         Pull Requests
       </UnderlineNav.Item>
       <UnderlineNav.Item icon={CommentDiscussionIcon} counter={7}>
@@ -62,10 +62,8 @@ export const withIcons = () => {
 export const withCounterLabels = () => {
   return (
     <UnderlineNav aria-label="Repository with counters">
-      <UnderlineNav.Item selected icon={CodeIcon}>
-        Code
-      </UnderlineNav.Item>
-      <UnderlineNav.Item icon={IssueOpenedIcon} counter={12}>
+      <UnderlineNav.Item icon={CodeIcon}>Code</UnderlineNav.Item>
+      <UnderlineNav.Item aria-current="page" icon={IssueOpenedIcon} counter={12}>
         Issues
       </UnderlineNav.Item>
     </UnderlineNav>
@@ -85,18 +83,19 @@ const items: {navigation: string; icon: React.FC<IconProps>; counter?: number | 
 ]
 
 export const InternalResponsiveNav = () => {
-  const [selectedIndex, setSelectedIndex] = React.useState<number | null>(1)
-
+  const currentHref = '#code'
   return (
     <UnderlineNav aria-label="Repository">
-      {items.map((item, index) => (
+      {items.map(item => (
         <UnderlineNav.Item
           key={item.navigation}
           icon={item.icon}
-          selected={index === selectedIndex}
-          onSelect={() => setSelectedIndex(index)}
+          aria-current={currentHref === item.href ? 'page' : undefined}
           counter={item.counter}
           href={item.href}
+          onSelect={e => {
+            e.preventDefault()
+          }}
         >
           {item.navigation}
         </UnderlineNav.Item>
@@ -106,17 +105,15 @@ export const InternalResponsiveNav = () => {
 }
 
 export const CountersLoadingState = () => {
-  const [selectedIndex, setSelectedIndex] = React.useState<number | null>(1)
-
+  const currentHref = '#code'
   return (
     <UnderlineNav aria-label="Repository with loading counters" loadingCounters={true}>
-      {items.map((item, index) => (
+      {items.map(item => (
         <UnderlineNav.Item
           key={item.navigation}
           icon={item.icon}
-          selected={index === selectedIndex}
-          onSelect={() => setSelectedIndex(index)}
           counter={item.counter}
+          aria-current={currentHref === item.href ? 'page' : undefined}
         >
           {item.navigation}
         </UnderlineNav.Item>


### PR DESCRIPTION
To be consistent with the recent navigation implementations (i.e. NavList), we are making the  `selected` prop redundant and expose `aria-current` as a prop to manage the the current, selected page. 

Note: I have not updated the docs yet. Once I get a 👍🏼 for the implementation, I'll update them.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
