### PR TITLE
UnderlineNav2: Update `a11yReviewed` status to `true`  🎉 

### DIFF
--- a/docs/content/drafts/UnderlineNav2.mdx
+++ b/docs/content/drafts/UnderlineNav2.mdx
@@ -2,6 +2,7 @@
 title: UnderlineNav v2
 componentId: underline_nav_2
 status: Draft
+a11yReviewed: true
 description: Use an underlined nav to allow tab like navigation with overflow behaviour in your UI.
 source: https://github.com/primer/react/tree/main/src/UnderlineNav2
 storybook: '/react/storybook/?path=/story/drafts-components-underlinenav--playground'
@@ -208,7 +209,7 @@ const Navigation = () => {
     usageExamplesDocumented: true,
     hasStorybookStories: true,
     designReviewed: true,
-    a11yReviewed: false,
+    a11yReviewed: true,
     stableApi: false,
     addressedApiFeedback: false,
     hasDesignGuidelines: false,


### PR DESCRIPTION
UnderlineNav is signed-off from accessibility review so updating its a11y status! 🥳  https://github.com/github/primer/issues/1112 


Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
