### PR TITLE
Create docs migration tracking workflow

### DIFF
--- a/.github/workflows/docs_migration.yml
+++ b/.github/workflows/docs_migration.yml
@@ -1,5 +1,5 @@
 name: Docs migration tracking
-on: [pull_request]
+on: [push]
 jobs:
   docs-migration:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs_migration.yml
+++ b/.github/workflows/docs_migration.yml
@@ -9,4 +9,5 @@ jobs:
         with:
           node-version: 16.x
           cache: 'npm'
+      - run: npm ci
       - run: node script/docs-migration.js >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docs_migration.yml
+++ b/.github/workflows/docs_migration.yml
@@ -1,0 +1,12 @@
+name: Docs migration tracking
+on: [pull_request]
+jobs:
+  docs-migration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'npm'
+      - run: node script/docs-migration.js >> $GITHUB_STEP_SUMMARY

--- a/script/docs-migration.js
+++ b/script/docs-migration.js
@@ -26,7 +26,7 @@ console.log(`## Migrated MDX files
 
 ${migratedMdxFiles.length} of ${mdxFiles.length} MDX files have corresponding JSON files.
 
-${migratedMdxFiles.map(file => `- [x] ${file}`).join('\n')}
+${migratedMdxFiles.map(file => `- [x] [${file}](https://github.com/primer/react/blob/main/${file})`).join('\n')}
 `)
 
 console.log(`## Not-yet migrated MDX files
@@ -35,6 +35,6 @@ ${mdxFiles.length - migratedMdxFiles.length} of ${mdxFiles.length} MDX files do 
 
 ${mdxFiles
   .filter(file => !migratedMdxFiles.includes(file))
-  .map(file => `- [ ] ${file}`)
+  .map(file => `- [ ] [${file}](https://github.com/primer/react/blob/main/${file})`)
   .join('\n')}
 `)

--- a/script/docs-migration.js
+++ b/script/docs-migration.js
@@ -1,0 +1,40 @@
+/* eslint-disable no-console */
+const glob = require('fast-glob')
+const fs = require('node:fs')
+
+const introduction = `# Docs migration tracking
+
+We're moving towards a [unified IA](https://github.com/github/primer/issues/1354) for Primer docs that will combine React and Rails component documentation. To implement this unified IA, we need to access Primer React component metadata from outside the primer/react repo.
+
+The first step to making Primer React component metadata more accessible is to move the prop metadata currently stored in MDX files into structured JSON files per component (example: [TreeView](https://github.com/primer/react/blob/main/src/TreeView/TreeView.docs.json)). These component JSON files are automatically compiled into a file called [generated/components.json](https://github.com/primer/react/blob/main/generated/components.json) that can be imported from outside the primer/react repo.
+
+This script tracks our progress as we move the source of truth for component metadata from MDX files to JSON files.
+`
+
+console.log(introduction)
+
+const mdxFiles = glob.sync('docs/content/**/[A-Z]*.{mdx,md}')
+
+const migratedMdxFiles = mdxFiles.filter(file => {
+  const content = fs.readFileSync(file, 'utf8')
+
+  // We consider an .mdx file "migrated" if it imports a corresponding .docs.json file
+  return /import .* from ['"].*\.docs\.json['"]/.test(content)
+})
+
+console.log(`## Migrated MDX files
+
+${migratedMdxFiles.length} of ${mdxFiles.length} MDX files have corresponding JSON files.
+
+${migratedMdxFiles.map(file => `- [x] ${file}`).join('\n')}
+`)
+
+console.log(`## Not-yet migrated MDX files
+
+${mdxFiles.length - migratedMdxFiles.length} of ${mdxFiles.length} MDX files do not have corresponding JSON files.
+
+${mdxFiles
+  .filter(file => !migratedMdxFiles.includes(file))
+  .map(file => `- [ ] ${file}`)
+  .join('\n')}
+`)

--- a/script/docs-migration.js
+++ b/script/docs-migration.js
@@ -22,6 +22,9 @@ const migratedMdxFiles = mdxFiles.filter(file => {
   return /import .* from ['"].*\.docs\.json['"]/.test(content)
 })
 
+console.log(`![Progress bar](https://geps.dev/progress/${Math.ceil((migratedMdxFiles.length / mdxFiles.length) * 100)})
+`)
+
 console.log(`## Migrated MDX files
 
 ${migratedMdxFiles.length} of ${mdxFiles.length} MDX files have corresponding JSON files.


### PR DESCRIPTION
We're moving towards a [unified IA](https://github.com/github/primer/issues/1354) for Primer docs that will combine React and Rails component documentation. To implement this unified IA, we need to access Primer React component metadata from outside the primer/react repo.

The first step to making Primer React component metadata more accessible is to move the prop metadata currently stored in MDX files into structured JSON files per component (example: [TreeView](https://github.com/primer/react/blob/main/src/TreeView/TreeView.docs.json)). These component JSON files are automatically compiled into a file called [generated/components.json](https://github.com/primer/react/blob/main/generated/components.json) that can be imported from outside the primer/react repo.

This workflow tracks our progress as we move the source of truth for component metadata from MDX files to JSON files.

### Screenshots

<img width="1349" alt="CleanShot 2023-01-04 at 14 00 20@2x" src="https://user-images.githubusercontent.com/4608155/210649107-e175de33-914b-40e4-9435-81c04f53cc79.png">

https://github.com/primer/react/actions/runs/3841554266
### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
