### PR TITLE
UnderlineNav2: Add transparent outline for focus ring to support WHCM

### DIFF
--- a/.changeset/green-crews-joke.md
+++ b/.changeset/green-crews-joke.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+UnderlineNav2: Add transparent outline for focus to support WHCM

--- a/src/UnderlineNav2/__snapshots__/UnderlineNav.test.tsx.snap
+++ b/src/UnderlineNav2/__snapshots__/UnderlineNav.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`UnderlineNav renders consistently 1`] = `
 }
 
 .c4:focus {
-  outline: 0;
+  outline: 2px solid transparent;
 }
 
 .c4:focus {
@@ -68,6 +68,7 @@ exports[`UnderlineNav renders consistently 1`] = `
 }
 
 .c4:focus-visible {
+  outline: 2px solid transparent;
   box-shadow: inset 0 0 0 2px #0969da;
 }
 

--- a/src/UnderlineNav2/styles.ts
+++ b/src/UnderlineNav2/styles.ts
@@ -94,7 +94,7 @@ export const getLinkStyles = (
     },
   },
   '&:focus': {
-    outline: '3px solid transparent',
+    outline: '2px solid transparent',
     '&': {
       boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`,
     },
@@ -104,7 +104,7 @@ export const getLinkStyles = (
     },
   },
   '&:focus-visible': {
-    outline: '3px solid transparent',
+    outline: '2px solid transparent',
     boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`,
   },
   // renders a visibly hidden "copy" of the label in bold, reserving box space for when label becomes bold on selected

--- a/src/UnderlineNav2/styles.ts
+++ b/src/UnderlineNav2/styles.ts
@@ -94,7 +94,7 @@ export const getLinkStyles = (
     },
   },
   '&:focus': {
-    outline: 0,
+    outline: '3px solid transparent',
     '&': {
       boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`,
     },
@@ -104,6 +104,7 @@ export const getLinkStyles = (
     },
   },
   '&:focus-visible': {
+    outline: '3px solid transparent',
     boxShadow: `inset 0 0 0 2px ${theme?.colors.accent.fg}`,
   },
   // renders a visibly hidden "copy" of the label in bold, reserving box space for when label becomes bold on selected


### PR DESCRIPTION
It came up on `PageHeader` accessibility sign-off review that the `UnderlineNav` links' focus rings are not visible on the Window High Contrast Theme. Added a transparent outline as suggested.

Closes https://github.com/github/primer/issues/2081 (Hubbers only link)

### Screenshots

#### Before
<img width="1189" alt="Screenshot 2023-04-12 at 2 32 44 pm" src="https://user-images.githubusercontent.com/1446503/231667258-678c4c69-c77d-491b-8311-92dcf035fd7f.png">

#### After
<img width="1198" alt="Screenshot 2023-04-13 at 3 40 31 pm" src="https://user-images.githubusercontent.com/1446503/231667214-1493c5ba-d1c9-4aed-a5dc-ed6885db62b8.png">

### Merge checklist

- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
