### PR TITLE
refactor(DataTable): update initial sort state logic

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -43,7 +43,7 @@ export type DataTableProps<Data extends UniqueRow> = {
    * using this `prop`, the input data must be sorted by this column in
    * ascending order
    */
-  initialSortColumn?: ObjectPaths<Data> | string
+  initialSortColumn?: ObjectPaths<Data> | Data['id']
 
   /**
    * Provide the sort direction that the table should be sorted by on the

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -43,7 +43,7 @@ export type DataTableProps<Data extends UniqueRow> = {
    * using this `prop`, the input data must be sorted by this column in
    * ascending order
    */
-  initialSortColumn?: ObjectPaths<Data> | Data['id']
+  initialSortColumn?: ObjectPaths<Data> | string | number
 
   /**
    * Provide the sort direction that the table should be sorted by on the

--- a/src/DataTable/__tests__/DataTable.test.tsx
+++ b/src/DataTable/__tests__/DataTable.test.tsx
@@ -274,144 +274,280 @@ describe('DataTable', () => {
   })
 
   describe('sorting', () => {
-    it('should set the default sort state of a sortable table', () => {
-      render(
-        <DataTable
-          data={[
-            {
-              id: 1,
-              value: 1,
-            },
-            {
-              id: 2,
-              value: 2,
-            },
-            {
-              id: 3,
-              value: 3,
-            },
-          ]}
-          columns={[
-            {
-              header: 'Value',
-              field: 'value',
-              sortBy: true,
-            },
-          ]}
-          initialSortColumn="value"
-          initialSortDirection="ASC"
-        />,
-      )
+    describe('initial state', () => {
+      it('should set the default sort state of a sortable table', () => {
+        render(
+          <DataTable
+            data={[
+              {
+                id: 1,
+                value: 1,
+              },
+              {
+                id: 2,
+                value: 2,
+              },
+              {
+                id: 3,
+                value: 3,
+              },
+            ]}
+            columns={[
+              {
+                header: 'Value',
+                field: 'value',
+                sortBy: true,
+              },
+            ]}
+            initialSortColumn="value"
+            initialSortDirection="ASC"
+          />,
+        )
 
-      const header = screen.getByRole('columnheader', {
-        name: 'Value',
-      })
-      expect(header).toHaveAttribute('aria-sort', 'ascending')
-
-      const rows = screen
-        .getAllByRole('row')
-        .filter(row => {
-          return queryByRole(row, 'cell')
+        const header = screen.getByRole('columnheader', {
+          name: 'Value',
         })
-        .map(row => {
-          const cell = getByRole(row, 'cell')
-          return cell.textContent
-        })
-      expect(rows).toEqual(['1', '2', '3'])
-    })
+        expect(header).toHaveAttribute('aria-sort', 'ascending')
 
-    it('should set the default sort state of the first sortable column if only `initialSortDirection` is provided', () => {
-      render(
-        <DataTable
-          data={[
-            {
-              id: 1,
-              fieldOne: 'a',
-              fieldTwo: 'c',
-            },
-            {
-              id: 2,
-              fieldOne: 'b',
-              fieldTwo: 'b',
-            },
-            {
-              id: 3,
-              fieldOne: 'c',
-              fieldTwo: 'a',
-            },
-          ]}
-          columns={[
-            {
-              header: 'Field One',
-              field: 'fieldOne',
-            },
-            {
-              header: 'Field Two',
-              field: 'fieldTwo',
-              sortBy: true,
-            },
-          ]}
-          initialSortDirection="ASC"
-        />,
-      )
-
-      const header = screen.getByRole('columnheader', {
-        name: 'Field Two',
+        const rows = screen
+          .getAllByRole('row')
+          .filter(row => {
+            return queryByRole(row, 'cell')
+          })
+          .map(row => {
+            const cell = getByRole(row, 'cell')
+            return cell.textContent
+          })
+        expect(rows).toEqual(['1', '2', '3'])
       })
-      expect(header).toHaveAttribute('aria-sort', 'ascending')
 
-      const body = screen.getByRole('table').querySelector('tbody') as HTMLTableSectionElement
-      const rows = queryAllByRole(body, 'row').map(row => {
-        const cells = queryAllByRole(row, 'cell').map(cell => {
-          return cell.textContent
+      it('should set the default sort state if `initialSortColumn` is provided', () => {
+        render(
+          <DataTable
+            data={[
+              {
+                id: 1,
+                fieldOne: 'a',
+                fieldTwo: 'c',
+              },
+              {
+                id: 2,
+                fieldOne: 'b',
+                fieldTwo: 'b',
+              },
+              {
+                id: 3,
+                fieldOne: 'c',
+                fieldTwo: 'a',
+              },
+            ]}
+            columns={[
+              {
+                header: 'Field One',
+                field: 'fieldOne',
+                sortBy: true,
+              },
+              {
+                header: 'Field Two',
+                field: 'fieldTwo',
+              },
+            ]}
+            initialSortColumn="fieldOne"
+          />,
+        )
+
+        const header = screen.getByRole('columnheader', {
+          name: 'Field One',
         })
-        return cells
+        expect(header).toHaveAttribute('aria-sort', 'ascending')
       })
-      expect(rows).toEqual([
-        ['a', 'c'],
-        ['b', 'b'],
-        ['c', 'a'],
-      ])
-    })
 
-    it('should not set a default sort state if `initialSortDirection` is provided but no columns are sortable', () => {
-      render(
-        <DataTable
-          data={[
-            {
-              id: 1,
-              fieldOne: 'a',
-              fieldTwo: 'c',
-            },
-            {
-              id: 2,
-              fieldOne: 'b',
-              fieldTwo: 'b',
-            },
-            {
-              id: 3,
-              fieldOne: 'c',
-              fieldTwo: 'a',
-            },
-          ]}
-          columns={[
-            {
-              header: 'Field One',
-              field: 'fieldOne',
-            },
-            {
-              header: 'Field Two',
-              field: 'fieldTwo',
-            },
-          ]}
-          initialSortDirection="ASC"
-        />,
-      )
+      it('should not set a default sort state if `initialSortColumn` is provided but no columns are sortable', () => {
+        const spy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {})
 
-      const headers = screen.getAllByRole('columnheader')
-      for (const header of headers) {
-        expect(header).not.toHaveAttribute('aria-sort')
-      }
+        render(
+          <DataTable
+            data={[
+              {
+                id: 1,
+                fieldOne: 'a',
+                fieldTwo: 'c',
+              },
+              {
+                id: 2,
+                fieldOne: 'b',
+                fieldTwo: 'b',
+              },
+              {
+                id: 3,
+                fieldOne: 'c',
+                fieldTwo: 'a',
+              },
+            ]}
+            columns={[
+              {
+                header: 'Field One',
+                field: 'fieldOne',
+              },
+              {
+                header: 'Field Two',
+                field: 'fieldTwo',
+              },
+            ]}
+            initialSortColumn={1}
+          />,
+        )
+
+        const headers = screen.getAllByRole('columnheader')
+        for (const header of headers) {
+          expect(header).not.toHaveAttribute('aria-sort')
+        }
+
+        expect(spy).toHaveBeenCalled()
+        spy.mockRestore()
+      })
+
+      it('should not set a default sort state if `initialSortColumn` is provided but does not correspond to a column', () => {
+        const spy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {})
+        render(
+          <DataTable
+            data={[
+              {
+                id: 1,
+                fieldOne: 'a',
+                fieldTwo: 'c',
+              },
+              {
+                id: 2,
+                fieldOne: 'b',
+                fieldTwo: 'b',
+              },
+              {
+                id: 3,
+                fieldOne: 'c',
+                fieldTwo: 'a',
+              },
+            ]}
+            columns={[
+              {
+                header: 'Field One',
+                field: 'fieldOne',
+              },
+              {
+                header: 'Field Two',
+                field: 'fieldTwo',
+              },
+            ]}
+            initialSortColumn={100}
+          />,
+        )
+
+        const headers = screen.getAllByRole('columnheader')
+        for (const header of headers) {
+          expect(header).not.toHaveAttribute('aria-sort')
+        }
+
+        expect(spy).toHaveBeenCalled()
+        spy.mockRestore()
+      })
+
+      it('should set the default sort state of the first sortable column if only `initialSortDirection` is provided', () => {
+        render(
+          <DataTable
+            data={[
+              {
+                id: 1,
+                fieldOne: 'a',
+                fieldTwo: 'c',
+              },
+              {
+                id: 2,
+                fieldOne: 'b',
+                fieldTwo: 'b',
+              },
+              {
+                id: 3,
+                fieldOne: 'c',
+                fieldTwo: 'a',
+              },
+            ]}
+            columns={[
+              {
+                header: 'Field One',
+                field: 'fieldOne',
+              },
+              {
+                header: 'Field Two',
+                field: 'fieldTwo',
+                sortBy: true,
+              },
+            ]}
+            initialSortDirection="ASC"
+          />,
+        )
+
+        const header = screen.getByRole('columnheader', {
+          name: 'Field Two',
+        })
+        expect(header).toHaveAttribute('aria-sort', 'ascending')
+
+        const body = screen.getByRole('table').querySelector('tbody') as HTMLTableSectionElement
+        const rows = queryAllByRole(body, 'row').map(row => {
+          const cells = queryAllByRole(row, 'cell').map(cell => {
+            return cell.textContent
+          })
+          return cells
+        })
+        expect(rows).toEqual([
+          ['a', 'c'],
+          ['b', 'b'],
+          ['c', 'a'],
+        ])
+      })
+
+      it('should not set a default sort state if `initialSortDirection` is provided but no columns are sortable', () => {
+        const spy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {})
+        render(
+          <DataTable
+            data={[
+              {
+                id: 1,
+                fieldOne: 'a',
+                fieldTwo: 'c',
+              },
+              {
+                id: 2,
+                fieldOne: 'b',
+                fieldTwo: 'b',
+              },
+              {
+                id: 3,
+                fieldOne: 'c',
+                fieldTwo: 'a',
+              },
+            ]}
+            columns={[
+              {
+                header: 'Field One',
+                field: 'fieldOne',
+              },
+              {
+                header: 'Field Two',
+                field: 'fieldTwo',
+              },
+            ]}
+            initialSortDirection="ASC"
+          />,
+        )
+
+        const headers = screen.getAllByRole('columnheader')
+        for (const header of headers) {
+          expect(header).not.toHaveAttribute('aria-sort')
+        }
+
+        expect(spy).toHaveBeenCalled()
+        spy.mockRestore()
+      })
     })
 
     it('should change the sort direction on mouse click', async () => {
@@ -575,6 +711,7 @@ describe('DataTable', () => {
               sortBy: true,
             },
           ]}
+          initialSortColumn="columnA"
         />,
       )
 

--- a/src/DataTable/useTable.ts
+++ b/src/DataTable/useTable.ts
@@ -7,7 +7,7 @@ import {ObjectPathValue} from './utils'
 interface TableConfig<Data extends UniqueRow> {
   columns: Array<Column<Data>>
   data: Array<Data>
-  initialSortColumn?: string
+  initialSortColumn?: string | number
   initialSortDirection?: Exclude<SortDirection, 'NONE'>
 }
 
@@ -39,7 +39,7 @@ interface Cell<Data extends UniqueRow> {
   rowHeader: boolean
 }
 
-type ColumnSortState = {id: string; direction: Exclude<SortDirection, 'NONE'>} | null
+type ColumnSortState = {id: string | number; direction: Exclude<SortDirection, 'NONE'>} | null
 
 export function useTable<Data extends UniqueRow>({
   columns,
@@ -51,42 +51,7 @@ export function useTable<Data extends UniqueRow>({
   const [prevData, setPrevData] = useState(data)
   const [prevColumns, setPrevColumns] = useState(columns)
   const [sortByColumn, setSortByColumn] = useState<ColumnSortState>(() => {
-    if (initialSortColumn) {
-      if (initialSortDirection) {
-        return {
-          id: initialSortColumn,
-          direction: initialSortDirection,
-        }
-      }
-      return {
-        id: initialSortColumn,
-        direction: DEFAULT_SORT_DIRECTION,
-      }
-    }
-
-    if (initialSortDirection) {
-      const defaultSortColumn = columns.find(column => {
-        return column.sortBy
-      })
-      if (defaultSortColumn) {
-        return {
-          id: defaultSortColumn.id ?? defaultSortColumn.field,
-          direction: initialSortDirection,
-        }
-      }
-    }
-
-    const sortableColumn = columns.find(column => {
-      return column.sortBy
-    })
-    if (sortableColumn) {
-      return {
-        id: sortableColumn.id ?? sortableColumn.field,
-        direction: DEFAULT_SORT_DIRECTION,
-      }
-    }
-
-    return null
+    return getInitialSortState(columns, initialSortColumn, initialSortDirection)
   })
 
   // Reset the `sortByColumn` state if the columns change and that column is no
@@ -205,6 +170,63 @@ export function useTable<Data extends UniqueRow>({
       sortBy,
     },
   }
+}
+
+function getInitialSortState<Data extends UniqueRow>(
+  columns: Array<Column<Data>>,
+  initialSortColumn?: string | number,
+  initialSortDirection?: Exclude<SortDirection, 'NONE'>,
+) {
+  if (initialSortColumn !== undefined) {
+    const column = columns.find(column => {
+      return column.id === initialSortColumn || column.field === initialSortColumn
+    })
+
+    if (column === undefined) {
+      if (__DEV__) {
+        console.warn(
+          `Warning: Unable to find a column with id or field set to: ${initialSortColumn}. Please provide a value to \`initialSortColumn\` which corresponds to a \`id\` or \`field\` value in a column.`,
+        )
+      }
+      return null
+    }
+
+    if (column.sortBy === false || column.sortBy === undefined) {
+      if (__DEV__) {
+        console.warn(
+          `Warning: The column specified by initialSortColumn={${initialSortColumn}} is not sortable. Please set \`sortBy\` to true or provide a sort strategy.`,
+        )
+      }
+      return null
+    }
+
+    return {
+      id: initialSortColumn,
+      direction: initialSortDirection ?? DEFAULT_SORT_DIRECTION,
+    }
+  }
+
+  if (initialSortDirection !== undefined) {
+    const column = columns.find(column => {
+      return column.sortBy !== false && column.sortBy !== undefined
+    })
+
+    if (!column) {
+      if (__DEV__) {
+        console.warn(
+          `Warning: An initialSortDirection value was provided but no columns are sortable. Please set \`sortBy\` to true or provide a sort strategy to a column.`,
+        )
+      }
+      return null
+    }
+
+    return {
+      id: column.id ?? column.field,
+      direction: initialSortDirection,
+    }
+  }
+
+  return null
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/DataTable/useTable.ts
+++ b/src/DataTable/useTable.ts
@@ -184,6 +184,7 @@ function getInitialSortState<Data extends UniqueRow>(
 
     if (column === undefined) {
       if (__DEV__) {
+        // eslint-disable-next-line no-console
         console.warn(
           `Warning: Unable to find a column with id or field set to: ${initialSortColumn}. Please provide a value to \`initialSortColumn\` which corresponds to a \`id\` or \`field\` value in a column.`,
         )
@@ -193,6 +194,7 @@ function getInitialSortState<Data extends UniqueRow>(
 
     if (column.sortBy === false || column.sortBy === undefined) {
       if (__DEV__) {
+        // eslint-disable-next-line no-console
         console.warn(
           `Warning: The column specified by initialSortColumn={${initialSortColumn}} is not sortable. Please set \`sortBy\` to true or provide a sort strategy.`,
         )
@@ -213,6 +215,7 @@ function getInitialSortState<Data extends UniqueRow>(
 
     if (!column) {
       if (__DEV__) {
+        // eslint-disable-next-line no-console
         console.warn(
           `Warning: An initialSortDirection value was provided but no columns are sortable. Please set \`sortBy\` to true or provide a sort strategy to a column.`,
         )


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/1854

This PR refactors the initial sort logic to both validate and test the different situations that we can find our selves in with `data`, `columns`, `initialSortColumn`, and `initialSortDirection`.

It also adds several validation warnings for these scenarios in order to make it easier to write and debug code related to sorting.

We are covering specifically the following scenarios with this work:

| Column `sortBy` | `initialSortColumn` | `initialSortDirection` | Outcome |
| :-------------- | :------------------ | :--------------------- | :------ |
| Set | Set to Column with `sortBy` | Not set | Sort by column in `ASC` order |
| Set | Set to Column with `sortBy` | Set to `ASC` | Sort by column in `ASC` order |
| Set | Not set | Set to `ASC` | Sort by first sortable column in `ASC` order |
| Any | Set to `Column` that does not exist | Not set | Unable to find column, warn about value |
| Not set | Set to `Column` without `sortBy` | Not set | No column is sortable, warn about no column with `sortBy` set |
| Not set | Not set | Set to `AC` | No column is sortable, warn about no column with `sortBy` set |

### Testing & Reviewing

- Double check the cases above to see if I missed any
- Make sure I covered all these cases with tests 😅 
- Double-check that no behavior has regressed in storybook demoes