### PR TITLE
refactor(ActionList): import merge from sx

### DIFF
--- a/src/ActionList/Heading.tsx
+++ b/src/ActionList/Heading.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import {ListContext} from './List'
 import Box from '../Box'
 import {get} from '../constants'
-import {SxProp} from '../sx'
-import {merge} from 'lodash'
+import {SxProp, merge} from '../sx'
 import {useId} from '../hooks/useId'
 
 export type ActionListHeadingProps = {

--- a/src/ActionList/Heading.tsx
+++ b/src/ActionList/Heading.tsx
@@ -4,6 +4,7 @@ import Box from '../Box'
 import {get} from '../constants'
 import {SxProp, merge} from '../sx'
 import {useId} from '../hooks/useId'
+import {defaultSxProp} from '../utils/defaultSxProp'
 
 export type ActionListHeadingProps = {
   variant?: 'subtle' | 'filled'
@@ -22,7 +23,7 @@ export const Heading: React.FC<React.PropsWithChildren<ActionListHeadingProps>> 
   title,
   subtitle,
   as = 'h3',
-  sx,
+  sx = defaultSxProp,
   ...props
 }) => {
   const {variant: listVariant, headingId: headingId} = React.useContext(ListContext)


### PR DESCRIPTION
Currently, `ActionList` imports the `merge` utility from `lodash`. This causes a downstream bundle increase since `lodash` is being brought in. This PR updates the usage to bring in `merge` from the `sx` module to avoid bringing in `merge` from `lodash`