### PR TITLE
chore: remove storybook-addon-html from storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -14,10 +14,7 @@ module.exports = {
       options: {
         optimizationLevel: 2
       }
-    },
-    ...(process.env.NODE_ENV === 'production' && process.env.GITHUB_JOB !== 'chromatic'
-      ? ['@whitespace/storybook-addon-html']
-      : [])
+    }
   ],
   core: {
     builder: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
         "@types/node": "16.11.11",
         "@typescript-eslint/eslint-plugin": "4.33.0",
         "@typescript-eslint/parser": "4.33.0",
-        "@whitespace/storybook-addon-html": "5.0.0",
         "@wojtekmaj/enzyme-adapter-react-17": "0.6.7",
         "babel-core": "7.0.0-bridge.0",
         "babel-loader": "^8.2.2",
@@ -15849,25 +15848,6 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@whitespace/storybook-addon-html": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@whitespace/storybook-addon-html/-/storybook-addon-html-5.0.0.tgz",
-      "integrity": "sha512-1OkgqEGNcXFzeOCGtJsEcPPswVy+mDRgDOFClXWX/f2SG/JBfkltXoFnCj2EfGwhIQaVGxjT7k1gqANKy5VeJQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/generator": "^7.13.9",
-        "@babel/parser": "^7.13.12",
-        "@storybook/api": "^6.1.21",
-        "@storybook/components": "^6.1.21",
-        "prettier": "^2.2.1",
-        "react-syntax-highlighter": "^15.4.3"
-      },
-      "peerDependencies": {
-        "@storybook/addons": "^6.1.21",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@wojtekmaj/enzyme-adapter-react-17": {
@@ -54541,20 +54521,6 @@
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "@whitespace/storybook-addon-html": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@whitespace/storybook-addon-html/-/storybook-addon-html-5.0.0.tgz",
-      "integrity": "sha512-1OkgqEGNcXFzeOCGtJsEcPPswVy+mDRgDOFClXWX/f2SG/JBfkltXoFnCj2EfGwhIQaVGxjT7k1gqANKy5VeJQ==",
-      "dev": true,
-      "requires": {
-        "@babel/generator": "^7.13.9",
-        "@babel/parser": "^7.13.12",
-        "@storybook/api": "^6.1.21",
-        "@storybook/components": "^6.1.21",
-        "prettier": "^2.2.1",
-        "react-syntax-highlighter": "^15.4.3"
       }
     },
     "@wojtekmaj/enzyme-adapter-react-17": {

--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "@types/node": "16.11.11",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
-    "@whitespace/storybook-addon-html": "5.0.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.7",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "^8.2.2",


### PR DESCRIPTION
Closes https://github.com/primer/react/issues/2582

#### Changelog

**New**

**Changed**

- Update storybook config to no longer refer to removed add-on

**Removed**

- Remove `@whitespace/storybook-addon-html` as it does not support React 18