### PR TITLE
refactor(project): remove @testing-library/react-hooks in favor of @testing-library/react

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+lib-esm
+lib
+dist
+.next
+generated
+node_modules

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -148,6 +148,11 @@ module.exports = {
                 importNames: ['useSSRSafeId'],
                 message: 'Please use the `useId` hook from `src/hooks/useId.ts` instead',
               },
+              {
+                name: '@testing-library/react-hooks',
+                importNames: ['renderHook'],
+                message: 'Please use `renderHook` from `@testing-library/react` instead',
+              },
             ],
             patterns: [],
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
         "@testing-library/dom": "9.2.0",
         "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "14.0.0",
-        "@testing-library/react-hooks": "7.0.2",
         "@testing-library/user-event": "^14.3.0",
         "@types/chroma-js": "2.1.4",
         "@types/jest": "29.4.0",
@@ -25004,35 +25003,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@testing-library/react-hooks": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
-      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@types/react": ">=16.9.0",
-        "@types/react-dom": ">=16.9.0",
-        "@types/react-test-renderer": ">=16.9.0",
-        "react-error-boundary": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0",
-        "react-test-renderer": ">=16.9.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-test-renderer": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@testing-library/user-event": {
       "version": "14.4.3",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
@@ -25545,15 +25515,6 @@
       "version": "18.0.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.9.tgz",
       "integrity": "sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-test-renderer": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
-      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -50166,22 +50127,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "node_modules/react-error-boundary": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
-      "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
-      }
-    },
     "node_modules/react-inspector": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-5.1.1.tgz",
@@ -74484,19 +74429,6 @@
         "@types/react-dom": "^18.0.0"
       }
     },
-    "@testing-library/react-hooks": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
-      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@types/react": ">=16.9.0",
-        "@types/react-dom": ">=16.9.0",
-        "@types/react-test-renderer": ">=16.9.0",
-        "react-error-boundary": "^3.1.0"
-      }
-    },
     "@testing-library/user-event": {
       "version": "14.4.3",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
@@ -74984,15 +74916,6 @@
       "version": "18.0.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.9.tgz",
       "integrity": "sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
-    "@types/react-test-renderer": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
-      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -93616,15 +93539,6 @@
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
           "dev": true
         }
-      }
-    },
-    "react-error-boundary": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
-      "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5"
       }
     },
     "react-inspector": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "@testing-library/dom": "9.2.0",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "14.0.0",
-    "@testing-library/react-hooks": "7.0.2",
     "@testing-library/user-event": "^14.3.0",
     "@types/chroma-js": "2.1.4",
     "@types/jest": "29.4.0",

--- a/src/__tests__/useSafeTimeout.test.tsx
+++ b/src/__tests__/useSafeTimeout.test.tsx
@@ -1,4 +1,4 @@
-import {renderHook} from '@testing-library/react-hooks'
+import {renderHook, waitFor} from '@testing-library/react'
 import useSafeTimeout from '../hooks/useSafeTimeout'
 
 afterEach(() => {
@@ -6,7 +6,7 @@ afterEach(() => {
 })
 
 test('should call callback after time', async () => {
-  const {result, waitFor} = renderHook(() => useSafeTimeout())
+  const {result} = renderHook(() => useSafeTimeout())
   const mockFunction = jest.fn()
   result.current.safeSetTimeout(mockFunction, 300)
   await waitFor(() => expect(mockFunction).toHaveBeenCalled())

--- a/src/drafts/hooks/useIgnoreKeyboardActionsWhileComposing.test.tsx
+++ b/src/drafts/hooks/useIgnoreKeyboardActionsWhileComposing.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {isMacOS} from '@primer/behaviors/utils'
 import {fireEvent, render, screen} from '@testing-library/react'
-import {renderHook} from '@testing-library/react-hooks'
+import {renderHook} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {useIgnoreKeyboardActionsWhileComposing} from './useIgnoreKeyboardActionsWhileComposing'
 

--- a/src/hooks/__tests__/useSlots.test.tsx
+++ b/src/hooks/__tests__/useSlots.test.tsx
@@ -1,4 +1,4 @@
-import {renderHook} from '@testing-library/react-hooks'
+import {renderHook} from '@testing-library/react'
 import React from 'react'
 import {useSlots} from '../useSlots'
 


### PR DESCRIPTION
Noticed over in: https://github.com/primer/react/pull/3077 that later versions of `@testing-library/react-hooks` do not support React 18 🤔 

When looking into this, it seems that the recommendation is to instead use `renderHook` from `@testing-library/react` directly: https://testing-library.com/docs/react-testing-library/api/#renderhook

This PR updates the call sites where we use `@testing-library/react-hooks` and also adds in an eslint rule to suggest importing from `@testing-library/react` instead, for example:

```bash
  4:9  error  'renderHook' import from '@testing-library/react-hooks' is restricted. Please use `renderHook` from `@testing-library/react` instead  no-restricted-imports
```