### PR TITLE
fix types for button close

### DIFF
--- a/src/deprecated/Button/ButtonClose.tsx
+++ b/src/deprecated/Button/ButtonClose.tsx
@@ -1,11 +1,15 @@
 import {XIcon} from '@primer/octicons-react'
-import React, {forwardRef} from 'react'
+import React, {ComponentPropsWithRef} from 'react'
 import styled from 'styled-components'
 import {get} from '../../constants'
 import sx, {SxProp} from '../../sx'
-import {ComponentProps} from '../../utils/types'
 
-const StyledButton = styled.button<SxProp>`
+const ButtonClose = styled.button.attrs(props => {
+  return {
+    children: <XIcon />,
+    'aria-label': props['aria-label'] ?? 'Close',
+  }
+})<SxProp & {children: never}>`
   border: none;
   padding: 0;
   background: transparent;
@@ -23,13 +27,6 @@ const StyledButton = styled.button<SxProp>`
   ${sx};
 `
 
-const ButtonClose = forwardRef<HTMLButtonElement, ComponentProps<typeof StyledButton>>((props, ref) => {
-  return (
-    <StyledButton ref={ref} aria-label="Close" {...props}>
-      <XIcon />
-    </StyledButton>
-  )
-})
+export type ButtonCloseProps = ComponentPropsWithRef<typeof ButtonClose>
 
-export type ButtonCloseProps = ComponentProps<typeof ButtonClose>
 export default ButtonClose


### PR DESCRIPTION
Describe your changes here.

fixes #2621 

This fixes type issues for ButtonClose, a deprecated component

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
