### PR TITLE
e2e PageLayout: Add await for `content.scrollIntoViewIfNeeded`

### DIFF
--- a/e2e/components/PageLayout.test.ts
+++ b/e2e/components/PageLayout.test.ts
@@ -94,7 +94,7 @@ test.describe('PageLayout', () => {
           expect(await page.screenshot()).toMatchSnapshot(`PageLayout.Sticky Pane.${theme}.png`)
 
           const content = page.getByTestId('content3')
-          content.scrollIntoViewIfNeeded()
+          await content.scrollIntoViewIfNeeded()
 
           const paragraphRect = await page.getByTestId('paragraph0').boundingBox()
           if (paragraphRect) {
@@ -182,7 +182,7 @@ test.describe('PageLayout', () => {
           expect(await page.screenshot()).toMatchSnapshot(`PageLayout.Custom Sticky Header.${theme}.png`)
 
           const content = page.getByTestId('content3')
-          content.scrollIntoViewIfNeeded()
+          await content.scrollIntoViewIfNeeded()
 
           const paragraphBoundaries = await page.getByTestId('paragraph0').boundingBox()
           const stickyHeaderBoundaries = await page.getByTestId('sticky-header').boundingBox()


### PR DESCRIPTION
Fix for failing test:

```[146/1242] components/PageLayout.test.ts:145:13 › PageLayout › Nested Scroll Container › light_high_contrast › default @vrt

Error: locator.scrollIntoViewIfNeeded: Target page, context or browser has been closed
   at components/PageLayout.test.ts:97
```

[More context on slack(github internal)](https://github.slack.com/archives/C02NUUQ9C30/p1681915433789379)