### PR TITLE
Remove shadow from `MarkdownEditor` `textarea`

### DIFF
--- a/.changeset/cool-jeans-applaud.md
+++ b/.changeset/cool-jeans-applaud.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Remove shadow from `MarkdownEditor` `textarea`

--- a/src/drafts/MarkdownEditor/_MarkdownInput.tsx
+++ b/src/drafts/MarkdownEditor/_MarkdownInput.tsx
@@ -117,6 +117,7 @@ export const MarkdownInput = forwardRef<HTMLTextAreaElement, MarkdownInputProps>
           sx={{
             width: '100%',
             borderStyle: 'none',
+            boxShadow: 'none',
             height: fullHeight ? '100%' : undefined,
             outline: theme => {
               return isDraggedOver ? `solid 2px ${theme.colors.accent.fg}` : undefined


### PR DESCRIPTION
There is a weird little subtle box-shadow on the `MarkdownEditor` input:

![screenshot](https://user-images.githubusercontent.com/2294248/211879240-909b3aca-518f-4de0-9689-542be1060a45.png)

This small fix removes that:

<img width="797" alt="screenshot" src="https://user-images.githubusercontent.com/2294248/211879331-fe4568e3-7dad-4fb1-866c-17caddda2204.png">

