### PR TITLE
Add a11yReviewed to `Text` component

### DIFF
--- a/docs/content/Text.mdx
+++ b/docs/content/Text.mdx
@@ -1,6 +1,7 @@
 ---
 componentId: text
 title: Text
+a11yReviewed: true
 status: Alpha
 ---
 

--- a/generated/components.json
+++ b/generated/components.json
@@ -618,7 +618,7 @@
       "id": "text",
       "name": "Text",
       "status": "alpha",
-      "a11yReviewed": false,
+      "a11yReviewed": true,
       "stories": [],
       "props": [
         {

--- a/src/Text.docs.json
+++ b/src/Text.docs.json
@@ -2,7 +2,7 @@
   "id": "text",
   "name": "Text",
   "status": "alpha",
-  "a11yReviewed": false,
+  "a11yReviewed": true,
   "stories": [],
   "props": [
     {


### PR DESCRIPTION
Adds `a11yReviewed` status to `<Text>` component.

Related: https://github.com/github/primer/issues/1604

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
