### PR TITLE
ci(vrt): update build storybook step

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build storybook
-        run: npx build-storybook
+        run: npx storybook build
       - name: Install browsers
         run: npx playwright install --with-deps
       - name: Run storybook


### PR DESCRIPTION
Update the build step for the vrt workflow from `npx build-storybook` from Storybook v6 to `npx storybook build` for Storybook v7