### PR TITLE
ci: update concurrency for canary release workflow

### DIFF
--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Canary Release
 on:
   push:
     branches-ignore:
@@ -7,8 +7,8 @@ on:
       - 'changeset-release/**'
 
 jobs:
-  release-canary:
-    name: Canary
+  release:
+    concurrency: npm-canary
     uses: primer/.github/.github/workflows/release_canary.yml@main
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add the [`concurrency` field](https://docs.github.com/en/actions/using-jobs/using-concurrency) for our release canary workflow to use a single named group. This should reduce the number of failures from this workflow ([list of previous runs](https://github.com/primer/react/actions/workflows/release_canary.yml)) as it limits this job from running in parallel and instead will process each release serially.

This also updates the name of the workflow to make it easier to find in the sidebar (currently there are 3 "Release" entries that can make it hard to find the right one) and the job name itself after making the top-level name chnage.