### PR TITLE
Fix Label `as` prop regression

### DIFF
--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -101,5 +101,5 @@ const Label = React.forwardRef(({size = 'small', variant = 'default', ...rest}, 
 
 Label.displayName = 'Label'
 
-export type LinkProps = ComponentProps<typeof Label>
+export type LabelProps = ComponentProps<typeof Label>
 export default Label

--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import styled from 'styled-components'
 import {variant} from 'styled-system'
-import sx, {SxProp, BetterSystemStyleObject} from './sx'
 import {get} from './constants'
+import sx, {BetterSystemStyleObject, SxProp} from './sx'
+import {ForwardRefComponent as PolymorphicForwardRefComponent} from './utils/polymorphic'
 
 type StyledLabelProps = {
   /** The color of the label */
@@ -77,7 +78,7 @@ const sizes: Record<LabelSizeKeys, BetterSystemStyleObject> = {
   },
 }
 
-const StyledLabel = styled.span<LabelProps>`
+const StyledLabel = styled.span<StyledLabelProps>`
   align-items: center;
   background-color: transparent;
   border-width: 1px;
@@ -93,10 +94,9 @@ const StyledLabel = styled.span<LabelProps>`
   ${sx};
 `
 
-export type LabelProps = StyledLabelProps & React.ComponentPropsWithoutRef<'span'>
-const Label = React.forwardRef<HTMLSpanElement, LabelProps>(({size = 'small', variant = 'default', ...rest}, ref) => (
+const Label = React.forwardRef(({size = 'small', variant = 'default', ...rest}, ref) => (
   <StyledLabel ref={ref} size={size} variant={variant} {...rest} />
-))
+)) as PolymorphicForwardRefComponent<'span', StyledLabelProps>
 
 Label.displayName = 'Label'
 

--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -4,6 +4,7 @@ import {variant} from 'styled-system'
 import {get} from './constants'
 import sx, {BetterSystemStyleObject, SxProp} from './sx'
 import {ForwardRefComponent as PolymorphicForwardRefComponent} from './utils/polymorphic'
+import {ComponentProps} from './utils/types'
 
 type StyledLabelProps = {
   /** The color of the label */
@@ -100,4 +101,5 @@ const Label = React.forwardRef(({size = 'small', variant = 'default', ...rest}, 
 
 Label.displayName = 'Label'
 
+export type LinkProps = ComponentProps<typeof Label>
 export default Label


### PR DESCRIPTION
Fixes a regression in #2759 that removed type support for the as prop on Label