### PR TITLE
test(e2e): update waitForSelector for storybook

### DIFF
--- a/e2e/test-helpers/storybook.ts
+++ b/e2e/test-helpers/storybook.ts
@@ -36,6 +36,7 @@ export async function visit(page: Page, options: Options) {
   }
 
   await page.goto(url.toString())
-  await page.waitForSelector('.sb-show-main')
+  await page.waitForSelector('body.sb-show-main:not(.sb-show-preparing-story)')
+  await page.waitForSelector('#root > *')
   await waitForImages(page)
 }


### PR DESCRIPTION
Closes #2743

Update the `page.waitForSelector` to include two specific checks:

> `body.sb-show-main:not(.sb-show-preparing-story)`

It seems like there is a condition that we run into where the `<body>` element has both `.sb-show-main` and `sb-show-preparing-story`. This check makes sure that we _only_ have `.sb-show-main`

> `#root > *`

This will check to make sure that content has been loaded within the story so that helpers like `waitForImages` work off of loaded content