### PR TITLE
Automatically add docs permalinks

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -26,3 +26,52 @@ jobs:
       install: npm ci && cd docs && npm ci && cd ..
       build: npm run build:docs:preview
       output_dir: docs/public
+  add-permalink-to-changelog:
+    needs: deploy-preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update CHANGELOG.md
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const fs = require('fs')
+            const fileName = 'CHANGELOG.md'
+            const contentToInsert = '### [Permalink to documentation](${{ needs['deploy-preview'].outputs.deployment_url }})'
+            const originalContents = fs.readFileSync(fileName, 'utf8')
+
+            let modifiedContents = originalContents.split('\n\n')
+
+            // the format of this file is standard
+            // so it's safe to add a line between version number and changes
+            //
+            //   [
+            // 0  '# @primer/components',
+            // 1  '## 35.14.0',
+            // 2+ '### [Permalink to documentation](https://primer-cc8b6b2260-13348165.drafts.github.io)',
+            // 3  '### Minor Changes',
+            //   ]
+
+            const index = 2
+            if (modifiedContents[index].includes('Permalink to documentation')) {
+              modifiedContents[index] = contentToInsert
+            } else {
+              modifiedContents.splice(index, 0, contentToInsert)
+            }
+
+            modifiedContents = modifiedContents.join('\n\n')
+            fs.writeFileSync(fileName, modifiedContents)
+
+      - id: get-current-sha
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const shortSha = '${{github.sha}}'.slice(0,7)
+            core.setOutput('sha', shortSha)
+      - uses: EndBug/add-and-commit@v4
+        with:
+          add: 'CHANGELOG.md'
+          message: 'Update permalink to documentation in CHANGELOG.md (for ${{steps.get-current-sha.outputs.sha}})'
+          author_email: actions@github.com
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -29,6 +29,7 @@ jobs:
   add-permalink-to-changelog:
     needs: deploy-preview
     runs-on: ubuntu-latest
+    if: ${{GITHUB_HEAD_REF}} === 'changeset-release/main'
     steps:
       - uses: actions/checkout@v3
       - name: Update CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 35.14.1
 
+### [Permalink to documentation](https://primer-3c8c1d9c2e-13348165.drafts.github.io/)
+
 ### Patch Changes
 
 - [#2510](https://github.com/primer/react/pull/2510) [`c326777e`](https://github.com/primer/react/commit/c326777ec0369968e49d9d9ceb21f7f5609f697b) Thanks [@langermank](https://github.com/langermank)! - Remove deprecated focus style primitives


### PR DESCRIPTION
Add a job after deploy_preview which adds the preview_url to changelog.md in a new commit. [Example](https://github.com/primer/react/pull/2559/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5)

⚠️ Potential blocker: To avoid an infinite loop, the automated comment needs to skip CI, but then we don't get a green PR because the last commit didn't run checks :/

---

### Why this approach:
By adding the permalink to changelog.md, it will
1. be published in release notes
2. committed to the repo for docs to parse & read and show a version switcher

### This solution isn't ideal, but there's a reason for that:

#### Constraints:
- To show a version switcher in docs, we need the permalinks on `main` branch for `deploy/production` action
- The needed permalink is only created on `deploy/preview` on `changeset-release/main` branch, not on `main` (on main, we don't have a `preview_url`, just `primer.style/react`)
- Keep this information in the repo instead of using an external database

#### Failed attempts:
- using actions/artifacts
  - we can't store preview_url permalinks as artifacts because artifacts created from one branch are not accessible in a different branch
- using actions/cache
  - cache created from a branch like `changeset-release/main` cannot be accessed on `main`
  - cache values cannot be read from rest api either
- using release assets
  - release assets can be accessed by rest api, but a release is created on `main`, while preview_url is on branch `changeset-release/main`

#### Successful attempt: 🤞 

- update changelog.md
   - on `changeset-release/main`, add preview_url to changelog.md as "Permalink to docs", commit it!
   - release notes will automatically use changelog.md and have a permalink

#### Alternative approach, haven't tried yet:

- Commit on main after release branch is merged
  - use same guard as production/deploy (= no changes since release)
  - get last deployment for release tracking branch ([rest api](https://api.github.com/repos/primer/react/deployments?ref=changeset-release/main))
  - Get preview_url (environment_url) for deployment ([rest api](https://api.github.com/repos/primer/react/deployments/700579767/statuses))
  - Add permalink to `deployments.json`, `changelog.md` (commit from actions)
  - Update release notes with permalink (rest api)
- Update release notes after release branch is merged
  - basically like the above approach, but don't commit, keeping main branch clean
  - fetch release notes before deploy/production to populate version switching
  - changelog.md does not have permalinks
- Use a closed issue as database
  - Instead of commits, add comments to issue. it's still in the repo
  - Accessible across branches
  - Doesn't trigger or skip actions
  - Doesn't update changelog or release notes though, need another action for that

later:
- what will happen on forks?
- after testing this out with a release, going to add past deployments manually + extract to primer/.github 

#### Open questions:

- To avoid an infinite loop, the automated comment needs to skip CI, but then we don't get a green PR :/
- ~changesets uses changelog.md for release notes, right? (i'm 99% sure)~ Confirmed ✅ 
- Deployments take a while, if there is another commit before deployment finishes, the commit will fail, which is good i think? (maybe we should [cancel ongoing deployments](https://github.com/styfle/cancel-workflow-action)) anyways