### PR TITLE
fix: Set roving tabindex in TreeView, before 'useRovingTabIndex' runs

### DIFF
--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -396,7 +396,7 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
         <li
           className="PRIVATE_TreeView-item"
           ref={ref as React.ForwardedRef<HTMLLIElement>}
-          tabIndex={0}
+          tabIndex={isCurrentItem ? 0 : -1}
           id={itemId}
           role="treeitem"
           aria-labelledby={labelId}


### PR DESCRIPTION
Describe your changes here.

Closes # (type the issue number after # if applicable; otherwise remove this line)

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
