### PR TITLE
Stop rendering `activeClassName` when there is no `to` prop is passed for react-router

### DIFF
--- a/.changeset/stupid-bats-end.md
+++ b/.changeset/stupid-bats-end.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Stop rendering `activeClassName` when there is no `to` prop is passed for react-router (TabNav, SubNav, BreadCrumb, UnderlineNav v1)

--- a/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/Breadcrumbs/Breadcrumbs.tsx
@@ -59,7 +59,7 @@ type StyledBreadcrumbsItemProps = {
 } & SxProp
 
 const BreadcrumbsItem = styled.a.attrs<StyledBreadcrumbsItemProps>(props => ({
-  activeClassName: typeof props.to === 'string' ? 'selected' : '',
+  activeClassName: typeof props.to === 'string' ? 'selected' : undefined,
   className: classnames(props.selected && SELECTED_CLASS, props.className),
   'aria-current': props.selected ? 'page' : null,
 }))<StyledBreadcrumbsItemProps>`

--- a/src/SubNav.tsx
+++ b/src/SubNav.tsx
@@ -63,7 +63,7 @@ type StyledSubNavLinkProps = {
 } & SxProp
 
 const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
-  activeClassName: typeof props.to === 'string' ? 'selected' : '',
+  activeClassName: typeof props.to === 'string' ? 'selected' : undefined,
   className: classnames(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
 }))<StyledSubNavLinkProps>`
   padding-left: ${get('space.3')};

--- a/src/TabNav/TabNav.tsx
+++ b/src/TabNav/TabNav.tsx
@@ -81,7 +81,7 @@ export type TabNavLinkProps = React.DetailedHTMLProps<React.HTMLAttributes<HTMLA
 } & SxProp
 
 const TabNavLink = styled.a.attrs<TabNavLinkProps>(props => ({
-  activeClassName: typeof props.to === 'string' ? 'selected' : '',
+  activeClassName: typeof props.to === 'string' ? 'selected' : undefined,
   className: classnames(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
   role: 'tab',
   'aria-selected': !!props.selected,

--- a/src/UnderlineNav.tsx
+++ b/src/UnderlineNav.tsx
@@ -70,7 +70,7 @@ type StyledUnderlineNavLinkProps = {
 } & SxProp
 
 const UnderlineNavLink = styled.a.attrs<StyledUnderlineNavLinkProps>(props => ({
-  activeClassName: typeof props.to === 'string' ? 'selected' : '',
+  activeClassName: typeof props.to === 'string' ? 'selected' : undefined,
   className: classnames(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
 }))<StyledUnderlineNavLinkProps>`
   padding: ${get('space.3')} ${get('space.2')};


### PR DESCRIPTION
As described in this [issue](https://github.com/primer/react/issues/2847), I realised that the same behaviour occurs in multiple components. 

Not rendering the `activeClassName` when there is no `to` prop seems to resolve the issue.  

Closes #3060
Closes #2847  

### Screenshots

No visual change

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
