### PR TITLE
SelectPanel: Add `role="dialog"` to overlay

### DIFF
--- a/.changeset/curvy-windows-walk.md
+++ b/.changeset/curvy-windows-walk.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+SelectPanel: Add `role="dialog"` to overlay

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -152,7 +152,7 @@ export function SelectPanel({
       open={open}
       onOpen={onOpen}
       onClose={onClose}
-      overlayProps={overlayProps}
+      overlayProps={{role: 'dialog', ...overlayProps}}
       focusTrapSettings={focusTrapSettings}
       focusZoneSettings={focusZoneSettings}
     >


### PR DESCRIPTION
Add `role="dialog"` to the overlay rendered by `SelectPanel`

Part of https://github.com/github/primer/issues/2087

### Screenshots

![Before and after screenshot showing that role=dialog is properly applied](https://github.com/primer/react/assets/4608155/f90e7274-a2e4-4f8a-850e-c977e7b7c9f3)

### Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
