### PR TITLE
Jdrush89/tree focus bug

### DIFF
--- a/.changeset/khaki-walls-applaud.md
+++ b/.changeset/khaki-walls-applaud.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fixing toggle bug on Treeview when it initially receives focus

--- a/src/TreeView/TreeView.features.stories.tsx
+++ b/src/TreeView/TreeView.features.stories.tsx
@@ -5,6 +5,7 @@ import Box from '../Box'
 import {Button} from '../Button'
 import Octicon from '../Octicon'
 import {SubTreeState, TreeView} from './TreeView'
+import TextInput from '../TextInput/TextInput'
 
 const meta: Meta = {
   title: 'Components/TreeView/Features',
@@ -23,6 +24,7 @@ const meta: Meta = {
 
 export const Files: Story = () => (
   <nav aria-label="Files">
+    <TextInput />
     <TreeView aria-label="Files">
       <TreeView.Item id="src" defaultExpanded>
         <TreeView.LeadingVisual>
@@ -54,9 +56,161 @@ export const Files: Story = () => (
                 </TreeView.LeadingVisual>
                 Button.test.tsx
               </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.test.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.test.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.test.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.test.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.test.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.test.tsx
+              </TreeView.Item>
             </TreeView.SubTree>
           </TreeView.Item>
           <TreeView.Item id="src/ReallyLongFileNameThatShouldBeTruncated.tsx">
+            <TreeView.LeadingVisual>
+              <FileIcon />
+            </TreeView.LeadingVisual>
+            ReallyLongFileNameThatShouldBeTruncated.tsx
+          </TreeView.Item>
+        </TreeView.SubTree>
+      </TreeView.Item>
+      <TreeView.Item id="src2" defaultExpanded>
+        <TreeView.LeadingVisual>
+          <TreeView.DirectoryIcon />
+        </TreeView.LeadingVisual>
+        src
+        <TreeView.SubTree>
+          <TreeView.Item id="src/Avatar.tsx2">
+            <TreeView.LeadingVisual>
+              <FileIcon />
+            </TreeView.LeadingVisual>
+            Avatar.tsx
+          </TreeView.Item>
+          <TreeView.Item id="src/Button2">
+            <TreeView.LeadingVisual>
+              <TreeView.DirectoryIcon />
+            </TreeView.LeadingVisual>
+            Button
+            <TreeView.SubTree>
+              <TreeView.Item id="src/Button/Button.tsx2">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.test.tsx2">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.test.tsx
+              </TreeView.Item>
+            </TreeView.SubTree>
+          </TreeView.Item>
+          <TreeView.Item id="src/ReallyLongFileNameThatShouldBeTruncated.tsx2">
+            <TreeView.LeadingVisual>
+              <FileIcon />
+            </TreeView.LeadingVisual>
+            ReallyLongFileNameThatShouldBeTruncated.tsx
+          </TreeView.Item>
+        </TreeView.SubTree>
+      </TreeView.Item>
+      <TreeView.Item id="src3">
+        <TreeView.LeadingVisual>
+          <TreeView.DirectoryIcon />
+        </TreeView.LeadingVisual>
+        src
+        <TreeView.SubTree>
+          <TreeView.Item id="src/Avatar.tsx3">
+            <TreeView.LeadingVisual>
+              <FileIcon />
+            </TreeView.LeadingVisual>
+            Avatar.tsx
+          </TreeView.Item>
+          <TreeView.Item id="src/Button3">
+            <TreeView.LeadingVisual>
+              <TreeView.DirectoryIcon />
+            </TreeView.LeadingVisual>
+            Button
+            <TreeView.SubTree>
+              <TreeView.Item id="src/Button/Button.tsx3">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.test.tsx3">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.test.tsx
+              </TreeView.Item>
+            </TreeView.SubTree>
+          </TreeView.Item>
+          <TreeView.Item id="src/ReallyLongFileNameThatShouldBeTruncated.tsx3">
             <TreeView.LeadingVisual>
               <FileIcon />
             </TreeView.LeadingVisual>

--- a/src/TreeView/TreeView.features.stories.tsx
+++ b/src/TreeView/TreeView.features.stories.tsx
@@ -24,7 +24,6 @@ const meta: Meta = {
 
 export const Files: Story = () => (
   <nav aria-label="Files">
-    <TextInput />
     <TreeView aria-label="Files">
       <TreeView.Item id="src" defaultExpanded>
         <TreeView.LeadingVisual>
@@ -56,161 +55,9 @@ export const Files: Story = () => (
                 </TreeView.LeadingVisual>
                 Button.test.tsx
               </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.test.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.test.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.test.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.test.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.test.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.test.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.test.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.test.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.test.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.test.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.test.tsx">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.test.tsx
-              </TreeView.Item>
             </TreeView.SubTree>
           </TreeView.Item>
           <TreeView.Item id="src/ReallyLongFileNameThatShouldBeTruncated.tsx">
-            <TreeView.LeadingVisual>
-              <FileIcon />
-            </TreeView.LeadingVisual>
-            ReallyLongFileNameThatShouldBeTruncated.tsx
-          </TreeView.Item>
-        </TreeView.SubTree>
-      </TreeView.Item>
-      <TreeView.Item id="src2" defaultExpanded>
-        <TreeView.LeadingVisual>
-          <TreeView.DirectoryIcon />
-        </TreeView.LeadingVisual>
-        src
-        <TreeView.SubTree>
-          <TreeView.Item id="src/Avatar.tsx2">
-            <TreeView.LeadingVisual>
-              <FileIcon />
-            </TreeView.LeadingVisual>
-            Avatar.tsx
-          </TreeView.Item>
-          <TreeView.Item id="src/Button2">
-            <TreeView.LeadingVisual>
-              <TreeView.DirectoryIcon />
-            </TreeView.LeadingVisual>
-            Button
-            <TreeView.SubTree>
-              <TreeView.Item id="src/Button/Button.tsx2">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.test.tsx2">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.test.tsx
-              </TreeView.Item>
-            </TreeView.SubTree>
-          </TreeView.Item>
-          <TreeView.Item id="src/ReallyLongFileNameThatShouldBeTruncated.tsx2">
-            <TreeView.LeadingVisual>
-              <FileIcon />
-            </TreeView.LeadingVisual>
-            ReallyLongFileNameThatShouldBeTruncated.tsx
-          </TreeView.Item>
-        </TreeView.SubTree>
-      </TreeView.Item>
-      <TreeView.Item id="src3">
-        <TreeView.LeadingVisual>
-          <TreeView.DirectoryIcon />
-        </TreeView.LeadingVisual>
-        src
-        <TreeView.SubTree>
-          <TreeView.Item id="src/Avatar.tsx3">
-            <TreeView.LeadingVisual>
-              <FileIcon />
-            </TreeView.LeadingVisual>
-            Avatar.tsx
-          </TreeView.Item>
-          <TreeView.Item id="src/Button3">
-            <TreeView.LeadingVisual>
-              <TreeView.DirectoryIcon />
-            </TreeView.LeadingVisual>
-            Button
-            <TreeView.SubTree>
-              <TreeView.Item id="src/Button/Button.tsx3">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.tsx
-              </TreeView.Item>
-              <TreeView.Item id="src/Button/Button.test.tsx3">
-                <TreeView.LeadingVisual>
-                  <FileIcon />
-                </TreeView.LeadingVisual>
-                Button.test.tsx
-              </TreeView.Item>
-            </TreeView.SubTree>
-          </TreeView.Item>
-          <TreeView.Item id="src/ReallyLongFileNameThatShouldBeTruncated.tsx3">
             <TreeView.LeadingVisual>
               <FileIcon />
             </TreeView.LeadingVisual>
@@ -931,11 +778,118 @@ export const InitialFocus: Story = () => (
   <div>
     <Button>Focusable element before TreeView</Button>
     <TreeView aria-label="Test tree">
-      <TreeView.Item id="item-1">Item 1</TreeView.Item>
-      <TreeView.Item id="item-2" current>
-        Item 2
+      <TreeView.Item id="src" defaultExpanded>
+        <TreeView.LeadingVisual>
+          <TreeView.DirectoryIcon />
+        </TreeView.LeadingVisual>
+        src
+        <TreeView.SubTree>
+          <TreeView.Item id="src/Avatar.tsx">
+            <TreeView.LeadingVisual>
+              <FileIcon />
+            </TreeView.LeadingVisual>
+            Avatar.tsx
+          </TreeView.Item>
+          <TreeView.Item id="src/Button" defaultExpanded>
+            <TreeView.LeadingVisual>
+              <TreeView.DirectoryIcon />
+            </TreeView.LeadingVisual>
+            Button
+            <TreeView.SubTree>
+              <TreeView.Item id="src/Button/Button.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button.test.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button2.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button2.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button2.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button2.test.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button3.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button3.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button3.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button3.test.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button4.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button4.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button4.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button4.test.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button5.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button5.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button5.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button5.test.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button6.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button6.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button6.test.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button6.test.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button7.tsx">
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button7.tsx
+              </TreeView.Item>
+              <TreeView.Item id="src/Button/Button7.test.tsx" current>
+                <TreeView.LeadingVisual>
+                  <FileIcon />
+                </TreeView.LeadingVisual>
+                Button7.test.tsx
+              </TreeView.Item>
+            </TreeView.SubTree>
+          </TreeView.Item>
+          <TreeView.Item id="src/ReallyLongFileNameThatShouldBeTruncated.tsx">
+            <TreeView.LeadingVisual>
+              <FileIcon />
+            </TreeView.LeadingVisual>
+            ReallyLongFileNameThatShouldBeTruncated.tsx
+          </TreeView.Item>
+        </TreeView.SubTree>
       </TreeView.Item>
-      <TreeView.Item id="item-3">Item 3</TreeView.Item>
     </TreeView>
     <Button>Focusable element after TreeView</Button>
   </div>

--- a/src/TreeView/TreeView.features.stories.tsx
+++ b/src/TreeView/TreeView.features.stories.tsx
@@ -5,7 +5,6 @@ import Box from '../Box'
 import {Button} from '../Button'
 import Octicon from '../Octicon'
 import {SubTreeState, TreeView} from './TreeView'
-import TextInput from '../TextInput/TextInput'
 
 const meta: Meta = {
   title: 'Components/TreeView/Features',

--- a/src/TreeView/TreeView.test.tsx
+++ b/src/TreeView/TreeView.test.tsx
@@ -247,6 +247,43 @@ describe('Markup', () => {
     const item2 = getByRole('treeitem', {name: /Item 2/})
     expect(item2).toHaveFocus()
   })
+
+  it('should toggle when receiving focus from chevron click', async () => {
+    const user = userEvent.setup({delay: null})
+    const {getByRole} = renderWithTheme(
+      <div>
+        <button>Focusable element</button>
+        <TreeView aria-label="Test tree">
+          <TreeView.Item id="item-1">
+            Item 1
+            <TreeView.SubTree>
+              <TreeView.Item id="subitem-1">SubItem 1</TreeView.Item>
+              <TreeView.Item id="subitem-2">SubItem 2</TreeView.Item>
+              <TreeView.Item id="subitem-3">SubItem 3</TreeView.Item>
+            </TreeView.SubTree>
+          </TreeView.Item>
+          <TreeView.Item id="item-2" current>
+            Item 2
+          </TreeView.Item>
+          <TreeView.Item id="item-3">Item 3</TreeView.Item>
+        </TreeView>
+      </div>,
+    )
+
+    // Focus button
+    const button = getByRole('button', {name: /Focusable element/})
+    await user.click(button)
+    expect(button).toHaveFocus()
+
+    // Move focus to tree
+    const item1 = getByRole('treeitem', {name: /Item 1/})
+    const toggle = item1.querySelector('.PRIVATE_TreeView-item-toggle')
+    await user.click(toggle!)
+
+    // Focus should be on current treeitem
+    const subItem1 = getByRole('treeitem', {name: /SubItem 1/})
+    expect(subItem1).toBeInTheDocument()
+  })
 })
 
 describe('Keyboard interactions', () => {

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -5,7 +5,7 @@ import {
   FileDirectoryOpenFillIcon,
 } from '@primer/octicons-react'
 import classnames from 'classnames'
-import React from 'react'
+import React, {useCallback, useEffect} from 'react'
 import styled, {keyframes} from 'styled-components'
 import {ConfirmationDialog} from '../Dialog/ConfirmationDialog'
 import Spinner from '../Spinner'
@@ -256,12 +256,21 @@ const Root: React.FC<TreeViewProps> = ({
   flat,
 }) => {
   const containerRef = React.useRef<HTMLUListElement>(null)
+  const mouseDownRef = React.useRef<boolean>(false)
   const [ariaLiveMessage, setAriaLiveMessage] = React.useState('')
   const announceUpdate = React.useCallback((message: string) => {
     setAriaLiveMessage(message)
   }, [])
 
-  useRovingTabIndex({containerRef})
+  const clickHandler = useCallback(() => {
+    mouseDownRef.current = false
+  }, [])
+
+  const mouseDownHandler = useCallback(() => {
+    mouseDownRef.current = true
+  }, [])
+
+  useRovingTabIndex({containerRef, mouseDownRef})
   useTypeahead({
     containerRef,
     onFocusChange: element => {
@@ -294,6 +303,8 @@ const Root: React.FC<TreeViewProps> = ({
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledby}
           data-omit-spacer={flat}
+          onClick={clickHandler}
+          onMouseDown={mouseDownHandler}
         >
           {children}
         </UlBox>

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -262,13 +262,20 @@ const Root: React.FC<TreeViewProps> = ({
     setAriaLiveMessage(message)
   }, [])
 
-  const clickHandler = useCallback(() => {
-    mouseDownRef.current = false
-  }, [])
-
   const mouseDownHandler = useCallback(() => {
     mouseDownRef.current = true
   }, [])
+
+  const mouseUpHandler = useCallback(() => {
+    mouseDownRef.current = false
+  }, [])
+
+  useEffect(() => {
+    document.addEventListener('mouseup', mouseUpHandler)
+    return () => {
+      document.removeEventListener('mouseup', mouseUpHandler)
+    }
+  })
 
   useRovingTabIndex({containerRef, mouseDownRef})
   useTypeahead({
@@ -303,7 +310,6 @@ const Root: React.FC<TreeViewProps> = ({
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledby}
           data-omit-spacer={flat}
-          onClick={clickHandler}
           onMouseDown={mouseDownHandler}
         >
           {children}

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -262,20 +262,19 @@ const Root: React.FC<TreeViewProps> = ({
     setAriaLiveMessage(message)
   }, [])
 
-  const mouseDownHandler = useCallback(() => {
+  const onMouseDown = useCallback(() => {
     mouseDownRef.current = true
   }, [])
 
-  const mouseUpHandler = useCallback(() => {
-    mouseDownRef.current = false
-  }, [])
-
   useEffect(() => {
-    document.addEventListener('mouseup', mouseUpHandler)
-    return () => {
-      document.removeEventListener('mouseup', mouseUpHandler)
+    function onMouseUp() {
+      mouseDownRef.current = false
     }
-  })
+    document.addEventListener('mouseup', onMouseUp)
+    return () => {
+      document.removeEventListener('mouseup', onMouseUp)
+    }
+  }, [])
 
   useRovingTabIndex({containerRef, mouseDownRef})
   useTypeahead({
@@ -310,7 +309,7 @@ const Root: React.FC<TreeViewProps> = ({
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledby}
           data-omit-spacer={flat}
-          onMouseDown={mouseDownHandler}
+          onMouseDown={onMouseDown}
         >
           {children}
         </UlBox>

--- a/src/TreeView/useRovingTabIndex.ts
+++ b/src/TreeView/useRovingTabIndex.ts
@@ -2,7 +2,13 @@ import React from 'react'
 import {FocusKeys, useFocusZone} from '../hooks/useFocusZone'
 import {getScrollContainer} from '../utils/scroll'
 
-export function useRovingTabIndex({containerRef}: {containerRef: React.RefObject<HTMLElement>}) {
+export function useRovingTabIndex({
+  containerRef,
+  mouseDownRef,
+}: {
+  containerRef: React.RefObject<HTMLElement>
+  mouseDownRef: React.RefObject<boolean>
+}) {
   // TODO: Initialize focus to the aria-current item if it exists
   useFocusZone({
     containerRef,
@@ -19,6 +25,13 @@ export function useRovingTabIndex({containerRef}: {containerRef: React.RefObject
       return getNextFocusableElement(from, event) ?? from
     },
     focusInStrategy: () => {
+      // Don't try to execute the focusInStrategy if focus is coming from a click.
+      // The clicked row will receive focus correctly by default.
+      // If a chevron is clicked, setting the focus through the focuszone will prevent its toggle.
+      if (mouseDownRef.current) {
+        return undefined
+      }
+
       const currentItem = containerRef.current?.querySelector('[aria-current]')
       const firstItem = containerRef.current?.querySelector('[role="treeitem"]')
 


### PR DESCRIPTION
When focus was set to the TreeView by clicking a toggle arrow on a row, the focusInStrategy would return the row element which has .focus() called on it, causing the click event to not go through to the toggle. This is a side effect of the toggle elements having a click handler, but no tabindex. The focusInStrategy does not need to execute for clicks, only when moving focus into the tree with the keyboard. When an element is clicked, that element should receive focus, which is the default behavior (In this case the row containing the toggle receives focus). Clicks can be detected by listening to mouseDown on the TreeView (onClick would happen after the focus change). mouseUp is listened to on the document in case the click is released outside the TreeView. We set a flag on mouseDown and avoid returning an element from the focusInStrategy while this flag is set.
Closes #3095 

### Screenshots

Before
https://github.com/primer/react/assets/955442/78342d93-79e6-4672-8e7e-7f92a771b25b

After
https://github.com/primer/react/assets/955442/2c93bb01-2109-4622-a32c-25681a71decc


### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
