### PR TITLE
Update release schedule to run every Monday

### DIFF
--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -1,6 +1,8 @@
 name: Release Schedule
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '30 13 * * MON'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
Updates our Release Schedule workflow to run every Monday at 13:30 UTC. This should automate this workflow instead of it needing a manual dispatch every week.

For the timing, it seemed like our Pagerduty schedule switches over at 8:30am CT so I converted that time to UTC for the cron schedule. Hope it makes sense 😅 