### PR TITLE
UnderlineNav2: Accessibility remediations (Take `&nbsp;` out of JS template literals)

### DIFF
--- a/.changeset/rotten-games-draw.md
+++ b/.changeset/rotten-games-draw.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+UnderlineNav2: Render non-breaking space properly for screen readers

--- a/src/UnderlineNav2/UnderlineNav.test.tsx
+++ b/src/UnderlineNav2/UnderlineNav.test.tsx
@@ -136,7 +136,7 @@ describe('UnderlineNav', () => {
   })
   it('respects counter prop', () => {
     const {getByRole} = render(<ResponsiveUnderlineNav />)
-    const item = getByRole('link', {name: 'Issues &nbsp;(120)'})
+    const item = getByRole('link', {name: 'Issues (120)'})
     const counter = item.getElementsByTagName('span')[3]
     expect(counter.className).toContain('CounterLabel')
     expect(counter.textContent).toBe('120')
@@ -162,7 +162,7 @@ describe('Keyboard Navigation', () => {
   it('should move focus to the next/previous item on the list with the tab key', async () => {
     const {getByRole} = render(<ResponsiveUnderlineNav />)
     const item = getByRole('link', {name: 'Code'})
-    const nextItem = getByRole('link', {name: 'Issues &nbsp;(120)'})
+    const nextItem = getByRole('link', {name: 'Issues (120)'})
     const user = userEvent.setup()
     await user.tab() // tab into the story, this should focus on the first link
     expect(item).toEqual(document.activeElement) // check if the first item is focused

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -319,7 +319,7 @@ export const UnderlineNav = forwardRef(
                   trailingIcon={TriangleDownIcon}
                 >
                   <Box as="span">
-                    More <VisuallyHidden as="span">{`${ariaLabel} items`}</VisuallyHidden>
+                    More<VisuallyHidden as="span">&nbsp;{`${ariaLabel} items`}</VisuallyHidden>
                   </Box>
                 </Button>
                 <ActionList
@@ -353,7 +353,7 @@ export const UnderlineNav = forwardRef(
                               actionElementProps.counter !== undefined && (
                                 <Box as="span" data-component="counter">
                                   <CounterLabel aria-hidden="true">{actionElementProps.counter}</CounterLabel>
-                                  <VisuallyHidden>{`&nbsp;(${actionElementProps.counter})`}</VisuallyHidden>
+                                  <VisuallyHidden>&nbsp;{`(${actionElementProps.counter})`}</VisuallyHidden>
                                 </Box>
                               )
                             )}

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -179,7 +179,7 @@ export const UnderlineNavItem = forwardRef(
               counter !== undefined && (
                 <Box as="span" data-component="counter" sx={counterStyles}>
                   <CounterLabel aria-hidden="true">{counter}</CounterLabel>
-                  <VisuallyHidden>{`&nbsp;(${counter})`}</VisuallyHidden>
+                  <VisuallyHidden>&nbsp;{`(${counter})`}</VisuallyHidden>
                 </Box>
               )
             )}

--- a/src/UnderlineNav2/__snapshots__/UnderlineNav.test.tsx.snap
+++ b/src/UnderlineNav2/__snapshots__/UnderlineNav.test.tsx.snap
@@ -317,7 +317,8 @@ exports[`UnderlineNav renders consistently 1`] = `
               <span
                 className="c0"
               >
-                &nbsp;(120)
+                 
+                (120)
               </span>
             </span>
           </div>
@@ -384,7 +385,8 @@ exports[`UnderlineNav renders consistently 1`] = `
               <span
                 className="c0"
               >
-                &nbsp;(13)
+                 
+                (13)
               </span>
             </span>
           </div>
@@ -451,7 +453,8 @@ exports[`UnderlineNav renders consistently 1`] = `
               <span
                 className="c0"
               >
-                &nbsp;(5)
+                 
+                (5)
               </span>
             </span>
           </div>
@@ -490,7 +493,8 @@ exports[`UnderlineNav renders consistently 1`] = `
               <span
                 className="c0"
               >
-                &nbsp;(4)
+                 
+                (4)
               </span>
             </span>
           </div>
@@ -557,7 +561,8 @@ exports[`UnderlineNav renders consistently 1`] = `
               <span
                 className="c0"
               >
-                &nbsp;(9)
+                 
+                (9)
               </span>
             </span>
           </div>
@@ -647,7 +652,8 @@ exports[`UnderlineNav renders consistently 1`] = `
               <span
                 className="c0"
               >
-                &nbsp;(10)
+                 
+                (10)
               </span>
             </span>
           </div>

--- a/src/UnderlineNav2/interactions.stories.tsx
+++ b/src/UnderlineNav2/interactions.stories.tsx
@@ -47,11 +47,11 @@ KeyboardNavigation.play = async ({canvasElement}: {canvasElement: HTMLElement}) 
   await delay(500)
   await userEvent.tab()
   await delay(500)
-  let menuItem = canvas.getByRole('link', {name: 'Settings &nbsp;(10)'})
+  let menuItem = canvas.getByRole('link', {name: 'Settings (10)'})
   userEvent.click(menuItem)
 
   expect(activeElement).toHaveFocus()
-  menuItem = canvas.getByRole('link', {name: 'Settings &nbsp;(10)'})
+  menuItem = canvas.getByRole('link', {name: 'Settings (10)'})
 
   expect(menuItem).toHaveAttribute('aria-current', 'page')
   const lastListItem = canvas.getByRole('list').children[5]
@@ -85,11 +85,11 @@ SelectAMenuItem.play = async ({canvasElement}: {canvasElement: HTMLElement}) => 
   userEvent.click(moreBtn)
 
   await delay(1000)
-  let menuItem = canvas.getByRole('link', {name: 'Settings &nbsp;(10)'})
+  let menuItem = canvas.getByRole('link', {name: 'Settings (10)'})
   userEvent.click(menuItem)
 
   expect(moreBtn).toHaveFocus()
-  menuItem = canvas.getByRole('link', {name: 'Settings &nbsp;(10)'})
+  menuItem = canvas.getByRole('link', {name: 'Settings (10)'})
 
   expect(menuItem).toHaveAttribute('aria-current', 'page')
   const lastListItem = canvas.getByRole('list').children[5]
@@ -107,7 +107,7 @@ KeepSelectedItemVisible.play = async ({canvasElement}: {canvasElement: HTMLEleme
   const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
   const canvas = within(canvasElement)
   // await delay(2000)
-  const selectedItem = canvas.getByRole('link', {name: 'Settings &nbsp;(10)'})
+  const selectedItem = canvas.getByRole('link', {name: 'Settings (10)'})
   expect(selectedItem).toHaveAttribute('aria-current', 'page')
   // change viewport
   canvasElement.style.width = '900px'


### PR DESCRIPTION
This PR addresses an issue came from accessibility sign-off review. 

## The Problem
```
<VisuallyHidden>{`&nbsp;(${counter})`}</VisuallyHidden>
```
It turns out, when non-breaking spaces are rendered within JS template literals, they are not treated as escaped characters in HTML.

## The Solution
 I took the non-breaking spaces out of the template literals and it seems that resolved the issue.

```
<VisuallyHidden>&nbsp;{`(${counter})`}</VisuallyHidden>
```

And MacOS VoiceOver announces the spacing properly.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
