### PR TITLE
CounterLabel should forward ref and dom props

### DIFF
--- a/.changeset/twenty-tips-attend.md
+++ b/.changeset/twenty-tips-attend.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Counter label forwards refs and dom props

--- a/src/CounterLabel/CounterLabel.tsx
+++ b/src/CounterLabel/CounterLabel.tsx
@@ -1,47 +1,49 @@
-import React from 'react'
+import React, {HTMLAttributes, forwardRef} from 'react'
 import Box from '../Box'
 import {BetterSystemStyleObject, SxProp, merge} from '../sx'
 import VisuallyHidden from '../_VisuallyHidden'
+import {defaultSxProp} from '../utils/defaultSxProp'
 
-export type CounterLabelProps = {
-  scheme?: 'primary' | 'secondary'
-} & SxProp
+export type CounterLabelProps = React.PropsWithChildren<
+  HTMLAttributes<HTMLSpanElement> & {
+    scheme?: 'primary' | 'secondary'
+  } & SxProp
+>
 
-const CounterLabel: React.FC<React.PropsWithChildren<CounterLabelProps>> = ({
-  scheme = 'secondary',
-  sx = {},
-  children,
-  ...props
-}) => {
-  return (
-    <>
-      <Box
-        as="span"
-        aria-hidden="true"
-        sx={merge<BetterSystemStyleObject>(
-          {
-            display: 'inline-block',
-            padding: '2px 5px',
-            fontSize: 0,
-            fontWeight: 'bold',
-            lineHeight: 'condensedUltra',
-            borderRadius: '20px',
-            backgroundColor: scheme === 'primary' ? 'neutral.emphasis' : 'neutral.muted',
-            color: scheme === 'primary' ? 'fg.onEmphasis' : 'fg.default',
-            '&:empty': {
-              display: 'none',
+const CounterLabel = forwardRef<HTMLSpanElement, CounterLabelProps>(
+  ({scheme = 'secondary', sx = defaultSxProp, children, ...props}, forwardedRef) => {
+    return (
+      <>
+        <Box
+          aria-hidden="true"
+          sx={merge<BetterSystemStyleObject>(
+            {
+              display: 'inline-block',
+              padding: '2px 5px',
+              fontSize: 0,
+              fontWeight: 'bold',
+              lineHeight: 'condensedUltra',
+              borderRadius: '20px',
+              backgroundColor: scheme === 'primary' ? 'neutral.emphasis' : 'neutral.muted',
+              color: scheme === 'primary' ? 'fg.onEmphasis' : 'fg.default',
+              '&:empty': {
+                display: 'none',
+              },
             },
-          },
-          sx,
-        )}
-        {...props}
-      >
-        {children}
-      </Box>
-      <VisuallyHidden>&nbsp;({children})</VisuallyHidden>
-    </>
-  )
-}
+            sx,
+          )}
+          {...props}
+          as="span"
+          // @ts-expect-error Box is expecting a divelement, but this component forces a span element
+          ref={forwardedRef}
+        >
+          {children}
+        </Box>
+        <VisuallyHidden>&nbsp;({children})</VisuallyHidden>
+      </>
+    )
+  },
+)
 
 CounterLabel.displayName = 'CounterLabel'
 

--- a/src/CounterLabel/CounterLabel.types.test.tsx
+++ b/src/CounterLabel/CounterLabel.types.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useRef} from 'react'
 import CounterLabel from '../CounterLabel'
 
 export function shouldAcceptCallWithNoProps() {
@@ -8,4 +8,16 @@ export function shouldAcceptCallWithNoProps() {
 export function shouldNotAcceptSystemProps() {
   // @ts-expect-error system props should not be accepted
   return <CounterLabel backgroundColor="whitesmoke" />
+}
+
+export function showAcceptARef() {
+  function Component() {
+    const ref = useRef<HTMLSpanElement>(null)
+    return <CounterLabel ref={ref} />
+  }
+  return <Component />
+}
+
+export function shouldPassThroughSpanProps() {
+  return <CounterLabel data-testid="some value" aria-label="some label" />
 }


### PR DESCRIPTION
CounterLabel should forward both dom props and refs tot he underlying box 

Closes # (type the issue number after # if applicable; otherwise remove this line)

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
