### PR TITLE
docs(DataTable): add example for custom table heading

### DIFF
--- a/src/DataTable/DataTable.features.stories.tsx
+++ b/src/DataTable/DataTable.features.stories.tsx
@@ -577,3 +577,69 @@ export const WithActionsOnly = () => (
     </Table.Container>
   </>
 )
+
+export const WithCustomHeading = () => (
+  <>
+    <Heading as="h2" id="repositories">
+      Security coverage
+    </Heading>
+    <p id="repositories-subtitle">
+      Organization members can only see data for the most recently-updated repositories. To see all repositories, talk
+      to your organization administrator about becoming a security manager.
+    </p>
+    <Table.Container>
+      <DataTable
+        aria-labelledby="repositories"
+        aria-describedby="repositories-subtitle"
+        data={data}
+        columns={[
+          {
+            header: 'Repository',
+            field: 'name',
+            rowHeader: true,
+          },
+          {
+            header: 'Type',
+            field: 'type',
+            renderCell: row => {
+              return <Label>{uppercase(row.type)}</Label>
+            },
+          },
+          {
+            header: 'Updated',
+            field: 'updatedAt',
+            renderCell: row => {
+              return <RelativeTime date={new Date(row.updatedAt)} />
+            },
+          },
+          {
+            header: 'Dependabot',
+            field: 'securityFeatures.dependabot',
+            renderCell: row => {
+              return row.securityFeatures.dependabot.length > 0 ? (
+                <LabelGroup>
+                  {row.securityFeatures.dependabot.map(feature => {
+                    return <Label key={feature}>{uppercase(feature)}</Label>
+                  })}
+                </LabelGroup>
+              ) : null
+            },
+          },
+          {
+            header: 'Code scanning',
+            field: 'securityFeatures.codeScanning',
+            renderCell: row => {
+              return row.securityFeatures.codeScanning.length > 0 ? (
+                <LabelGroup>
+                  {row.securityFeatures.codeScanning.map(feature => {
+                    return <Label key={feature}>{uppercase(feature)}</Label>
+                  })}
+                </LabelGroup>
+              ) : null
+            },
+          },
+        ]}
+      />
+    </Table.Container>
+  </>
+)


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/1836

Add story for custom heading example where a team may already have a heading on the page that would label the table.