### PR TITLE
CounterLabel: Accessibility improvements for better screen reader announcing

### DIFF
--- a/.changeset/two-timers-shout.md
+++ b/.changeset/two-timers-shout.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Accessibility improvements on CounterLabel for better screen reader announcing

--- a/src/CounterLabel.tsx
+++ b/src/CounterLabel.tsx
@@ -1,50 +1,48 @@
-import styled from 'styled-components'
-import {get} from './constants'
-import sx, {SxProp} from './sx'
-import {ComponentProps} from './utils/types'
+import React from 'react'
+import Box from './Box'
+import {BetterSystemStyleObject, SxProp, merge} from './sx'
+import VisuallyHidden from './_VisuallyHidden'
 
-type StyledCounterLabelProps = {
+export type CounterLabelProps = {
   scheme?: 'primary' | 'secondary'
 } & SxProp
 
-const colorStyles = ({scheme, ...props}: StyledCounterLabelProps) => {
-  return {
-    color:
-      scheme === 'secondary'
-        ? get('colors.fg.default')(props)
-        : scheme === 'primary'
-        ? get('colors.fg.onEmphasis')(props)
-        : get('colors.fg.default')(props)
-  }
+const CounterLabel: React.FC<React.PropsWithChildren<CounterLabelProps>> = ({
+  scheme = 'secondary',
+  sx = {},
+  children,
+  ...props
+}) => {
+  return (
+    <>
+      <Box
+        as="span"
+        aria-hidden="true"
+        sx={merge<BetterSystemStyleObject>(
+          {
+            display: 'inline-block',
+            padding: '2px 5px',
+            fontSize: 0,
+            fontWeight: 'bold',
+            lineHeight: 'condensedUltra',
+            borderRadius: '20px',
+            backgroundColor: scheme === 'primary' ? 'neutral.emphasis' : 'neutral.muted',
+            color: scheme === 'primary' ? 'fg.onEmphasis' : 'fg.default',
+            '&:empty': {
+              display: 'none'
+            }
+          },
+          sx
+        )}
+        {...props}
+      >
+        {children}
+      </Box>
+      <VisuallyHidden>&nbsp;{`(${children})`}</VisuallyHidden>
+    </>
+  )
 }
 
-const bgStyles = ({scheme, ...props}: StyledCounterLabelProps) => {
-  return {
-    backgroundColor:
-      scheme === 'secondary'
-        ? get('colors.neutral.muted')(props)
-        : scheme === 'primary'
-        ? get('colors.neutral.emphasis')(props)
-        : get('colors.neutral.muted')(props)
-  }
-}
+CounterLabel.displayName = 'CounterLabel'
 
-const CounterLabel = styled.span<StyledCounterLabelProps>`
-  display: inline-block;
-  padding: 2px 5px;
-  font-size: ${get('fontSizes.0')};
-  font-weight: ${get('fontWeights.bold')};
-  line-height: ${get('lineHeights.condensedUltra')};
-  border-radius: 20px;
-  ${colorStyles};
-  ${bgStyles};
-
-  &:empty {
-    display: none;
-  }
-
-  ${sx};
-`
-
-export type CounterLabelProps = ComponentProps<typeof CounterLabel>
 export default CounterLabel

--- a/src/UnderlineNav2/UnderlineNav.test.tsx
+++ b/src/UnderlineNav2/UnderlineNav.test.tsx
@@ -138,8 +138,15 @@ describe('UnderlineNav', () => {
     const {getByRole} = render(<ResponsiveUnderlineNav />)
     const item = getByRole('link', {name: 'Issues (120)'})
     const counter = item.getElementsByTagName('span')[3]
-    expect(counter.className).toContain('CounterLabel')
     expect(counter.textContent).toBe('120')
+    expect(counter).toHaveAttribute('aria-hidden', 'true')
+  })
+  it('renders the content of visually hidden span properly for screen readers', () => {
+    const {getByRole} = render(<ResponsiveUnderlineNav />)
+    const item = getByRole('link', {name: 'Issues (120)'})
+    const counter = item.getElementsByTagName('span')[4]
+    // non breaking space unified code
+    expect(counter.textContent).toBe('\u00A0(120)')
   })
   it('respects loadingCounters prop', () => {
     const {getByRole} = render(<ResponsiveUnderlineNav loadingCounters={true} />)

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -352,8 +352,7 @@ export const UnderlineNav = forwardRef(
                             ) : (
                               actionElementProps.counter !== undefined && (
                                 <Box as="span" data-component="counter">
-                                  <CounterLabel aria-hidden="true">{actionElementProps.counter}</CounterLabel>
-                                  <VisuallyHidden>&nbsp;{`(${actionElementProps.counter})`}</VisuallyHidden>
+                                  <CounterLabel>{actionElementProps.counter}</CounterLabel>
                                 </Box>
                               )
                             )}

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -7,7 +7,6 @@ import {UnderlineNavContext} from './UnderlineNavContext'
 import CounterLabel from '../CounterLabel'
 import {getLinkStyles, wrapperStyles, iconWrapStyles, counterStyles} from './styles'
 import {LoadingCounter} from './LoadingCounter'
-import VisuallyHidden from '../_VisuallyHidden'
 
 // adopted from React.AnchorHTMLAttributes
 type LinkProps = {
@@ -178,8 +177,7 @@ export const UnderlineNavItem = forwardRef(
             ) : (
               counter !== undefined && (
                 <Box as="span" data-component="counter" sx={counterStyles}>
-                  <CounterLabel aria-hidden="true">{counter}</CounterLabel>
-                  <VisuallyHidden>&nbsp;{`(${counter})`}</VisuallyHidden>
+                  <CounterLabel>{counter}</CounterLabel>
                 </Box>
               )
             )}

--- a/src/UnderlineNav2/__snapshots__/UnderlineNav.test.tsx.snap
+++ b/src/UnderlineNav2/__snapshots__/UnderlineNav.test.tsx.snap
@@ -132,8 +132,8 @@ exports[`UnderlineNav renders consistently 1`] = `
   font-weight: 600;
   line-height: 1;
   border-radius: 20px;
-  color: #24292f;
   background-color: rgba(175,184,193,0.2);
+  color: #24292f;
 }
 
 .c8:empty {

--- a/src/__tests__/CounterLabel.test.tsx
+++ b/src/__tests__/CounterLabel.test.tsx
@@ -1,21 +1,31 @@
 import React from 'react'
 import {CounterLabel} from '..'
-import {render, behavesAsComponent, checkExports} from '../utils/testing'
-import theme from '../theme'
+import {behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 
 expect.extend(toHaveNoViolations)
 
 describe('CounterLabel', () => {
-  behavesAsComponent({Component: CounterLabel})
+  behavesAsComponent({Component: CounterLabel, options: {skipAs: true, skipSx: true}})
 
   checkExports('CounterLabel', {
     default: CounterLabel
   })
 
   it('renders a <span>', () => {
-    expect(render(<CounterLabel />).type).toEqual('span')
+    const {container} = HTMLRender(<CounterLabel>1234</CounterLabel>)
+    expect(container.firstChild?.nodeName).toEqual('SPAN')
+  })
+
+  it('renders the counter correctly', () => {
+    const {container} = HTMLRender(<CounterLabel>12K</CounterLabel>)
+    expect(container.firstChild).toHaveTextContent('12K')
+  })
+
+  it('renders the visually visible span with "aria-hidden=true"', () => {
+    const {container} = HTMLRender(<CounterLabel>1234</CounterLabel>)
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true')
   })
 
   it('should have no axe violations', async () => {
@@ -25,24 +35,19 @@ describe('CounterLabel', () => {
   })
 
   it('respects the primary "scheme" prop', () => {
-    expect(render(<CounterLabel scheme="primary" />)).toHaveStyleRule(
-      'color',
-      theme.colorSchemes.light.colors.fg?.onEmphasis.trim()
-    )
-    expect(render(<CounterLabel scheme="primary" />)).toHaveStyleRule(
-      'background-color',
-      theme.colorSchemes.light.colors.neutral?.emphasis.trim()
-    )
+    const {container} = HTMLRender(<CounterLabel scheme="primary">1234</CounterLabel>)
+    expect(container).toMatchSnapshot()
   })
 
-  it('respects the secondary "scheme" prop', () => {
-    expect(render(<CounterLabel scheme="secondary" />)).toHaveStyleRule(
-      'color',
-      theme.colorSchemes.light.colors.fg?.default.trim()
-    )
-    expect(render(<CounterLabel scheme="secondary" />)).toHaveStyleRule(
-      'background-color',
-      theme.colorSchemes.light.colors.neutral?.muted
-    )
+  it('renders with secondary scheme when no "scheme" prop is provided', () => {
+    const {container} = HTMLRender(<CounterLabel>1234</CounterLabel>)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('should render visually hidden span correctly for screen readers', () => {
+    const {container} = HTMLRender(<CounterLabel>1234</CounterLabel>)
+    // Second span renders as visually hidden for screen readers and the content is &nbsp;(counter).
+    // Non-breaking space is used because browsers tend to strip a standard space.
+    expect(container.children[1].textContent).toEqual('\u00a0(1234)')
   })
 })

--- a/src/__tests__/__snapshots__/CounterLabel.test.tsx.snap
+++ b/src/__tests__/__snapshots__/CounterLabel.test.tsx.snap
@@ -1,15 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CounterLabel renders consistently 1`] = `
-.c0 {
+[
+  .c0 {
   display: inline-block;
   padding: 2px 5px;
   font-size: 12px;
   font-weight: 600;
   line-height: 1;
   border-radius: 20px;
-  color: #24292f;
   background-color: rgba(175,184,193,0.2);
+  color: #24292f;
 }
 
 .c0:empty {
@@ -17,6 +18,117 @@ exports[`CounterLabel renders consistently 1`] = `
 }
 
 <span
-  className="c0"
-/>
+    aria-hidden="true"
+    className="c0"
+  />,
+  .c0 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+<span
+    className="c0"
+  >
+     
+    (undefined)
+  </span>,
+]
+`;
+
+exports[`CounterLabel renders with secondary scheme when no "scheme" prop is provided 1`] = `
+.c0 {
+  display: inline-block;
+  padding: 2px 5px;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: condensedUltra;
+  border-radius: 20px;
+  background-color: neutral.muted;
+  color: fg.default;
+}
+
+.c0:empty {
+  display: none;
+}
+
+.c1 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+<div>
+  <span
+    aria-hidden="true"
+    class="c0"
+  >
+    1234
+  </span>
+  <span
+    class="c1"
+  >
+     
+    (1234)
+  </span>
+</div>
+`;
+
+exports[`CounterLabel respects the primary "scheme" prop 1`] = `
+.c0 {
+  display: inline-block;
+  padding: 2px 5px;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: condensedUltra;
+  border-radius: 20px;
+  background-color: neutral.emphasis;
+  color: fg.onEmphasis;
+}
+
+.c0:empty {
+  display: none;
+}
+
+.c1 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+<div>
+  <span
+    aria-hidden="true"
+    class="c0"
+  >
+    1234
+  </span>
+  <span
+    class="c1"
+  >
+     
+    (1234)
+  </span>
+</div>
 `;

--- a/src/__tests__/__snapshots__/ToggleSwitch.test.tsx.snap
+++ b/src/__tests__/__snapshots__/ToggleSwitch.test.tsx.snap
@@ -85,14 +85,6 @@ exports[`renders consistently 1`] = `
   flex-direction: row;
 }
 
-.c1 {
-  font-size: 14px;
-  color: #24292f;
-  margin-left: 8px;
-  margin-right: 8px;
-  position: relative;
-}
-
 .c5 {
   position: absolute;
   width: 1px;
@@ -104,6 +96,14 @@ exports[`renders consistently 1`] = `
   clip: rect(0,0,0,0);
   white-space: nowrap;
   border-width: 0;
+}
+
+.c1 {
+  font-size: 14px;
+  color: #24292f;
+  margin-left: 8px;
+  margin-right: 8px;
+  position: relative;
 }
 
 .c4 {

--- a/src/__tests__/deprecated/__snapshots__/ChoiceFieldset.test.tsx.snap
+++ b/src/__tests__/deprecated/__snapshots__/ChoiceFieldset.test.tsx.snap
@@ -217,11 +217,6 @@ exports[`ChoiceFieldset renders a fieldset with a description 1`] = `
   flex-direction: column;
 }
 
-.c3 {
-  font-size: 14px;
-  color: #24292f;
-}
-
 .c2 {
   font-size: 16px;
   padding: 0;
@@ -236,6 +231,11 @@ exports[`ChoiceFieldset renders a fieldset with a description 1`] = `
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
+}
+
+.c3 {
+  font-size: 14px;
+  color: #24292f;
 }
 
 .c7 {
@@ -423,12 +423,6 @@ exports[`ChoiceFieldset renders a list of items with leading visuals and caption
   fill: currentColor;
 }
 
-.c10 {
-  font-size: 12px;
-  color: #57606a;
-  display: block;
-}
-
 .c2 {
   font-size: 16px;
   padding: 0;
@@ -443,6 +437,12 @@ exports[`ChoiceFieldset renders a list of items with leading visuals and caption
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
+}
+
+.c10 {
+  font-size: 12px;
+  color: #57606a;
+  display: block;
 }
 
 .c6 {
@@ -1648,6 +1648,22 @@ exports[`ChoiceFieldset renders with a success validation message 1`] = `
   display: flex;
 }
 
+.c2 {
+  font-size: 16px;
+  padding: 0;
+}
+
+.c8 {
+  font-weight: bold;
+  font-size: 14px;
+  display: block;
+  color: fg.default;
+  cursor: pointer;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+}
+
 .c11 {
   -webkit-animation: 170ms eGcHP cubic-bezier(0.44,0.74,0.36,1);
   animation: 170ms eGcHP cubic-bezier(0.44,0.74,0.36,1);
@@ -1671,22 +1687,6 @@ exports[`ChoiceFieldset renders with a success validation message 1`] = `
   color: currentColor;
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.c2 {
-  font-size: 16px;
-  padding: 0;
-}
-
-.c8 {
-  font-weight: bold;
-  font-size: 14px;
-  display: block;
-  color: fg.default;
-  cursor: pointer;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: start;
-  align-self: flex-start;
 }
 
 .c6 {
@@ -1911,6 +1911,22 @@ exports[`ChoiceFieldset renders with an error validation message 1`] = `
   display: flex;
 }
 
+.c2 {
+  font-size: 16px;
+  padding: 0;
+}
+
+.c8 {
+  font-weight: bold;
+  font-size: 14px;
+  display: block;
+  color: fg.default;
+  cursor: pointer;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+}
+
 .c11 {
   -webkit-animation: 170ms eGcHP cubic-bezier(0.44,0.74,0.36,1);
   animation: 170ms eGcHP cubic-bezier(0.44,0.74,0.36,1);
@@ -1934,22 +1950,6 @@ exports[`ChoiceFieldset renders with an error validation message 1`] = `
   color: currentColor;
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.c2 {
-  font-size: 16px;
-  padding: 0;
-}
-
-.c8 {
-  font-weight: bold;
-  font-size: 14px;
-  display: block;
-  color: fg.default;
-  cursor: pointer;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: start;
-  align-self: flex-start;
 }
 
 .c6 {


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/1507

This PR brings improvement on the CounterLabel to make the counter data have an accessible name.
- Refactored CounterLabel to abandon `styled-components`
- Re-wrote unit tests with the user behavioural paradigm approach rather than checking `styled-components` specific implementation details
- Add `aria-hidden=true` to the existing span (visual representation of the counter)
- Add visually hidden span with extra spacing and parenthesis for screen readers to announce the counter more accessible. 

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
