### PR TITLE
TreeView: Ignore cmd/alt+arrow key events

### DIFF
--- a/.changeset/polite-kings-rhyme.md
+++ b/.changeset/polite-kings-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+TreeView: Ignore arrow key events when combined with cmd or alt keys to avoid interfering with native browser shortcuts.

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -397,11 +397,15 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
             }
             break
           case 'ArrowRight':
+            // Ignore if modifier keys are pressed
+            if (event.altKey || event.metaKey) return
             event.preventDefault()
             event.stopPropagation()
             setIsExpandedWithCache(true)
             break
           case 'ArrowLeft':
+            // Ignore if modifier keys are pressed
+            if (event.altKey || event.metaKey) return
             event.preventDefault()
             event.stopPropagation()
             setIsExpandedWithCache(false)


### PR DESCRIPTION
Ignore arrow key events when combined with cmd or alt keys to avoid interfering with native browser shortcuts.

Closes https://github.com/primer/react/issues/2788



