### PR TITLE
fix: prevent closing menu when `event.preventDefault()` is called on `ActionList.Item`'s `onSelect` handler by @gr2m

### DIFF
--- a/.changeset/brave-cherries-march.md
+++ b/.changeset/brave-cherries-march.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+ActionMenu: Calling `event.preventDefault` inside `onSelect` of `ActionList.Item` will prevent the default behavior of closing the menu

--- a/generated/components.json
+++ b/generated/components.json
@@ -163,7 +163,7 @@
               "name": "onSelect",
               "type": "(event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void",
               "defaultValue": "",
-              "description": "Callback that is called when the item is selected using either the mouse or keyboard."
+              "description": "Callback that is called when the item is selected using either the mouse or keyboard. `event.preventDefault()` will prevent a menu from closing when within an `<ActionMenu />`"
             },
             {
               "name": "selected",

--- a/src/ActionList/ActionList.docs.json
+++ b/src/ActionList/ActionList.docs.json
@@ -62,7 +62,7 @@
           "name": "onSelect",
           "type": "(event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void",
           "defaultValue": "",
-          "description": "Callback that is called when the item is selected using either the mouse or keyboard."
+          "description": "Callback that is called when the item is selected using either the mouse or keyboard. `event.preventDefault()` will prevent a menu from closing when within an `<ActionMenu />`"
         },
         {
           "name": "selected",

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -24,7 +24,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       disabled = false,
       selected = undefined,
       active = false,
-      onSelect,
+      onSelect: onSelectUser,
       sx: sxProp = defaultSxProp,
       id,
       role,
@@ -41,6 +41,19 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
     const {variant: listVariant, showDividers, selectionVariant: listSelectionVariant} = React.useContext(ListContext)
     const {container, afterSelect, selectionAttribute} = React.useContext(ActionListContainerContext)
     const {selectionVariant: groupSelectionVariant} = React.useContext(GroupContext)
+
+    const onSelect = React.useCallback(
+      (
+        event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>,
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        afterSelect?: Function,
+      ) => {
+        if (typeof onSelectUser === 'function') onSelectUser(event)
+        if (event.defaultPrevented) return
+        if (typeof afterSelect === 'function') afterSelect()
+      },
+      [onSelectUser],
+    )
 
     const selectionVariant: ActionListProps['selectionVariant'] = groupSelectionVariant
       ? groupSelectionVariant
@@ -149,11 +162,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
     const clickHandler = React.useCallback(
       (event: React.MouseEvent<HTMLLIElement>) => {
         if (disabled) return
-        if (!event.defaultPrevented) {
-          if (typeof onSelect === 'function') onSelect(event)
-          // if this Item is inside a Menu, close the Menu
-          if (typeof afterSelect === 'function') afterSelect()
-        }
+        onSelect(event, afterSelect)
       },
       [onSelect, disabled, afterSelect],
     )
@@ -161,10 +170,8 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
     const keyPressHandler = React.useCallback(
       (event: React.KeyboardEvent<HTMLLIElement>) => {
         if (disabled) return
-        if (!event.defaultPrevented && [' ', 'Enter'].includes(event.key)) {
-          if (typeof onSelect === 'function') onSelect(event)
-          // if this Item is inside a Menu, close the Menu
-          if (typeof afterSelect === 'function') afterSelect()
+        if ([' ', 'Enter'].includes(event.key)) {
+          onSelect(event, afterSelect)
         }
       },
       [onSelect, disabled, afterSelect],

--- a/src/ActionMenu/ActionMenu.examples.stories.tsx
+++ b/src/ActionMenu/ActionMenu.examples.stories.tsx
@@ -11,6 +11,8 @@ import {
   NumberIcon,
   CalendarIcon,
   XIcon,
+  CheckIcon,
+  CopyIcon,
 } from '@primer/octicons-react'
 
 export default {
@@ -280,5 +282,37 @@ export const MultipleSections = () => {
         </ActionList>
       </ActionMenu.Overlay>
     </ActionMenu>
+  )
+}
+
+export const DelayedMenuClose = () => {
+  const [open, setOpen] = React.useState(false)
+  const [copyLinkSuccess, setCopyLinkSuccess] = React.useState(false)
+  const onSelect = (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
+    event.preventDefault()
+
+    setCopyLinkSuccess(true)
+    setTimeout(() => {
+      setOpen(false)
+      setCopyLinkSuccess(false)
+    }, 700)
+  }
+
+  return (
+    <>
+      <h1>Delayed Menu Close</h1>
+
+      <ActionMenu open={open} onOpenChange={setOpen}>
+        <ActionMenu.Button>Anchor</ActionMenu.Button>
+        <ActionMenu.Overlay>
+          <ActionList>
+            <ActionList.Item onSelect={onSelect}>
+              <ActionList.LeadingVisual>{copyLinkSuccess ? <CheckIcon /> : <CopyIcon />}</ActionList.LeadingVisual>
+              {copyLinkSuccess ? 'Copied!' : 'Copy link'}
+            </ActionList.Item>
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+    </>
   )
 }

--- a/src/__tests__/ActionMenu.test.tsx
+++ b/src/__tests__/ActionMenu.test.tsx
@@ -22,7 +22,7 @@ function Example(): JSX.Element {
                 <ActionList.Divider />
                 <ActionList.Item>Copy link</ActionList.Item>
                 <ActionList.Item>Edit file</ActionList.Item>
-                <ActionList.Item variant="danger" onClick={event => event.preventDefault()}>
+                <ActionList.Item variant="danger" onSelect={event => event.preventDefault()}>
                   Delete file
                 </ActionList.Item>
                 <ActionList.LinkItem href="//github.com" title="anchor" aria-keyshortcuts="s">


### PR DESCRIPTION
- Closes #3162
- Original PR: https://github.com/primer/react/pull/3163

### Screenshots

https://user-images.githubusercontent.com/39992/231614248-7c26e213-c5cd-4c99-9b32-2542afc11a7c.mov

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox`*`
- [x] Tested in Safari
- [ ] Tested in Edge

`*` Selecting the single option doesn't work in Firefox, but I'm pretty sure that is an unrelated bug. When the menu has 2 or more items, selecting an item with keyboard navigation works in Firefox.

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
