### PR TITLE
Token: Omit `onResize` and `onResizeCapture` methods from the interface as they cause type issues in React 18

### DIFF
--- a/.changeset/olive-parents-search.md
+++ b/.changeset/olive-parents-search.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Token: Omit `onResize` and `onResizeCapture` methods that are included in the method expansion and causes type issues in React 18

--- a/src/Token/Token.tsx
+++ b/src/Token/Token.tsx
@@ -6,7 +6,9 @@ import TokenBase, {defaultTokenSize, isTokenInteractive, TokenBaseProps} from '.
 import RemoveTokenButton from './_RemoveTokenButton'
 import TokenTextContainer from './_TokenTextContainer'
 
-export interface TokenProps extends TokenBaseProps {
+// Omitting onResize and onResizeCapture because seems like React 18 types includes these menthod in the expansion but React 17 doesn't.
+// TODO: This is a temporary solution until we figure out why these methods are causing type errors.
+export interface TokenProps extends Omit<TokenBaseProps, 'onResize' | 'onResizeCapture'> {
   /**
    * A function that renders a component before the token text
    */


### PR DESCRIPTION
`Token` component causes type issues on memex ([ref](https://github.com/github/memex/pull/14174#issuecomment-1373594449)) and blocking the [release](https://github.com/primer/react/pull/2699). 

It might be because React 18 types differ from React 17 and `onResize` and `onResizeCapture` methods are included in the expansion in 18. This is a temporary solution until we know why this causes issues.

Thanks so much to @joshblack for figuring out the issue and proposing a solution 🙏🏼 

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
