### PR TITLE
test(e2e): add locators for contrast a11y checks

### DIFF
--- a/e2e/components/Select.test.ts
+++ b/e2e/components/Select.test.ts
@@ -127,6 +127,8 @@ test.describe('Select', () => {
               colorScheme: theme,
             },
           })
+
+          await expect(page.getByText('Something went wrong')).toBeVisible()
           await expect(page).toHaveNoViolations({
             rules: {
               'color-contrast': {
@@ -229,6 +231,8 @@ test.describe('Select', () => {
               colorScheme: theme,
             },
           })
+
+          await expect(page.getByText('Success')).toBeVisible()
           await expect(page).toHaveNoViolations({
             rules: {
               'color-contrast': {
@@ -297,6 +301,7 @@ test.describe('Select', () => {
               colorScheme: theme,
             },
           })
+          await expect(page.getByText('Warning')).toBeVisible()
           await expect(page).toHaveNoViolations({
             rules: {
               'color-contrast': {


### PR DESCRIPTION
Noticed that there was some flakiness in the Select test suite, specifically for the contrast of Select status messages. The common denominator across these tests were that they used animations to display the status message. This meant that axe was running against these components _too soon_ before the text even had a chance to become visible (therefore failing the contrast checks).

To remedy this, the PR adds an explicit locator to wait for the text to be visible before calling axe.