### PR TITLE
3096 remove aria live=polite on textinput wrapper

### DIFF
--- a/.changeset/swift-cobras-visit.md
+++ b/.changeset/swift-cobras-visit.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Removed default aria-live polite

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -126,7 +126,6 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
         hasTrailingAction={Boolean(trailingAction)}
         isInputFocused={isInputFocused}
         onClick={focusInput}
-        aria-live="polite"
         aria-busy={Boolean(loading)}
       >
         {IconComponent && <IconComponent className="TextInput-icon" />}

--- a/src/_InputValidation.tsx
+++ b/src/_InputValidation.tsx
@@ -43,6 +43,7 @@ const InputValidation: React.FC<React.PropsWithChildren<Props>> = ({children, id
         },
         ...sx,
       }}
+      aria-live="polite"
     >
       {IconComponent && (
         <Box as="span" mr={1} sx={{display: 'flex'}} aria-hidden="true">


### PR DESCRIPTION
Describe your changes here.

Closes #3096  

### Screenshots

Please provide before/after screenshots for any visual changes
![image](https://user-images.githubusercontent.com/16006513/232525657-373bc9fe-a2b4-47ae-8bda-b7f91dc21052.png)
![image](https://user-images.githubusercontent.com/16006513/232525683-d3ae2b83-c225-458c-84f6-2046a627b332.png)


### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
