### PR TITLE
adds rollup output auto

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -119,6 +119,7 @@ export default [
     ...baseConfig,
     external: dependencies.map(createPackageRegex),
     output: {
+      interop: 'auto',
       dir: 'lib-esm',
       format: 'esm',
       preserveModules: true,
@@ -131,6 +132,7 @@ export default [
     ...baseConfig,
     external: dependencies.filter(name => !ESM_ONLY.has(name)).map(createPackageRegex),
     output: {
+      interop: 'auto',
       dir: 'lib',
       format: 'commonjs',
       preserveModules: true,
@@ -154,6 +156,7 @@ export default [
       visualizer({sourcemap: true}),
     ],
     output: ['esm', 'umd'].map(format => ({
+      interop: 'auto',
       file: `dist/browser.${format}.js`,
       format,
       sourcemap: true,


### PR DESCRIPTION
Describe your changes here.

While installing the latest RC in 2 github codebases, we ran into test issues with the cjs build in jest, with tests failing along the lines of 

```
cannot read `withConfig` of undefined
```

This is usually part of the styled components transform.  Digging into the built code, for a random component

- https://unpkg.com/browse/@primer/react@35.19.0/lib/BaseStyles.js
- https://unpkg.com/browse/@primer/react@35.20.0-rc.7cd5e626/lib/BaseStyles.js


```
var styled = require('styled-components');
unction _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
var styled__default = /*#__PURE__*/_interopDefaultLegacy(styled);


const Base = styled__default["default"].div.withConfig({
    displayName: "BaseStyles__Base",
    componentId: "sc-nfjs56-0"
})(["", ";", ";"], constants.TYPOGRAPHY, constants.COMMON);
```

where the new version does

```
var styled = require('styled-components');
const Base = styled.div.withConfig({
   displayName: "BaseStyles__Base",
   componentId: "sc-nfjs56-0"
})(["", ";", ";"], constants.TYPOGRAPHY, constants.COMMON);
```

maybe styled-components needs to be calling styled.default.div here, or imported like

It looks like a change occured in our tansforms.  @broccolinisoup pointed out that there was a recent rollup upgrade to v3 https://github.com/primer/react/pull/2866

It seems that rollup v3 has a slightly different handling of this than, for instance, typescript, and typescript's output can be mirrored via a flag https://rollupjs.org/configuration-options/#output-interop

`output.interop: auto`

I've added that with reckless abandon to see if that helps

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
