### PR TITLE
docs: update actions call in Checkbox story

### DIFF
--- a/src/Checkbox/Checkbox.examples.stories.tsx
+++ b/src/Checkbox/Checkbox.examples.stories.tsx
@@ -13,7 +13,7 @@ export const Controlled = () => {
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setChecked(event.target.checked)
-    action('Change event triggered')
+    action('Change event triggered')()
   }
 
   return (


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/2332

Update the call to `action` to include another call to match the usage. For background, `action` is typically used in an event handler like `onClick={action('onClick')}` and so require another invocation in order to be emitted to docs

### Testing & Reviewing

- Visit the story for the controlled Checkbox example
- Interact with the checkbox
- Verify that the action is logged under the actions tab