### PR TITLE
Update `relative-time-element` version

### DIFF
--- a/.changeset/strange-shrimps-smile.md
+++ b/.changeset/strange-shrimps-smile.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Relative Time Element : Publish v4.1.2 in NPM and GPR

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@github/combobox-nav": "^2.1.5",
         "@github/markdown-toolbar-element": "^2.1.0",
         "@github/paste-markdown": "^1.4.0",
-        "@github/relative-time-element": "4.0.0",
+        "@github/relative-time-element": "4.1.2",
         "@lit-labs/react": "1.0.9",
         "@primer/behaviors": "1.3.1",
         "@primer/octicons-react": "^17.7.0",
@@ -2995,9 +2995,9 @@
       "dev": true
     },
     "node_modules/@github/relative-time-element": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.0.0.tgz",
-      "integrity": "sha512-A//nGe6GFciGP0GxSZZKZbULwSZuENZ19cTaAkvRU3Ptqgdpo95VF6YS5TPi54NVM/zt8q6KtDTOMyjdFQHj0g=="
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.1.2.tgz",
+      "integrity": "sha512-34izL9UqcgU2ZkziZVGuxQoCsswLM5jQ7Q7PYZ04GByaFASg8rdyZrLW3SaWzTFghANfr6l00RMBhjPX6PtxNw=="
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -45572,9 +45572,9 @@
       "dev": true
     },
     "@github/relative-time-element": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.0.0.tgz",
-      "integrity": "sha512-A//nGe6GFciGP0GxSZZKZbULwSZuENZ19cTaAkvRU3Ptqgdpo95VF6YS5TPi54NVM/zt8q6KtDTOMyjdFQHj0g=="
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.1.2.tgz",
+      "integrity": "sha512-34izL9UqcgU2ZkziZVGuxQoCsswLM5jQ7Q7PYZ04GByaFASg8rdyZrLW3SaWzTFghANfr6l00RMBhjPX6PtxNw=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@github/combobox-nav": "^2.1.5",
     "@github/markdown-toolbar-element": "^2.1.0",
     "@github/paste-markdown": "^1.4.0",
-    "@github/relative-time-element": "4.0.0",
+    "@github/relative-time-element": "4.1.2",
     "@lit-labs/react": "1.0.9",
     "@primer/behaviors": "1.3.1",
     "@primer/octicons-react": "^17.7.0",


### PR DESCRIPTION
`Relative-time-element` is now available in the GPR as well as in NPM under `@github` scope and with this change, it gives flexibility to install the package from both registries and this way we prevent the automation dependency management of the repos (memex, dotcom) from breaking because they were configured to install these private packages from GRP in the @github scope not NPM @github scope.

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
