### PR TITLE
Fix Storybook story control syntax

### DIFF
--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -21,14 +21,14 @@ export default {
     variant: {
       control: {
         type: 'radio',
-        options: ['default', 'primary', 'danger', 'invisible', 'outline'],
       },
+      options: ['default', 'primary', 'danger', 'invisible', 'outline'],
     },
     alignContent: {
       control: {
         type: 'radio',
-        options: ['center', 'start'],
       },
+      options: ['center', 'start'],
     },
     block: {
       control: {

--- a/src/Button/IconButton.stories.tsx
+++ b/src/Button/IconButton.stories.tsx
@@ -10,8 +10,8 @@ const meta: Meta<ComponentProps<typeof IconButton>> = {
     size: {
       control: {
         type: 'radio',
-        options: ['small', 'medium', 'large'],
       },
+      options: ['small', 'medium', 'large'],
     },
     disabled: {
       control: {
@@ -21,8 +21,8 @@ const meta: Meta<ComponentProps<typeof IconButton>> = {
     variant: {
       control: {
         type: 'radio',
-        options: ['default', 'primary', 'danger', 'invisible'],
       },
+      options: ['default', 'primary', 'danger', 'invisible'],
     },
     icon: OcticonArgType([EyeClosedIcon, EyeIcon, SearchIcon, XIcon, HeartIcon]),
   },

--- a/src/Button/LinkButton.stories.tsx
+++ b/src/Button/LinkButton.stories.tsx
@@ -10,20 +10,20 @@ export default {
     size: {
       control: {
         type: 'radio',
-        options: ['small', 'medium', 'large'],
       },
+      options: ['small', 'medium', 'large'],
     },
     variant: {
       control: {
         type: 'radio',
-        options: ['default', 'primary', 'danger', 'invisible', 'outline'],
       },
+      options: ['default', 'primary', 'danger', 'invisible', 'outline'],
     },
     alignContent: {
       control: {
         type: 'radio',
-        options: ['center', 'start'],
       },
+      options: ['center', 'start'],
     },
     block: {
       control: {

--- a/src/drafts/Button2/Button.stories.tsx
+++ b/src/drafts/Button2/Button.stories.tsx
@@ -21,14 +21,14 @@ export default {
     variant: {
       control: {
         type: 'radio',
-        options: ['default', 'primary', 'danger', 'invisible', 'outline'],
       },
+      options: ['default', 'primary', 'danger', 'invisible', 'outline'],
     },
     alignContent: {
       control: {
         type: 'radio',
-        options: ['center', 'start'],
       },
+      options: ['center', 'start'],
     },
     block: {
       control: {


### PR DESCRIPTION
In a few stories, `options` were set in the wrong place which made them unusable.


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
