### PR TITLE
Temporarily remove css components from drafts

### DIFF
--- a/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -132,8 +132,6 @@ exports[`@primer/react/decprecated should not update exports without a semver ch
 
 exports[`@primer/react/drafts should not update exports without a semver change 1`] = `
 [
-  "Button",
-  "Component",
   "Content",
   "DataTable",
   "Dialog",

--- a/src/drafts/index.ts
+++ b/src/drafts/index.ts
@@ -53,5 +53,5 @@ export * from '../SegmentedControl'
 export * from '../SplitPageLayout'
 
 // CSS Experiment
-export * from './CSSComponent'
-export * from './Button2'
+// export * from './CSSComponent'
+// export * from './Button2'


### PR DESCRIPTION
Temporary measure to unblock local docs development, cc @mperrotti 

These components don't have any usage, so it should be no problem