### PR TITLE
UnderlineNav2: Remove `selectionVariant` prop from stories and refactor accordingly

### DIFF
--- a/src/ActionList/Visuals.tsx
+++ b/src/ActionList/Visuals.tsx
@@ -9,6 +9,7 @@ type VisualProps = SxProp & React.HTMLAttributes<HTMLSpanElement>
 export const LeadingVisualContainer: React.FC<React.PropsWithChildren<VisualProps>> = ({sx = {}, ...props}) => {
   return (
     <Box
+      data-component="ActionList.LeadingVisual"
       as="span"
       sx={merge(
         {

--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -145,7 +145,6 @@ export const UnderlineNav = forwardRef(
       variant = 'default',
       loadingCounters = false,
       children,
-      ...props
     }: UnderlineNavProps,
     forwardedRef,
   ) => {
@@ -370,7 +369,6 @@ export const UnderlineNav = forwardRef(
                   ref={containerRef}
                   id={disclosureWidgetId}
                   sx={merge({display: isWidgetOpen ? 'block' : 'none'}, menuStyles)}
-                  {...props}
                 >
                   {actions.map((action, index) => {
                     const {children: actionElementChildren, ...actionElementProps} = action.props

--- a/src/UnderlineNav2/UnderlineNav2.features.stories.tsx
+++ b/src/UnderlineNav2/UnderlineNav2.features.stories.tsx
@@ -76,11 +76,7 @@ const items: {navigation: string; icon: React.FC<IconProps>; counter?: number | 
 export const OverflowTemplate = ({initialSelectedIndex = 1}: {initialSelectedIndex?: number}) => {
   const [selectedIndex, setSelectedIndex] = React.useState<number | null>(initialSelectedIndex)
   return (
-    <UnderlineNav
-      aria-label="Repository"
-      // @ts-ignore UnderlineNav does not take selectionVariant prop, but we need to pass it to the underlying ActionList so it doesn't show Selections.
-      selectionVariant={undefined}
-    >
+    <UnderlineNav aria-label="Repository">
       {items.map((item, index) => (
         <UnderlineNav.Item
           key={item.navigation}

--- a/src/UnderlineNav2/styles.ts
+++ b/src/UnderlineNav2/styles.ts
@@ -138,7 +138,7 @@ export const getLinkStyles = (
 
 export const menuItemStyles = {
   // This is needed to hide the selected check icon on the menu item. https://github.com/primer/react/blob/main/src/ActionList/Selection.tsx#L32
-  '& > span': {
+  '& span[data-component="ActionList.LeadingVisual"]': {
     display: 'none',
   },
   // To reset the style when the menu items are rendered as react router links


### PR DESCRIPTION
Reverting some changes back on `UnderlineNav` that was introduced https://github.com/primer/react/pull/2878

We need to pass `selectionVariant="single"` on  [the ActionList in UnderlineNav](https://github.com/primer/react/blob/main/src/UnderlineNav2/UnderlineNav.tsx#L369) because we call `onSelect` function. If we don't set it, it throws an error when an item is selected ([ActionList ref](https://github.com/primer/react/blob/main/src/ActionList/Selection.tsx#L18))

To be able to hide the `CheckIcon` we can use styling. This is how it was originally done but I took this as an opportunity and update the styling to check a data component rather than relying on the node order in the dom.  

### Screenshots

No visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
