### PR TITLE
SegmentedControl: Remove tooltip temporarily and add an accessible name to the button

### DIFF
--- a/.changeset/violet-phones-notice.md
+++ b/.changeset/violet-phones-notice.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+SegmentedControl: Resolve axe-violation by adding a discernible text to the icon button and removing the tooltip until it is marked as accessible

--- a/src/SegmentedControl/SegmentedControlIconButton.tsx
+++ b/src/SegmentedControl/SegmentedControlIconButton.tsx
@@ -3,7 +3,6 @@ import {IconProps} from '@primer/octicons-react'
 import styled from 'styled-components'
 import sx, {merge, SxProp} from '../sx'
 import {getSegmentedControlButtonStyles, getSegmentedControlListItemStyles} from './getSegmentedControlStyles'
-import Tooltip from '../Tooltip'
 import Box from '../Box'
 import {defaultSxProp} from '../utils/defaultSxProp'
 

--- a/src/SegmentedControl/SegmentedControlIconButton.tsx
+++ b/src/SegmentedControl/SegmentedControlIconButton.tsx
@@ -45,17 +45,17 @@ export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<Segmen
 
   return (
     <Box as="li" sx={mergedSx}>
-      <Tooltip text={ariaLabel}>
-        <SegmentedControlIconButtonStyled
-          aria-current={selected}
-          sx={getSegmentedControlButtonStyles({selected, isIconOnly: true})}
-          {...rest}
-        >
-          <span className="segmentedControl-content">
-            <Icon />
-          </span>
-        </SegmentedControlIconButtonStyled>
-      </Tooltip>
+      {/* TODO: Once the tooltip remediations are resolved (especially https://github.com/github/primer/issues/1909) - bring it back */}
+      <SegmentedControlIconButtonStyled
+        aria-label={ariaLabel}
+        aria-current={selected}
+        sx={getSegmentedControlButtonStyles({selected, isIconOnly: true})}
+        {...rest}
+      >
+        <span className="segmentedControl-content">
+          <Icon />
+        </span>
+      </SegmentedControlIconButtonStyled>
     </Box>
   )
 }


### PR DESCRIPTION
This PR resolves the axe-violation on the `SegmentedControlIconButton` 

**Storybook Link**

Before : https://primer.style/react/storybook/?path=/story/components-segmentedcontrol-features--icon-only&viewMode=story
After: https://primer-da95297a09-13348165.drafts.github.io/storybook/iframe.html?args=&id=components-segmentedcontrol-features--icon-only&viewMode=story

Closes https://github.com/github/primer/issues/1864 (Hubbers only link)

We decided to disable (remove) the tooltip for now and add a discernable name to the button itself until we resolve more critical issues on the tooltip (ref: https://github.com/github/primer/issues/1909). 

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist


- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
