### PR TITLE
Export useResizeObserver from @primer/react

### DIFF
--- a/.changeset/nasty-hats-smell.md
+++ b/.changeset/nasty-hats-smell.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Export `useResizeObserver` hook

--- a/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -89,6 +89,7 @@ exports[`@primer/react should not update exports without a semver change 1`] = `
   "useOpenAndCloseFocus",
   "useOverlay",
   "useRefObjectAsForwardedRef",
+  "useResizeObserver",
   "useSSRSafeId",
   "useSafeTimeout",
   "useTheme",

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export type {FocusTrapHookSettings} from './hooks/useFocusTrap'
 export {useFocusZone} from './hooks/useFocusZone'
 export type {FocusZoneHookSettings} from './hooks/useFocusZone'
 export {useRefObjectAsForwardedRef} from './hooks/useRefObjectAsForwardedRef'
+export {useResizeObserver} from './hooks/useResizeObserver'
 
 // Components
 export {default as Radio} from './Radio'


### PR DESCRIPTION
Exporting the `useResizeObserver` hook from @primer/react so it can be used outside of Primer!

Closes https://github.com/github/primer/issues/1908

### Screenshots

n/a

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
