### PR TITLE
NavList: Fix group dividers

### DIFF
--- a/src/NavList/NavList.stories.tsx
+++ b/src/NavList/NavList.stories.tsx
@@ -28,12 +28,17 @@ export const Simple: Story = () => (
 
 export const WithGroup: Story = () => (
   <NavList>
-    <NavList.Group title="Group title">
+    <NavList.Group title="Group 1">
       <NavList.Item href="#" aria-current="page">
         Item 1
       </NavList.Item>
       <NavList.Item href="#">Item 2</NavList.Item>
       <NavList.Item href="#">Item 3</NavList.Item>
+    </NavList.Group>
+    <NavList.Group title="Group 2">
+      <NavList.Item href="#">Item 4</NavList.Item>
+      <NavList.Item href="#">Item 5</NavList.Item>
+      <NavList.Item href="#">Item 6</NavList.Item>
     </NavList.Group>
   </NavList>
 )

--- a/src/NavList/NavList.tsx
+++ b/src/NavList/NavList.tsx
@@ -248,7 +248,7 @@ const Group: React.FC<NavListGroupProps> = ({title, children, sx: sxProp = defau
   return (
     <>
       {/* Hide divider if the group is the first item in the list */}
-      <ActionList.Divider sx={{'&:first-child': {display: 'none'}}} />
+      {/* <ActionList.Divider sx={{'&:first-of-type': {display: 'none'}}} /> */}
       <Box as="li" sx={sxProp} {...props}>
         {title && <ActionList.Heading title={title} />}
         <Box as="ul" sx={{paddingInlineStart: 0}}>

--- a/src/NavList/NavList.tsx
+++ b/src/NavList/NavList.tsx
@@ -246,14 +246,16 @@ const defaultSx = {}
 // TODO: ref prop
 const Group: React.FC<NavListGroupProps> = ({title, children, sx: sxProp = defaultSx, ...props}) => {
   return (
-    <Box as="li" sx={sxProp} {...props}>
+    <>
       {/* Hide divider if the group is the first item in the list */}
-      <ActionList.Divider as="div" sx={{'&:first-child': {display: 'none'}}} />
-      {title && <ActionList.Heading title={title} />}
-      <Box as="ul" sx={{paddingInlineStart: 0}}>
-        {children}
+      <ActionList.Divider sx={{'&:first-child': {display: 'none'}}} />
+      <Box as="li" sx={sxProp} {...props}>
+        {title && <ActionList.Heading title={title} />}
+        <Box as="ul" sx={{paddingInlineStart: 0}}>
+          {children}
+        </Box>
       </Box>
-    </Box>
+    </>
   )
 }
 

--- a/src/NavList/NavList.tsx
+++ b/src/NavList/NavList.tsx
@@ -248,7 +248,7 @@ const Group: React.FC<NavListGroupProps> = ({title, children, sx: sxProp = defau
   return (
     <>
       {/* Hide divider if the group is the first item in the list */}
-      {/* <ActionList.Divider sx={{'&:first-of-type': {display: 'none'}}} /> */}
+      <ActionList.Divider sx={{'&:first-of-type': {display: 'none'}}} />
       <Box as="li" sx={sxProp} {...props}>
         {title && <ActionList.Heading title={title} />}
         <Box as="ul" sx={{paddingInlineStart: 0}}>

--- a/src/NavList/__snapshots__/NavList.test.tsx.snap
+++ b/src/NavList/__snapshots__/NavList.test.tsx.snap
@@ -407,7 +407,7 @@ exports[`NavList renders with groups 1`] = `
   list-style: none;
 }
 
-.c2:first-child {
+.c2:first-of-type {
   display: none;
 }
 
@@ -702,14 +702,14 @@ exports[`NavList renders with groups 1`] = `
         class="c1"
       >
         <li
+          aria-hidden="true"
+          class="c2"
+          data-component="ActionList.Divider"
+          role="separator"
+        />
+        <li
           class=""
         >
-          <div
-            aria-hidden="true"
-            class="c2"
-            data-component="ActionList.Divider"
-            role="separator"
-          />
           <div
             class="c3"
           >
@@ -749,14 +749,14 @@ exports[`NavList renders with groups 1`] = `
           </ul>
         </li>
         <li
+          aria-hidden="true"
+          class="c2"
+          data-component="ActionList.Divider"
+          role="separator"
+        />
+        <li
           class=""
         >
-          <div
-            aria-hidden="true"
-            class="c2"
-            data-component="ActionList.Divider"
-            role="separator"
-          />
           <div
             class="c3"
           >


### PR DESCRIPTION
Fixes a bug introduced in [this PR](https://github.com/primer/react/pull/2878/files#diff-874836517a58028b99e00e884887b49d9c859a39d2fd2dc0f0a02eb679441a1d) where the dividers between NavList groups were not being displayed.

### Screenshots

| Before | After |
| --- | --- |
| <img width="256" alt="navlist with no dividers" src="https://github.com/primer/react/assets/4608155/94416a81-b06d-4981-bf52-f5aaefb35b7a"> | <img width="259" alt="navlist with dividers" src="https://github.com/primer/react/assets/4608155/6802b7d3-664c-4d7f-961e-57403dc9db1c"> |


### Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
