### PR TITLE
Remove aria-hidden=true from spans with required asterisk

### DIFF
--- a/.changeset/pink-beds-fetch.md
+++ b/.changeset/pink-beds-fetch.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Remove `aria-hidden=true` from `span`s with required asterisk

--- a/src/_InputLabel.tsx
+++ b/src/_InputLabel.tsx
@@ -55,7 +55,7 @@ const InputLabel: React.FC<React.PropsWithChildren<Props>> = ({
       {required ? (
         <Box display="flex" as="span">
           <Box mr={1}>{children}</Box>
-          <span aria-hidden="true">*</span>
+          <span>*</span>
         </Box>
       ) : (
         children

--- a/src/__tests__/deprecated/InputField.test.tsx
+++ b/src/__tests__/deprecated/InputField.test.tsx
@@ -6,6 +6,7 @@ import InputField from '../../deprecated/InputField'
 expect.extend(toHaveNoViolations)
 
 const TEXTINPUTFIELD_LABEL_TEXT = 'Name'
+const TEXTINPUTFIELD_LABEL_TEXT_WITH_ASTERISK = 'Name *'
 const TEXTINPUTFIELD_CAPTION_TEXT = 'Hint: your first name'
 const TEXTINPUTFIELD_SUCCESS_TEXT = 'This name is valid'
 const TEXTINPUTFIELD_ERROR_TEXT = 'This name is invalid'
@@ -66,7 +67,7 @@ describe('InputField', () => {
         </SSRProvider>,
       )
 
-      const input = getByRole('textbox', {name: TEXTINPUTFIELD_LABEL_TEXT})
+      const input = getByRole('textbox', {name: TEXTINPUTFIELD_LABEL_TEXT_WITH_ASTERISK})
 
       expect(input.getAttribute('required')).not.toBeNull()
     })


### PR DESCRIPTION
Describe your changes here.

Per accessibility feedback, removes `aria-hidden="true"` from the `span`s that add the `*` to `FormControl`s marked with the `required` attribute.

It's worth noting that the audit feedback was specific to an `ActionMenu` form control, which is relevant because it uses a `button` rather than an actual form element like `select` and hence can't actually have a required attribute. I wonder if we want to be more selective about which `<span>*</span>`s we want to remove `aria-hidden="true"` from, or if it's acceptable to remove it universally as currently proposed here?

### Screenshots

Before:
![Screenshot 2023-05-24 at 1 03 33 PM](https://github.com/primer/react/assets/15935667/236c710f-2a0b-43cd-86cf-2c147a039ba3)

After:
![Screenshot 2023-05-24 at 1 02 56 PM](https://github.com/primer/react/assets/15935667/ffd16c2b-0afb-44cf-a19d-cfb1f555a051)

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
