### PR TITLE
Expose`useIsSSR` from react aria

### DIFF
--- a/.changeset/six-books-brake.md
+++ b/.changeset/six-books-brake.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Expose the [`useIsSSR` hook from `@react-aria/ssr`](https://react-spectrum.adobe.com/react-aria/ssr.html#ssr-specific-rendering)

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,6 @@ export type {TextareaProps} from './Textarea'
 
 export {UnderlineNav as UnderlineNav2} from './UnderlineNav2'
 
-export {SSRProvider, useSSRSafeId} from './utils/ssr'
+export {SSRProvider, useSSRSafeId, useIsSSR} from './utils/ssr'
 export {default as sx, merge} from './sx'
 export type {SxProp} from './sx'

--- a/src/utils/ssr.tsx
+++ b/src/utils/ssr.tsx
@@ -1,2 +1,2 @@
 // eslint-disable-next-line no-restricted-imports
-export {SSRProvider, useSSRSafeId} from '@react-aria/ssr'
+export {SSRProvider, useSSRSafeId, useIsSSR} from '@react-aria/ssr'


### PR DESCRIPTION
I'd like to expose the [`useIsSSR` hook from `react-aria`](https://react-spectrum.adobe.com/react-aria/ssr.html#ssr-specific-rendering) as an export from primer.

## Why?

I was in the middle of re-implementing similar functionality in a consumer of `primer/react`'s `SSRProvider` [when I noticed that this hook already exists and could be available to me](https://github.com/github/github/pull/254652#issuecomment-1387386417).

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
