### PR TITLE
TextInput: Add labels to loading indicator stories for `axe-clean`

### DIFF
--- a/src/stories/TextInput.stories.tsx
+++ b/src/stories/TextInput.stories.tsx
@@ -163,7 +163,7 @@ export const WithTrailingAction = (args: FormControlArgs<TextInputProps>) => {
 }
 
 export const WithLoadingIndicator = (args: FormControlArgs<TextInputProps>) => {
-  const {parentArgs, labelArgs, captionArgs, validationArgs} = getFormControlArgsByChildComponent(args)
+  const {parentArgs, labelArgs} = getFormControlArgsByChildComponent(args)
   return (
     <Box as="form" sx={{padding: 3}}>
       <h3>No visual</h3>

--- a/src/stories/TextInput.stories.tsx
+++ b/src/stories/TextInput.stories.tsx
@@ -162,66 +162,111 @@ export const WithTrailingAction = (args: FormControlArgs<TextInputProps>) => {
   )
 }
 
-export const WithLoadingIndicator = (args: FormControlArgs<TextInputProps>) => (
-  <Box as="form" sx={{p: 3}}>
-    <h3>No visual</h3>
-    <Box mb={2}>
-      <TextInput value="auto" {...args} />
-    </Box>
-    <Box mb={2}>
-      <TextInput value="leading" {...args} loaderPosition="leading" />
-    </Box>
-    <Box mb={5}>
-      <TextInput value="trailing" {...args} loaderPosition="trailing" />
-    </Box>
+export const WithLoadingIndicator = (args: FormControlArgs<TextInputProps>) => {
+  const {parentArgs, labelArgs, captionArgs, validationArgs} = getFormControlArgsByChildComponent(args)
+  return (
+    <Box as="form" sx={{padding: 3}}>
+      <h3>No visual</h3>
 
-    <h3>Leading visual</h3>
-    <Box mb={2}>
-      <TextInput leadingVisual={CalendarIcon} {...args} value="auto" />
-    </Box>
-    <Box mb={2}>
-      <TextInput leadingVisual={CalendarIcon} {...args} loaderPosition="leading" value="leading" />
-    </Box>
-    <Box mb={5}>
-      <TextInput leadingVisual={CalendarIcon} {...args} loaderPosition="trailing" value="trailing" />
-    </Box>
+      <Box mb={2}>
+        <FormControl {...parentArgs}>
+          <FormControl.Label {...labelArgs} />
+          <TextInput value="auto" {...args} />
+        </FormControl>
+      </Box>
+      <Box mb={2}>
+        <FormControl {...parentArgs}>
+          <FormControl.Label {...labelArgs} />
+          <TextInput value="leading" {...args} loaderPosition="leading" />
+        </FormControl>
+      </Box>
+      <Box mb={5}>
+        <FormControl {...parentArgs}>
+          <FormControl.Label {...labelArgs} />
+          <FormControl.Label {...labelArgs} />
+          <TextInput value="trailing" {...args} loaderPosition="trailing" />
+        </FormControl>
+      </Box>
 
-    <h3>Trailing visual</h3>
-    <Box mb={2}>
-      <TextInput trailingVisual={CalendarIcon} {...args} value="auto" />
-    </Box>
-    <Box mb={2}>
-      <TextInput trailingVisual={CalendarIcon} {...args} loaderPosition="leading" value="leading" />
-    </Box>
-    <Box mb={5}>
-      <TextInput trailingVisual={CalendarIcon} {...args} loaderPosition="trailing" value="trailing" />
-    </Box>
+      <h3>Leading visual</h3>
 
-    <h3>Both visuals</h3>
-    <Box mb={2}>
-      <TextInput size="small" leadingVisual={CalendarIcon} trailingVisual={CalendarIcon} {...args} value="auto" />
+      <Box mb={2}>
+        <FormControl {...parentArgs}>
+          <FormControl.Label {...labelArgs} />
+          <TextInput leadingVisual={CalendarIcon} {...args} value="auto" />
+        </FormControl>
+      </Box>
+      <Box mb={2}>
+        <FormControl {...parentArgs}>
+          <FormControl.Label {...labelArgs} />
+          <TextInput leadingVisual={CalendarIcon} {...args} loaderPosition="leading" value="leading" />
+        </FormControl>
+      </Box>
+      <Box mb={5}>
+        <FormControl {...parentArgs}>
+          <FormControl.Label {...labelArgs} />
+          <TextInput leadingVisual={CalendarIcon} {...args} loaderPosition="trailing" value="trailing" />
+        </FormControl>
+      </Box>
+
+      <h3>Trailing visual</h3>
+      <FormControl {...parentArgs}>
+        <Box mb={2}>
+          <FormControl {...parentArgs}>
+            <FormControl.Label {...labelArgs} />
+            <TextInput trailingVisual={CalendarIcon} {...args} value="auto" />
+          </FormControl>
+        </Box>
+        <Box mb={2}>
+          <FormControl {...parentArgs}>
+            <FormControl.Label {...labelArgs} />
+            <TextInput trailingVisual={CalendarIcon} {...args} loaderPosition="leading" value="leading" />
+          </FormControl>
+        </Box>
+        <Box mb={5}>
+          <FormControl {...parentArgs}>
+            <FormControl.Label {...labelArgs} />
+            <TextInput trailingVisual={CalendarIcon} {...args} loaderPosition="trailing" value="trailing" />
+          </FormControl>
+        </Box>
+      </FormControl>
+
+      <h3>Both visuals</h3>
+
+      <Box mb={2}>
+        <FormControl {...parentArgs}>
+          <FormControl.Label {...labelArgs} />
+          <TextInput size="small" leadingVisual={CalendarIcon} trailingVisual={CalendarIcon} {...args} value="auto" />
+        </FormControl>
+      </Box>
+      <Box mb={2}>
+        <FormControl {...parentArgs}>
+          <FormControl.Label {...labelArgs} />
+          <TextInput
+            leadingVisual={CalendarIcon}
+            trailingVisual={CalendarIcon}
+            {...args}
+            loaderPosition="leading"
+            value="leading"
+          />
+        </FormControl>
+      </Box>
+      <Box mb={2}>
+        <FormControl {...parentArgs}>
+          <FormControl.Label {...labelArgs} />
+          <TextInput
+            size="large"
+            leadingVisual={CalendarIcon}
+            trailingVisual={CalendarIcon}
+            {...args}
+            loaderPosition="trailing"
+            value="trailing"
+          />
+        </FormControl>
+      </Box>
     </Box>
-    <Box mb={2}>
-      <TextInput
-        leadingVisual={CalendarIcon}
-        trailingVisual={CalendarIcon}
-        {...args}
-        loaderPosition="leading"
-        value="leading"
-      />
-    </Box>
-    <Box mb={2}>
-      <TextInput
-        size="large"
-        leadingVisual={CalendarIcon}
-        trailingVisual={CalendarIcon}
-        {...args}
-        loaderPosition="trailing"
-        value="trailing"
-      />
-    </Box>
-  </Box>
-)
+  )
+}
 
 WithLoadingIndicator.args = {
   loading: true,


### PR DESCRIPTION
Describe your changes here.

`TextInput` loading indicator stories report axe-violations due to lack of associated labels for the inputs. This PR adds labels to the stories.

Closes https://github.com/github/primer/issues/1862

Story: https://primer-04c73af4c7-13348165.drafts.github.io/storybook/?path=/story/components-forms-textinput--with-loading-indicator

### Screenshots

No significant visual changes. Just labels are visible. 

### Merge checklist

- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
