### PR TITLE
Docs: Update e2e test script command

### DIFF
--- a/contributor-docs/testing.md
+++ b/contributor-docs/testing.md
@@ -114,17 +114,17 @@ available, check out the table below.
 
 | Task                                                  | Command                                         |
 | :---------------------------------------------------- | :---------------------------------------------- |
-| Run playwright tests                                  | `scripts/test-e2e`                              |
-| Run a specific test                                   | `scripts/test-e2e TestName`                     |
+| Run playwright tests                                  | `script/test-e2e`                               |
+| Run a specific test                                   | `script/test-e2e TestName`                      |
 | View the report from a test run                       | `npx playwright show-report .playwright/report` |
-| Update snapshots                                      | `scripts/test-e2e --update-snapshots`           |
+| Update snapshots                                      | `script/test-e2e --update-snapshots`            |
 | Debug playwright tests                                | `npx playwright test --debug`                   |
 | Run playwright with browser visible                   | `npx playwright test --headed`                  |
-| Run playwright tests that match a specific tag        | `scripts/test-e2e --grep @tag-name`             |
-| Run playwright tests that do not match a specific tag | `scripts/test-e2e --grep-invert @tag-name`      |
+| Run playwright tests that match a specific tag        | `script/test-e2e --grep @tag-name`              |
+| Run playwright tests that do not match a specific tag | `script/test-e2e --grep-invert @tag-name`       |
 
 > **Note**
-> The `scripts/test-e2e` file is a helper to run Playwright in an environment
+> The `script/test-e2e` file is a helper to run Playwright in an environment
 > that mirrors CI. You can optionally run these tests natively on your machine
 > using `npx playwright test` if you would like to interact or debug tests.
 > However, screenshots will not match and new ones will need to be generated on


### PR DESCRIPTION
Describe your changes here.

The command to run Playwright tests with docker is not correct on the testing documentation. Just updating them here.

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
