### PR TITLE
Move theme dependencies on lodash from devDependencies to dependencies

### DIFF
--- a/.changeset/eleven-sloths-laugh.md
+++ b/.changeset/eleven-sloths-laugh.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Move  `lodash.isempty` and `lodash.isobject` from `devDependencies` to `dependencies`

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
         "focus-visible": "^5.2.0",
         "fzy.js": "0.4.1",
         "history": "^5.0.0",
+        "lodash.isempty": "4.4.0",
+        "lodash.isobject": "3.0.2",
         "react-intersection-observer": "9.4.3",
         "styled-system": "^5.1.5"
       },
@@ -133,8 +135,6 @@
         "jscodeshift": "0.14.0",
         "lint-staged": "13.2.2",
         "lodash.groupby": "4.6.0",
-        "lodash.isempty": "4.4.0",
-        "lodash.isobject": "3.0.2",
         "lodash.keyby": "4.6.0",
         "markdownlint-cli2": "^0.7.1",
         "markdownlint-cli2-formatter-pretty": "0.0.3",
@@ -32343,14 +32343,12 @@
     "node_modules/lodash.isempty": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
-      "dev": true
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "node_modules/lodash.isobject": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
-      "dev": true
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
     },
     "node_modules/lodash.iteratee": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
     "focus-visible": "^5.2.0",
     "fzy.js": "0.4.1",
     "history": "^5.0.0",
+    "lodash.isempty": "4.4.0",
+    "lodash.isobject": "3.0.2",
     "react-intersection-observer": "9.4.3",
     "styled-system": "^5.1.5"
   },
@@ -217,8 +219,6 @@
     "jscodeshift": "0.14.0",
     "lint-staged": "13.2.2",
     "lodash.groupby": "4.6.0",
-    "lodash.isempty": "4.4.0",
-    "lodash.isobject": "3.0.2",
     "lodash.keyby": "4.6.0",
     "markdownlint-cli2": "^0.7.1",
     "markdownlint-cli2-formatter-pretty": "0.0.3",


### PR DESCRIPTION
Based on [errors in the integration PR](https://github.com/github/github/pull/274199/checks?check_run_id=13772967906), moving `lodash.isempty` and `lodash.isobject` from devDependencies to dependencies

<details>
<summary>see relevant errors</summary>

```
ERROR in ./node_modules/@primer/react/lib-esm/utils/theme2.js 2:0-40
Module not found: Error: Can't resolve 'lodash.isempty' in '/workspace/github/node_modules/@primer/react/lib-esm/utils'
 @ ./node_modules/@primer/react/lib-esm/theme.js 2:0-49 12:10-27 13:8-25 35:6-29 39:14-31 40:15-32
 @ ./node_modules/@primer/react/lib-esm/index.js
 @ ./app/assets/modules/activity/pages/Activity.tsx 4:0-43 32:43-53
 @ ./app/assets/modules/activity/index.ts 4:0-40 15:27-35
 @ ./app/assets/modules/activity.ts 1:0-26

ERROR in ./node_modules/@primer/react/lib-esm/utils/theme2.js 3:0-41
Module not found: Error: Can't resolve 'lodash.isobject' in '/workspace/github/node_modules/@primer/react/lib-esm/utils'
 @ ./node_modules/@primer/react/lib-esm/theme.js 2:0-49 12:10-27 13:8-25 35:6-29 39:14-31 40:15-32
 @ ./node_modules/@primer/react/lib-esm/index.js
 @ ./app/assets/modules/activity/pages/Activity.tsx 4:0-43 32:43-53
 @ ./app/assets/modules/activity/index.ts 4:0-40 15:27-35
 @ ./app/assets/modules/activity.ts 1:0-26

ERROR in ./node_modules/@primer/react/lib-esm/utils/theme2.js 4:0-35
Module not found: Error: Can't resolve 'chroma-js' in '/workspace/github/node_modules/@primer/react/lib-esm/utils'
 @ ./node_modules/@primer/react/lib-esm/theme.js 2:0-49 12:10-27 13:8-25 35:6-29 39:14-31 40:15-32
 @ ./node_modules/@primer/react/lib-esm/index.js
 @ ./app/assets/modules/activity/pages/Activity.tsx 4:0-43 32:43-53
 @ ./app/assets/modules/activity/index.ts 4:0-40 15:27-35
 @ ./app/assets/modules/activity.ts 1:0-26
```
</details>



Note: chroma-js is not here, because we have removed it as a dependency completely in https://github.com/primer/react/pull/3325


Note 2: I have not moved `@types/*` for these dependencies because I'm assuming that should not be used or impact the build in dotcom