### PR TITLE
Use SSR-compatible slot implementation in MarkdownEditor

### DIFF
--- a/.changeset/chilled-brooms-grow.md
+++ b/.changeset/chilled-brooms-grow.md
@@ -1,0 +1,7 @@
+---
+"@primer/react": patch
+---
+
+`MarkdownEditor` is now SSR-compatible. 
+
+Warning: In this new implementation, `MarkdownEditor.Toolbar`, `MarkdownEditor.Actions`, and `MarkdownEditor.Label` must be direct children of `MarkdownEditor`.

--- a/src/drafts/MarkdownEditor/Actions.tsx
+++ b/src/drafts/MarkdownEditor/Actions.tsx
@@ -1,11 +1,8 @@
 import React, {forwardRef, useContext} from 'react'
 import {Button, ButtonProps} from '../../Button'
-import {MarkdownEditorSlot} from './MarkdownEditor'
 import {MarkdownEditorContext} from './_MarkdownEditorContext'
 
-export const Actions = ({children}: {children?: React.ReactNode}) => (
-  <MarkdownEditorSlot name="Actions">{children}</MarkdownEditorSlot>
-)
+export const Actions = ({children}: {children?: React.ReactNode}) => <>{children}</>
 Actions.displayName = 'MarkdownEditor.Actions'
 
 export const ActionButton = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {

--- a/src/drafts/MarkdownEditor/Label.tsx
+++ b/src/drafts/MarkdownEditor/Label.tsx
@@ -1,7 +1,6 @@
 import React, {FC, useContext} from 'react'
-import {SxProp} from '../../sx'
 import InputLabel from '../../_InputLabel'
-import {MarkdownEditorSlot} from './MarkdownEditor'
+import {SxProp} from '../../sx'
 import {MarkdownEditorContext} from './_MarkdownEditorContext'
 
 type LabelProps = SxProp & {
@@ -20,8 +19,4 @@ const Legend: FC<LabelProps> = ({sx, ...props}) => {
 }
 Legend.displayName = 'MarkdownEditor.Label'
 
-export const Label: FC<LabelProps> = props => (
-  <MarkdownEditorSlot name="Label">
-    <Legend {...props} />
-  </MarkdownEditorSlot>
-)
+export const Label: FC<LabelProps> = props => <Legend {...props} />

--- a/src/drafts/MarkdownEditor/Toolbar.tsx
+++ b/src/drafts/MarkdownEditor/Toolbar.tsx
@@ -18,7 +18,6 @@ import {isMacOS} from '@primer/behaviors/utils'
 import Box from '../../Box'
 import {IconButton, IconButtonProps} from '../../Button'
 import {useFocusZone} from '../../hooks/useFocusZone'
-import {MarkdownEditorSlot} from './MarkdownEditor'
 import {MarkdownEditorContext} from './_MarkdownEditorContext'
 import {SavedRepliesButton} from './_SavedReplies'
 
@@ -143,9 +142,5 @@ export const CoreToolbar = ({children}: {children?: React.ReactNode}) => {
   )
 }
 
-export const Toolbar = ({children}: {children?: React.ReactNode}) => (
-  <MarkdownEditorSlot name="Toolbar">
-    <CoreToolbar>{children}</CoreToolbar>
-  </MarkdownEditorSlot>
-)
+export const Toolbar = ({children}: {children?: React.ReactNode}) => <CoreToolbar>{children}</CoreToolbar>
 Toolbar.displayName = 'MarkdownEditor.Toolbar'


### PR DESCRIPTION
Swaps out the underlying slots implementation for `MarkdownEditor`.

See https://github.com/primer/react/issues/1690 for more context.

