### PR TITLE
Loosen `@primitives` dependency

### DIFF
--- a/.changeset/fluffy-pants-play.md
+++ b/.changeset/fluffy-pants-play.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Loosen `@primitives` dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@lit-labs/react": "1.1.1",
         "@primer/behaviors": "1.3.4",
         "@primer/octicons-react": "^19.1.0",
-        "@primer/primitives": "7.11.10",
+        "@primer/primitives": "^7.11.11",
         "@react-aria/ssr": "^3.1.0",
         "@styled-system/css": "^5.1.5",
         "@styled-system/props": "^5.1.5",
@@ -5311,9 +5311,9 @@
       }
     },
     "node_modules/@primer/primitives": {
-      "version": "7.11.10",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.11.10.tgz",
-      "integrity": "sha512-KwChxyp4qbLojZx5Nz8RUElM9K+ObzZWvzkYEu76TC4qEsqb9wW7n78jyov5WhUh5+qj2Qac1iCsPfeTQG5YBw=="
+      "version": "7.11.11",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.11.11.tgz",
+      "integrity": "sha512-5McPeE83AGcYm2uHbQEIOOa6JPv2SUFPDjYbf2I5QnvmNm9ZUbS446zWC3ygNi54uks7znuTDFrU325vpnze7g=="
     },
     "node_modules/@primer/view-components": {
       "version": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@lit-labs/react": "1.1.1",
     "@primer/behaviors": "1.3.4",
     "@primer/octicons-react": "^19.1.0",
-    "@primer/primitives": "7.11.10",
+    "@primer/primitives": "^7.11.11",
     "@react-aria/ssr": "^3.1.0",
     "@styled-system/css": "^5.1.5",
     "@styled-system/props": "^5.1.5",


### PR DESCRIPTION
- Bump primitives
- Add caret `^` as discussed in [this ADR](https://github.com/github/primer/pull/2268/files)

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge