### PR TITLE
test(e2e): update PageLayout test to await scrollIntoViewIfNeeded

### DIFF
--- a/e2e/components/PageLayout.test.ts
+++ b/e2e/components/PageLayout.test.ts
@@ -94,7 +94,7 @@ test.describe('PageLayout', () => {
           expect(await page.screenshot()).toMatchSnapshot(`PageLayout.Sticky Pane.${theme}.png`)
 
           const content = page.getByTestId('content3')
-          content.scrollIntoViewIfNeeded()
+          await content.scrollIntoViewIfNeeded()
 
           const paragraphRect = await page.getByTestId('paragraph0').boundingBox()
           if (paragraphRect) {
@@ -182,7 +182,7 @@ test.describe('PageLayout', () => {
           expect(await page.screenshot()).toMatchSnapshot(`PageLayout.Custom Sticky Header.${theme}.png`)
 
           const content = page.getByTestId('content3')
-          content.scrollIntoViewIfNeeded()
+          await content.scrollIntoViewIfNeeded()
 
           const paragraphBoundaries = await page.getByTestId('paragraph0').boundingBox()
           const stickyHeaderBoundaries = await page.getByTestId('sticky-header').boundingBox()


### PR DESCRIPTION
We've been getting an error that looks like the following in our e2e test suite:

```
Error: locator.scrollIntoViewIfNeeded: Target page, context or browser has been closed
```

This error seems to originate from calls to `.scrollIntoViewIfNeeded()` that are not await-ed, as the test will finish before this promise will settle. This PR updates `PageLayout.test.ts` so that calls to `scrollIntoViewIfNeeded` are await-ed.