### PR TITLE
Avoid calling `getCharacterCoordinates` when `fullHeight` is set in the MarkdownEditor

### DIFF
--- a/.changeset/honest-fishes-explain.md
+++ b/.changeset/honest-fishes-explain.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+improve performance of the MarkdownEditor component when fullHeight is enabled

--- a/src/drafts/MarkdownEditor/_MarkdownInput.tsx
+++ b/src/drafts/MarkdownEditor/_MarkdownInput.tsx
@@ -123,7 +123,14 @@ export const MarkdownInput = forwardRef<HTMLTextAreaElement, MarkdownInputProps>
       return subscription?.unsubscribe
     }, [pasteUrlsAsPlainText])
 
-    const heightStyles = useDynamicTextareaHeight({fullHeight, maxHeightLines, minHeightLines, elementRef: ref, value})
+    const heightStyles = useDynamicTextareaHeight({
+      // if fullHeight is enabled, there is no need to compute a dynamic height (for perfs reasons)
+      disabled: fullHeight,
+      maxHeightLines,
+      minHeightLines,
+      elementRef: ref,
+      value,
+    })
 
     return (
       <InlineAutocomplete

--- a/src/drafts/MarkdownEditor/_MarkdownInput.tsx
+++ b/src/drafts/MarkdownEditor/_MarkdownInput.tsx
@@ -123,8 +123,7 @@ export const MarkdownInput = forwardRef<HTMLTextAreaElement, MarkdownInputProps>
       return subscription?.unsubscribe
     }, [pasteUrlsAsPlainText])
 
-    const dynamicHeightStyles = useDynamicTextareaHeight({maxHeightLines, minHeightLines, elementRef: ref, value})
-    const heightStyles = fullHeight ? {} : dynamicHeightStyles
+    const heightStyles = useDynamicTextareaHeight({fullHeight, maxHeightLines, minHeightLines, elementRef: ref, value})
 
     return (
       <InlineAutocomplete

--- a/src/drafts/hooks/useDynamicTextareaHeight.ts
+++ b/src/drafts/hooks/useDynamicTextareaHeight.ts
@@ -4,7 +4,7 @@ import {SxProp} from '../../sx'
 import {getCharacterCoordinates} from '../utils/character-coordinates'
 
 type UseDynamicTextareaHeightSettings = {
-  fullHeight?: boolean
+  disabled?: boolean
   minHeightLines?: number
   maxHeightLines?: number
   elementRef: RefObject<HTMLTextAreaElement | null>
@@ -24,7 +24,7 @@ type UseDynamicTextareaHeightSettings = {
  * explicitly set in CSS.
  */
 export const useDynamicTextareaHeight = ({
-  fullHeight,
+  disabled,
   minHeightLines,
   maxHeightLines,
   elementRef,
@@ -35,7 +35,7 @@ export const useDynamicTextareaHeight = ({
   const [maxHeight, setMaxHeight] = useState<string | undefined>(undefined)
 
   useLayoutEffect(() => {
-    if (fullHeight) return
+    if (disabled) return
 
     const element = elementRef.current
     if (!element) return
@@ -60,9 +60,9 @@ export const useDynamicTextareaHeight = ({
     if (minHeightLines !== undefined) setMinHeight(`calc(${minHeightLines} * ${lineHeight})`)
     if (maxHeightLines !== undefined) setMaxHeight(`calc(${maxHeightLines} * ${lineHeight})`)
     // `value` is an unnecessary dependency but it enables us to recalculate as the user types
-  }, [minHeightLines, maxHeightLines, value, elementRef, fullHeight])
+  }, [minHeightLines, maxHeightLines, value, elementRef, disabled])
 
-  if (fullHeight) return {}
+  if (disabled) return {}
 
   return {height, minHeight, maxHeight, boxSizing: 'content-box'}
 }

--- a/src/drafts/hooks/useDynamicTextareaHeight.ts
+++ b/src/drafts/hooks/useDynamicTextareaHeight.ts
@@ -4,6 +4,7 @@ import {SxProp} from '../../sx'
 import {getCharacterCoordinates} from '../utils/character-coordinates'
 
 type UseDynamicTextareaHeightSettings = {
+  fullHeight?: boolean
   minHeightLines?: number
   maxHeightLines?: number
   elementRef: RefObject<HTMLTextAreaElement | null>
@@ -23,6 +24,7 @@ type UseDynamicTextareaHeightSettings = {
  * explicitly set in CSS.
  */
 export const useDynamicTextareaHeight = ({
+  fullHeight,
   minHeightLines,
   maxHeightLines,
   elementRef,
@@ -33,6 +35,8 @@ export const useDynamicTextareaHeight = ({
   const [maxHeight, setMaxHeight] = useState<string | undefined>(undefined)
 
   useLayoutEffect(() => {
+    if (fullHeight) return
+
     const element = elementRef.current
     if (!element) return
 
@@ -56,7 +60,9 @@ export const useDynamicTextareaHeight = ({
     if (minHeightLines !== undefined) setMinHeight(`calc(${minHeightLines} * ${lineHeight})`)
     if (maxHeightLines !== undefined) setMaxHeight(`calc(${maxHeightLines} * ${lineHeight})`)
     // `value` is an unnecessary dependency but it enables us to recalculate as the user types
-  }, [minHeightLines, maxHeightLines, value, elementRef])
+  }, [minHeightLines, maxHeightLines, value, elementRef, fullHeight])
+
+  if (fullHeight) return {}
 
   return {height, minHeight, maxHeight, boxSizing: 'content-box'}
 }


### PR DESCRIPTION
* fix https://github.com/github/primer/issues/2355

This fixes a performance issue where on each keystroke `getCharacterCoordinates` is called in the markdown editor. 
When `fullHeight` is set to true, we can skip this call and save some cpu cycles 🚀 

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
