### PR TITLE
Fix`MarkdownEditor` preview overflowing its container

### DIFF
--- a/.changeset/lovely-mangos-destroy.md
+++ b/.changeset/lovely-mangos-destroy.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fix `MarkdownEditor` preview overflowing its container

--- a/src/drafts/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/drafts/MarkdownEditor/MarkdownEditor.tsx
@@ -360,7 +360,7 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(
                 disabled /* if we set disabled={true}, we can't enable the buttons that should be enabled */
               }
               aria-describedby={describedBy ? `${descriptionId} ${describedBy}` : descriptionId}
-              style={{appearance: 'none', border: 'none'}}
+              style={{appearance: 'none', border: 'none', minInlineSize: 'auto'}}
             >
               <FormattingTools ref={formattingToolsRef} forInputId={id} />
               <div style={{display: 'none'}}>{children}</div>


### PR DESCRIPTION
The `MarkdownEditor`'s "Preview" view can overflow its container. For example, previewing a very long line of code in a code block will cause it to overflow. This issue is noted in https://github.com/github/memex/issues/12747.

This is because the entire editor is contained inside a `<fieldset>` element (for accessibility semantics) and this element has a default browser style of `min-inline-size: max-content`. 

This PR fixes this by adding `minInlineSize: auto` to the `fieldset`.

