### PR TITLE
Refactor MarkdownViewer to make it SSR-friendly

### DIFF
--- a/.changeset/chilly-dragons-crash.md
+++ b/.changeset/chilly-dragons-crash.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+`MarkdownViewer` is now SSR-compatible

--- a/src/drafts/MarkdownViewer/MarkdownViewer.test.tsx
+++ b/src/drafts/MarkdownViewer/MarkdownViewer.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
-import {render, waitFor, fireEvent} from '@testing-library/react'
+import {fireEvent, render, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import React from 'react'
 
 import MarkdownViewer from '../MarkdownViewer'
 
@@ -88,6 +88,42 @@ text after list`
       const items = getAllByRole('checkbox')
       fireEvent.change(items[0])
       await waitFor(() => expect(onChangeMock).toHaveBeenCalledWith(noItemsCheckedMarkdown))
+    })
+
+    it('attaches event handlers to new tasks', async () => {
+      const onChangeMock = jest.fn()
+      const TestComponent = () => {
+        const [html, setHtml] = React.useState(taskListHtml)
+        const [markdown, setMarkdown] = React.useState(noItemsCheckedMarkdown)
+        return (
+          <>
+            <button
+              onClick={() => {
+                setMarkdown(`${markdown}
+- [ ] item 3
+`)
+                setHtml(`${html}
+<ul class='contains-task-list'>
+  <li class='task-list-item'><input type='checkbox' class='task-list-item-checkbox' disabled/> item 3</li>
+</ul>
+`)
+              }}
+            >
+              Add markdown
+            </button>
+            <MarkdownViewer dangerousRenderedHTML={{__html: html}} markdownValue={markdown} onChange={onChangeMock} />
+          </>
+        )
+      }
+      const {getByRole, getAllByRole} = render(<TestComponent />)
+
+      // Change markdown and html content
+      const button = getByRole('button', {name: 'Add markdown'})
+      fireEvent.click(button)
+
+      const items = getAllByRole('checkbox')
+      fireEvent.change(items[2])
+      await waitFor(() => expect(onChangeMock).toHaveBeenCalledWith(`${noItemsCheckedMarkdown}\n- [x] item 3\n`))
     })
   })
 

--- a/src/drafts/MarkdownViewer/MarkdownViewer.tsx
+++ b/src/drafts/MarkdownViewer/MarkdownViewer.tsx
@@ -64,6 +64,8 @@ const MarkdownViewer = ({
   onLinkClick,
   openLinksInNewTab = false,
 }: MarkdownViewerProps) => {
+  // We're using state to store the HTML container because we want the value
+  // to re-run effects when it changes
   const [htmlContainer, setHtmlContainer] = React.useState<HTMLElement>()
   const htmlContainerRef = React.useCallback((node: HTMLElement | null) => {
     if (!node) return

--- a/src/drafts/MarkdownViewer/MarkdownViewer.tsx
+++ b/src/drafts/MarkdownViewer/MarkdownViewer.tsx
@@ -77,11 +77,12 @@ const MarkdownViewer = ({
       try {
         await externalOnChange?.(value)
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error(error)
+        if (htmlContainer) {
+          htmlContainer.innerHTML = dangerousRenderedHTML.__html
+        }
       }
     },
-    [externalOnChange],
+    [externalOnChange, htmlContainer, dangerousRenderedHTML],
   )
 
   useListInteraction({

--- a/src/drafts/MarkdownViewer/MarkdownViewer.tsx
+++ b/src/drafts/MarkdownViewer/MarkdownViewer.tsx
@@ -89,6 +89,7 @@ const MarkdownViewer = ({
     disabled: disabled || !externalOnChange,
     htmlContainer,
     markdownValue,
+    dependencies: [dangerousRenderedHTML],
   })
 
   useLinkInterception({

--- a/src/drafts/MarkdownViewer/_useLinkInterception.ts
+++ b/src/drafts/MarkdownViewer/_useLinkInterception.ts
@@ -1,7 +1,7 @@
 import {useEffect} from 'react'
 
 type UseLinkInterceptionSettings = {
-  htmlContainer: HTMLDivElement
+  htmlContainer?: HTMLElement
   onLinkClick?: (event: MouseEvent) => void
   openLinksInNewTab: boolean
 }
@@ -22,6 +22,8 @@ export const useLinkInterception = ({htmlContainer, onLinkClick, openLinksInNewT
         event.preventDefault()
       }
     }
+
+    if (!htmlContainer) return
 
     htmlContainer.addEventListener('click', clickHandler)
 

--- a/src/drafts/MarkdownViewer/_useListInteraction.ts
+++ b/src/drafts/MarkdownViewer/_useListInteraction.ts
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useRef, useState} from 'react'
+import useIsomorphicLayoutEffect from '../../utils/useIsomorphicLayoutEffect'
 import {ListItem, listItemToString, parseListItem} from '../MarkdownEditor/_useListEditing'
 
 type TaskListItem = ListItem & {taskBox: '[ ]' | '[x]'}
@@ -35,7 +36,7 @@ export const useListInteraction = ({
   // onToggleItem, which would mean we'd have to re-bind the event handlers on every change
   const markdownRef = useRef(markdownValue)
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     markdownRef.current = markdownValue
   }, [markdownValue])
 

--- a/src/drafts/MarkdownViewer/_useListInteraction.ts
+++ b/src/drafts/MarkdownViewer/_useListInteraction.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useMemo} from 'react'
+import {useCallback, useEffect, useRef, useState} from 'react'
 import {ListItem, listItemToString, parseListItem} from '../MarkdownEditor/_useListEditing'
 
 type TaskListItem = ListItem & {taskBox: '[ ]' | '[x]'}
@@ -15,6 +15,7 @@ type UseListInteractionSettings = {
   markdownValue: string
   onChange: (markdown: string) => void | Promise<void>
   disabled?: boolean
+  dependencies?: Array<unknown>
 }
 
 /**
@@ -28,6 +29,7 @@ export const useListInteraction = ({
   markdownValue,
   onChange,
   disabled = false,
+  dependencies = [],
 }: UseListInteractionSettings) => {
   // Storing the value in a ref allows not using the markdown value as a depdency of
   // onToggleItem, which would mean we'd have to re-bind the event handlers on every change
@@ -63,12 +65,18 @@ export const useListInteraction = ({
     [onChange],
   )
 
-  const checkboxElements = useMemo(
-    () =>
-      Array.from(
-        htmlContainer?.querySelectorAll<HTMLInputElement>('input[type=checkbox].task-list-item-checkbox') ?? [],
-      ),
-    [htmlContainer],
+  const [checkboxElements, setCheckboxElements] = useState<HTMLInputElement[]>([])
+
+  useEffect(
+    () => {
+      setCheckboxElements(
+        Array.from(
+          htmlContainer?.querySelectorAll<HTMLInputElement>('input[type=checkbox].task-list-item-checkbox') ?? [],
+        ),
+      )
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [htmlContainer, ...dependencies],
   )
 
   // This could be combined with the other effect, but then the checkboxes might have a flicker


### PR DESCRIPTION
## Problem

`MarkdownViewer` cannot be rendered on the server

## Solution

This PR refactors `MarkdownView` to be SSR-friendly:

- Renders HTML with `dangerouslySetInnerHTML` instead of setting `innerHTML` inside an effect.
- Replaces `useLayoutEffect` with `useEffect`. `useLayoutEffect` throws an error on server-side.

Addresses https://github.com/github/primer/issues/2090