### PR TITLE
test(UnderlineNav): wait for More button on viewport change

### DIFF
--- a/e2e/components/UnderlineNav.test.ts
+++ b/e2e/components/UnderlineNav.test.ts
@@ -369,6 +369,7 @@ test.describe('UnderlineNav', () => {
             width: 600,
             height: 480,
           })
+          await page.locator('button', {hasText: 'More Repository Items'}).waitFor()
           // Current state
           expect(await page.screenshot()).toMatchSnapshot()
         })


### PR DESCRIPTION
When resizing for the `UnderlineNav` test, sometimes the layout has not shifted when the snapshot is triggered. This updates the test to wait for the More button to appear before taking the snapshot.