### PR TITLE
docs(adr): add development-warnings adr

### DIFF
--- a/contributor-docs/adrs/adr-012-development-warnings.md
+++ b/contributor-docs/adrs/adr-012-development-warnings.md
@@ -1,4 +1,4 @@
-# ADR XXX: Development Warnings
+# ADR 012: Development Warnings
 
 ## Status
 

--- a/contributor-docs/adrs/adr-012-development-warnings.md
+++ b/contributor-docs/adrs/adr-012-development-warnings.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -44,10 +44,10 @@ When a contributor would like to communicate a warning to a developer, they
 should use the `warning()` helper.
 
 ```ts
-warning(condition, 'This is the message that is logged when condition is false-y')
+warning(condition, 'This is the message that is logged when condition is truth-y')
 ```
 
-This helper allows you to provide a `condition`. When the condition is false-y
+This helper allows you to provide a `condition`. When the condition is truth-y
 it will emit the message provided. This helper is automatically wrapped in a
 `__DEV__` block and will be removed from production builds.
 

--- a/contributor-docs/adrs/adr-XXX-development-warnings.md
+++ b/contributor-docs/adrs/adr-XXX-development-warnings.md
@@ -9,7 +9,7 @@ Proposed
 There are situations where we would like to provide warnings to developers who
 use `@primer/react` that something may be deprecated, unsupported, etc. Often,
 these will be emitted using `console.warn()`. When using `console.warn()` by
-itself, we run into a situation where code that is only be meant for development
+itself, we run into a situation where code that is only meant for development
 is included in production code. As a result, it would be helpful to establish
 patterns around how to provide warnings to developers in order to make sure
 that:
@@ -20,7 +20,7 @@ that:
 
 ## Decision
 
-Code that is meant for development-only warnings **must** be wrapped within a
+Code that is meant for development-only warnings or checks **must** be wrapped within a
 `__DEV__` block.
 
 ```tsx
@@ -32,7 +32,7 @@ function ExampleComponent() {
 ```
 
 Under-the-hood, the `__DEV__` block will be compiled to a `NODE_ENV` check so
-that it is stripped when `NODE_ENV` is `production`.
+that it is stripped when `NODE_ENV` is set to `'production'`.
 
 > **Note**
 > Contributors may wrap hooks within a `__DEV__` block even though hooks are not
@@ -48,7 +48,8 @@ warning(condition, 'This is the message that is logged when condition is false-y
 ```
 
 This helper allows you to provide a `condition`. When the condition is false-y
-it will emit the message provided.
+it will emit the message provided. This helper is automatically wrapped in a
+`__DEV__` block and will be removed from production builds.
 
 For more complex conditions, a contributor may combine `console.warn()` with
 `__DEV__` when `warning()` does not suffice.

--- a/contributor-docs/adrs/adr-XXX-development-warnings.md
+++ b/contributor-docs/adrs/adr-XXX-development-warnings.md
@@ -1,0 +1,59 @@
+# ADR XXX: Development Warnings
+
+## Status
+
+Proposed
+
+## Context
+
+There are situations where we would like to provide warnings to developers who
+use `@primer/react` that something may be deprecated, unsupported, etc. Often,
+these will be emitted using `console.warn()`. When using `console.warn()` by
+itself, we run into a situation where code that is only be meant for development
+is included in production code. As a result, it would be helpful to establish
+patterns around how to provide warnings to developers in order to make sure
+that:
+
+- Calls to `console.warn()` do not appear in production
+- Code related to development checks, warnings, or messages are removed from
+  production code
+
+## Decision
+
+Code that is meant for development-only warnings **must** be wrapped within a
+`__DEV__` block.
+
+```tsx
+function ExampleComponent() {
+  if (__DEV__) {
+    // This code only runs in development
+  }
+}
+```
+
+Under-the-hood, the `__DEV__` block will be compiled to a `NODE_ENV` check so
+that it is stripped when `NODE_ENV` is `production`.
+
+> **Note**
+> Contributors may wrap hooks within a `__DEV__` block even though hooks are not
+> meant to be called conditionally. This is because the `__DEV__` check can be
+> considered constant in that it will always be true or false for the
+> environment (development or production).
+
+When a contributor would like to communicate a warning to a developer, they
+should use the `warning()` helper.
+
+```ts
+warning(condition, 'This is the message that is logged when condition is false-y')
+```
+
+This helper allows you to provide a `condition`. When the condition is false-y
+it will emit the message provided.
+
+For more complex conditions, a contributor may combine `console.warn()` with
+`__DEV__` when `warning()` does not suffice.
+
+### Impact
+
+- Calls to `console.warn()` will be replaced by `warning()` or will be wrapped
+  in a `__DEV__` block


### PR DESCRIPTION
ADR for Development Warnings in `@primer/react`

[Rendered markdown](https://github.com/primer/react/blob/7e423651a13836a1ecebd0198c2d939fa37f027b/contributor-docs/adrs/adr-012-development-warnings.md)

[Pull Request](https://github.com/primer/react/pull/2901)