### PR TITLE
ci: update trigger and guard for production workflow

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -2,56 +2,25 @@ name: Deploy
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      # Matches tags that have the shape `vX.Y.Z`. Reference:
+      # https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requesttagsbranches
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+      # Ignore tags that use a preid after `vX.Y.Z`, for example: vX.Y.Z-alpha.0
+      # https://help.github.com/en/articles/workflow-syntax-for-github-actions#example-using-positive-and-negative-patterns
+      - '!v[0-9]+.[0-9]+.[0-9]+-*'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
-  guard:
-    name: Guard
-    runs-on: ubuntu-latest
-    outputs:
-      # To avoid deploying documentation for unrelease changes, we check the number of changeset files.
-      # If it's 0, we deploy.
-      should_deploy: ${{ steps.changeset-count.outputs.change_count == 0 && steps.has-pages.outputs.pages == 1 }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - id: changeset-count
-        run: echo "::set-output name=change_count::$(ls .changeset/*.md | grep -v README | wc -l | xargs)"
-
-      # Log changeset count for debugging purposes
-      - name: Log changeset count
-        run: echo ${{ steps.changeset-count.outputs.change_count }}
-
-      - id: has-pages
-        name: Check if pages is configured
-        run: |
-          if gh api --silent https://api.github.com/repos/${{ github.repository }}/pages ; then
-            echo "::set-output name=pages::1"
-          else
-            echo "::set-output name=pages::0"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log has pages
-        run: echo ${{ steps.has-pages.outputs.pages }}
-
-      # Log guard output for debugging purposes
-      - name: Log guard output
-        run: echo ${{ needs.guard.outputs.should_deploy }}
-
   deploy:
     name: Production
-    needs: [guard]
-    if: ${{ needs.guard.outputs.should_deploy == 'true' }}
+    if: ${{ github.repository == 'primer/react' }}
     uses: primer/.github/.github/workflows/deploy.yml@0cec9b9914f358846163f2428663b58da41028c9
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:


### PR DESCRIPTION
This updates the `deploy_production.yml` workflow to simplify the guard step and reduce the number of times it runs.

Currently, this workflow will run on push to main and will check if there are no changesets available. If there are none, and GitHub Pages is configured, the guard will pass and the changes will deploy.

This PR makes the following changes to this flow:

* Instead of triggering on a push to `main`, this workflow instead is called when a tag is pushed
  * This happens as a part of our release workflow and will cause the deploy to match the latest tagged release
  * Pre-release tags are ignored from this trigger
* With the change above, the `guard` job is no longer needed
* Instead of checking to see if GitHub Pages are supported, this action now will only run on the `primer/react` repository
* It moves the `permissions` block from the outermost scope to the deploy job in case another job is added to this workflow

At a high-level, the flow becomes:

* A tag is pushed for a release
* The `deploy_production.yml` workflow is triggered
* A GitHub Pages deployment is created

Alternatively, one can use the `workflow_dispatch` to trigger this workflow. This is used in two scenarios:

* Deploy from a specific `tag` (preferred)
* Deploy from `main` (not preferred)
