### PR TITLE
Add fixed `position` prop to Overlay

### DIFF
--- a/.changeset/wild-bananas-doubt.md
+++ b/.changeset/wild-bananas-doubt.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Overlay: Add `position`, `right`, and `bottom` props

--- a/docs/content/Overlay.mdx
+++ b/docs/content/Overlay.mdx
@@ -76,6 +76,8 @@ See the [W3C accessibility recommendations for modals](https://www.w3.org/TR/wai
 
 `Overlay` renders its `children` within a div positioned absolutely within a portal within the default portal root. The overlay will not update its positioning if the portal root's positioning changes (e.g., if the portal root is statically positioned after some DOM element that dynamically resizes). You may consider using the [AnchoredOverlay](/AnchoredOverlay) component or [customizing the portal root](/Portal#customizing-the-portal-root) to achieve different positioning behavior.
 
+If you wish to position the overlay fixed to the viewport, you may pass `position` with a value of `left` or `right`.
+
 ## Props
 
 <ComponentProps data={data} />

--- a/docs/content/Overlay.mdx
+++ b/docs/content/Overlay.mdx
@@ -76,7 +76,7 @@ See the [W3C accessibility recommendations for modals](https://www.w3.org/TR/wai
 
 `Overlay` renders its `children` within a div positioned absolutely within a portal within the default portal root. The overlay will not update its positioning if the portal root's positioning changes (e.g., if the portal root is statically positioned after some DOM element that dynamically resizes). You may consider using the [AnchoredOverlay](/AnchoredOverlay) component or [customizing the portal root](/Portal#customizing-the-portal-root) to achieve different positioning behavior.
 
-If you wish to position the overlay fixed to the viewport, you may pass `position` with a value of `left` or `right`.
+The position of the Overlay can be customized by using the `position` prop in conjunction with the `top|left|right|bottom` props.
 
 ## Props
 
@@ -98,6 +98,6 @@ If you wish to position the overlay fixed to the viewport, you may pass `positio
     stableApi: false,
     addressedApiFeedback: false,
     hasDesignGuidelines: false,
-    hasFigmaComponent: false
+    hasFigmaComponent: false,
   }}
 />

--- a/docs/content/Overlay.mdx
+++ b/docs/content/Overlay.mdx
@@ -98,6 +98,6 @@ If you wish to position the overlay fixed to the viewport, you may pass `positio
     stableApi: false,
     addressedApiFeedback: false,
     hasDesignGuidelines: false,
-    hasFigmaComponent: false,
+    hasFigmaComponent: false
   }}
 />

--- a/src/Overlay.docs.json
+++ b/src/Overlay.docs.json
@@ -72,13 +72,29 @@
       "name": "top",
       "type": "number",
       "defaultValue": "0",
-      "description": "Vertical position of the overlay, relative to its closest positioned ancestor (often its `Portal`)."
+      "description": "The top CSS property of the Overlay — affects the vertical position."
     },
     {
       "name": "left",
       "type": "number",
       "defaultValue": "0",
-      "description": "Horizontal position of the overlay, relative to its closest positioned ancestor (often its `Portal`)."
+      "description": "The left CSS property of the Overlay — affects the horizontal position."
+    },
+    {
+      "name": "right",
+      "type": "number",
+      "description": "The right CSS property of the Overlay — affects the horizontal position."
+    },
+    {
+      "name": "bottom",
+      "type": "number",
+      "description": "The bottom CSS property of the Overlay — affects the vertical position."
+    },
+    {
+      "name": "position",
+      "type": "| 'static' | 'relative' | 'absolute' | 'fixed' | 'sticky'",
+      "defaultValue": "absolute",
+      "description": "The position CSS property of the Overlay — sets how the Overlay is positioned relative to its Portal"
     },
     {
       "name": "portalContainerName",

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -190,8 +190,7 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
     }, [anchorSide, slideAnimationDistance, slideAnimationEasing, visibility])
 
     // To be backwards compatible with the old Overlay, we need to set the left prop if x-position is not specified
-    const leftPosition: React.CSSProperties =
-      left === undefined && right === undefined ? {left: 0} : left ? {left: `${left}px`} : {left}
+  const leftPosition: React.CSSProperties = left === undefined && right === undefined ? {left: 0} : {left}
 
     return (
       <Portal containerName={portalContainerName}>

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -190,7 +190,7 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
     }, [anchorSide, slideAnimationDistance, slideAnimationEasing, visibility])
 
     // To be backwards compatible with the old Overlay, we need to set the left prop if x-position is not specified
-  const leftPosition: React.CSSProperties = left === undefined && right === undefined ? {left: 0} : {left}
+    const leftPosition: React.CSSProperties = left === undefined && right === undefined ? {left: 0} : {left}
 
     return (
       <Portal containerName={portalContainerName}>

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -17,6 +17,7 @@ type StyledOverlayProps = {
   maxHeight?: keyof Omit<typeof heightMap, 'auto' | 'initial'>
   visibility?: 'visible' | 'hidden'
   anchorSide?: AnchorSide
+  position?: 'left' | 'right'
 } & SxProp
 
 const heightMap = {
@@ -138,6 +139,7 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
       anchorSide,
       portalContainerName,
       preventFocusOnOpen,
+      position,
       ...rest
     },
     forwardedRef,
@@ -180,6 +182,16 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
       )
     }, [anchorSide, slideAnimationDistance, slideAnimationEasing, visibility])
 
+    // Calculate position based on left and position props
+    let calculatedPosition: Record<string, string> = {left: `${left || 0}px`}
+    if (position && left === undefined) {
+      if (position === 'left') {
+        calculatedPosition = {left: '0px', position: 'fixed'}
+      } else {
+        calculatedPosition = {right: '0px', position: 'fixed'}
+      }
+    }
+
     return (
       <Portal containerName={portalContainerName}>
         <StyledOverlay
@@ -191,7 +203,7 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
           style={
             {
               top: `${top || 0}px`,
-              left: `${left || 0}px`,
+              ...calculatedPosition,
               '--styled-overlay-visibility': visibility,
             } as React.CSSProperties
           }

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -17,7 +17,11 @@ type StyledOverlayProps = {
   maxHeight?: keyof Omit<typeof heightMap, 'auto' | 'initial'>
   visibility?: 'visible' | 'hidden'
   anchorSide?: AnchorSide
-  position?: 'left' | 'right'
+  position?: React.CSSProperties['position']
+  top?: React.CSSProperties['top']
+  left?: React.CSSProperties['left']
+  right?: React.CSSProperties['right']
+  bottom?: React.CSSProperties['bottom']
 } & SxProp
 
 const heightMap = {
@@ -95,8 +99,11 @@ type BaseOverlayProps = {
   onEscape: (e: KeyboardEvent) => void
   visibility?: 'visible' | 'hidden'
   'data-test-id'?: unknown
-  top?: number
-  left?: number
+  position?: React.CSSProperties['position']
+  top?: React.CSSProperties['top']
+  left?: React.CSSProperties['left']
+  right?: React.CSSProperties['right']
+  bottom?: React.CSSProperties['bottom']
   portalContainerName?: string
   preventFocusOnOpen?: boolean
   role?: AriaRole
@@ -118,8 +125,11 @@ type OwnOverlayProps = Merge<StyledOverlayProps, BaseOverlayProps>
  * @param height Sets the height of the `Overlay`, pick from our set list of heights, or pass `auto` to automatically set the height based on the content of the `Overlay`, or pass `initial` to set the height based on the initial content of the `Overlay` (i.e. ignoring content changes). `xsmall` corresponds to `192px`, `small` corresponds to `256px`, `medium` corresponds to `320px`, `large` corresponds to `432px`, `xlarge` corresponds to `600px`.
  * @param maxHeight Sets the maximum height of the `Overlay`, pick from our set list of heights. `xsmall` corresponds to `192px`, `small` corresponds to `256px`, `medium` corresponds to `320px`, `large` corresponds to `432px`, `xlarge` corresponds to `600px`.
  * @param anchorSide If provided, the Overlay will slide into position from the side of the anchor with a brief animation
- * @param top Optional. Vertical position of the overlay, relative to its closest positioned ancestor (often its `Portal`).
- * @param left Optional. Horizontal position of the overlay, relative to its closest positioned ancestor (often its `Portal`).
+ * @param top Optional. Vertical top position of the overlay, relative to its closest positioned ancestor (often its `Portal`).
+ * @param left Optional. Horizontal left position of the overlay, relative to its closest positioned ancestor (often its `Portal`).
+ * @param right Optional. Horizontal right position of the overlay, relative to its closest positioned ancestor (often its `Portal`).
+ * @param bottom Optional. Vertical bottom position of the overlay, relative to its closest positioned ancestor (often its `Portal`).
+ * @param position Optional. Sets how an element is positioned in a document. Defaults to `absolute` positioning.
  * @param portalContainerName Optional. The name of the portal container to render the Overlay into.
  */
 const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
@@ -136,6 +146,8 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
       width = 'auto',
       top,
       left,
+      right,
+      bottom,
       anchorSide,
       portalContainerName,
       preventFocusOnOpen,
@@ -182,15 +194,9 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
       )
     }, [anchorSide, slideAnimationDistance, slideAnimationEasing, visibility])
 
-    // Calculate position based on left and position props
-    let calculatedPosition: Record<string, string> = {left: `${left || 0}px`}
-    if (position && left === undefined) {
-      if (position === 'left') {
-        calculatedPosition = {left: '0px', position: 'fixed'}
-      } else {
-        calculatedPosition = {right: '0px', position: 'fixed'}
-      }
-    }
+    // To be backwards compatible with the old Overlay, we need to set the left prop if x-position is not specified
+    const leftPosition: React.CSSProperties =
+      left === undefined && right === undefined ? {left: 0} : left ? {left: `${left}px`} : {left}
 
     return (
       <Portal containerName={portalContainerName}>
@@ -202,8 +208,11 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
           ref={overlayRef}
           style={
             {
-              top: `${top || 0}px`,
-              ...calculatedPosition,
+              ...leftPosition,
+              right,
+              top,
+              bottom,
+              position,
               '--styled-overlay-visibility': visibility,
             } as React.CSSProperties
           }

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -17,11 +17,6 @@ type StyledOverlayProps = {
   maxHeight?: keyof Omit<typeof heightMap, 'auto' | 'initial'>
   visibility?: 'visible' | 'hidden'
   anchorSide?: AnchorSide
-  position?: React.CSSProperties['position']
-  top?: React.CSSProperties['top']
-  left?: React.CSSProperties['left']
-  right?: React.CSSProperties['right']
-  bottom?: React.CSSProperties['bottom']
 } & SxProp
 
 const heightMap = {

--- a/src/__tests__/Overlay.test.tsx
+++ b/src/__tests__/Overlay.test.tsx
@@ -141,7 +141,35 @@ describe('Overlay', () => {
     spy.mockRestore()
   })
 
-  it('should right align when given position: right', async () => {
+  it('should right align when given `right: 0` and `position: fixed`', async () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(message => {
+      if (!message.startsWith('global handler')) {
+        throw new Error(
+          `Expected console.log() to be called with: 'global handler:' but instead it was called with: ${message}`,
+        )
+      }
+    })
+
+    const user = userEvent.setup()
+    const container = render(
+      <ThemeProvider>
+        <PositionedOverlays right />
+      </ThemeProvider>,
+    )
+
+    // open first menu
+    await user.click(container.getByText('Open right overlay'))
+    expect(container.getByText('Look! right aligned')).toBeInTheDocument()
+
+    const overlay = container.getByText('Look! right aligned').parentElement?.parentElement
+
+    expect(overlay).toHaveStyle({position: 'fixed', right: 0})
+    expect(overlay).not.toHaveStyle({left: 0})
+
+    spy.mockRestore()
+  })
+
+  it('should left align when not given position and left props', async () => {
     const spy = jest.spyOn(console, 'log').mockImplementation(message => {
       if (!message.startsWith('global handler')) {
         throw new Error(
@@ -158,41 +186,11 @@ describe('Overlay', () => {
     )
 
     // open first menu
-    await user.click(container.getByText('Open right overlay'))
-    expect(container.getByText('Look! right aligned')).toBeInTheDocument()
+    await user.click(container.getByText('Open left overlay'))
+    expect(container.getByText('Look! left aligned')).toBeInTheDocument()
 
-    const overlay = container.getByText('Look! right aligned').parentElement?.parentElement
-
-    expect(overlay).toHaveStyle({position: 'fixed', right: 0})
-    expect(overlay).not.toHaveStyle({left: 0})
-
-    spy.mockRestore()
-  })
-
-  it('should left align when given position and left props', async () => {
-    const spy = jest.spyOn(console, 'log').mockImplementation(message => {
-      if (!message.startsWith('global handler')) {
-        throw new Error(
-          `Expected console.log() to be called with: 'global handler:' but instead it was called with: ${message}`,
-        )
-      }
-    })
-
-    const user = userEvent.setup()
-    const container = render(
-      <ThemeProvider>
-        <PositionedOverlays left={0} />
-      </ThemeProvider>,
-    )
-
-    // open first menu
-    await user.click(container.getByText('Open right overlay'))
-    expect(container.getByText('Look! right aligned')).toBeInTheDocument()
-
-    const overlay = container.getByText('Look! right aligned').parentElement?.parentElement
-
-    expect(overlay).not.toHaveStyle({position: 'fixed', right: 0})
-    expect(overlay).toHaveStyle({left: 0})
+    const overlay = container.getByText('Look! left aligned').parentElement?.parentElement
+    expect(overlay).toHaveStyle({left: 0, position: 'absolute'})
 
     spy.mockRestore()
   })

--- a/src/__tests__/Overlay.test.tsx
+++ b/src/__tests__/Overlay.test.tsx
@@ -7,7 +7,7 @@ import {axe} from 'jest-axe'
 import theme from '../theme'
 import BaseStyles from '../BaseStyles'
 import {ThemeProvider} from '../ThemeProvider'
-import {NestedOverlays, MemexNestedOverlays, MemexIssueOverlay} from '../stories/Overlay.stories'
+import {NestedOverlays, MemexNestedOverlays, MemexIssueOverlay, PositionedOverlays} from '../stories/Overlay.stories'
 
 type TestComponentSettings = {
   initialFocus?: 'button'
@@ -137,6 +137,62 @@ describe('Overlay', () => {
     // hitting escape again in first overlay should close it
     fireEvent.keyDown(container.getByText('Add to list'), {key: 'Escape', code: 'Escape'})
     expect(container.queryByText('Add to list')).not.toBeInTheDocument()
+
+    spy.mockRestore()
+  })
+
+  it('should right align when given position: right', async () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(message => {
+      if (!message.startsWith('global handler')) {
+        throw new Error(
+          `Expected console.log() to be called with: 'global handler:' but instead it was called with: ${message}`,
+        )
+      }
+    })
+
+    const user = userEvent.setup()
+    const container = render(
+      <ThemeProvider>
+        <PositionedOverlays />
+      </ThemeProvider>,
+    )
+
+    // open first menu
+    await user.click(container.getByText('Open right overlay'))
+    expect(container.getByText('Look! right aligned')).toBeInTheDocument()
+
+    const overlay = container.getByText('Look! right aligned').parentElement?.parentElement
+
+    expect(overlay).toHaveStyle({position: 'fixed', right: 0})
+    expect(overlay).not.toHaveStyle({left: 0})
+
+    spy.mockRestore()
+  })
+
+  it('should left align when given position and left props', async () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(message => {
+      if (!message.startsWith('global handler')) {
+        throw new Error(
+          `Expected console.log() to be called with: 'global handler:' but instead it was called with: ${message}`,
+        )
+      }
+    })
+
+    const user = userEvent.setup()
+    const container = render(
+      <ThemeProvider>
+        <PositionedOverlays left={0} />
+      </ThemeProvider>,
+    )
+
+    // open first menu
+    await user.click(container.getByText('Open right overlay'))
+    expect(container.getByText('Look! right aligned')).toBeInTheDocument()
+
+    const overlay = container.getByText('Look! right aligned').parentElement?.parentElement
+
+    expect(overlay).not.toHaveStyle({position: 'fixed', right: 0})
+    expect(overlay).toHaveStyle({left: 0})
 
     spy.mockRestore()
   })

--- a/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
+++ b/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`AnchoredOverlay should render consistently when open 1`] = `
           data-focus-trap="active"
           height="auto"
           role="none"
-          style="top: 4px; left: 0px; --styled-overlay-visibility: visible;"
+          style="left: 0px; top: 4px; --styled-overlay-visibility: visible;"
           width="auto"
         >
           <span

--- a/src/drafts/InlineAutocomplete/InlineAutocomplete.tsx
+++ b/src/drafts/InlineAutocomplete/InlineAutocomplete.tsx
@@ -2,8 +2,8 @@ import React, {cloneElement, useRef} from 'react'
 import Box from '../../Box'
 import Portal from '../../Portal'
 import {BetterSystemStyleObject} from '../../sx'
-import {getAbsoluteCharacterCoordinates} from '../utils/character-coordinates'
 import {useSyntheticChange} from '../hooks/useSyntheticChange'
+import {getAbsoluteCharacterCoordinates} from '../utils/character-coordinates'
 
 import {ShowSuggestionsEvent, Suggestions, TextInputCompatibleChild, TextInputElement, Trigger} from './types'
 import {augmentHandler, calculateSuggestionsQuery, getSuggestionValue, requireChildrenToBeInput} from './utils'
@@ -198,8 +198,8 @@ const InlineAutocomplete = ({
         inputRef={inputRef}
         onCommit={onCommit}
         onClose={onHideSuggestions}
-        top={suggestionsOffset.top}
-        left={suggestionsOffset.left}
+        top={suggestionsOffset.top || 0}
+        left={suggestionsOffset.left || 0}
         visible={suggestionsVisible}
         tabInsertsSuggestions={tabInsertsSuggestions}
       />

--- a/src/stories/Overlay.stories.tsx
+++ b/src/stories/Overlay.stories.tsx
@@ -450,3 +450,62 @@ export const MemexIssueOverlay = () => {
     </>
   )
 }
+
+export const PositionedOverlays = ({left}: {left?: number}) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [direction, setDirection] = useState<'left' | 'right'>('left')
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const confirmButtonRef = useRef<HTMLButtonElement>(null)
+  const anchorRef = useRef<HTMLDivElement>(null)
+  const closeOverlay = () => setIsOpen(false)
+  return (
+    <Box ref={anchorRef}>
+      <Button
+        ref={buttonRef}
+        onClick={() => {
+          setIsOpen(!isOpen)
+          setDirection('left')
+        }}
+      >
+        Open left overlay
+      </Button>
+      <Button
+        ref={buttonRef}
+        onClick={() => {
+          setIsOpen(!isOpen)
+          setDirection('right')
+        }}
+        sx={{
+          mt: 2,
+        }}
+      >
+        Open right overlay
+      </Button>
+      {isOpen ? (
+        <Overlay
+          initialFocusRef={confirmButtonRef}
+          returnFocusRef={buttonRef}
+          ignoreClickRefs={[buttonRef]}
+          onEscape={closeOverlay}
+          onClickOutside={closeOverlay}
+          width="auto"
+          anchorSide="inside-left"
+          position={direction}
+          left={left}
+        >
+          <Box
+            sx={{
+              height: '100vh',
+              width: '500px',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            <Text>Look! {direction} aligned</Text>
+          </Box>
+        </Overlay>
+      ) : null}
+    </Box>
+  )
+}

--- a/src/stories/Overlay.stories.tsx
+++ b/src/stories/Overlay.stories.tsx
@@ -451,9 +451,9 @@ export const MemexIssueOverlay = () => {
   )
 }
 
-export const PositionedOverlays = ({left}: {left?: number}) => {
+export const PositionedOverlays = ({right}: {right?: boolean}) => {
   const [isOpen, setIsOpen] = useState(false)
-  const [direction, setDirection] = useState<'left' | 'right'>('left')
+  const [direction, setDirection] = useState<'left' | 'right'>(right ? 'right' : 'left')
   const buttonRef = useRef<HTMLButtonElement>(null)
   const confirmButtonRef = useRef<HTMLButtonElement>(null)
   const anchorRef = useRef<HTMLDivElement>(null)
@@ -482,29 +482,53 @@ export const PositionedOverlays = ({left}: {left?: number}) => {
         Open right overlay
       </Button>
       {isOpen ? (
-        <Overlay
-          initialFocusRef={confirmButtonRef}
-          returnFocusRef={buttonRef}
-          ignoreClickRefs={[buttonRef]}
-          onEscape={closeOverlay}
-          onClickOutside={closeOverlay}
-          width="auto"
-          anchorSide="inside-left"
-          position={direction}
-          left={left}
-        >
-          <Box
-            sx={{
-              height: '100vh',
-              width: '500px',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
+        direction === 'left' ? (
+          <Overlay
+            initialFocusRef={confirmButtonRef}
+            returnFocusRef={buttonRef}
+            ignoreClickRefs={[buttonRef]}
+            onEscape={closeOverlay}
+            onClickOutside={closeOverlay}
+            width="auto"
+            anchorSide="inside-right"
           >
-            <Text>Look! {direction} aligned</Text>
-          </Box>
-        </Overlay>
+            <Box
+              sx={{
+                height: '100vh',
+                width: '500px',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <Text>Look! left aligned</Text>
+            </Box>
+          </Overlay>
+        ) : (
+          <Overlay
+            initialFocusRef={confirmButtonRef}
+            returnFocusRef={buttonRef}
+            ignoreClickRefs={[buttonRef]}
+            onEscape={closeOverlay}
+            onClickOutside={closeOverlay}
+            width="auto"
+            anchorSide={'inside-left'}
+            right={0}
+            position="fixed"
+          >
+            <Box
+              sx={{
+                height: '100vh',
+                width: '500px',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <Text>Look! right aligned</Text>
+            </Box>
+          </Overlay>
+        )
       ) : null}
     </Box>
   )


### PR DESCRIPTION
This adds the following CSS properties as props to the Overlay prop to customize its position behavior. 

`position`
`top` (modified)
`left` (modified)
`right`
`bottom`

I added tests and a story to demonstrate the new behavior.


Closes #2713 

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
