### PR TITLE
Update storybook-tests.yml

### DIFF
--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -7,11 +7,14 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 60
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
       - name: Install dependencies
         run: npm i
       - name: Install Playwright


### PR DESCRIPTION
Use Node.js v16 instead of v18 in `storybook-tests.yml`. This should fix the timeout issue that we had starting last week.