### PR TITLE
Use button instead of span for disabled prev/next controls

### DIFF
--- a/.changeset/kind-scissors-type.md
+++ b/.changeset/kind-scissors-type.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+`Pagination`: Use `<button>` instead of `<span>` for disabled prev/next controls to improve accessibility

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -58,6 +58,18 @@ const Page = styled.a`
   }
 
   &[aria-disabled],
+  &[aria-disabled]:hover {
+    color: ${get('colors.primer.fg.disabled')}; // check
+    cursor: default;
+    background-color: transparent;
+    border-color: transparent;
+    font-size: inherit;
+    font-family: inherit;
+    padding-top: inherit;
+    padding-bottom: inherit;
+  }
+
+  &[aria-disabled],
   &[aria-disabled]:hover,
   &[role='presentation'],
   &[role='presentation']:hover {

--- a/src/Pagination/model.tsx
+++ b/src/Pagination/model.tsx
@@ -148,7 +148,7 @@ export function buildComponentData(
       key = 'page-prev'
       content = 'Previous'
       if (page.disabled) {
-        Object.assign(props, {as: 'span', 'aria-disabled': 'true'})
+        Object.assign(props, {as: 'button', 'aria-disabled': 'true'})
       } else {
         Object.assign(props, {
           rel: 'prev',
@@ -163,7 +163,7 @@ export function buildComponentData(
       key = 'page-next'
       content = 'Next'
       if (page.disabled) {
-        Object.assign(props, {as: 'span', 'aria-disabled': 'true'})
+        Object.assign(props, {as: 'button', 'aria-disabled': 'true'})
       } else {
         Object.assign(props, {
           rel: 'next',


### PR DESCRIPTION
Describe your changes here.

Per accessibility audit feedback, the current `span`s used for the prev/next links when disabled are not announcable by screen readers. Instead of `span`s, we should use `button`s so that these disabled elements are focusable.

I also updated the CSS to match the text styling of the buttons to the same styling used when the links aren't disabled.

### Screenshots

Please provide before/after screenshots for any visual changes

Before:
![Screenshot 2023-05-12 at 5 00 01 PM](https://github.com/primer/react/assets/15935667/de45b2aa-8086-466c-ac3c-6dd09f22f547)

After:
![Screenshot 2023-05-12 at 4 59 22 PM](https://github.com/primer/react/assets/15935667/9cf7c9c8-4728-4d87-8969-e1d51788a343)

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
