### PR TITLE
SelectPanel: Add filter input label and description

### DIFF
--- a/.github/workflows/accessibility-alt-text-bot.yml
+++ b/.github/workflows/accessibility-alt-text-bot.yml
@@ -1,0 +1,17 @@
+name: accessibility-alt-text-bot
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  accessibility_alt_text_bot:
+    name: Check alt text is set on issue or pull requests
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue || github.event.pull_request }}
+    steps:
+      - name: Get action 'github/accessibility-alt-text-bot'
+        uses: github/accessibility-alt-text-bot@v1.0.0

--- a/generated/components.json
+++ b/generated/components.json
@@ -3656,6 +3656,12 @@
           "description": ""
         },
         {
+          "name": "inputLabel",
+          "type": "string",
+          "defaultValue": "Same as placeholderText",
+          "description": "The aria-label for the filter input"
+        },
+        {
           "name": "overlayProps",
           "type": "Partial<OverlayProps>",
           "defaultValue": "",

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -22,7 +22,7 @@ export interface FilteredActionListProps
     ListPropsBase,
     SxProp {
   loading?: boolean
-  placeholderText: string
+  placeholderText?: string
   filterValue?: string
   onFilterChange: (value: string, e: React.ChangeEvent<HTMLInputElement>) => void
   textInputProps?: Partial<Omit<TextInputProps, 'onChange'>>

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -1,19 +1,20 @@
-import React, {KeyboardEventHandler, useCallback, useEffect, useRef} from 'react'
-import {GroupedListProps, ListPropsBase} from '../deprecated/ActionList/List'
-import TextInput, {TextInputProps} from '../TextInput'
-import Box from '../Box'
-import {ActionList} from '../deprecated/ActionList'
-import Spinner from '../Spinner'
-import {useFocusZone} from '../hooks/useFocusZone'
-import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
-import styled from 'styled-components'
-import {get} from '../constants'
-import {useProvidedRefOrCreate} from '../hooks/useProvidedRefOrCreate'
-import useScrollFlash from '../hooks/useScrollFlash'
-import {scrollIntoView} from '@primer/behaviors'
 import type {ScrollIntoViewOptions} from '@primer/behaviors'
-import {SxProp} from '../sx'
+import {scrollIntoView} from '@primer/behaviors'
+import React, {KeyboardEventHandler, useCallback, useEffect, useRef} from 'react'
+import styled from 'styled-components'
+import Box from '../Box'
+import Spinner from '../Spinner'
+import TextInput, {TextInputProps} from '../TextInput'
+import {get} from '../constants'
+import {ActionList} from '../deprecated/ActionList'
+import {GroupedListProps, ListPropsBase} from '../deprecated/ActionList/List'
+import {useFocusZone} from '../hooks/useFocusZone'
 import {useId} from '../hooks/useId'
+import {useProvidedRefOrCreate} from '../hooks/useProvidedRefOrCreate'
+import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
+import useScrollFlash from '../hooks/useScrollFlash'
+import {VisuallyHidden} from '../internal/components/VisuallyHidden'
+import {SxProp} from '../sx'
 
 const menuScrollMargins: ScrollIntoViewOptions = {startMargin: 0, endMargin: 8}
 
@@ -60,6 +61,7 @@ export function FilteredActionList({
   const inputRef = useProvidedRefOrCreate<HTMLInputElement>(providedInputRef)
   const activeDescendantRef = useRef<HTMLElement>()
   const listId = useId()
+  const inputDescriptionTextId = useId()
   const onInputKeyPress: KeyboardEventHandler = useCallback(
     event => {
       if (event.key === 'Enter' && activeDescendantRef.current) {
@@ -119,9 +121,11 @@ export function FilteredActionList({
           placeholder={placeholderText}
           aria-label={placeholderText}
           aria-controls={listId}
+          aria-describedby={inputDescriptionTextId}
           {...textInputProps}
         />
       </StyledHeader>
+      <VisuallyHidden id={inputDescriptionTextId}>Items will be filtered as you type</VisuallyHidden>
       <Box ref={scrollContainerRef} overflow="auto">
         {loading ? (
           <Box width="100%" display="flex" flexDirection="row" justifyContent="center" pt={6} pb={7}>

--- a/src/SelectPanel/SelectPanel.docs.json
+++ b/src/SelectPanel/SelectPanel.docs.json
@@ -19,6 +19,12 @@
       "description": ""
     },
     {
+      "name": "inputLabel",
+      "type": "string",
+      "defaultValue": "Same as placeholderText",
+      "description": "The aria-label for the filter input"
+    }
+    {
       "name": "overlayProps",
       "type": "Partial<OverlayProps>",
       "defaultValue": "",

--- a/src/SelectPanel/SelectPanel.docs.json
+++ b/src/SelectPanel/SelectPanel.docs.json
@@ -23,7 +23,7 @@
       "type": "string",
       "defaultValue": "Same as placeholderText",
       "description": "The aria-label for the filter input"
-    }
+    },
     {
       "name": "overlayProps",
       "type": "Partial<OverlayProps>",

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -10,6 +10,7 @@ import {TextInputProps} from '../TextInput'
 import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
 import {AnchoredOverlayWrapperAnchorProps} from '../AnchoredOverlay/AnchoredOverlay'
 import {useProvidedRefOrCreate} from '../hooks'
+import {SearchIcon} from '@primer/octicons-react'
 
 interface SelectPanelSingleSelection {
   selected: ItemInput | undefined
@@ -27,6 +28,8 @@ interface SelectPanelBaseProps {
     gesture: 'anchor-click' | 'anchor-key-press' | 'click-outside' | 'escape' | 'selection',
   ) => void
   placeholder?: string
+  // TODO: Make `inputLabel` required in next major version
+  inputLabel?: string
   overlayProps?: Partial<OverlayProps>
 }
 
@@ -53,6 +56,8 @@ export function SelectPanel({
   renderAnchor = props => <DropdownButton {...props} />,
   anchorRef: externalAnchorRef,
   placeholder,
+  placeholderText = 'Filter items',
+  inputLabel = placeholderText,
   selected,
   onSelectedChange,
   filterValue: externalFilterValue,
@@ -141,9 +146,11 @@ export function SelectPanel({
     return {
       sx: {m: 2},
       contrast: true,
+      leadingVisual: SearchIcon,
+      'aria-label': inputLabel,
       ...textInputProps,
     }
-  }, [textInputProps])
+  }, [inputLabel, textInputProps])
 
   return (
     <AnchoredOverlay
@@ -159,6 +166,7 @@ export function SelectPanel({
       <FilteredActionList
         filterValue={filterValue}
         onFilterChange={onFilterChange}
+        placeholderText={placeholderText}
         {...listProps}
         role="listbox"
         aria-multiselectable={isMultiSelectVariant(selected) ? 'true' : 'false'}


### PR DESCRIPTION
[Storybook preview](https://primer-373fec8c4e-13348165.drafts.github.io/storybook/iframe.html?args=&id=components-selectpanel--default&viewMode=story)

- Adds optional `inputLabel` prop that will set the `aria-label` of the filter input. By default, `inputLabel` is the same as the placeholder text.
- Makes the `placeholderText` prop optional.
- Adds an ARIA description to the filter input.
- Displays a search icon in the filter input.

Part of https://github.com/github/primer/issues/2087

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
