### PR TITLE
Remove as summary in filtered search component docs

### DIFF
--- a/docs/content/FilteredSearch.mdx
+++ b/docs/content/FilteredSearch.mdx
@@ -15,7 +15,7 @@ The FilteredSearch component helps style an ActionMenu and a TextInput side-by-s
 ```jsx live
 <FilteredSearch>
   <ActionMenu>
-    <ActionMenu.Button as="summary">Filter</ActionMenu.Button>
+    <ActionMenu.Button>Filter</ActionMenu.Button>
     <ActionMenu.Overlay>
       <ActionList>
         <ActionList.Item>Item 1</ActionList.Item>


### PR DESCRIPTION
Using as="summary" here results in a React warning.

In the console, it prints out

> react_devtools_backend_compact.js:2367 This component should be an instanceof a semantic button or anchor

Removing as="summary" resolves the warning, so I think we should update the docs! 


### Screenshots

n/a

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
