### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -33,9 +33,9 @@ jobs:
         name: Check if pages is configured
         run: |
           if gh api --silent https://api.github.com/repos/${{ github.repository }}/pages ; then
-            echo "::set-output name=pages::1"
+            echo "pages=1" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=pages::0"
+            echo "pages=0" >> $GITHUB_OUTPUT
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Closes #3468 

Update `.github/workflows/deploy_production.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
if gh api --silent https://api.github.com/repos/${{ github.repository }}/pages ; then
  echo "::set-output name=pages::1"
else
  echo "::set-output name=pages::0"
fi
```

**TO-BE**

```yaml
if gh api --silent https://api.github.com/repos/${{ github.repository }}/pages ; then
  echo "pages=1" >> $GITHUB_OUTPUT
else
  echo "pages=0" >> $GITHUB_OUTPUT
fi
```

### Screenshots

None

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
