### PR TITLE
Button: Do not add [data-size="medium"]` when size is explicitly specified as medium

### DIFF
--- a/.changeset/calm-moons-serve.md
+++ b/.changeset/calm-moons-serve.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Button: Fixes the style override issue when size is explicitly specified as medium

--- a/src/Button/Button.dev.stories.tsx
+++ b/src/Button/Button.dev.stories.tsx
@@ -39,6 +39,14 @@ export const TestSxProp = () => {
   return (
     <div style={{display: 'flex', flexDirection: 'row', gap: '1rem'}}>
       <Button
+        size="medium"
+        sx={{
+          color: 'deeppink',
+        }}
+      >
+        Medium Pink
+      </Button>
+      <Button
         size="small"
         sx={{
           ':hover': {

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -66,8 +66,7 @@ export function generateCustomSxProp(
   props: Partial<Pick<ButtonProps, 'size' | 'block' | 'leadingIcon' | 'trailingIcon' | 'trailingAction'>>,
   providedSx: BetterSystemStyleObject,
 ) {
-  // Possible data attributes: data-size, data-block, data-no-visuals
-  const size = props.size ? `[data-size="${props.size}"]` : ''
+  const size = props.size && props.size !== 'medium' ? `[data-size="${props.size}"]` : '' // medium is a default size therefore it doesn't have a data attribute that used for styling
   const block = props.block ? `[data-block="block"]` : ''
   const noVisuals = props.leadingIcon || props.trailingIcon || props.trailingAction ? '' : '[data-no-visuals="true"]'
 

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -66,6 +66,7 @@ export function generateCustomSxProp(
   props: Partial<Pick<ButtonProps, 'size' | 'block' | 'leadingIcon' | 'trailingIcon' | 'trailingAction'>>,
   providedSx: BetterSystemStyleObject,
 ) {
+  // Possible data attributes: data-size, data-block, data-no-visuals
   const size = props.size && props.size !== 'medium' ? `[data-size="${props.size}"]` : '' // medium is a default size therefore it doesn't have a data attribute that used for styling
   const block = props.block ? `[data-block="block"]` : ''
   const noVisuals = props.leadingIcon || props.trailingIcon || props.trailingAction ? '' : '[data-no-visuals="true"]'


### PR DESCRIPTION
Describe your changes here.

Closes https://github.com/primer/react/issues/2927

### Context
The issue is when `size="medium"` prop is passed to `Button`, the styles provided via `sx` prop don't apply. With the way we apply `Button` styles that were provided via `sx`  is described here. 

### Issue and solution
The reason that wasn't working for the `size="medium"` is because the function is adding `[data-size="medium"]` but we don't have any styles defined with that data-attribute (Because the default size of `Button` is `medium` therefore it is styled on the base class) so it was simply disregarding everything. Simply checking if the size is not equal to `medium`solves the issue.

### Screenshots

No visual changes

### Merge checklist

- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
