### PR TITLE
Avoid tokens weird type checking/eliding

### DIFF
--- a/.changeset/gentle-badgers-confess.md
+++ b/.changeset/gentle-badgers-confess.md
@@ -2,4 +2,6 @@
 '@primer/react': patch
 ---
 
-update types for tokens
+Token: Update component type to be PolymorphicForwardRefComponent.
+
+this avoids types being swallowed by forwardRef (which isn't polymorphic)

--- a/.changeset/gentle-badgers-confess.md
+++ b/.changeset/gentle-badgers-confess.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+update types for tokens

--- a/src/Token/AvatarToken.tsx
+++ b/src/Token/AvatarToken.tsx
@@ -4,6 +4,7 @@ import {get} from '../constants'
 import {TokenBaseProps, defaultTokenSize, tokenSizes, TokenSizeKeys} from './TokenBase'
 import Token from './Token'
 import Avatar from '../Avatar'
+import {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 
 // TODO: update props to only accept 'large' and 'xlarge' on the next breaking change
 export interface AvatarTokenProps extends TokenBaseProps {
@@ -20,7 +21,7 @@ const AvatarContainer = styled.span<{avatarSize: TokenSizeKeys}>`
   width: ${props => `calc(${tokenSizes[props.avatarSize]} - var(--spacing))`};
 `
 
-const AvatarToken = forwardRef<HTMLElement, AvatarTokenProps>(({avatarSrc, id, size, ...rest}, forwardedRef) => {
+const AvatarToken = forwardRef(({avatarSrc, id, size, ...rest}, forwardedRef) => {
   return (
     <Token
       leadingVisual={() => (
@@ -44,7 +45,7 @@ const AvatarToken = forwardRef<HTMLElement, AvatarTokenProps>(({avatarSrc, id, s
       ref={forwardedRef}
     />
   )
-})
+}) as PolymorphicForwardRefComponent<'span' | 'a' | 'button', AvatarTokenProps>
 
 AvatarToken.defaultProps = {
   size: defaultTokenSize,

--- a/src/Token/IssueLabelToken.tsx
+++ b/src/Token/IssueLabelToken.tsx
@@ -5,6 +5,7 @@ import RemoveTokenButton from './_RemoveTokenButton'
 import {parseToHsla, parseToRgba} from 'color2k'
 import {useTheme} from '../ThemeProvider'
 import TokenTextContainer from './_TokenTextContainer'
+import {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 
 export interface IssueLabelTokenProps extends TokenBaseProps {
   /**
@@ -39,7 +40,7 @@ const darkModeStyles = {
     'hsla(var(--label-h), calc(var(--label-s) * 1%),calc((var(--label-l) + var(--lighten-by)) * 1%),var(--border-alpha))',
 }
 
-const IssueLabelToken = forwardRef<HTMLElement, IssueLabelTokenProps>((props, forwardedRef) => {
+const IssueLabelToken = forwardRef((props, forwardedRef) => {
   const {as, fillColor = '#999', onRemove, id, isSelected, text, size, hideRemoveButton, href, onClick, ...rest} = props
   const interactiveTokenProps = {
     as,
@@ -134,7 +135,7 @@ const IssueLabelToken = forwardRef<HTMLElement, IssueLabelTokenProps>((props, fo
       ) : null}
     </TokenBase>
   )
-})
+}) as PolymorphicForwardRefComponent<'span' | 'a' | 'button', IssueLabelTokenProps>
 
 IssueLabelToken.defaultProps = {
   fillColor: '#999',

--- a/src/Token/Token.tsx
+++ b/src/Token/Token.tsx
@@ -5,10 +5,11 @@ import {defaultSxProp} from '../utils/defaultSxProp'
 import TokenBase, {defaultTokenSize, isTokenInteractive, TokenBaseProps} from './TokenBase'
 import RemoveTokenButton from './_RemoveTokenButton'
 import TokenTextContainer from './_TokenTextContainer'
+import {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 
 // Omitting onResize and onResizeCapture because seems like React 18 types includes these menthod in the expansion but React 17 doesn't.
 // TODO: This is a temporary solution until we figure out why these methods are causing type errors.
-export interface TokenProps extends Omit<TokenBaseProps, 'onResize' | 'onResizeCapture'> {
+export interface TokenProps extends TokenBaseProps {
   /**
    * A function that renders a component before the token text
    */
@@ -30,83 +31,81 @@ const LeadingVisualContainer: React.FC<React.PropsWithChildren<Pick<TokenBasePro
   </Box>
 )
 
-const Token = forwardRef<HTMLAnchorElement | HTMLButtonElement | HTMLSpanElement, TokenProps & SxProp>(
-  (props, forwardedRef) => {
-    const {
-      as,
-      onRemove,
-      id,
-      leadingVisual: LeadingVisual,
-      text,
-      size,
-      hideRemoveButton,
-      href,
-      onClick,
-      sx: sxProp = defaultSxProp,
-      ...rest
-    } = props
-    const hasMultipleActionTargets = isTokenInteractive(props) && Boolean(onRemove) && !hideRemoveButton
-    const onRemoveClick: MouseEventHandler = e => {
-      e.stopPropagation()
-      onRemove && onRemove()
-    }
-    const interactiveTokenProps = {
-      as,
-      href,
-      onClick,
-    }
-    const sx = merge(
-      {
-        backgroundColor: 'neutral.subtle',
-        borderColor: props.isSelected ? 'fg.default' : 'border.subtle',
-        borderStyle: 'solid',
-        borderWidth: `${tokenBorderWidthPx}px`,
-        color: props.isSelected ? 'fg.default' : 'fg.muted',
-        maxWidth: '100%',
-        paddingRight: !(hideRemoveButton || !onRemove) ? 0 : undefined,
-        ...(isTokenInteractive(props)
-          ? {
-              '&:hover': {
-                backgroundColor: 'neutral.muted',
-                boxShadow: 'shadow.medium',
-                color: 'fg.default',
-              },
-            }
-          : {}),
-      },
-      sxProp as SxProp,
-    )
+const Token = forwardRef((props, forwardedRef) => {
+  const {
+    as,
+    onRemove,
+    id,
+    leadingVisual: LeadingVisual,
+    text,
+    size,
+    hideRemoveButton,
+    href,
+    onClick,
+    sx: sxProp = defaultSxProp,
+    ...rest
+  } = props
+  const hasMultipleActionTargets = isTokenInteractive(props) && Boolean(onRemove) && !hideRemoveButton
+  const onRemoveClick: MouseEventHandler = e => {
+    e.stopPropagation()
+    onRemove && onRemove()
+  }
+  const interactiveTokenProps = {
+    as,
+    href,
+    onClick,
+  }
+  const sx = merge(
+    {
+      backgroundColor: 'neutral.subtle',
+      borderColor: props.isSelected ? 'fg.default' : 'border.subtle',
+      borderStyle: 'solid',
+      borderWidth: `${tokenBorderWidthPx}px`,
+      color: props.isSelected ? 'fg.default' : 'fg.muted',
+      maxWidth: '100%',
+      paddingRight: !(hideRemoveButton || !onRemove) ? 0 : undefined,
+      ...(isTokenInteractive(props)
+        ? {
+            '&:hover': {
+              backgroundColor: 'neutral.muted',
+              boxShadow: 'shadow.medium',
+              color: 'fg.default',
+            },
+          }
+        : {}),
+    },
+    sxProp as SxProp,
+  )
 
-    return (
-      <TokenBase
-        onRemove={onRemove}
-        id={id?.toString()}
-        text={text}
-        size={size}
-        sx={sx}
-        {...(!hasMultipleActionTargets ? interactiveTokenProps : {})}
-        {...rest}
-        ref={forwardedRef}
-      >
-        {LeadingVisual ? (
-          <LeadingVisualContainer size={size}>
-            <LeadingVisual />
-          </LeadingVisualContainer>
-        ) : null}
-        <TokenTextContainer {...(hasMultipleActionTargets ? interactiveTokenProps : {})}>{text}</TokenTextContainer>
-        {!hideRemoveButton && onRemove ? (
-          <RemoveTokenButton
-            borderOffset={tokenBorderWidthPx}
-            onClick={onRemoveClick}
-            size={size}
-            isParentInteractive={isTokenInteractive(props)}
-            aria-hidden={hasMultipleActionTargets ? 'true' : 'false'}
-          />
-        ) : null}
-      </TokenBase>
-    )
-  },
-)
+  return (
+    <TokenBase
+      onRemove={onRemove}
+      id={id?.toString()}
+      text={text}
+      size={size}
+      sx={sx}
+      {...(!hasMultipleActionTargets ? interactiveTokenProps : {})}
+      {...rest}
+      ref={forwardedRef}
+    >
+      {LeadingVisual ? (
+        <LeadingVisualContainer size={size}>
+          <LeadingVisual />
+        </LeadingVisualContainer>
+      ) : null}
+      <TokenTextContainer {...(hasMultipleActionTargets ? interactiveTokenProps : {})}>{text}</TokenTextContainer>
+      {!hideRemoveButton && onRemove ? (
+        <RemoveTokenButton
+          borderOffset={tokenBorderWidthPx}
+          onClick={onRemoveClick}
+          size={size}
+          isParentInteractive={isTokenInteractive(props)}
+          aria-hidden={hasMultipleActionTargets ? 'true' : 'false'}
+        />
+      ) : null}
+    </TokenBase>
+  )
+}) as PolymorphicForwardRefComponent<'a' | 'button' | 'span', TokenProps & SxProp>
 
 Token.displayName = 'Token'
 

--- a/src/Token/Token.tsx
+++ b/src/Token/Token.tsx
@@ -9,7 +9,7 @@ import {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/po
 
 // Omitting onResize and onResizeCapture because seems like React 18 types includes these menthod in the expansion but React 17 doesn't.
 // TODO: This is a temporary solution until we figure out why these methods are causing type errors.
-export interface TokenProps extends TokenBaseProps {
+export interface TokenProps extends TokenBaseProps, SxProp {
   /**
    * A function that renders a component before the token text
    */
@@ -105,7 +105,7 @@ const Token = forwardRef((props, forwardedRef) => {
       ) : null}
     </TokenBase>
   )
-}) as PolymorphicForwardRefComponent<'a' | 'button' | 'span', TokenProps & SxProp>
+}) as PolymorphicForwardRefComponent<'a' | 'button' | 'span', TokenProps>
 
 Token.displayName = 'Token'
 

--- a/src/Token/Token.tsx
+++ b/src/Token/Token.tsx
@@ -1,6 +1,6 @@
 import React, {forwardRef, MouseEventHandler} from 'react'
 import Box from '../Box'
-import {merge, SxProp} from '../sx'
+import {BetterSystemStyleObject, merge, SxProp} from '../sx'
 import {defaultSxProp} from '../utils/defaultSxProp'
 import TokenBase, {defaultTokenSize, isTokenInteractive, TokenBaseProps} from './TokenBase'
 import RemoveTokenButton from './_RemoveTokenButton'
@@ -55,7 +55,7 @@ const Token = forwardRef((props, forwardedRef) => {
     href,
     onClick,
   }
-  const sx = merge(
+  const sx = merge<BetterSystemStyleObject>(
     {
       backgroundColor: 'neutral.subtle',
       borderColor: props.isSelected ? 'fg.default' : 'border.subtle',
@@ -74,7 +74,7 @@ const Token = forwardRef((props, forwardedRef) => {
           }
         : {}),
     },
-    sxProp as SxProp,
+    sxProp,
   )
 
   return (

--- a/src/Token/TokenBase.tsx
+++ b/src/Token/TokenBase.tsx
@@ -23,7 +23,7 @@ export const tokenSizes: Record<TokenSizeKeys, string> = {
 export const defaultTokenSize: TokenSizeKeys = 'medium'
 
 export interface TokenBaseProps
-  extends Omit<React.HTMLProps<HTMLSpanElement & HTMLButtonElement & HTMLAnchorElement>, 'size' | 'id'> {
+  extends Omit<React.HTMLProps<HTMLSpanElement | HTMLButtonElement | HTMLAnchorElement>, 'size' | 'id'> {
   as?: 'button' | 'a' | 'span'
   /**
    * The function that gets called when a user clicks the remove button, or keys "Backspace" or "Delete" when focused on the token
@@ -49,8 +49,6 @@ export interface TokenBaseProps
    * Which size the token will be rendered at
    */
   size?: TokenSizeKeys
-
-  href?: string
 }
 
 export const isTokenInteractive = ({

--- a/src/__tests__/Token.types.test.tsx
+++ b/src/__tests__/Token.types.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import Token from '../Token'
+import {CheckIcon} from '@primer/octicons-react'
+
+export function requiresAtLeastaTextProp() {
+  // @ts-expect-error text is required
+  return <Token />
+}
+
+export function shouldPassWithOnlyTextProp() {
+  return <Token text="Token test" />
+}
+
+export function shouldNotAcceptSystemProps() {
+  // @ts-expect-error system props should not be accepted
+  return <Token backgroundColor="thistle" />
+}
+
+export function acceptsAsProps() {
+  return (
+    <>
+      <Token as="button" text="Token test" />
+      <Token as="a" text="Token test" />
+      <Token as="span" text="Token test" />
+    </>
+  )
+}
+
+export function acceptsOnRemoveProps() {
+  return <Token text="Token test" onRemove={() => {}} />
+}
+
+export function acceptsHideRemoveButtonProps() {
+  return <Token text="Token test" hideRemoveButton />
+}
+
+export function acceptsIsSelectedProps() {
+  return <Token text="Token test" isSelected />
+}
+
+export function acceptsIdProps() {
+  return <Token text="Token test" id="token-id" />
+}
+
+export function acceptsSizeProps() {
+  return (
+    <>
+      <Token text="Token test" size="small" />
+      <Token text="Token test" size="medium" />
+      <Token text="Token test" size="large" />
+    </>
+  )
+}
+
+export function acceptsHrefProps() {
+  return <Token text="Token test" as="a" href="https://github.com" />
+}
+
+export function acceptsLeadingVisualProps() {
+  return <Token text="Token test" leadingVisual={CheckIcon} />
+}
+
+export function acceptsTrailingVisualProps() {
+  // @ts-expect-error unUsedPropsThatAreTotallyDefinitelyNotAllowed is not a valid prop
+  return <Token text="Token test" unUsedPropsThatAreTotallyDefinitelyNotAllowed={CheckIcon} />
+}
+
+export function allowsOnResizeProps() {
+  return <Token text="Token test" onResize={() => {}} onResizeCapture={() => {}} />
+}
+
+export function hasReasonableEventsForTargets() {
+  const handleButtonClick: React.MouseEventHandler<HTMLButtonElement> = _event => {}
+  const handleAnchorClick: React.MouseEventHandler<HTMLAnchorElement> = _event => {}
+  const handleSpanClick: React.MouseEventHandler<HTMLSpanElement> = _event => {}
+  return (
+    <>
+      <Token text="Token test" as="button" onClick={handleButtonClick} />
+      <Token text="Token test" as="a" onClick={handleAnchorClick} />
+      <Token text="Token test" as="span" onClick={handleSpanClick} />
+    </>
+  )
+}

--- a/src/__tests__/Token.types.test.tsx
+++ b/src/__tests__/Token.types.test.tsx
@@ -71,6 +71,17 @@ export function allowsOnResizeProps() {
   return <Token text="Token test" onResize={() => {}} onResizeCapture={() => {}} />
 }
 
+export function allowsSxProp() {
+  return (
+    <Token
+      text="Token test"
+      sx={{
+        backgroundColor: 'canvas.default',
+      }}
+    />
+  )
+}
+
 export function hasReasonableEventsForTargets() {
   const handleButtonClick: React.MouseEventHandler<HTMLButtonElement> = _event => {}
   const handleAnchorClick: React.MouseEventHandler<HTMLAnchorElement> = _event => {}

--- a/src/__tests__/Token.types.test.tsx
+++ b/src/__tests__/Token.types.test.tsx
@@ -81,3 +81,16 @@ export function hasReasonableEventsForTargets() {
     </>
   )
 }
+
+export function acceptsASubsetOfDomProps() {
+  return (
+    <>
+      <Token text="Token test" className="token-class" />
+      <Token text="Token test" style={{color: 'red'}} />
+      <Token text="Token test" title="token-title" />
+      <Token text="Token test" tabIndex={0} />
+      <Token text="Token test" role="button" />
+      <Token text="Token test" aria-label="token-aria-label" />
+    </>
+  )
+}

--- a/src/__tests__/Token.types.test.tsx
+++ b/src/__tests__/Token.types.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import Token from '../Token'
+import AvatarToken from '../Token/AvatarToken'
+import IssueLabelToken from '../Token/IssueLabelToken'
 import {CheckIcon} from '@primer/octicons-react'
 
 export function requiresAtLeastaTextProp() {
@@ -91,6 +93,33 @@ export function acceptsASubsetOfDomProps() {
       <Token text="Token test" tabIndex={0} />
       <Token text="Token test" role="button" />
       <Token text="Token test" aria-label="token-aria-label" />
+    </>
+  )
+}
+
+export function specialTokenExtensionsAcceptTheirSpecificProps() {
+  return (
+    <>
+      <AvatarToken text="Token test" avatarSrc="https://github.com" />
+      <IssueLabelToken text="Token test" fillColor="red" />
+    </>
+  )
+}
+
+export function specialTokenExtensionsDoNotAcceptOtherProps() {
+  return (
+    <>
+      {' '}
+      <AvatarToken
+        text="Token test"
+        // @ts-expect-error fillColor is not a valid prop for AvatarToken
+        fillColor="red"
+      />
+      <IssueLabelToken
+        text="Token test"
+        // @ts-expect-error avatarSrc is not a valid prop for IssueLabelToken
+        avatarSrc="https://github.com"
+      />
     </>
   )
 }

--- a/src/__tests__/Token.types.test.tsx
+++ b/src/__tests__/Token.types.test.tsx
@@ -109,7 +109,6 @@ export function specialTokenExtensionsAcceptTheirSpecificProps() {
 export function specialTokenExtensionsDoNotAcceptOtherProps() {
   return (
     <>
-      {' '}
       <AvatarToken
         text="Token test"
         // @ts-expect-error fillColor is not a valid prop for AvatarToken


### PR DESCRIPTION
Describe your changes here.

Relates to https://github.com/primer/react/pull/2760

In this pr we omitted `onResize` and `onResizeCapture` as typescript was causing these to elide a mandator unknown type, which was super confusing.

I believe this was caused by the fact that these props aren't equally defined across all polymorphic types, and forwardRef swallows polymorphism, making things wonky. 

I've re-typed these components using the polymorphic helper, and added some type tests to help validate they don't regress.  I think we would be well served extending our type tests further to cover most/all components, as I'm sure others are limited in the same or similar ways

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
