### PR TITLE
Remove aria-hidden=true from spans with required asterisk (re-introducing reverted PR)

### DIFF
--- a/.changeset/pink-beds-fetch.md
+++ b/.changeset/pink-beds-fetch.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Remove `aria-hidden=true` from `span`s with required asterisk

--- a/src/__tests__/deprecated/InputField.test.tsx
+++ b/src/__tests__/deprecated/InputField.test.tsx
@@ -6,6 +6,7 @@ import InputField from '../../deprecated/InputField'
 expect.extend(toHaveNoViolations)
 
 const TEXTINPUTFIELD_LABEL_TEXT = 'Name'
+const TEXTINPUTFIELD_LABEL_TEXT_WITH_ASTERISK = 'Name *'
 const TEXTINPUTFIELD_CAPTION_TEXT = 'Hint: your first name'
 const TEXTINPUTFIELD_SUCCESS_TEXT = 'This name is valid'
 const TEXTINPUTFIELD_ERROR_TEXT = 'This name is invalid'
@@ -66,7 +67,7 @@ describe('InputField', () => {
         </SSRProvider>,
       )
 
-      const input = getByRole('textbox', {name: TEXTINPUTFIELD_LABEL_TEXT})
+      const input = getByRole('textbox', {name: TEXTINPUTFIELD_LABEL_TEXT_WITH_ASTERISK})
 
       expect(input.getAttribute('required')).not.toBeNull()
     })

--- a/src/internal/components/InputLabel.tsx
+++ b/src/internal/components/InputLabel.tsx
@@ -55,7 +55,7 @@ const InputLabel: React.FC<React.PropsWithChildren<Props>> = ({
       {required ? (
         <Box display="flex" as="span">
           <Box mr={1}>{children}</Box>
-          <span aria-hidden="true">*</span>
+          <span>*</span>
         </Box>
       ) : (
         children


### PR DESCRIPTION
* Remove aria-hidden=true from spans with required asterisk

* Create pink-beds-fetch.md

---------

Describe your changes here.

Reintroduces the changes from https://github.com/primer/react/commit/47b7ea073d745c25b5841487b7ea7d78d16d0804 that had to be reverted for the previous release. It may be worth noting that I added in  https://github.com/primer/react/commit/dfbf5511f01c16bb3262a2895b2f5020074e71d4 after the initial commit above to address a snapshot regression, but it seems like this commit wasn't reverted and so doesn't need to be cherry-picked back in.

### Screenshots

Please provide before/after screenshots for any visual changes

See https://github.com/primer/react/pull/3320 for the details!

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
