### PR TITLE
Bump @primer/primitives to `7.11.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@lit-labs/react": "1.1.1",
         "@primer/behaviors": "1.3.3",
         "@primer/octicons-react": "^18.0.0",
-        "@primer/primitives": "7.11.1",
+        "@primer/primitives": "7.11.2",
         "@react-aria/ssr": "^3.1.0",
         "@styled-system/css": "^5.1.5",
         "@styled-system/props": "^5.1.5",
@@ -6503,9 +6503,9 @@
       }
     },
     "node_modules/@primer/primitives": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.11.1.tgz",
-      "integrity": "sha512-Sdss4XG96nqBqrTAyg+RuFOj+U5wkICK8n2hafcyT+lpSlZoIwcbmhyFjmDy9f88FkhHe2q0uCpQ8PjKd8ILTQ=="
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.11.2.tgz",
+      "integrity": "sha512-2PzQNfiBXdCEC9Xxbc08vl05e0ny63K8VHH2nJmkRRI7y+em+8mHgXvgRhrAi+cFGtTi2Er2RptaREstyvLCYw=="
     },
     "node_modules/@react-aria/ssr": {
       "version": "3.5.0",
@@ -60550,9 +60550,9 @@
       "requires": {}
     },
     "@primer/primitives": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.11.1.tgz",
-      "integrity": "sha512-Sdss4XG96nqBqrTAyg+RuFOj+U5wkICK8n2hafcyT+lpSlZoIwcbmhyFjmDy9f88FkhHe2q0uCpQ8PjKd8ILTQ=="
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.11.2.tgz",
+      "integrity": "sha512-2PzQNfiBXdCEC9Xxbc08vl05e0ny63K8VHH2nJmkRRI7y+em+8mHgXvgRhrAi+cFGtTi2Er2RptaREstyvLCYw=="
     },
     "@react-aria/ssr": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@lit-labs/react": "1.1.1",
     "@primer/behaviors": "1.3.3",
     "@primer/octicons-react": "^18.0.0",
-    "@primer/primitives": "7.11.1",
+    "@primer/primitives": "7.11.2",
     "@react-aria/ssr": "^3.1.0",
     "@styled-system/css": "^5.1.5",
     "@styled-system/props": "^5.1.5",


### PR DESCRIPTION
This bumps `@primer/primitives` to [`7.11.2`](https://github.com/primer/primitives/pull/500).

### Screenshots

Most noticeable change is the Primary button:

Before | After
--- | ---
![Screen Shot 2023-03-29 at 18 05 36](https://user-images.githubusercontent.com/378023/228484504-a3ea19ee-6a85-4837-8a60-c5102cb4da59.png) | ![Screen Shot 2023-03-29 at 18 05 43](https://user-images.githubusercontent.com/378023/228484510-0ea56a4c-4ecb-4d54-a79d-5daebca26441.png)

### Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
