### PR TITLE
chore: add release-blocker command

### DIFF
--- a/.github/commands/release-blocker.yml
+++ b/.github/commands/release-blocker.yml
@@ -2,6 +2,8 @@
 trigger: release-blocker
 title: Release Blocker
 description: Describe the issue(s) preventing a release from being published
+surfaces:
+  - issue
 steps:
   - type: form
     style: embedded
@@ -11,6 +13,21 @@ steps:
           id: blocker-description
           label: Description
           placeholder: Describe the issue that prevents the release from being published.
+
+      - type: dropdown
+        attributes:
+          id: blocker-type
+          label: Type
+          options:
+            - 'Component or type removed'
+            - 'Type incompatability'
+            - 'Other'
+
+      - type: input
+        id: other
+        attributes:
+          label: Other
+          description: 'Provide a custom blocker type if other was used above'
 
       - type: textarea
         attributes:

--- a/.github/commands/release-blocker.yml
+++ b/.github/commands/release-blocker.yml
@@ -1,0 +1,29 @@
+---
+trigger: release-blocker
+title: Release Blocker
+description: Describe the issue(s) preventing a release from being published
+steps:
+  - type: form
+    style: embedded
+    body:
+      - type: textarea
+        attributes:
+          id: blocker-description
+          label: Description
+          placeholder: Describe the issue that prevents the release from being published.
+
+      - type: textarea
+        attributes:
+          id: pull-requests-to-revert
+          label: Pull Requests
+          placeholder: Provide one or more Pull Requests that need to be reverted in order to publish the release.
+
+      - type: checkboxes
+        id: confirm
+        attributes:
+          label: Please confirm the following
+          options:
+            - label: I have re-opened any issues that were closed due to the reverted Pull Requests
+              required: true
+            - label: I have left a comment on these issues with a link to the reverted Pull Request
+              required: true

--- a/.github/commands/release-blocker.yml
+++ b/.github/commands/release-blocker.yml
@@ -18,8 +18,11 @@ steps:
         attributes:
           id: blocker-type
           label: Type
+          description: Specify the type(s) of changes that prevent the release from being published.
+          multiple: true
           options:
-            - 'Component or type removed'
+            - 'Component removed'
+            - 'Type removed'
             - 'Type incompatability'
             - 'Other'
 


### PR DESCRIPTION
This PR adds a custom slash command, `/release-blocker`, that can be used on Release Tracking issues to provide incident details for something that is preventing a release. This looks to mirror some of our recent guidance that has been updated and provide a structured way to review incidents in releases over time.

Would love to hear your feedback on the format here! Generally it has three areas:

- Describe the issue
- List the PRs that cause the issue
- Confirm necessary steps to revert and re-open corresponding issues