### PR TITLE
Remove incorrect focus styles on ActionList items

### DIFF
--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -92,13 +92,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
           backgroundColor: `actionListItem.${variant}.hoverBg`,
           color: getVariantStyles(variant, disabled).hoverColor,
         },
-        ':focus:not([data-focus-visible-added]), > a:focus:not([data-focus-visible-added])': {
-          backgroundColor: `actionListItem.${variant}.selectedBg`,
-          color: getVariantStyles(variant, disabled).hoverColor,
-          outline: 'none',
-        },
-        '&[data-focus-visible-added], > a[data-focus-visible-added]': {
-          // we don't use :focus-visible because not all browsers (safari) have it yet
+        '&:focus-visible, > a:focus-visible': {
           outline: 'none',
           border: `2 solid`,
           boxShadow: `0 0 0 2px ${theme?.colors.accent.emphasis}`,

--- a/src/NavList/__snapshots__/NavList.test.tsx.snap
+++ b/src/NavList/__snapshots__/NavList.test.tsx.snap
@@ -239,15 +239,8 @@ exports[`NavList renders a simple list 1`] = `
     color: #24292f;
   }
 
-  .c2:focus:not([data-focus-visible-added]),
-  .c2 > a:focus:not([data-focus-visible-added]) {
-    background-color: rgba(208,215,222,0.24);
-    color: #24292f;
-    outline: none;
-  }
-
-  .c2[data-focus-visible-added],
-  .c2 > a[data-focus-visible-added] {
+  .c2:focus-visible,
+  .c2 > a:focus-visible {
     outline: none;
     border: 2 solid;
     box-shadow: 0 0 0 2px #0969da;
@@ -271,15 +264,8 @@ exports[`NavList renders a simple list 1`] = `
     color: #24292f;
   }
 
-  .c6:focus:not([data-focus-visible-added]),
-  .c6 > a:focus:not([data-focus-visible-added]) {
-    background-color: rgba(208,215,222,0.24);
-    color: #24292f;
-    outline: none;
-  }
-
-  .c6[data-focus-visible-added],
-  .c6 > a[data-focus-visible-added] {
+  .c6:focus-visible,
+  .c6 > a:focus-visible {
     outline: none;
     border: 2 solid;
     box-shadow: 0 0 0 2px #0969da;
@@ -649,15 +635,8 @@ exports[`NavList renders with groups 1`] = `
     color: #24292f;
   }
 
-  .c6:focus:not([data-focus-visible-added]),
-  .c6 > a:focus:not([data-focus-visible-added]) {
-    background-color: rgba(208,215,222,0.24);
-    color: #24292f;
-    outline: none;
-  }
-
-  .c6[data-focus-visible-added],
-  .c6 > a[data-focus-visible-added] {
+  .c6:focus-visible,
+  .c6 > a:focus-visible {
     outline: none;
     border: 2 solid;
     box-shadow: 0 0 0 2px #0969da;
@@ -681,15 +660,8 @@ exports[`NavList renders with groups 1`] = `
     color: #24292f;
   }
 
-  .c10:focus:not([data-focus-visible-added]),
-  .c10 > a:focus:not([data-focus-visible-added]) {
-    background-color: rgba(208,215,222,0.24);
-    color: #24292f;
-    outline: none;
-  }
-
-  .c10[data-focus-visible-added],
-  .c10 > a[data-focus-visible-added] {
+  .c10:focus-visible,
+  .c10 > a:focus-visible {
     outline: none;
     border: 2 solid;
     box-shadow: 0 0 0 2px #0969da;
@@ -1141,15 +1113,8 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
     color: #24292f;
   }
 
-  .c10:focus:not([data-focus-visible-added]),
-  .c10 > a:focus:not([data-focus-visible-added]) {
-    background-color: rgba(208,215,222,0.24);
-    color: #24292f;
-    outline: none;
-  }
-
-  .c10[data-focus-visible-added],
-  .c10 > a[data-focus-visible-added] {
+  .c10:focus-visible,
+  .c10 > a:focus-visible {
     outline: none;
     border: 2 solid;
     box-shadow: 0 0 0 2px #0969da;
@@ -1173,15 +1138,8 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
     color: #24292f;
   }
 
-  .c3:focus:not([data-focus-visible-added]),
-  .c3 > a:focus:not([data-focus-visible-added]) {
-    background-color: rgba(208,215,222,0.24);
-    color: #24292f;
-    outline: none;
-  }
-
-  .c3[data-focus-visible-added],
-  .c3 > a[data-focus-visible-added] {
+  .c3:focus-visible,
+  .c3 > a:focus-visible {
     outline: none;
     border: 2 solid;
     box-shadow: 0 0 0 2px #0969da;
@@ -1628,15 +1586,8 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
     color: #24292f;
   }
 
-  .c10:focus:not([data-focus-visible-added]),
-  .c10 > a:focus:not([data-focus-visible-added]) {
-    background-color: rgba(208,215,222,0.24);
-    color: #24292f;
-    outline: none;
-  }
-
-  .c10[data-focus-visible-added],
-  .c10 > a[data-focus-visible-added] {
+  .c10:focus-visible,
+  .c10 > a:focus-visible {
     outline: none;
     border: 2 solid;
     box-shadow: 0 0 0 2px #0969da;
@@ -1660,15 +1611,8 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
     color: #24292f;
   }
 
-  .c3:focus:not([data-focus-visible-added]),
-  .c3 > a:focus:not([data-focus-visible-added]) {
-    background-color: rgba(208,215,222,0.24);
-    color: #24292f;
-    outline: none;
-  }
-
-  .c3[data-focus-visible-added],
-  .c3 > a[data-focus-visible-added] {
+  .c3:focus-visible,
+  .c3 > a:focus-visible {
     outline: none;
     border: 2 solid;
     box-shadow: 0 0 0 2px #0969da;


### PR DESCRIPTION
I don't think the first item in `ActionMenu` should be focused at all by default, but this at least fixes the design bug with it. Focus styles utilize the accent blue outline, while the background is reserved for hover and active states.

Closes # https://github.com/github/primer/issues/1455

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/18661030/226497290-84eb6e1a-8e83-4256-b956-72b6b132ff23.png)

After:
![image](https://user-images.githubusercontent.com/18661030/226497247-cbb5e1a1-e882-4ddb-818e-17e24ebfc6f4.png)


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
