### PR TITLE
UnderlineNav2: expose aria-current in the API and enable to use it for select status

### DIFF
--- a/.changeset/light-lemons-shave.md
+++ b/.changeset/light-lemons-shave.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+UnderlineNav2: expose aria-current in the API to enable it to be used as the selected status of UnderlineNav.Item

--- a/docs/content/drafts/UnderlineNav2.mdx
+++ b/docs/content/drafts/UnderlineNav2.mdx
@@ -4,7 +4,7 @@ componentId: underline_nav_2
 status: Draft
 description: Use an underlined nav to allow tab like navigation with overflow behaviour in your UI.
 source: https://github.com/primer/react/tree/main/src/UnderlineNav2
-storybook: '/react/storybook/?path=/story/components-underlinenav'
+storybook: '/react/storybook/?path=/story/drafts-components-underlinenav--playground'
 ---
 
 ```js
@@ -127,7 +127,11 @@ const Navigation = () => {
 ### UnderlineNav
 
 <PropsTable>
-  <PropsTableRow name="children" required type="UnderlineNav.Item[]" />
+  <PropsTableRow
+    name="afterSelect"
+    type="(event) => void"
+    description="The handler that gets called when a nav link child is selected"
+  />
   <PropsTableRow
     name="aria-label"
     type="string"
@@ -136,16 +140,12 @@ const Navigation = () => {
         'Scroll ${aria-label} left/right')
      "
   />
+  <PropsTableRow name="children" required type="UnderlineNav.Item[]" />
   <PropsTableRow
     name="loadingCounters"
     type="boolean"
     defaultValue="false"
     description="Whether the navigation items are in loading state. Component waits for all the counters to finish loading to prevent multiple layout shifts."
-  />
-  <PropsTableRow
-    name="afterSelect"
-    type="(event) => void"
-    description="The handler that gets called when a nav link child is selected"
   />
   <PropsTableSxRow />
 </PropsTable>
@@ -154,23 +154,24 @@ const Navigation = () => {
 
 <PropsTable>
   <PropsTableRow
-    name="href"
-    type="string"
-    description="The URL that the item navigates to. 'href' is passed to the underlying '<a>' element. If 'as' is specified, the component may need different props and 'href' is ignored. (Required prop for the react router is 'to' for example)"
-  />
-  <PropsTableRow name="icon" type="Component" description="The leading icon comes before item label" />
-  <PropsTableRow name="selected" type="boolean" description="Whether the link is selected" />
-  <PropsTableRow
-    name="onSelect"
-    type="(event) => void"
-    description="The handler that gets called when a nav link is selected. For example, a manual route binding can be done here(I.e. 'navigate(href)' for the react router.)"
-  />
-  <PropsTableRow
     name="as"
     type="string | React.ElementType"
     defaultValue="a"
     description="The underlying element to render — either a HTML element name or a React component."
   />
+  <PropsTableRow name="counter" type="number" description="The number to display in the counter label." />
+  <PropsTableRow
+    name="href"
+    type="string"
+    description="The URL that the item navigates to. 'href' is passed to the underlying '<a>' element. If 'as' is specified, the component may need different props and 'href' is ignored. (Required prop for the react router is 'to' for example)"
+  />
+  <PropsTableRow name="icon" type="Component" description="The leading icon comes before item label" />
+  <PropsTableRow
+    name="onSelect"
+    type="(event) => void"
+    description="The handler that gets called when a nav link is selected. For example, a manual route binding can be done here(I.e. 'navigate(href)' for the react router.)"
+  />
+  <PropsTableRow name="selected" type="boolean" description="Whether the link is selected" />
   <PropsTableSxRow />
 </PropsTable>
 
@@ -184,9 +185,9 @@ const Navigation = () => {
     adaptsToScreenSizes: true,
     fullTestCoverage: false,
     usedInProduction: false,
-    usageExamplesDocumented: false,
-    hasStorybookStories: false,
-    designReviewed: false,
+    usageExamplesDocumented: true,
+    hasStorybookStories: true,
+    designReviewed: true,
     a11yReviewed: false,
     stableApi: false,
     addressedApiFeedback: false,

--- a/docs/content/drafts/UnderlineNav2.mdx
+++ b/docs/content/drafts/UnderlineNav2.mdx
@@ -17,7 +17,7 @@ import {UnderlineNav} from '@primer/react/drafts'
 
 ```jsx live drafts
 <UnderlineNav aria-label="Repository">
-  <UnderlineNav.Item selected>Code</UnderlineNav.Item>
+  <UnderlineNav.Item aria-current="page">Code</UnderlineNav.Item>
   <UnderlineNav.Item>Issues</UnderlineNav.Item>
   <UnderlineNav.Item>Pull Requests</UnderlineNav.Item>
 </UnderlineNav>
@@ -27,7 +27,7 @@ import {UnderlineNav} from '@primer/react/drafts'
 
 ```jsx live drafts
 <UnderlineNav aria-label="Repository">
-  <UnderlineNav.Item selected icon={CodeIcon}>
+  <UnderlineNav.Item aria-current="page" icon={CodeIcon}>
     Code
   </UnderlineNav.Item>
   <UnderlineNav.Item icon={IssueOpenedIcon} counter={30}>
@@ -71,7 +71,7 @@ const Navigation = () => {
           <UnderlineNav.Item
             key={item.navigation}
             icon={item.icon}
-            selected={index === selectedIndex}
+            aria-current={index === selectedIndex ? 'page' : undefined}
             onSelect={e => {
               setSelectedIndex(index)
               e.preventDefault()
@@ -92,7 +92,7 @@ render(<Navigation />)
 
 ```jsx live drafts
 <UnderlineNav aria-label="Repository" loadingCounters={true}>
-  <UnderlineNav.Item counter={4} selected>
+  <UnderlineNav.Item counter={4} aria-current="page">
     Code
   </UnderlineNav.Item>
   <UnderlineNav.Item counter={44}>Issues</UnderlineNav.Item>
@@ -108,7 +108,7 @@ import {UnderlineNav} from '@primer/react/drafts'
 const Navigation = () => {
   return (
     <UnderlineNav aria-label="Repository">
-      <UnderlineNav.Item as={Link} to="code" counter={4} selected>
+      <UnderlineNav.Item as={Link} to="code" counter={4} aria-current="page">
         Code
       </UnderlineNav.Item>
       <UnderlineNav.Item counter={44} as={Link} to="issues">
@@ -154,11 +154,27 @@ const Navigation = () => {
 
 <PropsTable>
   <PropsTableRow
-    name="as"
-    type="string | React.ElementType"
-    defaultValue="a"
-    description="The underlying element to render — either a HTML element name or a React component."
+    name="aria-current"
+    type={`| 'page'
+| 'step'
+| 'location'
+| 'date'
+| 'time'
+| true
+| false`}
+    defaultValue="false"
+    description={
+      <>
+        Set <InlineCode>aria-current</InlineCode> to <InlineCode>"page"</InlineCode> to indicate that the item
+        represents the current page. Set <InlineCode>aria-current</InlineCode> to <InlineCode>"location"</InlineCode> to
+        indicate that the item represents the current location on a page. For more information about{' '}
+        <InlineCode>aria-current</InlineCode>, see{' '}
+        <Link href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current">MDN</Link>.
+      </>
+    }
   />
+
+  <PropsTableAsRow defaultElementType="a" />
   <PropsTableRow name="counter" type="number" description="The number to display in the counter label." />
   <PropsTableRow
     name="href"
@@ -171,8 +187,12 @@ const Navigation = () => {
     type="(event) => void"
     description="The handler that gets called when a nav link is selected. For example, a manual route binding can be done here(I.e. 'navigate(href)' for the react router.)"
   />
-  <PropsTableRow name="selected" type="boolean" description="Whether the link is selected" />
-  <PropsTableSxRow />
+  <PropsTableBasePropRows
+    passthroughPropsLink={
+      <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Attributes">MDN</Link>
+    }
+    elementType="a"
+  />
 </PropsTable>
 
 ## Status

--- a/src/UnderlineNav2/UnderlineNav.Item.stories.tsx
+++ b/src/UnderlineNav2/UnderlineNav.Item.stories.tsx
@@ -39,10 +39,6 @@ export default {
   }
 } as Meta<typeof UnderlineNavItem>
 
-// UnderlineNav.Item controls only work on the "Docs" tab. Because UnderlineNav children don't get re-rendered when they are changed.
-// This is an intentional behaviour of UnderlineNav for keeping a selected menu item visible. I will update here once I find a better solution.
-// In the meantime, you can use the "Docs" tab to see the controls.
-
 export const Playground: Story = args => {
   return (
     <UnderlineNavItem aria-current="page" {...args}>

--- a/src/UnderlineNav2/UnderlineNav.Item.stories.tsx
+++ b/src/UnderlineNav2/UnderlineNav.Item.stories.tsx
@@ -45,7 +45,7 @@ export default {
 
 export const Playground: Story = args => {
   return (
-    <UnderlineNavItem selected {...args}>
+    <UnderlineNavItem aria-current="page" {...args}>
       {args.children}
     </UnderlineNavItem>
   )

--- a/src/UnderlineNav2/UnderlineNav.test.tsx
+++ b/src/UnderlineNav2/UnderlineNav.test.tsx
@@ -60,7 +60,7 @@ const ResponsiveUnderlineNav = ({
           <UnderlineNav.Item
             key={item.navigation}
             icon={item.icon}
-            selected={item.navigation === selectedItemText}
+            aria-current={item.navigation === selectedItemText ? 'page' : undefined}
             counter={item.counter}
           >
             {item.navigation}

--- a/src/UnderlineNav2/UnderlineNav.test.tsx
+++ b/src/UnderlineNav2/UnderlineNav.test.tsx
@@ -119,7 +119,7 @@ describe('UnderlineNav', () => {
       <UnderlineNav aria-label="Test Navigation">
         <UnderlineNav.Item onSelect={onSelect}>Item 1</UnderlineNav.Item>
         <UnderlineNav.Item onSelect={onSelect}>Item 2</UnderlineNav.Item>
-        <UnderlineNav.Item selected onSelect={onSelect}>
+        <UnderlineNav.Item aria-current="page" onSelect={onSelect}>
           Item 3
         </UnderlineNav.Item>
       </UnderlineNav>

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -90,8 +90,10 @@ const overflowEffect = (
       if (index < numberOfListItems) {
         items.push(child)
       } else {
+        const ariaCurrent = child.props['aria-current']
+        const isCurrent = ariaCurrent !== undefined && ariaCurrent !== 'false' && ariaCurrent !== false
         // We need to make sure to keep the selected item always visible.
-        if (child.props['aria-current'] === 'page') {
+        if (isCurrent) {
           // If selected item couldn't make in to the list, we swap it with the last item in the list.
           const indexToReplaceAt = numberOfListItems - 1 // because we are replacing the last item in the list
           // splice method modifies the array by removing 1 item here at the given index and replace it with the "child" element then returns the removed item.

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -91,7 +91,7 @@ const overflowEffect = (
         items.push(child)
       } else {
         const ariaCurrent = child.props['aria-current']
-        const isCurrent = ariaCurrent !== undefined && ariaCurrent !== 'false' && ariaCurrent !== false
+        const isCurrent = Boolean(ariaCurrent) && ariaCurrent !== 'false'
         // We need to make sure to keep the selected item always visible.
         if (isCurrent) {
           // If selected item couldn't make in to the list, we swap it with the last item in the list.

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -20,11 +20,12 @@ import {useSSRSafeId} from '@react-aria/ssr'
 export type UnderlineNavProps = {
   'aria-label'?: React.AriaAttributes['aria-label']
   as?: React.ElementType
-  align?: 'right'
   sx?: SxProp
+  // cariant and align are currently not in used. Keeping here until some design explorations are finalized.
   variant?: 'default' | 'small'
+  align?: 'right'
   /**
-   * loading state for all counters (to prevent multiple layout shifts)
+   * loading state for all counters. It displays loading animation for individual counters (UnderlineNav.Item) until all are resolved. It is needed to prevent multiple layout shift.
    */
   loadingCounters?: boolean
   afterSelect?: (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -220,7 +220,7 @@ export const UnderlineNav = forwardRef(
 
     /*
      * This is needed to make sure responsiveProps.items and ResponsiveProps.actions are updated when children are changed
-     *  Particually when an item is selected. It adds 'aria-current="page"' attribute to the child and we need to make sure
+     * Particually when an item is selected. It adds 'aria-current="page"' attribute to the child and we need to make sure
      * responsiveProps.items and ResponsiveProps.actions are updated with that attribute
      */
     useEffect(() => {

--- a/src/UnderlineNav2/UnderlineNav2.stories.tsx
+++ b/src/UnderlineNav2/UnderlineNav2.stories.tsx
@@ -40,7 +40,7 @@ export const Playground: Story = args => {
   return (
     <UnderlineNav {...args}>
       {children.map((child: string, index: number) => (
-        <UnderlineNavItem key={index} href="#" selected={index === 0}>
+        <UnderlineNavItem key={index} href="#" aria-current={index === 0 ? 'page' : undefined}>
           {child}
         </UnderlineNavItem>
       ))}

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -104,8 +104,9 @@ export const UnderlineNavItem = forwardRef(
         setChildrenWidth({text, width: domRect.width})
         setNoIconChildrenWidth({text, width: domRect.width - iconWidthWithMargin})
 
-        if (selectedLink === undefined && ariaCurrent !== undefined && ariaCurrent !== 'false' && ariaCurrent !== false)
+        if (selectedLink === undefined && ariaCurrent !== undefined && ariaCurrent !== 'false' && ariaCurrent !== false) {
           setSelectedLink(ref as RefObject<HTMLElement>)
+        }
 
         // Only runs when a menu item is selected (swapping the menu item with the list item to keep it visible)
         if (selectedLinkText === text) {

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -104,7 +104,7 @@ export const UnderlineNavItem = forwardRef(
         setChildrenWidth({text, width: domRect.width})
         setNoIconChildrenWidth({text, width: domRect.width - iconWidthWithMargin})
 
-        if (selectedLink === undefined && ariaCurrent !== undefined && ariaCurrent !== 'false' && ariaCurrent !== false) {
+        if (selectedLink === undefined && Boolean(ariaCurrent) && ariaCurrent !== 'false') {
           setSelectedLink(ref as RefObject<HTMLElement>)
         }
 

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -104,7 +104,7 @@ export const UnderlineNavItem = forwardRef(
         setChildrenWidth({text, width: domRect.width})
         setNoIconChildrenWidth({text, width: domRect.width - iconWidthWithMargin})
 
-        if (selectedLink === undefined && ariaCurrent !== undefined && ariaCurrent !== 'false')
+        if (selectedLink === undefined && ariaCurrent !== undefined && ariaCurrent !== 'false' && ariaCurrent !== false)
           setSelectedLink(ref as RefObject<HTMLElement>)
 
         // Only runs when a menu item is selected (swapping the menu item with the list item to keep it visible)

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -24,7 +24,7 @@ type LinkProps = {
 
 export type UnderlineNavItemProps = {
   /**
-   * Primary content for an NavLink
+   * Primary content for an UnderlineNav
    */
   children?: React.ReactNode
   /**
@@ -32,13 +32,16 @@ export type UnderlineNavItemProps = {
    */
   onSelect?: (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void
   /**
-   * Is the `Link` is currently selected?
+   * Is `UnderlineNav.Item` current page?
    */
-  selected?: boolean
+  'aria-current'?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false' | boolean
   /**
    *  Icon before the text
    */
   icon?: React.FunctionComponent<IconProps>
+  /**
+   * Renders `UnderlineNav.Item` as given component
+   **/
   as?: React.ElementType
   /**
    * Counter
@@ -56,7 +59,7 @@ export const UnderlineNavItem = forwardRef(
       children,
       counter,
       onSelect,
-      selected: preSelected = false,
+      'aria-current': ariaCurrent,
       icon: Icon,
       ...props
     },
@@ -100,7 +103,9 @@ export const UnderlineNavItem = forwardRef(
 
         setChildrenWidth({text, width: domRect.width})
         setNoIconChildrenWidth({text, width: domRect.width - iconWidthWithMargin})
-        preSelected && selectedLink === undefined && setSelectedLink(ref as RefObject<HTMLElement>)
+
+        if (selectedLink === undefined && ariaCurrent !== undefined && ariaCurrent !== 'false')
+          setSelectedLink(ref as RefObject<HTMLElement>)
 
         // Only runs when a menu item is selected (swapping the menu item with the list item to keep it visible)
         if (selectedLinkText === text) {
@@ -111,7 +116,7 @@ export const UnderlineNavItem = forwardRef(
       }
     }, [
       ref,
-      preSelected,
+      ariaCurrent,
       selectedLink,
       selectedLinkText,
       setSelectedLinkText,
@@ -150,7 +155,7 @@ export const UnderlineNavItem = forwardRef(
           href={href}
           onKeyPress={keyPressHandler}
           onClick={clickHandler}
-          {...(selectedLink === ref ? {'aria-current': 'page'} : {})}
+          aria-current={ariaCurrent}
           sx={merge(getLinkStyles(theme, {variant}, selectedLink, ref), sxProp as SxProp)}
           {...props}
           ref={ref}

--- a/src/UnderlineNav2/__snapshots__/UnderlineNav.test.tsx.snap
+++ b/src/UnderlineNav2/__snapshots__/UnderlineNav.test.tsx.snap
@@ -206,6 +206,7 @@ exports[`UnderlineNav renders consistently 1`] = `
         className="c3"
       >
         <a
+          aria-current="page"
           className="c4"
           href="#"
           onClick={[Function]}

--- a/src/UnderlineNav2/examples.stories.tsx
+++ b/src/UnderlineNav2/examples.stories.tsx
@@ -47,7 +47,7 @@ export const PullRequestPage = () => {
         </Box>
       </Box>
       <UnderlineNav aria-label="Pull Request">
-        <UnderlineNav.Item icon={CommentDiscussionIcon} counter="0" selected>
+        <UnderlineNav.Item icon={CommentDiscussionIcon} counter="0" aria-current="page">
           Conversation
         </UnderlineNav.Item>
         <UnderlineNav.Item counter={3} icon={CommitIcon}>
@@ -85,7 +85,7 @@ export const ReposPage = () => {
         <UnderlineNav.Item
           key={item.navigation}
           icon={item.icon}
-          selected={index === selectedIndex}
+          aria-current={index === selectedIndex ? 'page' : undefined}
           onSelect={event => {
             event.preventDefault()
             setSelectedIndex(index)
@@ -149,7 +149,7 @@ export const ProfilePage = () => {
             <UnderlineNav.Item
               key={item.navigation}
               icon={item.icon}
-              selected={index === selectedIndex}
+              aria-current={index === selectedIndex ? 'page' : undefined}
               onSelect={event => {
                 event.preventDefault()
                 setSelectedIndex(index)

--- a/src/UnderlineNav2/features.stories.tsx
+++ b/src/UnderlineNav2/features.stories.tsx
@@ -81,7 +81,7 @@ export const OverflowTemplate = ({initialSelectedIndex = 1}: {initialSelectedInd
         <UnderlineNav.Item
           key={item.navigation}
           icon={item.icon}
-          selected={index === selectedIndex}
+          aria-current={index === selectedIndex ? 'page' : undefined}
           onSelect={event => {
             event.preventDefault()
             setSelectedIndex(index)
@@ -125,7 +125,7 @@ export const CountersLoadingState = () => {
         <UnderlineNav.Item
           key={item.navigation}
           icon={item.icon}
-          selected={index === selectedIndex}
+          aria-current={index === selectedIndex ? 'page' : undefined}
           onSelect={() => setSelectedIndex(index)}
           counter={item.counter}
         >

--- a/src/UnderlineNav2/features.stories.tsx
+++ b/src/UnderlineNav2/features.stories.tsx
@@ -23,7 +23,7 @@ export default {
 export const Default = () => {
   return (
     <UnderlineNav aria-label="Repository">
-      <UnderlineNav.Item selected>Code</UnderlineNav.Item>
+      <UnderlineNav.Item aria-current="page">Code</UnderlineNav.Item>
       <UnderlineNav.Item>Issues</UnderlineNav.Item>
       <UnderlineNav.Item>Pull Requests</UnderlineNav.Item>
     </UnderlineNav>
@@ -37,7 +37,7 @@ export const withIcons = () => {
       <UnderlineNav.Item icon={EyeIcon} counter={6}>
         Issues
       </UnderlineNav.Item>
-      <UnderlineNav.Item selected icon={GitPullRequestIcon}>
+      <UnderlineNav.Item aria-current="page" icon={GitPullRequestIcon}>
         Pull Requests
       </UnderlineNav.Item>
       <UnderlineNav.Item icon={CommentDiscussionIcon} counter={7}>
@@ -51,7 +51,7 @@ export const withIcons = () => {
 export const withCounterLabels = () => {
   return (
     <UnderlineNav aria-label="Repository with counters">
-      <UnderlineNav.Item selected icon={CodeIcon} counter="11K">
+      <UnderlineNav.Item aria-current="page" icon={CodeIcon} counter="11K">
         Code
       </UnderlineNav.Item>
       <UnderlineNav.Item icon={IssueOpenedIcon} counter={12}>

--- a/src/UnderlineNav2/interactions.stories.tsx
+++ b/src/UnderlineNav2/interactions.stories.tsx
@@ -123,6 +123,11 @@ KeepSelectedItemVisible.play = async ({canvasElement}: {canvasElement: HTMLEleme
   await delay(1000)
   expect(selectedItem).toHaveAttribute('aria-current', 'page')
   canvasElement.style.width = '500px'
+  await delay(1000)
+  const lastListItem = canvas.getByRole('list').children[2].children[0]
+  const menuListItem = canvas.getByRole('link', {name: 'Settings (10)'})
+  // expect Settings be the last element on the list.
+  expect(lastListItem).toEqual(menuListItem)
 }
 
 export {KeyboardNavigation, SelectAMenuItem, KeepSelectedItemVisible}


### PR DESCRIPTION
This PR is mainly created for API consistency purposes between `NavList` and `UnderlineNav v2`.

`UnderlineNav` was using `select` prop for the selected `UnderlineNav.Item` whereas `NavList` does the same thing with aria-current. This PR exposes `aria-current` attribute in the API for managing its selected state. 

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
