### PR TITLE
feat(DataTable): add support for actions and different layouts

### DIFF
--- a/src/DataTable/DataTable.features.stories.tsx
+++ b/src/DataTable/DataTable.features.stories.tsx
@@ -1,6 +1,9 @@
+import {DownloadIcon, PlusIcon} from '@primer/octicons-react'
 import {Meta} from '@storybook/react'
 import React from 'react'
+import {Button, IconButton} from '../Button'
 import {DataTable, Table} from '../DataTable'
+import Heading from '../Heading'
 import Label from '../Label'
 import LabelGroup from '../LabelGroup'
 import RelativeTime from '../RelativeTime'
@@ -115,69 +118,6 @@ const data: Array<Repo> = [
 function uppercase(input: string): string {
   return input[0].toUpperCase() + input.slice(1)
 }
-
-export const Default = () => (
-  <Table.Container>
-    <Table.Title as="h2" id="repositories">
-      Repositories
-    </Table.Title>
-    <Table.Subtitle as="p" id="repositories-subtitle">
-      A subtitle could appear here to give extra context to the data.
-    </Table.Subtitle>
-    <DataTable
-      aria-labelledby="repositories"
-      aria-describedby="repositories-subtitle"
-      data={data}
-      columns={[
-        {
-          header: 'Repository',
-          field: 'name',
-          rowHeader: true,
-        },
-        {
-          header: 'Type',
-          field: 'type',
-          renderCell: row => {
-            return <Label>{uppercase(row.type)}</Label>
-          },
-        },
-        {
-          header: 'Updated',
-          field: 'updatedAt',
-          renderCell: row => {
-            return <RelativeTime date={new Date(row.updatedAt)} />
-          },
-        },
-        {
-          header: 'Dependabot',
-          field: 'securityFeatures.dependabot',
-          renderCell: row => {
-            return row.securityFeatures.dependabot.length > 0 ? (
-              <LabelGroup>
-                {row.securityFeatures.dependabot.map(feature => {
-                  return <Label key={feature}>{uppercase(feature)}</Label>
-                })}
-              </LabelGroup>
-            ) : null
-          },
-        },
-        {
-          header: 'Code scanning',
-          field: 'securityFeatures.codeScanning',
-          renderCell: row => {
-            return row.securityFeatures.codeScanning.length > 0 ? (
-              <LabelGroup>
-                {row.securityFeatures.codeScanning.map(feature => {
-                  return <Label key={feature}>{uppercase(feature)}</Label>
-                })}
-              </LabelGroup>
-            ) : null
-          },
-        },
-      ]}
-    />
-  </Table.Container>
-)
 
 export const WithTitle = () => (
   <Table.Container>
@@ -373,3 +313,267 @@ export const WithSorting = () => {
     </Table.Container>
   )
 }
+
+export const WithAction = () => (
+  <Table.Container>
+    <Table.Title as="h2" id="repositories">
+      Repositories
+    </Table.Title>
+    <Table.Actions>
+      <Button>Action</Button>
+    </Table.Actions>
+    <Table.Divider />
+    <Table.Subtitle as="p" id="repositories-subtitle">
+      A subtitle could appear here to give extra context to the data.
+    </Table.Subtitle>
+    <DataTable
+      aria-labelledby="repositories"
+      aria-describedby="repositories-subtitle"
+      data={data}
+      columns={[
+        {
+          header: 'Repository',
+          field: 'name',
+          rowHeader: true,
+        },
+        {
+          header: 'Type',
+          field: 'type',
+          renderCell: row => {
+            return <Label>{uppercase(row.type)}</Label>
+          },
+        },
+        {
+          header: 'Updated',
+          field: 'updatedAt',
+          renderCell: row => {
+            return <RelativeTime date={new Date(row.updatedAt)} />
+          },
+        },
+        {
+          header: 'Dependabot',
+          field: 'securityFeatures.dependabot',
+          renderCell: row => {
+            return row.securityFeatures.dependabot.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.dependabot.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+        {
+          header: 'Code scanning',
+          field: 'securityFeatures.codeScanning',
+          renderCell: row => {
+            return row.securityFeatures.codeScanning.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.codeScanning.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+      ]}
+    />
+  </Table.Container>
+)
+
+export const WithActionOnly = () => (
+  <>
+    <Heading as="h2" id="table-title">
+      Repositories
+    </Heading>
+    <Table.Container>
+      <Table.Actions>
+        <Button>Action</Button>
+      </Table.Actions>
+      <DataTable
+        aria-labelledby="table-title"
+        data={data}
+        columns={[
+          {
+            header: 'Repository',
+            field: 'name',
+            rowHeader: true,
+          },
+          {
+            header: 'Type',
+            field: 'type',
+            renderCell: row => {
+              return <Label>{uppercase(row.type)}</Label>
+            },
+          },
+          {
+            header: 'Updated',
+            field: 'updatedAt',
+            renderCell: row => {
+              return <RelativeTime date={new Date(row.updatedAt)} />
+            },
+          },
+          {
+            header: 'Dependabot',
+            field: 'securityFeatures.dependabot',
+            renderCell: row => {
+              return row.securityFeatures.dependabot.length > 0 ? (
+                <LabelGroup>
+                  {row.securityFeatures.dependabot.map(feature => {
+                    return <Label key={feature}>{uppercase(feature)}</Label>
+                  })}
+                </LabelGroup>
+              ) : null
+            },
+          },
+          {
+            header: 'Code scanning',
+            field: 'securityFeatures.codeScanning',
+            renderCell: row => {
+              return row.securityFeatures.codeScanning.length > 0 ? (
+                <LabelGroup>
+                  {row.securityFeatures.codeScanning.map(feature => {
+                    return <Label key={feature}>{uppercase(feature)}</Label>
+                  })}
+                </LabelGroup>
+              ) : null
+            },
+          },
+        ]}
+      />
+    </Table.Container>
+  </>
+)
+
+export const WithActions = () => (
+  <Table.Container>
+    <Table.Title as="h2" id="repositories">
+      Repositories
+    </Table.Title>
+    <Table.Actions>
+      <IconButton aria-label="Download" icon={DownloadIcon} variant="invisible" />
+      <IconButton aria-label="Add row" icon={PlusIcon} variant="invisible" />
+    </Table.Actions>
+    <Table.Divider />
+    <Table.Subtitle as="p" id="repositories-subtitle">
+      A subtitle could appear here to give extra context to the data.
+    </Table.Subtitle>
+    <DataTable
+      aria-labelledby="repositories"
+      aria-describedby="repositories-subtitle"
+      data={data}
+      columns={[
+        {
+          header: 'Repository',
+          field: 'name',
+          rowHeader: true,
+        },
+        {
+          header: 'Type',
+          field: 'type',
+          renderCell: row => {
+            return <Label>{uppercase(row.type)}</Label>
+          },
+        },
+        {
+          header: 'Updated',
+          field: 'updatedAt',
+          renderCell: row => {
+            return <RelativeTime date={new Date(row.updatedAt)} />
+          },
+        },
+        {
+          header: 'Dependabot',
+          field: 'securityFeatures.dependabot',
+          renderCell: row => {
+            return row.securityFeatures.dependabot.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.dependabot.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+        {
+          header: 'Code scanning',
+          field: 'securityFeatures.codeScanning',
+          renderCell: row => {
+            return row.securityFeatures.codeScanning.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.codeScanning.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+      ]}
+    />
+  </Table.Container>
+)
+
+export const WithActionsOnly = () => (
+  <>
+    <Heading as="h2" id="table-title">
+      Repositories
+    </Heading>
+    <Table.Container>
+      <Table.Actions>
+        <IconButton aria-label="Download" icon={DownloadIcon} variant="invisible" />
+        <IconButton aria-label="Add row" icon={PlusIcon} variant="invisible" />
+      </Table.Actions>
+      <DataTable
+        aria-labelledby="table-title"
+        data={data}
+        columns={[
+          {
+            header: 'Repository',
+            field: 'name',
+            rowHeader: true,
+          },
+          {
+            header: 'Type',
+            field: 'type',
+            renderCell: row => {
+              return <Label>{uppercase(row.type)}</Label>
+            },
+          },
+          {
+            header: 'Updated',
+            field: 'updatedAt',
+            renderCell: row => {
+              return <RelativeTime date={new Date(row.updatedAt)} />
+            },
+          },
+          {
+            header: 'Dependabot',
+            field: 'securityFeatures.dependabot',
+            renderCell: row => {
+              return row.securityFeatures.dependabot.length > 0 ? (
+                <LabelGroup>
+                  {row.securityFeatures.dependabot.map(feature => {
+                    return <Label key={feature}>{uppercase(feature)}</Label>
+                  })}
+                </LabelGroup>
+              ) : null
+            },
+          },
+          {
+            header: 'Code scanning',
+            field: 'securityFeatures.codeScanning',
+            renderCell: row => {
+              return row.securityFeatures.codeScanning.length > 0 ? (
+                <LabelGroup>
+                  {row.securityFeatures.codeScanning.map(feature => {
+                    return <Label key={feature}>{uppercase(feature)}</Label>
+                  })}
+                </LabelGroup>
+              ) : null
+            },
+          },
+        ]}
+      />
+    </Table.Container>
+  </>
+)

--- a/src/DataTable/DataTable.stories.tsx
+++ b/src/DataTable/DataTable.stories.tsx
@@ -116,6 +116,69 @@ function uppercase(input: string): string {
   return input[0].toUpperCase() + input.slice(1)
 }
 
+export const Default = () => (
+  <Table.Container>
+    <Table.Title as="h2" id="repositories">
+      Repositories
+    </Table.Title>
+    <Table.Subtitle as="p" id="repositories-subtitle">
+      A subtitle could appear here to give extra context to the data.
+    </Table.Subtitle>
+    <DataTable
+      aria-labelledby="repositories"
+      aria-describedby="repositories-subtitle"
+      data={data}
+      columns={[
+        {
+          header: 'Repository',
+          field: 'name',
+          rowHeader: true,
+        },
+        {
+          header: 'Type',
+          field: 'type',
+          renderCell: row => {
+            return <Label>{uppercase(row.type)}</Label>
+          },
+        },
+        {
+          header: 'Updated',
+          field: 'updatedAt',
+          renderCell: row => {
+            return <RelativeTime date={new Date(row.updatedAt)} />
+          },
+        },
+        {
+          header: 'Dependabot',
+          field: 'securityFeatures.dependabot',
+          renderCell: row => {
+            return row.securityFeatures.dependabot.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.dependabot.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+        {
+          header: 'Code scanning',
+          field: 'securityFeatures.codeScanning',
+          renderCell: row => {
+            return row.securityFeatures.codeScanning.length > 0 ? (
+              <LabelGroup>
+                {row.securityFeatures.codeScanning.map(feature => {
+                  return <Label key={feature}>{uppercase(feature)}</Label>
+                })}
+              </LabelGroup>
+            ) : null
+          },
+        },
+      ]}
+    />
+  </Table.Container>
+)
+
 export const Playground: ComponentStory<typeof DataTable> = args => {
   return (
     <Table.Container>

--- a/src/DataTable/Table.tsx
+++ b/src/DataTable/Table.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Box from '../Box'
 import {get} from '../constants'
-import {SxProp} from '../sx'
+import sx, {SxProp} from '../sx'
 import {SortDirection} from './sorting'
 
 // ----------------------------------------------------------------------------
@@ -138,12 +138,6 @@ const StyledTable = styled.table<React.ComponentPropsWithoutRef<'table'>>`
     font-weight: 600;
     text-align: start;
   }
-
-  /* Spacing if table details are present */
-  .TableTitle + &,
-  .TableSubtitle + & {
-    margin-top: ${get('space.2')};
-  }
 `
 
 export type TableProps = React.ComponentPropsWithoutRef<'table'> & {
@@ -165,7 +159,7 @@ export type TableProps = React.ComponentPropsWithoutRef<'table'> & {
 }
 
 const Table = React.forwardRef<HTMLTableElement, TableProps>(function Table({cellPadding = 'normal', ...rest}, ref) {
-  return <StyledTable {...rest} data-cell-padding={cellPadding} ref={ref} />
+  return <StyledTable {...rest} data-cell-padding={cellPadding} className="Table" ref={ref} />
 })
 
 // ----------------------------------------------------------------------------
@@ -275,10 +269,63 @@ function TableCell({children, scope, ...rest}: TableCellProps) {
 // ----------------------------------------------------------------------------
 // TableContainer
 // ----------------------------------------------------------------------------
+const StyledTableContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-areas:
+    'title actions'
+    'divider divider'
+    'subtitle subtitle'
+    'filter filter'
+    'table table'
+    'footer footer';
+  column-gap: ${get('space.2')};
+
+  ${sx}
+
+  /* TableTitle */
+  .TableTitle {
+    grid-area: title;
+  }
+
+  /* TableSubtitle */
+  .TableSubtitle {
+    grid-area: subtitle;
+  }
+
+  /* TableActions */
+  .TableActions {
+    display: flex;
+    column-gap: ${get('space.2')};
+    align-items: center;
+    grid-area: actions;
+    justify-self: end;
+  }
+
+  /* TableDivider */
+  .TableDivider {
+    grid-area: divider;
+    margin-top: ${get('space.3')};
+    margin-bottom: ${get('space.2')};
+  }
+
+  /* Table */
+  .Table {
+    grid-area: table;
+  }
+
+  /* Spacing before the table */
+  .TableTitle + .Table,
+  .TableSubtitle + .Table,
+  .TableActions + .Table {
+    margin-top: ${get('space.2')};
+  }
+`
+
 type TableContainerProps = React.PropsWithChildren<SxProp>
 
 function TableContainer({children, sx}: TableContainerProps) {
-  return <Box sx={sx}>{children}</Box>
+  return <StyledTableContainer sx={sx}>{children}</StyledTableContainer>
 }
 
 type TableTitleProps = React.PropsWithChildren<{
@@ -349,6 +396,28 @@ function TableSubtitle({as, children, id}: TableSubtitleProps) {
   )
 }
 
+type TableDividerProps = {}
+
+function TableDivider(_props: TableDividerProps) {
+  return (
+    <Box
+      className="TableDivider"
+      role="presentation"
+      sx={{
+        backgroundColor: 'border.default',
+        width: '100%',
+        height: 1,
+      }}
+    />
+  )
+}
+
+type TableActionsProps = React.PropsWithChildren
+
+function TableActions({children}: TableActionsProps) {
+  return <div className="TableActions">{children}</div>
+}
+
 // ----------------------------------------------------------------------------
 // Utilities
 // ----------------------------------------------------------------------------
@@ -376,14 +445,16 @@ const Button = styled.button`
 `
 
 export {
+  TableContainer,
+  TableTitle,
+  TableSubtitle,
+  TableActions,
+  TableDivider,
   Table,
   TableHead,
   TableBody,
   TableRow,
   TableHeader,
   TableCell,
-  TableContainer,
-  TableTitle,
-  TableSubtitle,
   TableSortHeader,
 }

--- a/src/DataTable/index.ts
+++ b/src/DataTable/index.ts
@@ -9,12 +9,16 @@ import {
   TableContainer,
   TableTitle,
   TableSubtitle,
+  TableActions,
+  TableDivider,
 } from './Table'
 
 const Table = Object.assign(TableImpl, {
   Container: TableContainer,
   Title: TableTitle,
   Subtitle: TableSubtitle,
+  Actions: TableActions,
+  Divider: TableDivider,
   Head: TableHead,
   Body: TableBody,
   Header: TableHeader,


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/1889

Add support for the different layouts for a `DataTable` (excluding filter). This adds a couple of stories that show support for the table with both a single action and multiple actions. It also includes support for a footer but this will be implemented by [pagination](https://github.com/github/primer/issues/1890)

This PR adds two new components to accomplish this: `Table.Divider` and `Table.Actions`. It extends `Table.Container` to be a CSS Grid with different areas for the parts of the table.

#### Feedback

I would love to hear what you all think about this approach for the layout and if there are any other alternatives that I should explore here or that you suggest using!

#### Changelog

**New**

- Add `Table.Divider` for rendering a divider in a table
- Add `Table.Actions` for rendering a group of actions for a table
- Add stories for the following situations:
  - With action
  - With action only (no title)
  - With actions
  - With actions only (no title)

**Changed**

- Add support for `sx` prop to `Table.Container`
- `Table.Container` is now a CSS Grid
- Add `.Table` class name for `Table` component

**Removed**