### PR TITLE
Only render `VisuallyHidden` component when the component is visually hidden

### DIFF
--- a/src/Autocomplete/AutocompleteMenu.tsx
+++ b/src/Autocomplete/AutocompleteMenu.tsx
@@ -9,7 +9,7 @@ import Spinner from '../Spinner'
 import {useSSRSafeId} from '../utils/ssr'
 import {AutocompleteContext} from './AutocompleteContext'
 import {PlusIcon} from '@primer/octicons-react'
-import VisuallyHidden from '../_VisuallyHidden'
+import ToggleVisibility from '../_ToggleVisibility'
 
 type OnSelectedChange<T> = (item: T | T[]) => void
 type AutocompleteMenuItem = MandateProps<ItemProps, 'id'>
@@ -300,7 +300,7 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
   }, [selectedItemIds, setSelectedItemLength])
 
   return (
-    <VisuallyHidden isVisible={showMenu}>
+    <ToggleVisibility isVisible={showMenu}>
       {loading ? (
         <Box p={3} display="flex" justifyContent="center">
           <Spinner />
@@ -322,7 +322,7 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
           )}
         </div>
       )}
-    </VisuallyHidden>
+    </ToggleVisibility>
   )
 }
 

--- a/src/CounterLabel/CounterLabel.tsx
+++ b/src/CounterLabel/CounterLabel.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Box from '../Box'
 import {BetterSystemStyleObject, SxProp, merge} from '../sx'
-import VisuallyHidden from '../_VisuallyHidden'
+import ToggleVisibility from '../_ToggleVisibility'
 
 export type CounterLabelProps = {
   scheme?: 'primary' | 'secondary'
@@ -38,7 +38,7 @@ const CounterLabel: React.FC<React.PropsWithChildren<CounterLabelProps>> = ({
       >
         {children}
       </Box>
-      <VisuallyHidden>&nbsp;({children})</VisuallyHidden>
+      <ToggleVisibility>&nbsp;({children})</ToggleVisibility>
     </>
   )
 }

--- a/src/PageHeader/PageHeader.features.stories.tsx
+++ b/src/PageHeader/PageHeader.features.stories.tsx
@@ -16,7 +16,7 @@ import {
   GitBranchIcon,
   KebabHorizontalIcon,
 } from '@primer/octicons-react'
-import VisuallyHidden from '../_VisuallyHidden'
+import ToggleVisibility from '../_ToggleVisibility'
 
 import {PageHeader} from './PageHeader'
 import {Hidden} from '../Hidden'
@@ -78,7 +78,7 @@ export const WithComponentAsATitle = () => (
           <Breadcrumbs.Item href="#">PageHeader</Breadcrumbs.Item>
           <Breadcrumbs.Item href="#">PageHeader.tsx</Breadcrumbs.Item>
         </Breadcrumbs>
-        <VisuallyHidden as="h2">Visually Hidden Title</VisuallyHidden>
+        <ToggleVisibility as="h2">Visually Hidden Title</ToggleVisibility>
       </PageHeader.TitleArea>
     </PageHeader>
   </Box>

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -10,7 +10,7 @@ import {Theme} from '../ThemeProvider'
 import {canUseDOM} from '../utils/environment'
 import {invariant} from '../utils/invariant'
 import {useOverflow} from '../utils/useOverflow'
-import VisuallyHidden from '../_VisuallyHidden'
+import ToggleVisibility from '../_ToggleVisibility'
 import {useStickyPaneHeight} from './useStickyPaneHeight'
 
 const REGION_ORDER = {
@@ -754,7 +754,7 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
           {...(id && {id: paneId})}
         >
           {resizable && (
-            <VisuallyHidden>
+            <ToggleVisibility>
               <form onSubmit={handleWidthFormSubmit}>
                 {/* eslint-disable-next-line jsx-a11y/label-has-for */}
                 <label htmlFor={`${paneId}-width-input`}>Pane width</label>
@@ -777,7 +777,7 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
                 />
                 <button type="submit">Change width</button>
               </form>
-            </VisuallyHidden>
+            </ToggleVisibility>
           )}
           {children}
         </Box>

--- a/src/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/ToggleSwitch/ToggleSwitch.tsx
@@ -7,7 +7,7 @@ import Text from '../Text'
 import {get} from '../constants'
 import {useProvidedStateOrCreate} from '../hooks'
 import sx, {BetterSystemStyleObject, SxProp} from '../sx'
-import VisuallyHidden from '../_VisuallyHidden'
+import ToggleVisibility from '../_ToggleVisibility'
 
 const TRANSITION_DURATION = '80ms'
 const EASE_OUT_QUAD_CURVE = 'cubic-bezier(0.5, 1, 0.89, 1)'
@@ -272,7 +272,7 @@ const ToggleSwitch: React.FC<React.PropsWithChildren<ToggleSwitchProps>> = ({
         size={size}
         disabled={!acceptsInteraction}
       >
-        <VisuallyHidden>{isOn ? 'On' : 'Off'}</VisuallyHidden>
+        <ToggleVisibility>{isOn ? 'On' : 'Off'}</ToggleVisibility>
         <Box aria-hidden="true" display="flex" alignItems="center" width="100%" height="100%" overflow="hidden">
           <Box
             flexGrow={1}

--- a/src/Token/Token.tsx
+++ b/src/Token/Token.tsx
@@ -6,7 +6,7 @@ import TokenBase, {defaultTokenSize, isTokenInteractive, TokenBaseProps} from '.
 import RemoveTokenButton from './_RemoveTokenButton'
 import TokenTextContainer from './_TokenTextContainer'
 import {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
-import VisuallyHidden from '../_VisuallyHidden'
+import ToggleVisibility from '../_ToggleVisibility'
 
 // Omitting onResize and onResizeCapture because seems like React 18 types includes these menthod in the expansion but React 17 doesn't.
 // TODO: This is a temporary solution until we figure out why these methods are causing type errors.
@@ -95,7 +95,7 @@ const Token = forwardRef((props, forwardedRef) => {
         </LeadingVisualContainer>
       ) : null}
       <TokenTextContainer {...(hasMultipleActionTargets ? interactiveTokenProps : {})}>{text}</TokenTextContainer>
-      {onRemove && <VisuallyHidden> (press backspace or delete to remove)</VisuallyHidden>}
+      {onRemove && <ToggleVisibility> (press backspace or delete to remove)</ToggleVisibility>}
       {!hideRemoveButton && onRemove ? (
         <RemoveTokenButton
           borderOffset={tokenBorderWidthPx}

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -16,7 +16,7 @@ import Spinner from '../Spinner'
 import sx, {SxProp} from '../sx'
 import Text from '../Text'
 import createSlots from '../utils/create-slots'
-import VisuallyHidden from '../_VisuallyHidden'
+import ToggleVisibility from '../_ToggleVisibility'
 import {getAccessibleName} from './shared'
 import {getFirstChildElement, useRovingTabIndex} from './useRovingTabIndex'
 import {useTypeahead} from './useTypeahead'
@@ -275,9 +275,9 @@ const Root: React.FC<TreeViewProps> = ({'aria-label': ariaLabel, 'aria-labelledb
       }}
     >
       <>
-        <VisuallyHidden role="status" aria-live="polite" aria-atomic="true">
+        <ToggleVisibility role="status" aria-live="polite" aria-atomic="true">
           {ariaLiveMessage}
-        </VisuallyHidden>
+        </ToggleVisibility>
         <UlBox ref={containerRef} role="tree" aria-label={ariaLabel} aria-labelledby={ariaLabelledby}>
           {children}
         </UlBox>

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -6,7 +6,7 @@ import {useResizeObserver, ResizeObserverEntry} from '../hooks/useResizeObserver
 import CounterLabel from '../CounterLabel'
 import {useTheme} from '../ThemeProvider'
 import {ChildWidthArray, ResponsiveProps, ChildSize} from './types'
-import VisuallyHidden from '../_VisuallyHidden'
+import ToggleVisibility from '../_ToggleVisibility'
 import {moreBtnStyles, getDividerStyle, getNavStyles, ulStyles, menuStyles, menuItemStyles, GAP} from './styles'
 import styled from 'styled-components'
 import {LoadingCounter} from './LoadingCounter'
@@ -332,7 +332,7 @@ export const UnderlineNav = forwardRef(
           iconsVisible,
         }}
       >
-        {ariaLabel && <VisuallyHidden as="h2">{`${ariaLabel} navigation`}</VisuallyHidden>}
+        {ariaLabel && <ToggleVisibility as="h2">{`${ariaLabel} navigation`}</ToggleVisibility>}
         <Box
           as={as}
           sx={merge<BetterSystemStyleObject>(getNavStyles(theme, {align}), sxProp)}
@@ -355,11 +355,11 @@ export const UnderlineNav = forwardRef(
                   <Box as="span">
                     {onlyMenuVisible ? (
                       <>
-                        <VisuallyHidden as="span">{`${ariaLabel}`}&nbsp;</VisuallyHidden>Menu
+                        <ToggleVisibility as="span">{`${ariaLabel}`}&nbsp;</ToggleVisibility>Menu
                       </>
                     ) : (
                       <>
-                        More<VisuallyHidden as="span">&nbsp;{`${ariaLabel} items`}</VisuallyHidden>
+                        More<ToggleVisibility as="span">&nbsp;{`${ariaLabel} items`}</ToggleVisibility>
                       </>
                     )}
                   </Box>

--- a/src/_CheckboxOrRadioGroup/CheckboxOrRadioGroup.tsx
+++ b/src/_CheckboxOrRadioGroup/CheckboxOrRadioGroup.tsx
@@ -9,7 +9,7 @@ import {Slots} from './slots'
 import styled from 'styled-components'
 import {get} from '../constants'
 import CheckboxOrRadioGroupContext from './_CheckboxOrRadioGroupContext'
-import VisuallyHidden from '../_VisuallyHidden'
+import ToggleVisibility from '../_ToggleVisibility'
 import {SxProp} from '../sx'
 
 export type CheckboxOrRadioGroupProps = {
@@ -114,7 +114,7 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
                     {slots.Label}
                     {slots.Caption}
                     {React.isValidElement(slots.Validation) && slots.Validation.props.children && (
-                      <VisuallyHidden>{slots.Validation.props.children}</VisuallyHidden>
+                      <ToggleVisibility>{slots.Validation.props.children}</ToggleVisibility>
                     )}
                   </Box>
                 ) : (

--- a/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupLabel.tsx
+++ b/src/_CheckboxOrRadioGroup/_CheckboxOrRadioGroupLabel.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Box from '../Box'
 import {SxProp} from '../sx'
-import VisuallyHidden from '../_VisuallyHidden'
+import ToggleVisibility from '../_ToggleVisibility'
 import {CheckboxOrRadioGroupContext} from './CheckboxOrRadioGroup'
 import {Slot} from './slots'
 
@@ -19,7 +19,7 @@ const CheckboxOrRadioGroupLabel: React.FC<React.PropsWithChildren<CheckboxOrRadi
 }) => (
   <Slot name="Label">
     {({required, disabled}: CheckboxOrRadioGroupContext) => (
-      <VisuallyHidden
+      <ToggleVisibility
         isVisible={!visuallyHidden}
         title={required ? 'required field' : undefined}
         sx={{
@@ -37,7 +37,7 @@ const CheckboxOrRadioGroupLabel: React.FC<React.PropsWithChildren<CheckboxOrRadi
         ) : (
           children
         )}
-      </VisuallyHidden>
+      </ToggleVisibility>
     )}
   </Slot>
 )

--- a/src/_InputLabel.tsx
+++ b/src/_InputLabel.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Box from './Box'
 import {SxProp} from './sx'
-import VisuallyHidden from './_VisuallyHidden'
+import ToggleVisibility from './_ToggleVisibility'
 
 type BaseProps = SxProp & {
   disabled?: boolean
@@ -33,7 +33,7 @@ const InputLabel: React.FC<React.PropsWithChildren<Props>> = ({
   as = 'label',
 }) => {
   return (
-    <VisuallyHidden
+    <ToggleVisibility
       isVisible={!visuallyHidden}
       as={
         as as 'label' /* This assertion is clearly wrong, but it's the only way TS will allow the htmlFor prop to be possibly defined */
@@ -58,7 +58,7 @@ const InputLabel: React.FC<React.PropsWithChildren<Props>> = ({
       ) : (
         children
       )}
-    </VisuallyHidden>
+    </ToggleVisibility>
   )
 }
 

--- a/src/_ToggleVisibility.tsx
+++ b/src/_ToggleVisibility.tsx
@@ -5,7 +5,7 @@ interface Props {
   isVisible?: boolean
 }
 
-const VisuallyHidden = styled.span<Props & SxProp>`
+const ToggleVisibility = styled.span<Props & SxProp>`
   ${({isVisible = false}) => {
     if (isVisible) {
       return sx
@@ -25,4 +25,4 @@ const VisuallyHidden = styled.span<Props & SxProp>`
   }}
 `
 
-export default VisuallyHidden
+export default ToggleVisibility

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldsetLegend.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldsetLegend.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Box} from '../..'
-import VisuallyHidden from '../../_VisuallyHidden'
+import VisuallyHidden from '../../_ToggleVisibility'
 import {ChoiceFieldsetContext, Slot} from './ChoiceFieldset'
 
 export interface ChoiceFieldsetLegendProps {
@@ -16,7 +16,7 @@ const ChoiceFieldsetLegend: React.FC<React.PropsWithChildren<ChoiceFieldsetLegen
 }) => (
   <Slot name="Legend">
     {({required, disabled}: ChoiceFieldsetContext) => (
-      <VisuallyHidden
+      <ToggleVisibility
         as="legend"
         isVisible={!visuallyHidden}
         title={required ? 'required field' : undefined}
@@ -34,7 +34,7 @@ const ChoiceFieldsetLegend: React.FC<React.PropsWithChildren<ChoiceFieldsetLegen
         ) : (
           children
         )}
-      </VisuallyHidden>
+      </ToggleVisibility>
     )}
   </Slot>
 )

--- a/src/deprecated/ChoiceFieldset/ChoiceFieldsetLegend.tsx
+++ b/src/deprecated/ChoiceFieldset/ChoiceFieldsetLegend.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Box} from '../..'
-import VisuallyHidden from '../../_ToggleVisibility'
+import ToggleVisibility from '../../_ToggleVisibility'
 import {ChoiceFieldsetContext, Slot} from './ChoiceFieldset'
 
 export interface ChoiceFieldsetLegendProps {

--- a/src/drafts/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/drafts/MarkdownEditor/MarkdownEditor.tsx
@@ -17,7 +17,7 @@ import {useSyntheticChange} from '../hooks/useSyntheticChange'
 import MarkdownViewer from '../MarkdownViewer'
 import {SxProp} from '../../sx'
 import createSlots from '../../utils/create-slots'
-import VisuallyHidden from '../../_VisuallyHidden'
+import VisuallyHidden from '../../_ToggleVisibility'
 import {FormattingTools} from './_FormattingTools'
 import {MarkdownEditorContext} from './_MarkdownEditorContext'
 import {CoreToolbar, DefaultToolbarButtons} from './Toolbar'
@@ -385,10 +385,10 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(
                 }}
                 ref={containerRef}
               >
-                <VisuallyHidden id={descriptionId} aria-live="polite">
+                <ToggleVisibility id={descriptionId} aria-live="polite">
                   Markdown input:
                   {view === 'preview' ? ' preview mode selected.' : ' edit mode selected.'}
-                </VisuallyHidden>
+                </ToggleVisibility>
 
                 <Box sx={{display: 'flex', pb: 2, gap: 2, justifyContent: 'space-between'}} as="header">
                   <ViewSwitch


### PR DESCRIPTION
This PR turns out to be more of a proposal than fix. 

I was looking into [this issue](https://github.com/primer/react/issues/2947) and realised that the labels are not intended to be visually hidden, I don't think at least. The `VisuallyHidden` classname in the dom is probably misleading. What is actually happening here is that apparently we have `isVisible` prop for `VisuallyHidden` component and when it is `true` we still render the content as `VisuallyHidden` but keep it visible, see [this](https://github.com/primer/react/blob/main/src/_InputLabel.tsx#L36) as an example. 

I was wondering would it reduce confusion if we only use `VisuallyHidden` component to render visually hidden content and in visible cases, we can render as usual like I pushed in this PR. Looking forward to hearing what you think

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
