### PR TITLE
ActionList.Item: Check defaultPrevented between onSelect & afterSelect

### DIFF
--- a/.changeset/actionlist-check-event-after-onselect.md
+++ b/.changeset/actionlist-check-event-after-onselect.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+ActionMenu: Calling `event.preventDefault` inside `onSelect` of `ActionList.Item` will prevent the default behavior of closing the menu

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -146,29 +146,28 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       ...(active ? activeStyles : {}),
     }
 
-    const clickHandler = React.useCallback(
-      (event: React.MouseEvent<HTMLLIElement>) => {
+    const internalOnSelect = React.useCallback(
+      (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
         if (disabled) return
-        if (!event.defaultPrevented) {
-          if (typeof onSelect === 'function') onSelect(event)
-          // if this Item is inside a Menu, close the Menu
-          if (typeof afterSelect === 'function') afterSelect()
-        }
+        if (event.defaultPrevented) return
+
+        if (typeof onSelect === 'function') onSelect(event)
+
+        // typescript does not know onSelect can call event.preventDefault, so this check is valid
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (event.defaultPrevented) return
+
+        // if this Item is inside a Menu, close the Menu
+        if (typeof afterSelect === 'function') afterSelect()
       },
-      [onSelect, disabled, afterSelect],
+      [disabled, onSelect, afterSelect],
     )
 
-    const keyPressHandler = React.useCallback(
-      (event: React.KeyboardEvent<HTMLLIElement>) => {
-        if (disabled) return
-        if (!event.defaultPrevented && [' ', 'Enter'].includes(event.key)) {
-          if (typeof onSelect === 'function') onSelect(event)
-          // if this Item is inside a Menu, close the Menu
-          if (typeof afterSelect === 'function') afterSelect()
-        }
-      },
-      [onSelect, disabled, afterSelect],
-    )
+    const clickHandler = internalOnSelect
+
+    const keyPressHandler = (event: React.KeyboardEvent<HTMLLIElement>) => {
+      if ([' ', 'Enter'].includes(event.key)) internalOnSelect(event)
+    }
 
     // use props.id if provided, otherwise generate one.
     const labelId = useId(id)

--- a/src/ActionMenu/ActionMenu.examples.stories.tsx
+++ b/src/ActionMenu/ActionMenu.examples.stories.tsx
@@ -11,6 +11,8 @@ import {
   NumberIcon,
   CalendarIcon,
   XIcon,
+  CheckIcon,
+  CopyIcon,
 } from '@primer/octicons-react'
 
 export default {
@@ -280,5 +282,38 @@ export const MultipleSections = () => {
         </ActionList>
       </ActionMenu.Overlay>
     </ActionMenu>
+  )
+}
+
+export const DelayedMenuClose = () => {
+  const [open, setOpen] = React.useState(false)
+  const [copyLinkSuccess, setCopyLinkSuccess] = React.useState(false)
+  const onSelect = (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
+    // don't close the menu
+    event.preventDefault()
+
+    setCopyLinkSuccess(true)
+    setTimeout(() => {
+      setOpen(false)
+      setCopyLinkSuccess(false)
+    }, 1000)
+  }
+
+  return (
+    <>
+      <h1>Delayed Menu Close</h1>
+
+      <ActionMenu open={open} onOpenChange={setOpen}>
+        <ActionMenu.Button>Anchor</ActionMenu.Button>
+        <ActionMenu.Overlay>
+          <ActionList>
+            <ActionList.Item onSelect={onSelect}>
+              <ActionList.LeadingVisual>{copyLinkSuccess ? <CheckIcon /> : <CopyIcon />}</ActionList.LeadingVisual>
+              {copyLinkSuccess ? 'Copied!' : 'Copy link'}
+            </ActionList.Item>
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+    </>
   )
 }

--- a/src/ActionMenu/ActionMenu.examples.stories.tsx
+++ b/src/ActionMenu/ActionMenu.examples.stories.tsx
@@ -287,15 +287,15 @@ export const MultipleSections = () => {
 
 export const DelayedMenuClose = () => {
   const [open, setOpen] = React.useState(false)
-  const [copyLinkSuccess, setCopyLinkSuccess] = React.useState(false)
+  const [copied, setCopied] = React.useState(false)
   const onSelect = (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
     // don't close the menu
     event.preventDefault()
 
-    setCopyLinkSuccess(true)
+    setCopied(true)
     setTimeout(() => {
       setOpen(false)
-      setCopyLinkSuccess(false)
+      setCopied(false)
     }, 1000)
   }
 
@@ -308,8 +308,8 @@ export const DelayedMenuClose = () => {
         <ActionMenu.Overlay>
           <ActionList>
             <ActionList.Item onSelect={onSelect}>
-              <ActionList.LeadingVisual>{copyLinkSuccess ? <CheckIcon /> : <CopyIcon />}</ActionList.LeadingVisual>
-              {copyLinkSuccess ? 'Copied!' : 'Copy link'}
+              <ActionList.LeadingVisual>{copied ? <CheckIcon /> : <CopyIcon />}</ActionList.LeadingVisual>
+              {copied ? 'Copied!' : 'Copy link'}
             </ActionList.Item>
           </ActionList>
         </ActionMenu.Overlay>

--- a/src/ActionMenu/ActionMenu.examples.stories.tsx
+++ b/src/ActionMenu/ActionMenu.examples.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Box, ActionMenu, ActionList, Button, IconButton} from '../'
+import {Box, ActionMenu, ActionList, Button, IconButton, ActionListItemProps} from '../'
 import {
   GearIcon,
   MilestoneIcon,
@@ -288,8 +288,8 @@ export const MultipleSections = () => {
 export const DelayedMenuClose = () => {
   const [open, setOpen] = React.useState(false)
   const [copied, setCopied] = React.useState(false)
-  const onSelect = (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
-    // don't close the menu
+  const onSelect: ActionListItemProps['onSelect'] = event => {
+    // prevent default behavior of closing menu
     event.preventDefault()
 
     setCopied(true)

--- a/src/__tests__/ActionMenu.test.tsx
+++ b/src/__tests__/ActionMenu.test.tsx
@@ -22,7 +22,7 @@ function Example(): JSX.Element {
                 <ActionList.Divider />
                 <ActionList.Item>Copy link</ActionList.Item>
                 <ActionList.Item>Edit file</ActionList.Item>
-                <ActionList.Item variant="danger" onClick={event => event.preventDefault()}>
+                <ActionList.Item variant="danger" onSelect={event => event.preventDefault()}>
                   Delete file
                 </ActionList.Item>
                 <ActionList.LinkItem href="//github.com" title="anchor" aria-keyshortcuts="s">


### PR DESCRIPTION
- Closes https://github.com/primer/react/issues/3162
- Implements @gr2m's changes from https://github.com/primer/react/pull/3163

---

Context: Today, if you want to customize the behaviour of a menu after selection (like in the video below) you have to opt out of `onSelect` and implement it yourself using `onClick` and `onKeypress`

As you can imagine, this can create bugs if not done well. This PR adds the ability to prevent the default behavior after onSelect by calling `event.preventDefault` inside it. ([See newly added story for example](https://github.com/primer/react/pull/3314/files#diff-cea465aa60ef37eb6568e169b075302a53f942da72d3e4c4fa35d5660ce77ce3R291))

https://github.com/primer/react/assets/1863771/415a0ec7-40e6-430c-bd4d-b0a3dc941775


