### PR TITLE
Add repro for ActionList + Trailing button bug

### DIFF
--- a/src/ActionList/ActionList.examples.stories.tsx
+++ b/src/ActionList/ActionList.examples.stories.tsx
@@ -18,6 +18,8 @@ import TextInput from '../TextInput'
 import Spinner from '../Spinner'
 import Box from '../Box'
 import Text from '../Text'
+import Tooltip from '../Tooltip'
+import {IconButton} from '../Button'
 
 const meta: Meta = {
   title: 'Components/ActionList/Examples',
@@ -438,6 +440,32 @@ export function AllCombinations(): JSX.Element {
             <ActionList.Description variant="block">Block description</ActionList.Description>
             <ActionList.TrailingVisual>
               <StarIcon />
+            </ActionList.TrailingVisual>
+          </ActionList.Item>
+          <ActionList.Item>
+            trailing with tooltip<ActionList.Description variant="inline">buggy</ActionList.Description>
+            {/* <ActionList.Description variant="block">Block description</ActionList.Description> */}
+            <ActionList.TrailingVisual>
+              <Tooltip aria-label="star this repo">
+                <IconButton icon={StarIcon} aria-label="star this repo" />
+              </Tooltip>
+            </ActionList.TrailingVisual>
+          </ActionList.Item>
+          <ActionList.Item>
+            trailing with tooltip<ActionList.Description variant="inline">fixed with sx</ActionList.Description>
+            <ActionList.TrailingVisual sx={{height: 'fit-content'}}>
+              <Tooltip aria-label="star this repo">
+                <IconButton icon={StarIcon} aria-label="star this repo" />
+              </Tooltip>
+            </ActionList.TrailingVisual>
+          </ActionList.Item>
+          <ActionList.Item>
+            trailing with tooltip<ActionList.Description variant="inline">inline description</ActionList.Description>
+            <ActionList.Description variant="block">works like a charm</ActionList.Description>
+            <ActionList.TrailingVisual>
+              <Tooltip aria-label="star this repo">
+                <IconButton icon={StarIcon} aria-label="star this repo" />
+              </Tooltip>
             </ActionList.TrailingVisual>
           </ActionList.Item>
         </ActionList>


### PR DESCRIPTION
before: 

<img width="297" alt="image" src="https://user-images.githubusercontent.com/1863771/227258832-c08bc386-7a3a-40b7-ad6e-e3f0da86bc08.png">

can be overwritten with sx, but does it look fixed?

```jsx
<ActionList.TrailingVisual sx={{height: 'fit-content'}}>
  <IconButton icon={StarIcon} aria-label="star this repo" />
</ActionList.TrailingVisual>
```

<img width="295" alt="image" src="https://user-images.githubusercontent.com/1863771/227259031-75db8fb6-a12c-4de9-a138-49293ee49758.png">
