### PR TITLE
Fix mode switcher

### DIFF
--- a/src/BaseStyles.tsx
+++ b/src/BaseStyles.tsx
@@ -61,7 +61,7 @@ function BaseStyles(props: BaseStylesProps) {
       fontFamily={fontFamily}
       lineHeight={lineHeight}
       data-portal-root
-      data-color-mode={primerColorModeToPrimitiveColorMode[colorMode || defaultColorMode]}
+      data-color-mode={colorScheme?.includes('dark') ? 'dark' : 'light'}
       data-light-theme={dayScheme}
       data-dark-theme={nightScheme}
     >

--- a/src/BaseStyles.tsx
+++ b/src/BaseStyles.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled, {createGlobalStyle} from 'styled-components'
 import {COMMON, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from './constants'
-import {useTheme, defaultColorMode, ColorModeWithAuto} from './ThemeProvider'
+import {useTheme} from './ThemeProvider'
 import {ComponentProps} from './utils/types'
 
 // load polyfill for :focus-visible
@@ -38,21 +38,13 @@ export type BaseStylesProps = ComponentProps<typeof Base>
 function BaseStyles(props: BaseStylesProps) {
   const {children, color = 'fg.default', fontFamily = 'normal', lineHeight = 'default', ...rest} = props
 
-  const {colorScheme, colorMode, dayScheme, nightScheme} = useTheme()
+  const {colorScheme, dayScheme, nightScheme} = useTheme()
 
   /**
    * We need to map valid primer/react color modes onto valid color modes for primer/primitives
    * valid color modes for primer/primitives: auto | light | dark
    * valid color modes for primer/primer: auto | day | night | light | dark
    */
-  type colorModesForPrimitives = 'auto' | 'light' | 'dark'
-  const primerColorModeToPrimitiveColorMode: {[key in ColorModeWithAuto]: colorModesForPrimitives} = {
-    auto: 'auto',
-    light: 'light',
-    dark: 'dark',
-    day: 'light',
-    night: 'dark',
-  }
 
   return (
     <Base


### PR DESCRIPTION
**Summary**
Update the way we add the `data-color-mode` attribute. It was wrong before so that the `data-color-mode` attribute did not update when the user changed the theme from the theme switcher.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
