### PR TITLE
TextArea: Resolve storybook axe violation that was caused by explicitly setting an id

### DIFF
--- a/src/stories/Textarea.stories.tsx
+++ b/src/stories/Textarea.stories.tsx
@@ -69,7 +69,7 @@ export const TextareaStory = (args: FormControlArgs<TextareaProps>) => {
     <Box as="form" sx={{p: 3}}>
       <FormControl {...parentArgs}>
         <FormControl.Label {...labelArgs} />
-        <Textarea id="textarea" {...args} />
+        <Textarea {...args} />
         {captionArgs.children && <FormControl.Caption {...captionArgs} />}
         {validationArgs.children && validationArgs.variant && (
           <FormControl.Validation {...validationArgs} variant={validationArgs.variant} />


### PR DESCRIPTION
Describe your changes here.

No need to explicitly set an id for `TextArea` component on its story. The id is inferred from the `args`

Closes https://github.com/github/primer/issues/1863

### Screenshots

No visual changes

### Merge checklist

- [x] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
