### PR TITLE
Fix ActionMenu focused divider

### DIFF
--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -153,7 +153,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       '&:hover:not([aria-disabled]), &:focus:not([aria-disabled]), &[data-focus-visible-added]:not([aria-disabled])': {
         '--divider-color': 'transparent',
       },
-      '&:hover:not([aria-disabled]) + &, &:focus:not([aria-disabled]) + &, &[data-focus-visible-added] + li': {
+      '&:hover:not([aria-disabled]) + &, &[data-focus-visible-added] + li': {
         '--divider-color': 'transparent',
       },
       ...(active ? activeStyles : {}),


### PR DESCRIPTION
- Fixes https://github.com/primer/react/issues/3461

Context:

- When you open ActionMenu with mouse click, we focus the first item by default (this matched a11y guidance at the time)
- In the past, we treated both focus and focus-visible the same and added a focus ring on the focused item
- To avoid both a divider and focus ring at the same time, we have some logic to hide divider if a surrounding item has focus or focus-visible
- In https://github.com/primer/react/pull/3056, we removed the focus ring on focus (keeping it only on focus-visible)
- Without matching divider logic, we end up with the divider hidden on focus even when there is no ring (reported in https://github.com/primer/react/issues/3461)


This pull request fixes that by removing divider logic for focus (while keeping it for focus-visible)