### PR TITLE
fix: add experimental folder to npm files

### DIFF
--- a/.changeset/silver-olives-wave.md
+++ b/.changeset/silver-olives-wave.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Add the experimental folder to the npm package for @primer/react

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "index.d.ts",
     "deprecated/package.json",
     "drafts/package.json",
+    "experimental/package.json",
     "!lib/__tests__",
     "!lib/stories",
     "!lib-esm/__tests__",


### PR DESCRIPTION
We currently publish a folder that contains the experimental files in `lib-esm` and `lib`: https://unpkg.com/browse/@primer/react@35.26.0/lib-esm/experimental/ 

However, we don't currently include the folder `experimental` which contains the same `package.json` info that `drafts` and `deprecated` have. This PR introduces this file to the `files` array in `package.json`