### PR TITLE
UnderlineNav2: Use useIsomorphicLayoutEffect to make it SSR friendly

### DIFF
--- a/.changeset/old-lies-boil.md
+++ b/.changeset/old-lies-boil.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+UnderlineNav2: Use useIsomorphicLayoutEffect to make it SSR friendly

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef, useLayoutEffect, useRef, useContext, MutableRefObject, RefObject} from 'react'
+import React, {forwardRef, useRef, useContext, MutableRefObject, RefObject} from 'react'
 import Box from '../Box'
 import {merge, SxProp} from '../sx'
 import {IconProps} from '@primer/octicons-react'
@@ -7,6 +7,7 @@ import {UnderlineNavContext} from './UnderlineNavContext'
 import CounterLabel from '../CounterLabel'
 import {getLinkStyles, wrapperStyles, iconWrapStyles, counterStyles} from './styles'
 import {LoadingCounter} from './LoadingCounter'
+import useLayoutEffect from '../utils/useIsomorphicLayoutEffect'
 
 // adopted from React.AnchorHTMLAttributes
 type LinkProps = {


### PR DESCRIPTION
Closes #2617

This PR updates UnderlineNav using `useIsomorphicLayoutEffect` instead of React's default `useLayoutEffect` to make it SSR friendly. 

Note: UnderlineNav's initial layout rendering is very much depending on viewport size and JS being ran on the browser to calculate how many items that can fit into the current viewport. Because of that, this update causes an undesirable behaviour in SSR. Nothing blocking the functionality though it is just something we have not worked thoroughly. I'll work with the design team to think about a "loading state" (Thanks @joshblack for this terminology!) until we get JS running on the browser. 

In the meantime, it believe this should solve the issue. 

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
