### PR TITLE
Add `isolation:isolate` to `ButtonGroup` container

### DIFF
--- a/.changeset/fair-lobsters-sin.md
+++ b/.changeset/fair-lobsters-sin.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Add `isolation:isolate` to `ButtonGroup` container

--- a/src/ButtonGroup.tsx
+++ b/src/ButtonGroup.tsx
@@ -6,6 +6,7 @@ import {ComponentProps} from './utils/types'
 const ButtonGroup = styled.div`
   display: inline-flex;
   vertical-align: middle;
+  isolation: isolate;
 
   && > * {
     position: relative;

--- a/src/__tests__/deprecated/__snapshots__/Button.test.tsx.snap
+++ b/src/__tests__/deprecated/__snapshots__/Button.test.tsx.snap
@@ -301,6 +301,7 @@ exports[`ButtonGroup renders consistently 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   vertical-align: middle;
+  isolation: isolate;
 }
 
 .c0.c0 > * {


### PR DESCRIPTION
Using `z-index` in reusable components is generally a bad idea, because `z-index` is one of the most subtle side-effecting CSS rules in existence. It will inevitably break things down the road. The only way to use `z-index` internally without affecting surrounding UI is to create a new [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) to isolate the effects

In `ButtonGroup`, the `z-index` on the focused element _is_ necessary to be able to show the focused button's outline above the other buttons. So we can't remove it altogether. But we can definitely isolate it, and there's no reason not to - the only goal here is to make the element show above its fellow buttons - not above the entire app. The easiest way to make a new stacking context with no other effects is `isolation: isolate`.

Fixes https://github.com/github/memex/issues/8722
