### PR TITLE
Upgrade deploy preview to 16

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -26,7 +26,7 @@ jobs:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:
       node_version: 16
-      install: npm ci && cd docs && npm ci && cd ..
+      install: npm ci && cd docs && npm ci --legacy-peer-deps && cd ..
       build: npm run build:docs:preview
       output_dir: docs/public
 

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -25,7 +25,7 @@ jobs:
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:
-      node_version: 14
+      node_version: 16
       install: npm ci && cd docs && npm ci && cd ..
       build: npm run build:docs:preview
       output_dir: docs/public

--- a/.github/workflows/deploy_preview_forks.yml
+++ b/.github/workflows/deploy_preview_forks.yml
@@ -18,7 +18,7 @@ jobs:
       pages: write
       id-token: write
     with:
-      node_version: 14
+      node_version: 16
       install: npm ci && cd docs && npm ci && cd ..
       build: npm run build:docs:preview
       output_dir: docs/public

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -40,7 +40,7 @@ jobs:
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:
-      node_version: 14
+      node_version: 16
       install: npm ci && cd docs && npm ci && cd ..
       build: npm run build:docs
       output_dir: docs/public

--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Install node deps
         run: npm ci
       - name: Install ruby deps


### PR DESCRIPTION
https://github.com/primer/react/pull/1681 upgraded us to NodeJS 16 across the board, but it missed some of the GitHub actions. 

This PR upgrades all of our GitHub actions to use `node_version: 16`.
