### PR TITLE
ci: increase runners for vrt and aat jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3, 4]
     needs: storybook
     steps:
       - uses: actions/checkout@v3
@@ -191,7 +191,7 @@ jobs:
           echo "pid=$pid" >> $GITHUB_OUTPUT
           sleep 5
       - name: Run VRT
-        run: npx playwright test --grep @vrt --shard="${{ matrix.shard }}/2"
+        run: npx playwright test --grep @vrt --shard="${{ matrix.shard }}/${{ strategy.job-total }}"
       - name: Stop storybook
         run: kill ${{ steps.storybook.outputs.pid }}
       - name: Upload report
@@ -207,12 +207,16 @@ jobs:
     needs: vrt-runner
     steps:
       - name: Check VRT Runner job status
-        if: ${{ needs.vrt-runner.result != 'success' }}
+        if: ${{ needs.vrt-runner.result == 'failure' }}
         run: exit 1
 
-  aat:
+  aat-runner:
     runs-on: ubuntu-latest
     needs: storybook
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x
@@ -236,21 +240,30 @@ jobs:
           echo "pid=$pid" >> $GITHUB_OUTPUT
           sleep 5
       - name: Run AAT
-        run: npx playwright test --grep @aat
+        run: npx playwright test --grep @aat --shard="${{ matrix.shard }}/${{ strategy.job-total }}"
       - name: Stop storybook
         run: kill ${{ steps.storybook.outputs.pid }}
       - name: Upload axe reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
-          name: axe
+          name: axe-${{ matrix.shard }}
           path: .playwright/axe
       - name: Upload report
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
-          name: aat
+          name: aat-${{ matrix.shard }}
           path: .playwright/report
+
+  aat:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: aat-runner
+    steps:
+      - name: Check VRT Runner job status
+        if: ${{ needs.aat-runner.result == 'failure' }}
+        run: exit 1
 
   build-components-json:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update our VRT and AAT jobs to use additional runners. This decreases average CI time by around 50% (21min to 11min) after we switched from the larger runner for AAT due to a challenge when installing browsers in that environment.

#### Changelog

**New**

**Changed**

- Update `aat` job to split tests across runners instead of running in one process
- Update `vrt` job to run across 4 runners instead of 2
- Artifacts for `aat` and `axe` now have a shard number suffix

**Removed**