### PR TITLE
Revert "Reintroduce aria-hidden=true asterisk changes"

### DIFF
--- a/.changeset/pink-beds-fetch.md
+++ b/.changeset/pink-beds-fetch.md
@@ -1,5 +1,0 @@
----
-'@primer/react': patch
----
-
-Remove `aria-hidden=true` from `span`s with required asterisk

--- a/src/__tests__/deprecated/InputField.test.tsx
+++ b/src/__tests__/deprecated/InputField.test.tsx
@@ -6,7 +6,6 @@ import InputField from '../../deprecated/InputField'
 expect.extend(toHaveNoViolations)
 
 const TEXTINPUTFIELD_LABEL_TEXT = 'Name'
-const TEXTINPUTFIELD_LABEL_TEXT_WITH_ASTERISK = 'Name *'
 const TEXTINPUTFIELD_CAPTION_TEXT = 'Hint: your first name'
 const TEXTINPUTFIELD_SUCCESS_TEXT = 'This name is valid'
 const TEXTINPUTFIELD_ERROR_TEXT = 'This name is invalid'
@@ -67,7 +66,7 @@ describe('InputField', () => {
         </SSRProvider>,
       )
 
-      const input = getByRole('textbox', {name: TEXTINPUTFIELD_LABEL_TEXT_WITH_ASTERISK})
+      const input = getByRole('textbox', {name: TEXTINPUTFIELD_LABEL_TEXT})
 
       expect(input.getAttribute('required')).not.toBeNull()
     })

--- a/src/internal/components/InputLabel.tsx
+++ b/src/internal/components/InputLabel.tsx
@@ -55,7 +55,7 @@ const InputLabel: React.FC<React.PropsWithChildren<Props>> = ({
       {required ? (
         <Box display="flex" as="span">
           <Box mr={1}>{children}</Box>
-          <span>*</span>
+          <span aria-hidden="true">*</span>
         </Box>
       ) : (
         children


### PR DESCRIPTION
Reverts primer/react#3439

So sorry @adrianababakanian for reverting this again but there are still failing tests at dotcom that relys on having `aria-hidden="true"` attribute https://github.com/github/github/actions/runs/5418650975/jobs/9850965487?pr=278549

Let us know if you need more support on re-introducing this PR.