### PR TITLE
UnderlineNav2: Remove unnecessary ThemeProvider and refactor primitives accordingly

### DIFF
--- a/.changeset/dirty-wolves-divide.md
+++ b/.changeset/dirty-wolves-divide.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+UnderlineNav: Remove unnecessary ThemeProvider

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -4,10 +4,9 @@ import sx, {merge, BetterSystemStyleObject, SxProp} from '../sx'
 import {UnderlineNavContext} from './UnderlineNavContext'
 import {useResizeObserver, ResizeObserverEntry} from '../hooks/useResizeObserver'
 import CounterLabel from '../CounterLabel'
-import {useTheme} from '../ThemeProvider'
 import {ChildWidthArray, ResponsiveProps} from './types'
 import VisuallyHidden from '../_VisuallyHidden'
-import {moreBtnStyles, getDividerStyle, getNavStyles, ulStyles, menuStyles, menuItemStyles, GAP} from './styles'
+import {moreBtnStyles, getNavStyles, ulStyles, menuStyles, menuItemStyles, GAP} from './styles'
 import styled from 'styled-components'
 import {LoadingCounter} from './LoadingCounter'
 import {Button} from '../Button'
@@ -149,8 +148,6 @@ export const UnderlineNav = forwardRef(
     const moreMenuBtnRef = useRef<HTMLButtonElement>(null)
     const containerRef = React.useRef<HTMLUListElement>(null)
     const disclosureWidgetId = useSSRSafeId()
-
-    const {theme} = useTheme()
 
     function getItemsWidth(itemText: string): number {
       return noIconChildWidthArray.find(item => item.text === itemText)?.width || 0
@@ -310,7 +307,6 @@ export const UnderlineNav = forwardRef(
     return (
       <UnderlineNavContext.Provider
         value={{
-          theme,
           setChildrenWidth,
           setNoIconChildrenWidth,
           selectedLink,
@@ -327,7 +323,7 @@ export const UnderlineNav = forwardRef(
         {ariaLabel && <VisuallyHidden as="h2">{`${ariaLabel} navigation`}</VisuallyHidden>}
         <Box
           as={as}
-          sx={merge<BetterSystemStyleObject>(getNavStyles(theme, {align}), sxProp)}
+          sx={merge<BetterSystemStyleObject>(getNavStyles({align}), sxProp)}
           aria-label={ariaLabel}
           ref={navRef}
         >
@@ -335,7 +331,15 @@ export const UnderlineNav = forwardRef(
             {responsiveProps.items}
             {actions.length > 0 && (
               <MoreMenuListItem ref={moreMenuRef}>
-                <Box sx={getDividerStyle(theme)}></Box>
+                <Box
+                  sx={{
+                    display: 'inline-block',
+                    borderLeft: '1px solid',
+                    width: '1px',
+                    borderLeftColor: 'border.muted',
+                    marginRight: 1
+                  }}
+                ></Box>
                 <Button
                   ref={moreMenuBtnRef}
                   sx={moreBtnStyles}

--- a/src/UnderlineNav2/UnderlineNavContext.tsx
+++ b/src/UnderlineNav2/UnderlineNavContext.tsx
@@ -1,8 +1,6 @@
 import React, {createContext, RefObject} from 'react'
-import {Theme} from '../ThemeProvider'
 
 export const UnderlineNavContext = createContext<{
-  theme: Theme | undefined
   setChildrenWidth: React.Dispatch<{text: string; width: number}>
   setNoIconChildrenWidth: React.Dispatch<{text: string; width: number}>
   selectedLink: RefObject<HTMLElement> | undefined
@@ -15,7 +13,6 @@ export const UnderlineNavContext = createContext<{
   loadingCounters: boolean
   iconsVisible: boolean
 }>({
-  theme: {},
   setChildrenWidth: () => null,
   setNoIconChildrenWidth: () => null,
   selectedLink: undefined,

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef, useRef, useContext, MutableRefObject, RefObject} from 'react'
+import React, {forwardRef, useLayoutEffect, useRef, useContext, MutableRefObject, RefObject} from 'react'
 import Box from '../Box'
 import {merge, SxProp} from '../sx'
 import {IconProps} from '@primer/octicons-react'
@@ -7,7 +7,6 @@ import {UnderlineNavContext} from './UnderlineNavContext'
 import CounterLabel from '../CounterLabel'
 import {getLinkStyles, wrapperStyles, iconWrapStyles, counterStyles} from './styles'
 import {LoadingCounter} from './LoadingCounter'
-import useLayoutEffect from '../utils/useIsomorphicLayoutEffect'
 
 // adopted from React.AnchorHTMLAttributes
 type LinkProps = {
@@ -68,7 +67,6 @@ export const UnderlineNavItem = forwardRef(
     const backupRef = useRef<HTMLElement>(null)
     const ref = (forwardedRef ?? backupRef) as RefObject<HTMLElement>
     const {
-      theme,
       setChildrenWidth,
       setNoIconChildrenWidth,
       selectedLink,
@@ -157,7 +155,7 @@ export const UnderlineNavItem = forwardRef(
           onKeyPress={keyPressHandler}
           onClick={clickHandler}
           aria-current={ariaCurrent}
-          sx={merge(getLinkStyles(theme, {variant}, selectedLink, ref), sxProp as SxProp)}
+          sx={merge(getLinkStyles({variant}, selectedLink, ref), sxProp as SxProp)}
           {...props}
           ref={ref}
         >

--- a/src/UnderlineNav2/styles.ts
+++ b/src/UnderlineNav2/styles.ts
@@ -1,4 +1,3 @@
-import {Theme} from '../ThemeProvider'
 import {UnderlineNavProps} from './UnderlineNav'
 
 // The gap between the list items. It is a constant because the gap is used to calculate the possible number of items that can fit in the container.
@@ -32,12 +31,12 @@ export const counterStyles = {
   alignItems: 'center'
 }
 
-export const getNavStyles = (theme?: Theme, props?: Partial<Pick<UnderlineNavProps, 'align'>>) => ({
+export const getNavStyles = (props?: Partial<Pick<UnderlineNavProps, 'align'>>) => ({
   display: 'flex',
   paddingX: 3,
   justifyContent: props?.align === 'right' ? 'flex-end' : 'flex-start',
   borderBottom: '1px solid',
-  borderBottomColor: `${theme?.colors.border.muted}`,
+  borderBottomColor: 'border.muted',
   align: 'row',
   alignItems: 'center'
 })
@@ -55,14 +54,6 @@ export const ulStyles = {
   position: 'relative'
 }
 
-export const getDividerStyle = (theme?: Theme) => ({
-  display: 'inline-block',
-  borderLeft: '1px solid',
-  width: '1px',
-  borderLeftColor: `${theme?.colors.border.muted}`,
-  marginRight: 1
-})
-
 export const moreBtnStyles = {
   //set margin 0 here because safari puts extra margin around the button, rest is to reset style to make it look like a list element
   margin: 0,
@@ -78,7 +69,6 @@ export const moreBtnStyles = {
 }
 
 export const getLinkStyles = (
-  theme?: Theme,
   props?: Partial<Pick<UnderlineNavProps, 'variant'>>,
   selectedLink?: React.RefObject<HTMLElement>,
   ref?: React.RefObject<HTMLElement>
@@ -91,14 +81,14 @@ export const getLinkStyles = (
   ...(props?.variant === 'small' ? smallVariantLinkStyles : defaultVariantLinkStyles),
   '@media (hover:hover)': {
     '&:hover > div[data-component="wrapper"] ': {
-      backgroundColor: theme?.colors.neutral.muted,
+      backgroundColor: 'neutral.muted',
       transition: 'background .12s ease-out'
     }
   },
   '&:focus': {
     outline: 0,
     '& > div[data-component="wrapper"]': {
-      boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`
+      boxShadow: `inset 0 0 0 2px accent.fg`
     },
     // where focus-visible is supported, remove the focus box-shadow
     '&:not(:focus-visible) > div[data-component="wrapper"]': {
@@ -106,7 +96,7 @@ export const getLinkStyles = (
     }
   },
   '&:focus-visible > div[data-component="wrapper"]': {
-    boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`
+    boxShadow: `inset 0 0 0 2px accent.fg`
   },
   // renders a visibly hidden "copy" of the label in bold, reserving box space for when label becomes bold on selected
   '& span[data-content]::before': {
@@ -125,7 +115,7 @@ export const getLinkStyles = (
     width: '100%',
     height: 2,
     content: '""',
-    bg: selectedLink === ref ? theme?.colors.primer.border.active : 'transparent',
+    bg: selectedLink === ref ? 'primer.border.active' : 'transparent',
     borderRadius: 0,
     transform: 'translate(50%, -50%)'
   },


### PR DESCRIPTION
Following up our best practises for [referencing theme values](https://primer.style/react/theming#referencing-theme-values), I removed the ThemeProvider and refactored the primitives accordingly.  

### Screenshots

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
