### PR TITLE
ci: add vrt workflow for updating snapshots

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -1,7 +1,7 @@
 name: vrt
 on:
   workflow_run:
-    workflows: [ci]
+    workflows: [CI]
     types:
       - completed
 

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -1,0 +1,51 @@
+name: vrt
+on:
+  workflow_run:
+    workflows: [ci]
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  update-snapshots:
+    if: >
+      github.repository == 'primer/react' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      contains(github.event.pull_request.labels.*.name, 'visual changes approved')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install browsers
+        run: npx playwright install --with-deps
+      - name: Build storybook
+        run: npx build-storybook
+      - name: Run storybook
+        id: storybook
+        run: |
+          npx serve -l 6006 storybook-static &
+          pid=$!
+          echo "pid=$pid" >> $GITHUB_OUTPUT
+          sleep 5
+      - name: Run VRT
+        run: npx playwright test --grep @vrt
+      - name: Stop storybook
+        if: ${{ always() }}
+        run: kill ${{ steps.storybook.outputs.pid }}
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: 'test(vrt): update snapshots'

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -32,8 +32,27 @@ jobs:
         run: npm ci
       - name: Install browsers
         run: npx playwright install --with-deps
-      - name: Build storybook
-        run: npx build-storybook
+      - uses: actions/github-script@v3.1.0
+        name: Download built storybook from CI
+        with:
+          script: |
+            const fs = require('fs');
+            const artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+            const [matchArtifact] = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "storybook"
+            });
+            const download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            fs.writeFileSync('${{github.workspace}}/storybook.zip', Buffer.from(download.data));
+      - run: unzip storybook.zip -d storybook-static
       - name: Run storybook
         id: storybook
         run: |

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -18,7 +18,7 @@ jobs:
       github.repository == 'primer/react' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
-      contains(github.event.pull_request.labels.*.name, 'visual changes approved')
+      contains(github.event.pull_request.labels.*.name, 'update snapshots')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds in a workflow for updating snapshots when the label "visual changes approved" is present. This is useful when a contributor would like to update snapshots automatically for their changes or is unable to update them locally.

The current strategy for this workflow is to run after the `workflow_run` event. The sole job in this workflow, `update-snapshots`, only runs when the following conditions are met:

- The CI workflow has completed and was successful
- The event is from the `primer/react` repository
- The Pull Request has the label "visual changes approved"

The `workflow_run` event and the label check is inspired by: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ to try and make sure the action only runs in the appropriate context since it will can use secrets/permissions.

One thing to consider is that this workflow may not be able to trigger status checks to fire on the commit it creates. If so, we will need to figure out a way to use a PAT in order to get these status checks to fire.

**Testing & Reviewing**

Unfortunately, these types of actions are hard to test from the Pull Request stage so this will likely require merging and then we can test and correct from there.