### PR TITLE
CSS: Change import style to make gatsby happy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,7 @@ module.exports = {
     'github/no-inner-html': 'off',
     'github/role-supports-aria-props': 'off',
     'no-restricted-syntax': 'off',
+    'import/no-namespace': ['error', {ignore: ['*.module.css']}],
   },
   overrides: [
     // rules which apply only to JS

--- a/src/drafts/CSSComponent/index.tsx
+++ b/src/drafts/CSSComponent/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import merge from 'classnames'
-import classNames from './component.module.css'
+import * as classNames from './component.module.css'
 
 export const Component: React.FC<React.HTMLProps<HTMLDivElement>> = ({className, ...props}) => {
   return <div className={merge(classNames.component, className)} {...props} />


### PR DESCRIPTION
No change for consumers

Gatsby excepts css modules imported as ES modules

```diff
- import classNames from './component.module.css'
+ import * as classNames from './component.module.css'

<button className={className.button} />
```

`eslint-plugin-github` except us not to use namespaces 😅 

suggestion:

```diff
- import * as classNames from './component.module.css'
+ import {button} from './component.module.css'

<button className={button} />
```

However, this feels less readable and could conflict with other variables on the page, so I've chosen to ignore the rule just for `*.module.css` files in our eslint config

---

Possible alternate to explore later: We could configure the internal plugin gatsby uses to accept non esModules, not sure if we want that in the long term though. [Documentation](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#css-modules-are-imported-as-es-modules)