### PR TITLE
Adds Storybook and source code links to StateLabel docs

### DIFF
--- a/docs/content/StateLabel.mdx
+++ b/docs/content/StateLabel.mdx
@@ -2,6 +2,8 @@
 componentId: state_label
 title: StateLabel
 status: Alpha
+storybook: '/react/storybook/?path=/story/components-statelabel--default'
+source: https://github.com/primer/react/tree/main/src/StateLabel
 ---
 
 import data from '../../src/StateLabel/StateLabel.docs.json'


### PR DESCRIPTION
Now that we have StateLabel stories, we can link to the Storybook.
