### PR TITLE
Update accessibility-alt-text-bot.yml

### DIFF
--- a/.github/workflows/accessibility-alt-text-bot.yml
+++ b/.github/workflows/accessibility-alt-text-bot.yml
@@ -6,12 +6,18 @@ on:
     types: [opened, edited]
   issue_comment:
     types: [created, edited]
+  discussion:
+    types: [created, edited]
+    
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   accessibility_alt_text_bot:
     name: Check alt text is set on issue or pull requests
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue || github.event.pull_request }}
+    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion  }}
     steps:
       - name: Get action 'github/accessibility-alt-text-bot'
-        uses: github/accessibility-alt-text-bot@v1.0.0
+        uses: github/accessibility-alt-text-bot@v1.1.0


### PR DESCRIPTION
### What

The accessibility-alt-text-bot workflow does not have permissions to write a comment on an issue. This is likely due to how permissions are setup in this repo. In order to keep permissions, at the repo level, unchanged, we need to add permission directly to the workflow. 

I also took this as an opportunity to bump the alt-text-bot version and give you access to reminders in discussions

Describe your changes here.

Closes # (type the issue number after # if applicable; otherwise remove this line)

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
