### PR TITLE
Add Storybook link for AvatarStack.mdx

### DIFF
--- a/docs/content/AvatarStack.mdx
+++ b/docs/content/AvatarStack.mdx
@@ -4,6 +4,7 @@ title: AvatarStack
 status: Alpha
 description: Use an avatar stack to display two or more avatars in an inline stack.
 source: https://github.com/primer/react/blob/main/src/AvatarStack
+storybook: '/react/storybook?path=/story/components-avatarstack--default'
 ---
 
 import data from '../../src/AvatarStack/AvatarStack.docs.json'


### PR DESCRIPTION
I noticed that https://primer.style/react/AvatarStack doesn't include a Storybook link to this component, so this PR adds one.