### PR TITLE
test(e2e): update underline nav test to wait for visibility

### DIFF
--- a/e2e/components/UnderlineNav.test.ts
+++ b/e2e/components/UnderlineNav.test.ts
@@ -333,12 +333,10 @@ test.describe('UnderlineNav', () => {
               colorScheme: theme,
             },
           })
-
           await page.setViewportSize({width: viewports['primer.breakpoint.sm'], height: 768})
+
           await page.locator('button', {hasText: 'More Repository Items'}).waitFor()
-
           await page.getByRole('button', {name: 'More Repository Items'}).click()
-
           await page.getByRole('link', {name: 'Settings (10)'}).click()
 
           // State after selecting the second last item
@@ -349,6 +347,9 @@ test.describe('UnderlineNav', () => {
             width: 1100,
             height: 480,
           })
+          await page.locator('button', {hasText: 'More Repository Items'}).waitFor({
+            state: 'hidden',
+          })
 
           // Current state
           expect(await page.screenshot()).toMatchSnapshot()
@@ -358,6 +359,7 @@ test.describe('UnderlineNav', () => {
             width: 800,
             height: 480,
           })
+          await page.locator('button', {hasText: 'More Repository Items'}).waitFor()
 
           // Current state
           expect(await page.screenshot()).toMatchSnapshot()
@@ -367,7 +369,6 @@ test.describe('UnderlineNav', () => {
             width: 600,
             height: 480,
           })
-
           // Current state
           expect(await page.screenshot()).toMatchSnapshot()
         })


### PR DESCRIPTION
We've been running into a specific test in `UnderlineNav` that seems to fail intermittently. When looking into previous failures, they seem to revolve around the screenshot happening at a point _before_ JavaScript has run to resize the layout. In other words, the screenshot is taken of the underline nav before it has a chance to expand to the larger viewport size.

This PR updates the `UnderlineNav` test to specifically wait for the "More" button to either appear or disappear in order to time it correctly with the layout changes that are happening when the viewport changes.