### PR TITLE
feat(DataTable): add support for title and subtitle

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -29,6 +29,9 @@ export const parameters = {
     root: '#html-addon-root',
     removeEmptyComments: true,
   },
+  controls: {
+    hideNoControlsWarning: true,
+  },
   options: {
     storySort: (a, b) => {
       const defaultOrder = [

--- a/src/DataTable/DataTable.docs.json
+++ b/src/DataTable/DataTable.docs.json
@@ -105,6 +105,43 @@
           "description": "Provide the scope for a table cell, useful for defining a row header using `scope=\"row\"`"
         }
       ]
+    },
+    {
+      "name": "TableContainer",
+      "props": [
+        {
+          "name": "children",
+          "type": "React.ReactNode"
+        }
+      ]
+    },
+    {
+      "name": "TableTitle",
+      "props": [
+        {
+          "name": "children",
+          "type": "React.ReactNode"
+        },
+        {
+          "name": "id",
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "TableSubtitle",
+      "props": [
+        {
+          "name": "children",
+          "type": "React.ReactNode"
+        },
+        {
+          "name": "id",
+          "type": "string",
+          "required": true
+        }
+      ]
     }
   ]
 }

--- a/src/DataTable/DataTable.features.stories.tsx
+++ b/src/DataTable/DataTable.features.stories.tsx
@@ -1,0 +1,319 @@
+import {Meta} from '@storybook/react'
+import React from 'react'
+import {
+  DataTable,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableHeader,
+  TableCell,
+  TableContainer,
+  TableTitle,
+  TableSubtitle,
+} from '../DataTable'
+import Label from '../Label'
+import LabelGroup from '../LabelGroup'
+import RelativeTime from '../RelativeTime'
+
+export default {
+  title: 'Drafts/Components/DataTable/Features',
+  component: DataTable,
+  subcomponents: {
+    Table,
+    TableHead,
+    TableBody,
+    TableRow,
+    TableHeader,
+    TableCell,
+    TableContainer,
+    TableTitle,
+    TableSubtitle,
+  },
+} as Meta<typeof DataTable>
+
+const now = Date.now()
+const Second = 1000
+const Minute = 60 * Second
+const Hour = 60 * Minute
+const Day = 24 * Hour
+const Week = 7 * Day
+const Month = 4 * Week
+
+interface Repo {
+  id: number
+  name: string
+  type: 'public' | 'internal'
+  updatedAt: number
+  securityFeatures: {
+    dependabot: Array<string>
+    codeScanning: Array<string>
+  }
+}
+
+const data: Array<Repo> = [
+  {
+    id: 1,
+    name: 'codeql-dca-worker',
+    type: 'internal',
+    updatedAt: now,
+    securityFeatures: {
+      dependabot: ['alerts', 'security updates'],
+      codeScanning: ['report secrets'],
+    },
+  },
+  {
+    id: 2,
+    name: 'aegir',
+    type: 'public',
+    updatedAt: now - 5 * Minute,
+    securityFeatures: {
+      dependabot: ['alerts'],
+      codeScanning: ['report secrets'],
+    },
+  },
+  {
+    id: 3,
+    name: 'strapi',
+    type: 'public',
+    updatedAt: now - 1 * Hour,
+    securityFeatures: {
+      dependabot: [],
+      codeScanning: [],
+    },
+  },
+  {
+    id: 4,
+    name: 'codeql-ci-nightlies',
+    type: 'public',
+    updatedAt: now - 6 * Hour,
+    securityFeatures: {
+      dependabot: ['alerts'],
+      codeScanning: [],
+    },
+  },
+  {
+    id: 5,
+    name: 'dependabot-updates',
+    type: 'public',
+    updatedAt: now - 1 * Day,
+    securityFeatures: {
+      dependabot: [],
+      codeScanning: [],
+    },
+  },
+  {
+    id: 6,
+    name: 'tsx-create-react-app',
+    type: 'public',
+    updatedAt: now - 1 * Week,
+    securityFeatures: {
+      dependabot: [],
+      codeScanning: [],
+    },
+  },
+  {
+    id: 7,
+    name: 'bootstrap',
+    type: 'public',
+    updatedAt: now - 1 * Month,
+    securityFeatures: {
+      dependabot: ['alerts'],
+      codeScanning: [],
+    },
+  },
+  {
+    id: 8,
+    name: 'docker-templates',
+    type: 'public',
+    updatedAt: now - 3 * Month,
+    securityFeatures: {
+      dependabot: ['alerts'],
+      codeScanning: [],
+    },
+  },
+]
+
+function uppercase(input: string): string {
+  return input[0].toUpperCase() + input.slice(1)
+}
+
+export const Default = () => (
+  <TableContainer>
+    <TableTitle as="h2" id="repositories">
+      Repositories
+    </TableTitle>
+    <TableSubtitle as="p" id="repositories-subtitle">
+      A subtitle could appear here to give extra context to the data.
+    </TableSubtitle>
+    <DataTable
+      aria-labelledby="repositories"
+      aria-describedby="repositories-subtitle"
+      data={data}
+      columns={[
+        {
+          header: 'Repository',
+          field: 'name',
+          rowHeader: true,
+        },
+        {
+          header: 'Type',
+          field: 'type',
+          renderCell: row => {
+            return <Label>{uppercase(row.type)}</Label>
+          },
+        },
+        {
+          header: 'Updated',
+          field: 'updatedAt',
+          renderCell: row => {
+            return <RelativeTime date={new Date(row.updatedAt)} />
+          },
+        },
+        {
+          header: 'Dependabot',
+          renderCell: row => {
+            return row.securityFeatures.dependabot.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.dependabot.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+        {
+          header: 'Code scanning',
+          renderCell: row => {
+            return row.securityFeatures.codeScanning.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.codeScanning.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+      ]}
+    />
+  </TableContainer>
+)
+
+export const WithTitle = () => (
+  <TableContainer>
+    <TableTitle as="h2" id="repositories">
+      Repositories
+    </TableTitle>
+    <DataTable
+      aria-labelledby="repositories"
+      aria-describedby="repositories-subtitle"
+      data={data}
+      columns={[
+        {
+          header: 'Repository',
+          field: 'name',
+          rowHeader: true,
+        },
+        {
+          header: 'Type',
+          field: 'type',
+          renderCell: row => {
+            return <Label>{uppercase(row.type)}</Label>
+          },
+        },
+        {
+          header: 'Updated',
+          field: 'updatedAt',
+          renderCell: row => {
+            return <RelativeTime date={new Date(row.updatedAt)} />
+          },
+        },
+        {
+          header: 'Dependabot',
+          renderCell: row => {
+            return row.securityFeatures.dependabot.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.dependabot.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+        {
+          header: 'Code scanning',
+          renderCell: row => {
+            return row.securityFeatures.codeScanning.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.codeScanning.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+      ]}
+    />
+  </TableContainer>
+)
+
+export const WithTitleAndSubtitle = () => (
+  <TableContainer>
+    <TableTitle as="h2" id="repositories">
+      Repositories
+    </TableTitle>
+    <TableSubtitle as="p" id="repositories-subtitle">
+      A subtitle could appear here to give extra context to the data.
+    </TableSubtitle>
+    <DataTable
+      aria-labelledby="repositories"
+      aria-describedby="repositories-subtitle"
+      data={data}
+      columns={[
+        {
+          header: 'Repository',
+          field: 'name',
+          rowHeader: true,
+        },
+        {
+          header: 'Type',
+          field: 'type',
+          renderCell: row => {
+            return <Label>{uppercase(row.type)}</Label>
+          },
+        },
+        {
+          header: 'Updated',
+          field: 'updatedAt',
+          renderCell: row => {
+            return <RelativeTime date={new Date(row.updatedAt)} />
+          },
+        },
+        {
+          header: 'Dependabot',
+          renderCell: row => {
+            return row.securityFeatures.dependabot.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.dependabot.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+        {
+          header: 'Code scanning',
+          renderCell: row => {
+            return row.securityFeatures.codeScanning.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.codeScanning.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+      ]}
+    />
+  </TableContainer>
+)

--- a/src/DataTable/DataTable.stories.tsx
+++ b/src/DataTable/DataTable.stories.tsx
@@ -1,6 +1,17 @@
 import {Meta, ComponentStory} from '@storybook/react'
 import React from 'react'
-import {DataTable, Table, TableHead, TableBody, TableRow, TableHeader, TableCell} from '../DataTable'
+import {
+  DataTable,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableHeader,
+  TableCell,
+  TableContainer,
+  TableTitle,
+  TableSubtitle,
+} from '../DataTable'
 import Label from '../Label'
 import LabelGroup from '../LabelGroup'
 import RelativeTime from '../RelativeTime'
@@ -15,6 +26,9 @@ export default {
     TableRow,
     TableHeader,
     TableCell,
+    TableContainer,
+    TableTitle,
+    TableSubtitle,
   },
 } as Meta<typeof DataTable>
 
@@ -126,55 +140,65 @@ function uppercase(input: string): string {
 
 export const Playground: ComponentStory<typeof DataTable> = args => {
   return (
-    <DataTable
-      {...args}
-      data={data}
-      columns={[
-        {
-          header: 'Repository',
-          field: 'name',
-          rowHeader: true,
-        },
-        {
-          header: 'Type',
-          field: 'type',
-          renderCell: row => {
-            return <Label>{uppercase(row.type)}</Label>
+    <TableContainer>
+      <TableTitle as="h2" id="repositories">
+        Repositories
+      </TableTitle>
+      <TableSubtitle as="p" id="repositories-subtitle">
+        A subtitle could appear here to give extra context to the data.
+      </TableSubtitle>
+      <DataTable
+        {...args}
+        aria-labelledby="repositories"
+        aria-describedby="repositories-subtitle"
+        data={data}
+        columns={[
+          {
+            header: 'Repository',
+            field: 'name',
+            rowHeader: true,
           },
-        },
-        {
-          header: 'Updated',
-          field: 'updatedAt',
-          renderCell: row => {
-            return <RelativeTime date={new Date(row.updatedAt)} />
+          {
+            header: 'Type',
+            field: 'type',
+            renderCell: row => {
+              return <Label>{uppercase(row.type)}</Label>
+            },
           },
-        },
-        {
-          header: 'Dependabot',
-          renderCell: row => {
-            return row.securityFeatures.dependabot.length > 0 ? (
-              <LabelGroup>
-                {row.securityFeatures.dependabot.map(feature => {
-                  return <Label key={feature}>{uppercase(feature)}</Label>
-                })}
-              </LabelGroup>
-            ) : null
+          {
+            header: 'Updated',
+            field: 'updatedAt',
+            renderCell: row => {
+              return <RelativeTime date={new Date(row.updatedAt)} />
+            },
           },
-        },
-        {
-          header: 'Code scanning',
-          renderCell: row => {
-            return row.securityFeatures.codeScanning.length > 0 ? (
-              <LabelGroup>
-                {row.securityFeatures.codeScanning.map(feature => {
-                  return <Label key={feature}>{uppercase(feature)}</Label>
-                })}
-              </LabelGroup>
-            ) : null
+          {
+            header: 'Dependabot',
+            renderCell: row => {
+              return row.securityFeatures.dependabot.length > 0 ? (
+                <LabelGroup>
+                  {row.securityFeatures.dependabot.map(feature => {
+                    return <Label key={feature}>{uppercase(feature)}</Label>
+                  })}
+                </LabelGroup>
+              ) : null
+            },
           },
-        },
-      ]}
-    />
+          {
+            header: 'Code scanning',
+            renderCell: row => {
+              return row.securityFeatures.codeScanning.length > 0 ? (
+                <LabelGroup>
+                  {row.securityFeatures.codeScanning.map(feature => {
+                    return <Label key={feature}>{uppercase(feature)}</Label>
+                  })}
+                </LabelGroup>
+              ) : null
+            },
+          },
+        ]}
+      />
+    </TableContainer>
   )
 }
 

--- a/src/DataTable/__tests__/DataTable.test.tsx
+++ b/src/DataTable/__tests__/DataTable.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {DataTable} from '..'
+import {DataTable, TableContainer, TableTitle, TableSubtitle} from '..'
 import {render, screen} from '@testing-library/react'
 
 describe('DataTable', () => {
@@ -109,6 +109,38 @@ describe('DataTable', () => {
     expect(screen.getByRole('table', {name: 'custom-title'})).toBeInTheDocument()
   })
 
+  it('should support custom labeling through `aria-labelledby` and `TableTitle`', () => {
+    const columns = [
+      {
+        header: 'Name',
+        field: 'name',
+      },
+    ]
+    const data = [
+      {
+        id: 1,
+        name: 'one',
+      },
+      {
+        id: 2,
+        name: 'two',
+      },
+      {
+        id: 3,
+        name: 'three',
+      },
+    ]
+    render(
+      <TableContainer>
+        <TableTitle as="h2" id="custom-title">
+          custom-title
+        </TableTitle>
+        <DataTable data={data} columns={columns} aria-labelledby="custom-title" />
+      </TableContainer>,
+    )
+    expect(screen.getByRole('table', {name: 'custom-title'})).toBeInTheDocument()
+  })
+
   it('should support custom descriptions through `aria-describedby`', () => {
     const columns = [
       {
@@ -135,6 +167,38 @@ describe('DataTable', () => {
         <p id="custom-description">custom-description</p>
         <DataTable data={data} columns={columns} aria-describedby="custom-description" />
       </>,
+    )
+    expect(screen.getByRole('table', {description: 'custom-description'})).toBeInTheDocument()
+  })
+
+  it('should support custom descriptions through `aria-describedby` and `TableSubtitle`', () => {
+    const columns = [
+      {
+        header: 'Name',
+        field: 'name',
+      },
+    ]
+    const data = [
+      {
+        id: 1,
+        name: 'one',
+      },
+      {
+        id: 2,
+        name: 'two',
+      },
+      {
+        id: 3,
+        name: 'three',
+      },
+    ]
+    render(
+      <TableContainer>
+        <TableSubtitle as="p" id="custom-description">
+          custom-description
+        </TableSubtitle>
+        <DataTable data={data} columns={columns} aria-describedby="custom-description" />
+      </TableContainer>,
     )
     expect(screen.getByRole('table', {description: 'custom-description'})).toBeInTheDocument()
   })

--- a/src/DataTable/index.tsx
+++ b/src/DataTable/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import Box from '../Box'
 import {get} from '../constants'
 
 // ----------------------------------------------------------------------------
@@ -233,6 +234,12 @@ const StyledTable = styled.table<React.ComponentPropsWithoutRef<'table'>>`
     font-weight: 600;
     text-align: start;
   }
+
+  /* Spacing if table details are present */
+  .TableTitle + &,
+  .TableSubtitle + & {
+    margin-top: ${get('space.2')};
+  }
 `
 
 interface TableProps extends React.ComponentPropsWithoutRef<'table'> {
@@ -331,4 +338,98 @@ function TableCell({children, scope}: TableCellProps) {
   )
 }
 
-export {DataTable, Table, TableHead, TableBody, TableRow, TableHeader, TableCell}
+// ----------------------------------------------------------------------------
+// TableContainer
+// ----------------------------------------------------------------------------
+interface TableContainerProps {
+  children?: React.ReactNode | undefined
+}
+
+function TableContainer({children}: TableContainerProps) {
+  return <Box>{children}</Box>
+}
+
+interface TableTitleProps {
+  /**
+   * Provide an alternate element or component to use as the container for
+   * `TableSubtitle`. This is useful when specifying markup that is more
+   * semantic for your use-case, such as a heading tag.
+   */
+  as?: keyof JSX.IntrinsicElements | React.ComponentType
+
+  children?: React.ReactNode | undefined
+
+  /**
+   * Provide a unique id for the table subtitle. This should be used along with
+   * `aria-labelledby` on `DataTable`
+   */
+  id: string
+}
+
+function TableTitle({as, children, id}: TableTitleProps) {
+  return (
+    <Box
+      as={as}
+      className="TableTitle"
+      id={id}
+      sx={{
+        color: 'fg.default',
+        fontWeight: 600,
+        fontSize: '0.875rem',
+        lineHeight: 'calc(20 / 14)',
+        margin: 0,
+      }}
+    >
+      {children}
+    </Box>
+  )
+}
+
+interface TableSubtitleProps {
+  /**
+   * Provide an alternate element or component to use as the container for
+   * `TableSubtitle`. This is useful when specifying markup that is more
+   * semantic for your use-case
+   */
+  as?: keyof JSX.IntrinsicElements | React.ComponentType
+
+  children?: React.ReactNode | undefined
+
+  /**
+   * Provide a unique id for the table subtitle. This should be used along with
+   * `aria-describedby` on `DataTable`
+   */
+  id: string
+}
+
+function TableSubtitle({as, children, id}: TableSubtitleProps) {
+  return (
+    <Box
+      as={as}
+      className="TableSubtitle"
+      id={id}
+      sx={{
+        color: 'fg.default',
+        fontWeight: 400,
+        fontSize: '0.75rem',
+        lineHeight: 'calc(18 / 12)',
+        margin: 0,
+      }}
+    >
+      {children}
+    </Box>
+  )
+}
+
+export {
+  DataTable,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableHeader,
+  TableCell,
+  TableContainer,
+  TableTitle,
+  TableSubtitle,
+}


### PR DESCRIPTION
Add support for title and subtitle for `DataTable` based on: https://github.com/github/primer/pull/1712

#### Changelog

**New**

- Add `TableContainer` component for laying out the table
- Add `TableTitle` component for providing a table title
- Add `TableSubtitle` component for providing a table description
- Add feature stories for `DataTable`

**Changed**

- Update label and description tests to include support for `TableTitle` and `TableSubtitle` for labeling and describing a `Table`
- Update docs.json for `DataTable` to include `TableContainer`, `TableTitle`, and `TableSubtitle`
- Update storybook config to no longer warn on controls in feature stories

**Removed**