### PR TITLE
Update release-schedule.yml

### DIFF
--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -2,7 +2,7 @@ name: Release Schedule
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 16 * * MON'
+    - cron: '0 0 * * TUE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
Update our release schedule workflow to run on Tuesday in order for the assignee to be correctly assigned. At the moment, when running on Monday it seems like it does not use the correct value until a switch-over on Tuesday in the PagerDuty schedule.