### PR TITLE
refactor(TextInputInnerAction): tooltipDirection prop

### DIFF
--- a/src/_TextInputInnerAction.tsx
+++ b/src/_TextInputInnerAction.tsx
@@ -52,10 +52,10 @@ const invisibleButtonStyleOverrides = {
 const ConditionalTooltip: React.FC<
   React.PropsWithChildren<{
     ['aria-label']?: string
-    ['tooltipDirection']?: 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw'
+    tooltipDirection?: 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw'
     children: React.ReactNode
   }>
-> = ({'aria-label': ariaLabel, children, tooltipDirection: tooltipDirection}) => (
+> = ({'aria-label': ariaLabel, children, tooltipDirection}) => (
   <>
     {ariaLabel ? (
       <Tooltip
@@ -79,7 +79,7 @@ const TextInputAction = forwardRef<HTMLButtonElement, TextInputActionProps>(
   (
     {
       'aria-label': ariaLabel,
-      tooltipDirection: tooltipDirection,
+      tooltipDirection,
       children,
       icon,
       sx: sxProp,

--- a/src/_TextInputInnerAction.tsx
+++ b/src/_TextInputInnerAction.tsx
@@ -77,15 +77,7 @@ const ConditionalTooltip: React.FC<
 
 const TextInputAction = forwardRef<HTMLButtonElement, TextInputActionProps>(
   (
-    {
-      'aria-label': ariaLabel,
-      tooltipDirection,
-      children,
-      icon,
-      sx: sxProp,
-      variant = 'invisible',
-      ...rest
-    },
+    {'aria-label': ariaLabel, tooltipDirection, children, icon, sx: sxProp, variant = 'invisible', ...rest},
     forwardedRef,
   ) => {
     const sx =


### PR DESCRIPTION
Removing unnecessary object property shorthands after renaming the prop name from `tooltip-direction` -> `tooltipDirection` https://github.com/primer/react/pull/3101

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
