### PR TITLE
Delete TreeView.LinkItem.

### DIFF
--- a/docs/content/TreeView.mdx
+++ b/docs/content/TreeView.mdx
@@ -19,7 +19,7 @@ description: A hierarchical list of items where nested items can be expanded and
         </TreeView.LeadingVisual>
         src
         <TreeView.SubTree>
-          <TreeView.LinkItem id="src/Avatar.tsx" href="#">
+          <TreeView.Item id="src/Avatar.tsx">
             <TreeView.LeadingVisual>
               <FileIcon />
             </TreeView.LeadingVisual>
@@ -27,8 +27,8 @@ description: A hierarchical list of items where nested items can be expanded and
             <TreeView.TrailingVisual>
               <StyledOcticon icon={DiffAddedIcon} color="success.fg" aria-label="added" />
             </TreeView.TrailingVisual>
-          </TreeView.LinkItem>
-          <TreeView.LinkItem id="src/Button.tsx" href="#" current>
+          </TreeView.Item>
+          <TreeView.Item id="src/Button.tsx" current>
             <TreeView.LeadingVisual>
               <FileIcon />
             </TreeView.LeadingVisual>
@@ -36,10 +36,10 @@ description: A hierarchical list of items where nested items can be expanded and
             <TreeView.TrailingVisual>
               <StyledOcticon icon={DiffModifiedIcon} color="attention.fg" aria-label="modified" />
             </TreeView.TrailingVisual>
-          </TreeView.LinkItem>
+          </TreeView.Item>
         </TreeView.SubTree>
       </TreeView.Item>
-      <TreeView.LinkItem id="package.json" href="#">
+      <TreeView.Item id="package.json">
         <TreeView.LeadingVisual>
           <FileIcon />
         </TreeView.LeadingVisual>
@@ -47,7 +47,7 @@ description: A hierarchical list of items where nested items can be expanded and
         <TreeView.TrailingVisual>
           <StyledOcticon icon={DiffModifiedIcon} color="attention.fg" aria-label="modified" />
         </TreeView.TrailingVisual>
-      </TreeView.LinkItem>
+      </TreeView.Item>
     </TreeView>
   </nav>
 </Box>
@@ -59,46 +59,46 @@ description: A hierarchical list of items where nested items can be expanded and
 <Box sx={{maxWidth: 400}}>
   <nav aria-label="Files">
     <TreeView aria-label="Files">
-      <TreeView.LinkItem id="src" href="#">
+      <TreeView.Item id="src">
         <TreeView.LeadingVisual>
           <TreeView.DirectoryIcon />
         </TreeView.LeadingVisual>
         src
         <TreeView.SubTree>
-          <TreeView.LinkItem id="src/Avatar.tsx" href="#">
+          <TreeView.Item id="src/Avatar.tsx"> 
             <TreeView.LeadingVisual>
               <FileIcon />
             </TreeView.LeadingVisual>
             Avatar.tsx
-          </TreeView.LinkItem>
-          <TreeView.LinkItem id="src/Button" href="#" current>
+          </TreeView.Item>
+          <TreeView.Item id="src/Button" current>
             <TreeView.LeadingVisual>
               <TreeView.DirectoryIcon />
             </TreeView.LeadingVisual>
             Button
             <TreeView.SubTree>
-              <TreeView.LinkItem id="src/Button/Button.tsx" href="#">
+              <TreeView.Item id="src/Button/Button.tsx">
                 <TreeView.LeadingVisual>
                   <FileIcon />
                 </TreeView.LeadingVisual>
                 Button.tsx
-              </TreeView.LinkItem>
-              <TreeView.LinkItem id="src/Button/Button.test.tsx" href="#">
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.test.tsx">
                 <TreeView.LeadingVisual>
                   <FileIcon />
                 </TreeView.LeadingVisual>
                 Button.test.tsx
-              </TreeView.LinkItem>
+              </TreeView.Item>
             </TreeView.SubTree>
-          </TreeView.LinkItem>
+          </TreeView.Item>
         </TreeView.SubTree>
-      </TreeView.LinkItem>
-      <TreeView.LinkItem id="package.json" href="#">
+      </TreeView.Item>
+      <TreeView.Item id="package.json">
         <TreeView.LeadingVisual>
           <FileIcon />
         </TreeView.LeadingVisual>
         package.json
-      </TreeView.LinkItem>
+      </TreeView.Item>
     </TreeView>
   </nav>
 </Box>
@@ -118,12 +118,12 @@ function ControlledTreeView() {
           <TreeView.Item id="src" expanded={expanded} onExpandedChange={setExpanded}>
             src
             <TreeView.SubTree>
-              <TreeView.LinkItem id="src/Avatar.tsx" href="#">
+              <TreeView.Item id="src/Avatar.tsx">
                 Avatar.tsx
-              </TreeView.LinkItem>
-              <TreeView.LinkItem id="src/Button.tsx" href="#" current>
+              </TreeView.Item>
+              <TreeView.Item id="src/Button.tsx" current>
                 Button.tsx
-              </TreeView.LinkItem>
+              </TreeView.Item>
             </TreeView.SubTree>
           </TreeView.Item>
         </TreeView>
@@ -149,12 +149,12 @@ To render stateful visuals, pass a render function to `TreeView.LeadingVisual` o
         </TreeView.LeadingVisual>
         src
         <TreeView.SubTree>
-          <TreeView.LinkItem id="src/Avatar.tsx" href="#">
+          <TreeView.Item id="src/Avatar.tsx">
             Avatar.tsx
-          </TreeView.LinkItem>
-          <TreeView.LinkItem id="src/Button.tsx" href="#" current>
+          </TreeView.Item>
+          <TreeView.Item id="src/Button.tsx" current>
             Button.tsx
-          </TreeView.LinkItem>
+          </TreeView.Item>
         </TreeView.SubTree>
       </TreeView.Item>
     </TreeView>
@@ -174,12 +174,12 @@ Since stateful directory icons are a common use case for TreeView, we provide a 
         </TreeView.LeadingVisual>
         src
         <TreeView.SubTree>
-          <TreeView.LinkItem id="src/Avatar.tsx" href="#">
+          <TreeView.Item id="src/Avatar.tsx">
             Avatar.tsx
-          </TreeView.LinkItem>
-          <TreeView.LinkItem id="src/Button.tsx" href="#" current>
+          </TreeView.Item>
+          <TreeView.Item id="src/Button.tsx" current>
             Button.tsx
-          </TreeView.LinkItem>
+          </TreeView.Item>
         </TreeView.SubTree>
       </TreeView.Item>
     </TreeView>
@@ -215,52 +215,6 @@ See [Storybook](https://primer.style/react/storybook?path=/story/components-tree
     name="defaultExpanded"
     type="boolean"
     description="The expanded state of the item when it is initially rendered. Use when you do not need to control the state."
-  />
-  <PropsTableRow
-    name="expanded"
-    type="boolean"
-    description="The controlled expanded state of item. Must be used in conjunction with onExpandedChange."
-  />
-  <PropsTableRow
-    name="onExpandedChange"
-    type="(expanded: boolean) => void"
-    description="Event handler called when the expanded state of the item changes."
-  />
-  <PropsTableRow
-    name="onSelect"
-    type="(event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void"
-  />
-  <PropsTableRefRow refType="HTMLElement" />
-  {/* <PropsTableSxRow /> */}
-</PropsTable>
-
-### TreeView.LinkItem
-
-<PropsTable>
-  <PropsTableRow name="id" type="string" required description="Unique identifier for the item." />
-  <PropsTableRow name="children" type="React.ReactNode" required />
-  <PropsTableRow
-    name="href"
-    type="string"
-    description={
-      <>
-        The URL that the item navigates to. <InlineCode>href</InlineCode> is passed to the underlying{' '}
-        <InlineCode>&lt;a&gt;</InlineCode> element. If <InlineCode>as</InlineCode> is specified, the component may need
-        different props. If the item contains a sub-nav, the item is rendered as a{' '}
-        <InlineCode>&lt;button&gt;</InlineCode> and <InlineCode>href</InlineCode> is ignored.
-      </>
-    }
-  />
-  <PropsTableRow
-    name="current"
-    type="boolean"
-    defaultValue="false"
-    description="Whether the item is the current item. No more than one item should be current at once. The path to the current item will be expanded by default."
-  />
-  <PropsTableRow
-    name="defaultExpanded"
-    type="boolean"
-    description="The expanded state of the item when it is initially rendered. Use when you do not need to control its state."
   />
   <PropsTableRow
     name="expanded"
@@ -322,7 +276,7 @@ See [Storybook](https://primer.style/react/storybook?path=/story/components-tree
   <PropsTableRow name="children" type="React.ReactNode" />
   <PropsTableRow
     name="state"
-    type={`| 'initial' 
+    type={`| 'initial'
 | 'loading'
 | 'done'
 | 'error'`}

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -470,29 +470,6 @@ const LevelIndicatorLines: React.FC<{level: number}> = ({level}) => {
 Item.displayName = 'TreeView.Item'
 
 // ----------------------------------------------------------------------------
-// TreeView.LinkItem
-
-export type TreeViewLinkItemProps = TreeViewItemProps & {
-  href?: string
-}
-
-// TODO: Use an <a> element to enable native browser behavior like opening links in a new tab
-const LinkItem = React.forwardRef<HTMLElement, TreeViewLinkItemProps>(({href, onSelect, ...props}, ref) => {
-  return (
-    <Item
-      ref={ref}
-      onSelect={event => {
-        window.open(href, '_self')
-        onSelect?.(event)
-      }}
-      {...props}
-    />
-  )
-})
-
-LinkItem.displayName = 'TreeView.LinkItem'
-
-// ----------------------------------------------------------------------------
 // TreeView.SubTree
 
 export type SubTreeState = 'initial' | 'loading' | 'done' | 'error'
@@ -830,7 +807,6 @@ ErrorDialog.displayName = 'TreeView.ErrorDialog'
 
 export const TreeView = Object.assign(Root, {
   Item,
-  LinkItem,
   SubTree,
   LeadingVisual,
   TrailingVisual,


### PR DESCRIPTION
Removing the `TreeView.LinkItem`. It's a small extension of the `TreeView.Item` component, and would be unused if one is using a front-end router like `react-router`.

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
