### PR TITLE
Docs(Tooltip): Adds `defaultValue` of tooltip direction to documentation

### DIFF
--- a/.changeset/silent-dragons-train.md
+++ b/.changeset/silent-dragons-train.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+adds `defaultValue` of `tooltip direction` to documentation

--- a/.changeset/silent-dragons-train.md
+++ b/.changeset/silent-dragons-train.md
@@ -1,5 +1,0 @@
----
-'@primer/react': minor
----
-
-adds `defaultValue` of `tooltip direction` to documentation

--- a/src/Tooltip.docs.json
+++ b/src/Tooltip.docs.json
@@ -12,6 +12,7 @@
     {
       "name": "direction",
       "type": "'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw'",
+      "defaultValue": "n",
       "description": "Sets where the tooltip renders in relation to the target."
     },
     {


### PR DESCRIPTION
Describe your changes here.

The purpose of this PR is just to add the default tooltip direction value to the documentation. Which was reversed from PR #3169 . I apologize for not reviewing the review PR before the merge. Sorry.

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
