### PR TITLE
docs: enable fastRefresh and strictMode for storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,7 +6,6 @@ module.exports = {
     '@storybook/addon-interactions',
     '@storybook/addon-a11y',
     '@storybook/addon-links',
-    'storybook-addon-performance/register',
     {
       name: 'storybook-addon-turbo-build',
       options: {
@@ -30,5 +29,9 @@ module.exports = {
     interactionsDebugger: true,
     storyStoreV7: true
   },
-  framework: '@storybook/react'
+  framework: '@storybook/react',
+  reactOptions: {
+    fastRefresh: true,
+    strictMode: true
+  }
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,8 @@
 import {addons} from '@storybook/addons'
-import {withPerformance} from 'storybook-addon-performance'
 import {withThemeProvider, toolbarTypes} from '../src/utils/story-helpers'
 
 export const globalTypes = toolbarTypes
-export const decorators = [withThemeProvider, withPerformance]
+export const decorators = [withThemeProvider]
 
 addons.setConfig({
   // Some stories may set up keyboard event handlers, which can be interfered

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,7 +128,6 @@
         "rollup-plugin-visualizer": "5.8.1",
         "semver": "7.3.5",
         "size-limit": "7.0.3",
-        "storybook-addon-performance": "0.16.1",
         "storybook-addon-turbo-build": "1.1.0",
         "styled-components": "4.4.1",
         "ts-toolbelt": "9.6.0",
@@ -2881,12 +2880,6 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "dev": true
-    },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
       "dev": true
     },
     "node_modules/@emotion/unitless": {
@@ -14878,29 +14871,6 @@
         "react": "^17.0.0-0"
       }
     },
-    "node_modules/@xstate/react": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-1.6.1.tgz",
-      "integrity": "sha512-M3b32nGhA0K3N6NrYKAMXx3dgGlLmuZfJU/EsZT04kQyVbWSiT3z7p9rdPisQyaQYFUwdqspQZ68wRNWbUkfVQ==",
-      "dev": true,
-      "dependencies": {
-        "use-isomorphic-layout-effect": "^1.0.0",
-        "use-subscription": "^1.3.0"
-      },
-      "peerDependencies": {
-        "@xstate/fsm": "^1.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "xstate": "^4.11.0"
-      },
-      "peerDependenciesMeta": {
-        "@xstate/fsm": {
-          "optional": true
-        },
-        "xstate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -18800,18 +18770,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/crc32": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz",
-      "integrity": "sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo=",
-      "dev": true,
-      "bin": {
-        "crc32": "bin/runner.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -19695,19 +19653,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/deflate-js": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz",
-      "integrity": "sha1-+Fq7WOvFFRowYUdHPVfD5PfkQms=",
-      "dev": true,
-      "bin": {
-        "deflate-js": "bin/deflate.js",
-        "inflate-js": "bin/inflate.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/del": {
@@ -24398,23 +24343,6 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
-    },
-    "node_modules/gzip-js": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
-      "integrity": "sha1-IxF+/usozzhSSN7/Df+tiUg22Ws=",
-      "dev": true,
-      "dependencies": {
-        "crc32": ">= 0.2.2",
-        "deflate-js": ">= 0.2.2"
-      },
-      "bin": {
-        "gunzip-js": "bin/gunzip.js",
-        "gzip-js": "bin/gzip.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
@@ -38425,182 +38353,6 @@
       "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==",
       "dev": true
     },
-    "node_modules/storybook-addon-performance": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/storybook-addon-performance/-/storybook-addon-performance-0.16.1.tgz",
-      "integrity": "sha512-hDMRXvZljwBXYKrNegB9+LvT1b0ZQlkvTEDqq4gbMovQcD9yR0mka1eDuhwZfzxcgY1PrhkN3EhNxLybA/ql9Q==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addons": "^6.2.9",
-        "@storybook/api": "^6.2.9",
-        "@storybook/channels": "^6.2.9",
-        "@storybook/components": "^6.2.9",
-        "@storybook/core-events": "^6.2.9",
-        "@storybook/theming": "^6.2.9",
-        "@testing-library/dom": "^7.22.0",
-        "@testing-library/jest-dom": "^5.11.2",
-        "@xstate/react": "^1.5.1",
-        "gzip-js": "^0.3.2",
-        "styled-components": "^5.1.1",
-        "tiny-invariant": "^1.1.0",
-        "xstate": "^4.22.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/storybook-addon-performance/node_modules/@testing-library/dom": {
-      "version": "7.31.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-      "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^4.2.2",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.6",
-        "lz-string": "^1.4.4",
-        "pretty-format": "^26.6.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/storybook-addon-performance/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/storybook-addon-performance/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/storybook-addon-performance/node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/storybook-addon-performance/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/storybook-addon-performance/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/storybook-addon-performance/node_modules/css-to-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
-      "dev": true,
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
-      }
-    },
-    "node_modules/storybook-addon-performance/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/storybook-addon-performance/node_modules/pretty-format": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/storybook-addon-performance/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
-    },
-    "node_modules/storybook-addon-performance/node_modules/styled-components": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.3.tgz",
-      "integrity": "sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^0.8.8",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
-      }
-    },
     "node_modules/storybook-addon-turbo-build": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/storybook-addon-turbo-build/-/storybook-addon-turbo-build-1.1.0.tgz",
@@ -39684,12 +39436,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==",
-      "dev": true
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -40738,32 +40484,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "dev": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-subscription": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
-      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
-      "dev": true,
-      "dependencies": {
-        "object-assign": "^4.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
-      }
-    },
     "node_modules/util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -41746,16 +41466,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "node_modules/xstate": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.25.0.tgz",
-      "integrity": "sha512-qP7lc/ypOuuWME4ArOBnzaCa90TfHkjiqYDmxpiCjPy6FcXstInA2vH6qRVAHbPXRK4KQIYfIEOk1X38P+TldQ==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/xstate"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -43912,12 +43622,6 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "dev": true
-    },
-    "@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
       "dev": true
     },
     "@emotion/unitless": {
@@ -53026,16 +52730,6 @@
         "prop-types": "^15.7.0"
       }
     },
-    "@xstate/react": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-1.6.1.tgz",
-      "integrity": "sha512-M3b32nGhA0K3N6NrYKAMXx3dgGlLmuZfJU/EsZT04kQyVbWSiT3z7p9rdPisQyaQYFUwdqspQZ68wRNWbUkfVQ==",
-      "dev": true,
-      "requires": {
-        "use-isomorphic-layout-effect": "^1.0.0",
-        "use-subscription": "^1.3.0"
-      }
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -56060,12 +55754,6 @@
         }
       }
     },
-    "crc32": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz",
-      "integrity": "sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo=",
-      "dev": true
-    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -56770,12 +56458,6 @@
           }
         }
       }
-    },
-    "deflate-js": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz",
-      "integrity": "sha1-+Fq7WOvFFRowYUdHPVfD5PfkQms=",
-      "dev": true
     },
     "del": {
       "version": "6.1.1",
@@ -60251,16 +59933,6 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
-    },
-    "gzip-js": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
-      "integrity": "sha1-IxF+/usozzhSSN7/Df+tiUg22Ws=",
-      "dev": true,
-      "requires": {
-        "crc32": ">= 0.2.2",
-        "deflate-js": ">= 0.2.2"
-      }
     },
     "handlebars": {
       "version": "4.7.7",
@@ -71023,143 +70695,6 @@
       "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==",
       "dev": true
     },
-    "storybook-addon-performance": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/storybook-addon-performance/-/storybook-addon-performance-0.16.1.tgz",
-      "integrity": "sha512-hDMRXvZljwBXYKrNegB9+LvT1b0ZQlkvTEDqq4gbMovQcD9yR0mka1eDuhwZfzxcgY1PrhkN3EhNxLybA/ql9Q==",
-      "dev": true,
-      "requires": {
-        "@storybook/addons": "^6.2.9",
-        "@storybook/api": "^6.2.9",
-        "@storybook/channels": "^6.2.9",
-        "@storybook/components": "^6.2.9",
-        "@storybook/core-events": "^6.2.9",
-        "@storybook/theming": "^6.2.9",
-        "@testing-library/dom": "^7.22.0",
-        "@testing-library/jest-dom": "^5.11.2",
-        "@xstate/react": "^1.5.1",
-        "gzip-js": "^0.3.2",
-        "styled-components": "^5.1.1",
-        "tiny-invariant": "^1.1.0",
-        "xstate": "^4.22.0"
-      },
-      "dependencies": {
-        "@testing-library/dom": {
-          "version": "7.31.2",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-          "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@types/aria-query": "^4.2.0",
-            "aria-query": "^4.2.2",
-            "chalk": "^4.1.0",
-            "dom-accessibility-api": "^0.5.6",
-            "lz-string": "^1.4.4",
-            "pretty-format": "^26.6.2"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "css-to-react-native": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-          "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
-          "dev": true,
-          "requires": {
-            "camelize": "^1.0.0",
-            "css-color-keywords": "^1.0.0",
-            "postcss-value-parser": "^4.0.2"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.2",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^17.0.1"
-          }
-        },
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true
-        },
-        "styled-components": {
-          "version": "5.3.3",
-          "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.3.tgz",
-          "integrity": "sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@babel/traverse": "^7.4.5",
-            "@emotion/is-prop-valid": "^0.8.8",
-            "@emotion/stylis": "^0.8.4",
-            "@emotion/unitless": "^0.7.4",
-            "babel-plugin-styled-components": ">= 1.12.0",
-            "css-to-react-native": "^3.0.0",
-            "hoist-non-react-statics": "^3.0.0",
-            "shallowequal": "^1.1.0",
-            "supports-color": "^5.5.0"
-          }
-        }
-      }
-    },
     "storybook-addon-turbo-build": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/storybook-addon-turbo-build/-/storybook-addon-turbo-build-1.1.0.tgz",
@@ -71992,12 +71527,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "tiny-invariant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==",
-      "dev": true
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -72758,22 +72287,6 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
-    "use-isomorphic-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "use-subscription": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
-      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.1"
-      }
-    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -73527,12 +73040,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
-    },
-    "xstate": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.25.0.tgz",
-      "integrity": "sha512-qP7lc/ypOuuWME4ArOBnzaCa90TfHkjiqYDmxpiCjPy6FcXstInA2vH6qRVAHbPXRK4KQIYfIEOk1X38P+TldQ==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,6 @@
     "rollup-plugin-visualizer": "5.8.1",
     "semver": "7.3.5",
     "size-limit": "7.0.3",
-    "storybook-addon-performance": "0.16.1",
     "storybook-addon-turbo-build": "1.1.0",
     "styled-components": "4.4.1",
     "ts-toolbelt": "9.6.0",

--- a/src/utils/story-helpers.tsx
+++ b/src/utils/story-helpers.tsx
@@ -53,7 +53,7 @@ const GlobalStyleMultiTheme = createGlobalStyle`
 
 export const withThemeProvider = (Story: React.FC<React.PropsWithChildren<StoryContext>>, context: StoryContext) => {
   // used for testing ThemeProvider.stories.tsx
-  if (context.parameters.disableThemeDecorator) return <Story {...context} />
+  if (context.parameters.disableThemeDecorator) return Story(context)
 
   const {colorScheme} = context.globals
 
@@ -78,9 +78,7 @@ export const withThemeProvider = (Story: React.FC<React.PropsWithChildren<StoryC
                   color: 'fg.default'
                 }}
               >
-                <div id={`html-addon-root-${scheme}`}>
-                  <Story {...context} />
-                </div>
+                <div id={`html-addon-root-${scheme}`}>{Story(context)}</div>
               </Box>
             </BaseStyles>
           </ThemeProvider>
@@ -93,9 +91,7 @@ export const withThemeProvider = (Story: React.FC<React.PropsWithChildren<StoryC
     <ThemeProvider colorMode="day" dayScheme={colorScheme}>
       <GlobalStyle />
       <BaseStyles>
-        <div id="html-addon-root">
-          <Story {...context} />
-        </div>
+        <div id="html-addon-root">{Story(context)}</div>
       </BaseStyles>
     </ThemeProvider>
   )


### PR DESCRIPTION
Update the storybook config to enable `React.StrictMode` in stories. This tool highlights potential problems in components, for more information check out this post: https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state

You can verify that `React.StrictMode` is enabled when using "unsafe" code, for example:

![Screenshot 2022-11-07 at 4 33 01 PM](https://user-images.githubusercontent.com/3901764/200431030-9bb1ee81-5b9d-4346-858f-9a21a18b07b2.png)

And you should see an error like this in the console:

![Screenshot 2022-11-07 at 4 42 22 PM](https://user-images.githubusercontent.com/3901764/200431085-2692c385-3253-4896-b6fa-327902e834fa.png)


#### Changelog

**New**

**Changed**

- Update storybook config to enable `strictMode`

**Removed**

- `storybook-addon-performance`, it does not seem to support React 18 and doesn't work when `strictMode` is enabled, unfortunately 😞 