### PR TITLE
Add vscode snippets for story templates

### DIFF
--- a/.vscode/default-story-template.code-snippets
+++ b/.vscode/default-story-template.code-snippets
@@ -1,0 +1,23 @@
+  {
+    "default-story-template": {
+    "prefix": "default-story-template",
+    "body": [
+      "import React from 'react'",
+      "import {Meta, Story} from '@storybook/react'",
+      "import {ComponentProps} from '../utils/types'",
+      "import ComponentName from './ComponentName'",
+      "",
+      "export default {",
+      "\ttitle: 'Components/ComponentName',",
+      "\tcomponent: ComponentName,",
+      "} as Meta<ComponentProps<typeof ComponentName>>",
+      "",
+      "export const Playground: Story<ComponentProps<typeof ComponentName>> = args => <ComponentName {...args}></ComponentName>",
+      "",
+      "Playground.args = {}",
+      "Playground.argTypes = {}",
+      "export const Default = <ComponentName></ComponentName>"
+    ],
+    "description": "Generate a default/playground story file"
+  }
+}

--- a/.vscode/feature-story-template.code-snippets
+++ b/.vscode/feature-story-template.code-snippets
@@ -1,0 +1,16 @@
+{
+    "feature-story-template": {
+        "prefix": "feature-story-template",
+        "body": [
+            "import React from 'react'",
+            "import ComponentName from './ComponentName'",
+            "",
+            "export default {",
+            "  title: 'Components/ComponentName/Features',",
+            "}",
+            "",
+            "export const SomeFeature = () => <ComponentName></ComponentName>"
+        ],
+        "description": "Generate a feature story file"
+    }
+}


### PR DESCRIPTION
Just adding some snippets to quickly generate a new story file.

To use: 
- `cmd` + `shift` + `p`
- type "insert snippet"
- search for respective template
- hit enter

https://user-images.githubusercontent.com/18661030/221718921-2efeec35-3e40-4d79-a262-f29fb6a8bc58.mp4
