### PR TITLE
ci: update pages check in deploy_production workflow

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -33,7 +34,11 @@ jobs:
         run: |
           if gh api --silent https://api.github.com/repos/${{ github.repository }}/pages ; then
             echo "::set-output name=pages::1"
+          else
+            echo "::set-output name=pages::0"
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log has pages
         run: echo ${{ steps.has-pages.outputs.pages }}


### PR DESCRIPTION
An extra step in the `deploy_production` workflow has the following error message:

![The terminal output of a GitHub Actions workflow. There are several steps being shown with empty output due to an error message from the usage of the gh cli](https://user-images.githubusercontent.com/3901764/236508276-f6a05fcf-f6fa-42cc-9a05-2cfd1299a75a.png)

Unfortunately, this output is used in the outputs of the guard. Specifically, in this check:

```yml
      should_deploy: ${{ steps.changeset-count.outputs.change_count == 0 && steps.has-pages.outputs.pages == 1 }}
```

As a result of this usage, our deploy guard is never truth-y and therefore storybook and an updated docs site does not get deployed.

This PR updates this step to use the built-in `GITHUB_TOKEN` secret for the `gh` cli check and adds a manual `workflow_dispatch` trigger to help with debugging in the future.