### PR TITLE
Improve initial `useCombobox` initialization process

### DIFF
--- a/.changeset/olive-glasses-listen.md
+++ b/.changeset/olive-glasses-listen.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Improve initial `useCombobox` initialization process to avoid race conditions

--- a/src/drafts/hooks/useCombobox.ts
+++ b/src/drafts/hooks/useCombobox.ts
@@ -97,7 +97,6 @@ export const useCombobox = <T>({
         if (!list.getAttribute('role')) list.setAttribute('role', 'listbox')
 
         const cb = new Combobox(input, list, {tabInsertsSuggestions, defaultFirstOption})
-        if (isOpenRef.current) cb.start()
 
         // By using state instead of a ref here, we trigger the toggleKeyboardEventHandling
         // effect. Otherwise we'd have to depend on isOpen in this effect to start the instance
@@ -116,7 +115,9 @@ export const useCombobox = <T>({
   useEffect(
     function toggleKeyboardEventHandling() {
       const wasOpen = isOpenRef.current
-      isOpenRef.current = isOpen
+
+      // It cannot be open if the instance hasn't yet been initialized
+      isOpenRef.current = isOpen && comboboxInstance !== null
 
       if (isOpen === wasOpen || !comboboxInstance) return
 


### PR DESCRIPTION
The `useCombobox` hook can sometimes fail to properly initialize when the menu is open before the `Combobox` instance initializes. This is a race condition that appears in applications with synchronous suggestion data when the menu initially opens.

This fixes that problem by updating the effect in which the combobox is initialized to wait to try to initialize until after the instantiation completes.

Fix https://github.com/primer/react/issues/2813


### Merge checklist

- ~~[ ] Added/updated tests~~
 - This race condition unfortunately does not seem replicable in tests
- ~~[ ] Added/updated documentation~~
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
