### PR TITLE
Forks: npm install with `--legacy-peer-deps` in forks

### DIFF
--- a/.github/workflows/deploy_preview_forks.yml
+++ b/.github/workflows/deploy_preview_forks.yml
@@ -19,6 +19,6 @@ jobs:
       id-token: write
     with:
       node_version: 16
-      install: npm ci && cd docs && npm ci && cd ..
+      install: npm ci --legacy-peer-deps && cd docs && npm ci --legacy-peer-deps && cd ..
       build: npm run build:docs:preview
       output_dir: docs/public


### PR DESCRIPTION
Preview / Deploy workflow gives error for conflicting peer dependency in forks. 

See the log for an example: https://github.com/primer/react/actions/runs/4548466652/jobs/8019530673?pr=3011

### Screenshots

No visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
