### PR TITLE
ci(deploy_production): add --legacy-peer-deps to docs install

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -41,6 +41,6 @@ jobs:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:
       node_version: 16
-      install: npm ci && cd docs && npm ci && cd ..
+      install: npm ci && cd docs && npm ci --legacy-peer-deps && cd ..
       build: npm run build:docs
       output_dir: docs/public


### PR DESCRIPTION
Update our `deploy_production.yml` workflow to use `--legacy-peer-deps`. Currently, this workflow is failing with an `ERESOLVE` code for gatsby as a peer dependency: https://github.com/primer/react/actions/runs/3587802262/jobs/6038542087#step:5:39

It seems like we've had a couple deploys fail in the last couple of weeks:

- https://github.com/primer/react/actions/runs/3587802262
- https://github.com/primer/react/actions/runs/3587802262

The last successful deploy that I could find was:

- https://github.com/primer/react/actions/runs/3411762907