### PR TITLE
Add back check for GroupContext in ActionList.Selection to fix issues introduced to github/github

### DIFF
--- a/src/ActionList/Selection.tsx
+++ b/src/ActionList/Selection.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import {CheckIcon} from '@primer/octicons-react'
-import {ListContext, ActionListProps} from './List'
+import {ListContext} from './List'
 import {ActionListItemProps} from './shared'
 import {LeadingVisualContainer} from './Visuals'
-import {ActionListGroupProps, GroupContext} from './Group'
+import {GroupContext} from './Group'
 
 type SelectionProps = Pick<ActionListItemProps, 'selected'>
 export const Selection: React.FC<React.PropsWithChildren<SelectionProps>> = ({selected}) => {

--- a/src/ActionList/Selection.tsx
+++ b/src/ActionList/Selection.tsx
@@ -3,14 +3,18 @@ import {CheckIcon} from '@primer/octicons-react'
 import {ListContext, ActionListProps} from './List'
 import {ActionListItemProps} from './shared'
 import {LeadingVisualContainer} from './Visuals'
+import {ActionListGroupProps, GroupContext} from './Group'
 
 type SelectionProps = Pick<ActionListItemProps, 'selected'>
 export const Selection: React.FC<React.PropsWithChildren<SelectionProps>> = ({selected}) => {
+  const {selectionVariant: groupSelectionVariant} = React.useContext(GroupContext)
   const {selectionVariant: listSelectionVariant} = React.useContext(ListContext)
 
   /** selectionVariant in Group can override the selectionVariant in List root */
   /** fallback to selectionVariant from container menu if any (ActionMenu, SelectPanel ) */
-  const selectionVariant: ActionListProps['selectionVariant'] = listSelectionVariant
+  let selectionVariant: ActionListProps['selectionVariant'] | ActionListGroupProps['selectionVariant']
+  if (typeof groupSelectionVariant !== 'undefined') selectionVariant = groupSelectionVariant
+  else selectionVariant = listSelectionVariant
 
   if (!selectionVariant) {
     // if selectionVariant is not set on List, but Item is selected

--- a/src/ActionList/Selection.tsx
+++ b/src/ActionList/Selection.tsx
@@ -12,7 +12,7 @@ export const Selection: React.FC<React.PropsWithChildren<SelectionProps>> = ({se
 
   /** selectionVariant in Group can override the selectionVariant in List root */
   /** fallback to selectionVariant from container menu if any (ActionMenu, SelectPanel ) */
-  const selectionVariant = groupSelectionVariant ?? listSelectionVariant;
+  const selectionVariant = groupSelectionVariant ?? listSelectionVariant
 
   if (!selectionVariant) {
     // if selectionVariant is not set on List, but Item is selected

--- a/src/ActionList/Selection.tsx
+++ b/src/ActionList/Selection.tsx
@@ -12,9 +12,7 @@ export const Selection: React.FC<React.PropsWithChildren<SelectionProps>> = ({se
 
   /** selectionVariant in Group can override the selectionVariant in List root */
   /** fallback to selectionVariant from container menu if any (ActionMenu, SelectPanel ) */
-  let selectionVariant: ActionListProps['selectionVariant'] | ActionListGroupProps['selectionVariant']
-  if (typeof groupSelectionVariant !== 'undefined') selectionVariant = groupSelectionVariant
-  else selectionVariant = listSelectionVariant
+  const selectionVariant = groupSelectionVariant ?? listSelectionVariant;
 
   if (!selectionVariant) {
     // if selectionVariant is not set on List, but Item is selected


### PR DESCRIPTION
While refactoring the ActionList component, there was some back and forth about how to handle ActionList.Group. Initially, it was going to be deleted, but we ultimately decided to mark it as deprecated to not introduce a breaking change. I forgot to add back this code, so existing usages of ActionList.Group were breaking in subtle ways.

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [X] Added/updated tests
- [X] Added/updated documentation
- [X] Tested in Chrome
- [X] Tested in Firefox
- [X] Tested in Safari
- [X] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
