### PR TITLE
ci:  update ci workflow to run against next-major branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,12 @@ on:
   push:
     branches:
       - main
+      - next-major
   pull_request:
   merge_group:
     branches:
       - main
+      - next-major
     types:
       - checks_requested
 


### PR DESCRIPTION
This PR updates our `CI` workflow to also run when pushing to `next-major` or when a merge group is requested for the `next-major` branch.