### PR TITLE
Add `Noto Sans` to fontStack

### DIFF
--- a/.changeset/ninety-bobcats-worry.md
+++ b/.changeset/ninety-bobcats-worry.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Add `Noto Sans` to fontStack

--- a/src/__tests__/__snapshots__/ActionMenu.test.tsx.snap
+++ b/src/__tests__/__snapshots__/ActionMenu.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ActionMenu renders consistently 1`] = `
 .c0 {
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   line-height: 1.5;
   color: #24292f;
 }

--- a/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
+++ b/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`AnchoredOverlay renders consistently 1`] = `
 .c0 {
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   line-height: 1.5;
   color: #24292f;
 }
@@ -93,7 +93,7 @@ exports[`AnchoredOverlay renders consistently 1`] = `
 
 exports[`AnchoredOverlay should render consistently when open 1`] = `
 .c0 {
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   line-height: 1.5;
   color: #24292f;
 }

--- a/src/__tests__/__snapshots__/ConfirmationDialog.test.tsx.snap
+++ b/src/__tests__/__snapshots__/ConfirmationDialog.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ConfirmationDialog renders consistently 1`] = `
 .c0 {
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   line-height: 1.5;
   color: #24292f;
 }

--- a/src/__tests__/__snapshots__/SelectPanel.test.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectPanel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SelectPanel renders consistently 1`] = `
 .c0 {
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   line-height: 1.5;
   color: #24292f;
 }

--- a/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1546,7 +1546,7 @@ exports[`TextInput renders trailingAction icon button 1`] = `
   z-index: 1000000;
   display: none;
   padding: 0.5em 0.75em;
-  font: normal normal 11px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font: normal normal 11px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   -webkit-font-smoothing: subpixel-antialiased;
   color: #ffffff;
   text-align: center;
@@ -2562,7 +2562,7 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
   z-index: 1000000;
   display: none;
   padding: 0.5em 0.75em;
-  font: normal normal 11px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font: normal normal 11px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   -webkit-font-smoothing: subpixel-antialiased;
   color: #ffffff;
   text-align: center;

--- a/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Tooltip renders consistently 1`] = `
   z-index: 1000000;
   display: none;
   padding: 0.5em 0.75em;
-  font: normal normal 11px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font: normal normal 11px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   -webkit-font-smoothing: subpixel-antialiased;
   color: #ffffff;
   text-align: center;

--- a/src/__tests__/__snapshots__/themePreval.test.ts.snap
+++ b/src/__tests__/__snapshots__/themePreval.test.ts.snap
@@ -13,7 +13,7 @@ var themePreval = {
   "borderWidths": [0, "1px"],
   "breakpoints": ["544px", "768px", "1012px", "1280px"],
   "fonts": {
-    "normal": "-apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\"",
+    "normal": "-apple-system, BlinkMacSystemFont, \\"Segoe UI\\", \"Noto Sans\", Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\"",
     "mono": "SFMono-Regular, Consolas, \\"Liberation Mono\\", Menlo, Courier, monospace"
   },
   "fontSizes": ["12px", "14px", "16px", "20px", "24px", "32px", "40px", "48px"],

--- a/src/__tests__/__snapshots__/themePreval.test.ts.snap
+++ b/src/__tests__/__snapshots__/themePreval.test.ts.snap
@@ -13,7 +13,7 @@ var themePreval = {
   "borderWidths": [0, "1px"],
   "breakpoints": ["544px", "768px", "1012px", "1280px"],
   "fonts": {
-    "normal": "-apple-system, BlinkMacSystemFont, \\"Segoe UI\\", \"Noto Sans\", Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\"",
+    "normal": "-apple-system, BlinkMacSystemFont, \\"Segoe UI\\", \\"Noto Sans\\", Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\"",
     "mono": "SFMono-Regular, Consolas, \\"Liberation Mono\\", Menlo, Courier, monospace"
   },
   "fontSizes": ["12px", "14px", "16px", "20px", "24px", "32px", "40px", "48px"],

--- a/src/theme-preval.js
+++ b/src/theme-preval.js
@@ -18,6 +18,7 @@ const fonts = {
     '-apple-system',
     'BlinkMacSystemFont',
     'Segoe UI',
+    'Noto Sans',
     'Helvetica',
     'Arial',
     'sans-serif',


### PR DESCRIPTION
This adds `Noto Sans` to the `fontStack`. It's a side-stream (not sure if that's a term 😆) from PCSS's https://github.com/primer/css/pull/2300. It should improve [alignment issues](https://github.com/primer/css/issues/1209) on Linux.

Closes https://github.com/github/primer/issues/1493

### Screenshots

Before | After
--- | ---
![Screenshot from 2022-10-25 20-50-42](https://user-images.githubusercontent.com/378023/209079893-3648e517-d5c1-4d1b-a22b-9ba66e7850c5.png) | ![Screenshot from 2022-10-25 20-58-03](https://user-images.githubusercontent.com/378023/209079903-87ca9b2c-6ed5-4bfb-ac54-7fb18333f8df.png)

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
