### PR TITLE
Docs: Add snapshot section and how to update `theme-preval` snapshosts

### DIFF
--- a/contributor-docs/testing.md
+++ b/contributor-docs/testing.md
@@ -89,6 +89,11 @@ npm run test -- -u
 
 After running that command, make sure to update the cache-busting timestamp in [src/theme-preval.js](https://github.com/primer/react/blob/main/src/theme-preval.js)
 
+```diff
+- // Cache bust: 2022-02-23 12:00:00 GMT (This file is cached by our deployment tooling, update this timestamp to rebuild this file)
++ // Cache bust: 2023-02-24 12:00:00 GMT (This file is cached by our deployment tooling, update this timestamp to rebuild this file)
+```
+
 ### Running Tests
 
 | Task                | Command                  |

--- a/contributor-docs/testing.md
+++ b/contributor-docs/testing.md
@@ -74,6 +74,21 @@ To make assertions about the elements we use [Jest](https://jestjs.io/) and [jes
 
 \*: Read about the [differences between `fireEvent` and `UserEvent`](https://testing-library.com/docs/user-event/intro/#differences-from-fireevent).
 
+### Snapshots
+
+We are slowly moving away from using `Jest` snapshots as a way to test visual changes of our components. You can read more about the decision in this [ADR](https://github.com/primer/react/blob/main/contributor-docs/adrs/adr-011-snapshot-tests.md). We are in the proces of migrating our existing snapshot tests to use [Playwright](https://playwright.dev/) for visual regression testing. If you are writing a new test and you need to test the visual changes of the component, please refer to the [Visual Regression Tests](#visual-regression-tests) section.
+
+#### Updating `theme-preval` snapshots
+
+If you need to update the `theme-preval` snapshots, you will need to run the following commands:
+
+```sh
+npm run build
+npm run test -- -u
+```
+
+After running that command, make sure to update the cache-busting timestamp in [src/theme-preval.js](https://github.com/primer/react/blob/main/src/theme-preval.js)
+
 ### Running Tests
 
 | Task                | Command                  |
@@ -214,3 +229,9 @@ and downloading the relevant report.
 The browser executables need to be installed so that playwright can run tests
 inside chromium, firefox, etc. They can be installed by running
 `npx playwright install --with-deps`
+
+<!-- theme preval snapshots are poping up but I didn't change anything theme related -->
+
+### Why do I see the `theme-preval` snapshots being updated when I run `npm test -- -u` even though I didn't change anything theme related?
+
+It is likely that you are using the previous version of the theme values. To fix this, you can run `npm run build` to re-build the components with the latest theme values.


### PR DESCRIPTION
This came up in a conversation while trying to resolve CI issues on @mperrotti's [PR](https://github.com/primer/react/pull/2843) and we got to realise that we don't have docs on how to update the `theme-preval` snapshots. So I added a `Snapshots` section and documented that, while I was already there, added some info about our direction of moving away from `Jest` snapshots. 

After updating the `theme-preval` snapshots, @langermank unexpectedly saw a bunch of snapshots are in the diff in her [PR](https://github.com/primer/react/pull/2945/commits/be3f348bd42f5c282f276b9d9b912482408f0fb3) and we resolved the issue by making sure we have re-built the components on our locals. So I added that bit to the FAQ. 

Let me know what you think 🙌🏻 

### Screenshots

No visual changes

### Merge checklist

- [x] Added/updated documentation

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
