### PR TITLE
Fix forwardRef regression

### DIFF
--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import styled from 'styled-components'
 import {get} from './constants'
 import sx, {SxProp} from './sx'
-import {ComponentProps} from './utils/types'
 
 type StyledAvatarProps = {
   /** Sets the width and height of the avatar. */
@@ -36,7 +35,9 @@ const StyledAvatar = styled.img.attrs<StyledAvatarProps>(props => ({
   ${sx}
 `
 
-const Avatar = ({size = 20, alt = '', ...rest}: StyledAvatarProps) => <StyledAvatar alt={alt} size={size} {...rest} />
+export type AvatarProps = StyledAvatarProps & React.ComponentPropsWithoutRef<'img'>
+const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(({size = 20, alt = '', ...rest}, ref) => (
+  <StyledAvatar ref={ref} alt={alt} size={size} {...rest} />
+))
 
-export type AvatarProps = ComponentProps<typeof Avatar>
 export default Avatar

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -40,4 +40,6 @@ const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(({size = 20, alt 
   <StyledAvatar ref={ref} alt={alt} size={size} {...rest} />
 ))
 
+Avatar.displayName = 'Avatar'
+
 export default Avatar

--- a/src/Flash.tsx
+++ b/src/Flash.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import {variant} from 'styled-system'
 import {get} from './constants'
 import sx, {SxProp} from './sx'
-import {ComponentProps} from './utils/types'
 
 const variants = variant({
   variants: {
@@ -68,7 +67,9 @@ const StyledFlash = styled.div<StyledFlashProps>`
   ${sx};
 `
 
-export type FlashProps = ComponentProps<typeof StyledFlash>
-const Flash = ({variant = 'default', ...rest}: FlashProps) => <StyledFlash variant={variant} {...rest} />
+export type FlashProps = StyledFlashProps & React.ComponentPropsWithoutRef<'div'>
+const Flash = React.forwardRef<HTMLDivElement, FlashProps>(({variant = 'default', ...rest}, ref) => (
+  <StyledFlash ref={ref} variant={variant} {...rest} />
+))
 
 export default Flash

--- a/src/Flash.tsx
+++ b/src/Flash.tsx
@@ -72,4 +72,6 @@ const Flash = React.forwardRef<HTMLDivElement, FlashProps>(({variant = 'default'
   <StyledFlash ref={ref} variant={variant} {...rest} />
 ))
 
+Flash.displayName = 'Flash'
+
 export default Flash

--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -3,9 +3,8 @@ import styled from 'styled-components'
 import {variant} from 'styled-system'
 import sx, {SxProp, BetterSystemStyleObject} from './sx'
 import {get} from './constants'
-import {ComponentProps} from './utils/types'
 
-export type LabelProps = {
+type StyledLabelProps = {
   /** The color of the label */
   variant?: LabelColorOptions
   /** How large the label is rendered */
@@ -94,7 +93,9 @@ const StyledLabel = styled.span<LabelProps>`
   ${sx};
 `
 
-const Label = ({size = 'small', variant = 'default', ...rest}: ComponentProps<typeof StyledLabel>) => (
-  <StyledLabel size={size} variant={variant} {...rest} />
-)
+export type LabelProps = StyledLabelProps & React.ComponentPropsWithoutRef<'span'>
+const Label = React.forwardRef<HTMLSpanElement, LabelProps>(({size = 'small', variant = 'default', ...rest}, ref) => (
+  <StyledLabel ref={ref} size={size} variant={variant} {...rest} />
+))
+
 export default Label

--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -98,4 +98,6 @@ const Label = React.forwardRef<HTMLSpanElement, LabelProps>(({size = 'small', va
   <StyledLabel ref={ref} size={size} variant={variant} {...rest} />
 ))
 
+Label.displayName = 'Label'
+
 export default Label


### PR DESCRIPTION
Fixes a regression in https://github.com/primer/react/pull/2759 that removed support for the `ref` prop on Avatar, Flash, and Label.