### PR TITLE
[Docs] SelectPanel

### DIFF
--- a/docs/content/SelectPanel.mdx
+++ b/docs/content/SelectPanel.mdx
@@ -33,7 +33,7 @@ const items = [
   {leadingVisual: getColorCircle('#ffd78e'), text: 'design', id: 4},
   {leadingVisual: getColorCircle('#ff0000'), text: 'blocker', id: 5},
   {leadingVisual: getColorCircle('#a4f287'), text: 'backend', id: 6},
-  {leadingVisual: getColorCircle('#8dc6fc'), text: 'frontend', id: 7}
+  {leadingVisual: getColorCircle('#8dc6fc'), text: 'frontend', id: 7},
 ]
 
 function DemoComponent() {
@@ -113,18 +113,16 @@ alternative to activating the save button.
   <PropsTableRow name="title" type="string" />
   <PropsTableRow name="inputLabel" type="string" />
   <PropsTableRow name="inputPlaceholder" type="string" />
-
-    <PropsTableRow
-      name="selected"
-      type="ItemInput | ItemInput[] | undefined"
-      description="Specify the selected item(s)"
-    />
-    <PropsTableRow
-      name="onSelectedChange"
-      type="(selected: ItemInput | ItemInput[]) => void"
-      description="Provide a callback called when the selected item(s) change"
-    />
-
+  <PropsTableRow
+    name="selected"
+    type="ItemInput | ItemInput[] | undefined"
+    description="Specify the selected item(s)"
+  />
+  <PropsTableRow
+    name="onSelectedChange"
+    type="(selected: ItemInput | ItemInput[]) => void"
+    description="Provide a callback called when the selected item(s) change"
+  />
 </PropsTable>
 
 ## Status
@@ -144,6 +142,6 @@ alternative to activating the save button.
     stableApi: false,
     addressedApiFeedback: false,
     hasDesignGuidelines: false,
-    hasFigmaComponent: false
+    hasFigmaComponent: false,
   }}
 />


### PR DESCRIPTION

Spotted by @lukasoppermann: fix indentation on `SelectPanel` to avoid Props section breaking 

### Screenshots

Before

<img width="1102" alt="screenshot_2022-12-13_at_13 18 23" src="https://user-images.githubusercontent.com/912236/207327192-98f84f19-52b5-4988-94f4-c27f4053e289.png">

After

<img width="933" alt="Screenshot 2022-12-13 at 14 27 50" src="https://user-images.githubusercontent.com/912236/207333169-0cd2fc54-07fb-40fc-8958-8f9e34a4a8be.png">


### Merge checklist

- [] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
