### PR TITLE
DO NOT MERGE - testing new changesets setup

Follow up to #3352

### DIFF
--- a/.changeset/famous-points-tie.md
+++ b/.changeset/famous-points-tie.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+test summary
+
+<!-- Changed components: Dialog, AvatarStack, Checkbox, Label, Octicon, RelativeTime -->

--- a/.changeset/famous-points-tie.md
+++ b/.changeset/famous-points-tie.md
@@ -3,5 +3,3 @@
 ---
 
 test summary
-
-<!-- Changed components: Dialog, AvatarStack, Checkbox, Label, Octicon, RelativeTime, Invalid -->

--- a/.changeset/famous-points-tie.md
+++ b/.changeset/famous-points-tie.md
@@ -4,4 +4,4 @@
 
 test summary
 
-<!-- Changed components: Dialog, AvatarStack, Checkbox, Label, Octicon, RelativeTime -->
+<!-- Changed components: Dialog, AvatarStack, Checkbox, Label, Octicon, RelativeTime, Invalid -->


### PR DESCRIPTION
> **Warning**
> This pull request is not meant to be merged. Sorry for the noise, I'll close it shortly

Testing changes from https://github.com/primer/react/pull/3352

- [x] check passed for valid changeset file: https://github.com/primer/react/actions/runs/5403794889/jobs/9817106040#step:3:7
- [x] check failed for invalid component name: https://github.com/primer/react/actions/runs/5403832847/jobs/9817198155?pr=3458#step:3:8
- [x] check failed for missing footer: https://github.com/primer/react/actions/runs/5403871581/jobs/9817291542#step:3:7
- [x] check passed when https://github.com/primer/react/labels/skip%20changeset label was added (without another push): https://github.com/primer/react/actions/runs/5404006981/jobs/9817609157#step:3:6