### PR TITLE
Triggering onSelect for tree item middle click

### DIFF
--- a/.changeset/yellow-shoes-glow.md
+++ b/.changeset/yellow-shoes-glow.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Trigger onSelect when TreeView items are middle clicked

--- a/src/TreeView/TreeView.test.tsx
+++ b/src/TreeView/TreeView.test.tsx
@@ -778,6 +778,13 @@ describe('Keyboard interactions', () => {
 
       // onSelect should have been called
       expect(onSelect).toHaveBeenCalledTimes(1)
+
+      onSelect.mockClear()
+      // Press middle click
+      fireEvent.click(document.activeElement?.firstChild || document.body, {button: 1})
+
+      // onSelect should have been called
+      expect(onSelect).toHaveBeenCalledTimes(1)
     })
 
     it('toggles expanded state if no onSelect function is provided', () => {

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -429,6 +429,11 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
                 toggle(event)
               }
             }}
+            onAuxClick={event => {
+              if (onSelect && event.button === 1) {
+                onSelect(event)
+              }
+            }}
           >
             <div style={{gridArea: 'spacer', display: 'flex'}}>
               <LevelIndicatorLines level={level} />


### PR DESCRIPTION
Describe your changes here.

Triggering onSelect when middle click is pressed on a tree item. Users need to support the link shortcut of middle clicking to open in a new tab. onClick does not trigger an event for middle clicks, onAuxClick has to be used instead. Consumers can check the event.button when they get onSelect to handle opening the new tab. I could see an alternative solution being that the primer tree checks for ctrl/cmd + click and middle click and fires a different selection event for these cases. I'm happy to implement that if it seems like a better solution.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
