### PR TITLE
StyledOcticon/Octicon: Update the render func to use `React.forwardRef()`

### DIFF
--- a/.changeset/spicy-shoes-press.md
+++ b/.changeset/spicy-shoes-press.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Octicons (previously known StyledOcticons) to use React.forwardRef()

--- a/src/Octicon/Octicon.tsx
+++ b/src/Octicon/Octicon.tsx
@@ -6,9 +6,14 @@ import {ComponentProps} from '../utils/types'
 
 type StyledOcticonProps = {icon: React.ElementType; color?: string} & IconProps
 
-function Icon({icon: IconComponent, ...rest}: StyledOcticonProps) {
-  return <IconComponent {...rest} />
-}
+// function Icon({icon: IconComponent, ...rest}: StyledOcticonProps) {
+//   return <IconComponent {...rest} />
+// }
+
+const Icon = React.forwardRef((props: StyledOcticonProps, ref: React.Ref<SVGSVGElement>) => {
+  const {icon: IconComponent, ...rest} = props
+  return <IconComponent {...rest} ref={ref} />
+})
 
 const Octicon = styled(Icon)<SxProp>`
   ${({color, sx: sxProp}) => sx({sx: {color, ...sxProp}})}

--- a/src/Octicon/Octicon.tsx
+++ b/src/Octicon/Octicon.tsx
@@ -6,10 +6,6 @@ import {ComponentProps} from '../utils/types'
 
 type StyledOcticonProps = {icon: React.ElementType; color?: string} & IconProps
 
-// function Icon({icon: IconComponent, ...rest}: StyledOcticonProps) {
-//   return <IconComponent {...rest} />
-// }
-
 const Icon = React.forwardRef((props: StyledOcticonProps, ref: React.Ref<SVGSVGElement>) => {
   const {icon: IconComponent, ...rest} = props
   return <IconComponent {...rest} ref={ref} />


### PR DESCRIPTION
We updated our icons to use `React.forwardRef()` from being a normal function components. https://github.com/primer/octicons/pull/943 

This was required for the `Tooltip` a11y remediation work and we also need to update the `Octicons` (aka `StyledOcticon`) render function so that we can access their refs to do our accessibility checks. I tested the changes at dotcom and seems to be good. 

### Screenshots

No visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
