### PR TITLE
[docs only] Add octicons-react import to Octicon docs example

### DIFF
--- a/docs/content/Octicon.mdx
+++ b/docs/content/Octicon.mdx
@@ -11,6 +11,8 @@ import data from '../../src/Octicon/Octicon.docs.json'
 ## Example
 
 ```jsx live
+import {CheckIcon, XIcon} from '@primer/octicons-react'
+
 <>
   <Octicon icon={CheckIcon} size={32} color="success.fg" sx={{mr: 2}} />
   <Octicon icon={XIcon} size={32} color="danger.fg" />


### PR DESCRIPTION
When reading through the `StyledOcticon` docs, I had a hard time figuring out where to import the `*Icon`s from, and had to grep the primer/react code base for bit before I found it. I figured this would help others from having to do the same. 

### Merge checklist

- ~[ ] Added/updated tests~
- [x] Added/updated documentation
- ~[ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)~
- ~[ ] Tested in Chrome~
- ~[ ] Tested in Firefox~
- ~[ ] Tested in Safari~
- ~[ ] Tested in Edge~

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
