### PR TITLE
fix(Radio): remove redundant aria-disabled

### DIFF
--- a/src/Radio.tsx
+++ b/src/Radio.tsx
@@ -76,7 +76,6 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
         name={name}
         ref={ref}
         disabled={disabled}
-        aria-disabled={disabled ? 'true' : 'false'}
         checked={checked}
         aria-checked={checked ? 'true' : 'false'}
         required={required}


### PR DESCRIPTION
Closes #2634 

Removes redundant `aria-disabled` when the `<input>` is disabled.

> **Note**
> Waiting for a good way to repro this with axe so that we can make sure this doesn't regress in the future 👀 