### PR TITLE
feat: Introduces `<Toast />`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@primer/behaviors": "^1.3.4",
         "@primer/octicons-react": "^19.3.0",
         "@primer/primitives": "^7.11.11",
-        "@react-aria/ssr": "^3.5.0",
+        "@react-aria/ssr": "^3.1.0",
         "@styled-system/css": "^5.1.5",
         "@styled-system/props": "^5.1.5",
         "@styled-system/theme-get": "^5.1.2",
@@ -6046,9 +6046,9 @@
       }
     },
     "node_modules/@primer/primitives": {
-      "version": "7.11.11",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.11.11.tgz",
-      "integrity": "sha512-5McPeE83AGcYm2uHbQEIOOa6JPv2SUFPDjYbf2I5QnvmNm9ZUbS446zWC3ygNi54uks7znuTDFrU325vpnze7g=="
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.12.0.tgz",
+      "integrity": "sha512-QKNxfWm7Ik1Ulswyp3KeUL2xnQj8i0E7DdB6lOrh29o7LgyuutwcOHi4CGapBIOR1fYURu+yROSTHQ2C2aDK7A=="
     },
     "node_modules/@primer/view-components": {
       "version": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@primer/octicons-react": "^19.3.0",
     "@primer/primitives": "^7.11.11",
     "@react-aria/ssr": "^3.5.0",
+    "@react-aria/ssr": "^3.1.0",
     "@styled-system/css": "^5.1.5",
     "@styled-system/props": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",

--- a/src/experimental/Toast/ToastUI.features.stories.tsx
+++ b/src/experimental/Toast/ToastUI.features.stories.tsx
@@ -1,0 +1,42 @@
+import React, {Meta} from '@storybook/react'
+import BaseStyles from '../../BaseStyles'
+import ThemeProvider from '../../ThemeProvider'
+import {Box, Text} from '../..'
+import {ToastUI} from './ToastUI'
+
+const meta: Meta = {
+  title: 'Components/Toast/UI/Features',
+  decorators: [
+    Story => {
+      return (
+        <ThemeProvider>
+          <BaseStyles>
+            <Box sx={{display: 'inline-flex', flexDirection: 'column', gap: 3}}>{Story()}</Box>
+          </BaseStyles>
+        </ThemeProvider>
+      )
+    },
+  ],
+  component: ToastUI,
+}
+export default meta
+
+export const Default = () => <ToastUI variant="default">Message</ToastUI>
+export const Success = () => <ToastUI variant="success">Message</ToastUI>
+export const Attention = () => <ToastUI variant="attention">Message</ToastUI>
+export const Danger = () => <ToastUI variant="danger">Message</ToastUI>
+export const Loading = () => <ToastUI variant="loading">Message</ToastUI>
+
+export const Dismissible = () => (
+  <ToastUI variant="danger" dismissible>
+    Message
+  </ToastUI>
+)
+export const Multiline = () => (
+  <ToastUI variant="loading" dismissible>
+    <Text as="p">
+      Toast with longer message. It is advised that the content should <strong>not</strong> go longer than 140
+      characters or three message lines.
+    </Text>
+  </ToastUI>
+)

--- a/src/experimental/Toast/ToastUI.features.stories.tsx
+++ b/src/experimental/Toast/ToastUI.features.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta = {
       return (
         <ThemeProvider>
           <BaseStyles>
-            <Box sx={{display: 'inline-flex', flexDirection: 'column', gap: 3}}>{Story()}</Box>
+            <div>{Story()}</div>
           </BaseStyles>
         </ThemeProvider>
       )

--- a/src/experimental/Toast/ToastUI.module.css
+++ b/src/experimental/Toast/ToastUI.module.css
@@ -1,0 +1,59 @@
+.ToastUI {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: flex-start;
+  column-gap: var(--stack-padding-normal);
+
+  padding-block: var(--stack-padding-normal);
+  padding-inline: var(--stack-padding-normal);
+
+  color: var(--overlay-inverse-fgColor-default);
+
+  background-color: var(--overlay-inverse-bgColor);
+  border-radius: var(--borderRadius-medium);
+  box-shadow: var(--shadow-floating-large);
+
+  &[data-dismissable='true'] {
+    padding-inline-end: var(--stack-padding-condensed);
+  }
+}
+
+.ToastUI__wrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  width: auto;
+}
+
+.ToastUI__Icon {
+  display: flex;
+
+  &[data-variant='default'] {
+    color: var(--overlay-inverse-fgColor-accent);
+  }
+
+  &[data-variant='success'] {
+    color: var(--overlay-inverse-fgColor-success);
+  }
+
+  &[data-variant='attention'] {
+    color: var(--overlay-inverse-fgColor-attention);
+  }
+
+  &[data-variant='danger'] {
+    color: var(--overlay-inverse-fgColor-danger);
+  }
+
+  &[data-variant='loading'] {
+    color: var(--overlay-inverse-fgColor-default);
+  }
+}
+
+.ToastUI__text {
+  max-width: 450px;
+
+  & * {
+    margin: 0;
+  }
+}

--- a/src/experimental/Toast/ToastUI.stories.tsx
+++ b/src/experimental/Toast/ToastUI.stories.tsx
@@ -1,0 +1,36 @@
+import React from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react'
+import BaseStyles from '../../BaseStyles'
+import ThemeProvider from '../../ThemeProvider'
+import {ToastUI} from './ToastUI'
+
+const meta: Meta<typeof ToastUI> = {
+  title: 'Components/Toast/UI',
+  decorators: [
+    Story => (
+      <ThemeProvider>
+        <BaseStyles>{Story()}</BaseStyles>
+      </ThemeProvider>
+    ),
+  ],
+  component: ToastUI,
+  argTypes: {
+    children: {
+      name: 'body',
+    },
+  },
+}
+export default meta
+
+export const Default = () => <ToastUI>Message</ToastUI>
+
+export const Playground: StoryObj<typeof ToastUI> = {
+  render: args => <ToastUI {...args} />,
+  args: {
+    children: 'Message',
+    role: 'status',
+    dismissible: false,
+    dismissLabel: 'Dismiss this message',
+    variant: 'default',
+  },
+}

--- a/src/experimental/Toast/ToastUI.stories.tsx
+++ b/src/experimental/Toast/ToastUI.stories.tsx
@@ -28,7 +28,6 @@ export const Playground: StoryObj<typeof ToastUI> = {
   render: args => <ToastUI {...args} />,
   args: {
     children: 'Message',
-    role: 'status',
     dismissible: false,
     dismissLabel: 'Dismiss this message',
     variant: 'default',

--- a/src/experimental/Toast/ToastUI.tsx
+++ b/src/experimental/Toast/ToastUI.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import {CheckIcon, AlertIcon, StopIcon, InfoIcon, XIcon} from '@primer/octicons-react'
 
-import {Spinner, Box, IconButton} from '../..'
+import {Spinner, Text, IconButton} from '../..'
+
+import classNames from './ToastUI.module.css'
+import {useLayoutEffect, useRef, useState} from 'react'
 
 const variants = ['default', 'success', 'attention', 'danger', 'loading'] as const
 
@@ -16,7 +19,6 @@ const icon: Record<ToastVariants, React.ReactNode> = {
 export const ToastUI = ({
   dismissible = false,
   variant = 'default',
-  role = 'status',
   dismissLabel = 'Dismiss this message',
   children,
 }: React.PropsWithChildren<ToastUIProps>) => {
@@ -28,85 +30,53 @@ export const ToastUI = ({
     )
   }
 
+  const textRef = useRef<HTMLDivElement>(null)
+  const [height, setHeight] = useState<string>('0px')
+
+  useLayoutEffect(() => {
+    if (textRef.current) {
+      setHeight(window.getComputedStyle(textRef.current).lineHeight)
+    }
+  }, [])
+
+  const body = React.createElement(
+    typeof children === 'string' ? Text : 'div',
+    {
+      role: 'main',
+      className: classNames.ToastUI__text,
+      ref: textRef,
+    },
+    children,
+  )
+
   return (
-    <Box role={role} sx={{display: 'flex', justifyContent: 'flex-start'}}>
-      <Box
-        sx={{display: 'inline-flex', maxWidth: '450px', borderRadius: 2, boxShadow: 'shadow.large', overflow: 'hidden'}}
-      >
-        <Box
-          sx={{
-            display: 'flex',
-            justifyItems: 'center',
-            alignItems: 'center',
-            borderTopLeftRadius: 2,
-            borderBottomLeftRadius: 2,
-            border: '1px solid',
-            borderColor: 'border.default',
-            borderInlineEnd: 'none',
-            p: 3,
-            color: 'fg.onEmphasis',
-            '&[data-variant="default"]': {
-              backgroundColor: 'accent.emphasis',
-              borderColor: 'accent.emphasis',
-            },
-            '&[data-variant="success"]': {
-              backgroundColor: 'success.emphasis',
-              borderColor: 'success.emphasis',
-            },
-            '&[data-variant="attention"]': {
-              backgroundColor: 'attention.emphasis',
-              borderColor: 'attention.emphasis',
-            },
-            '&[data-variant="danger"]': {
-              backgroundColor: 'danger.emphasis',
-              borderColor: 'danger.emphasis',
-            },
-            '&[data-variant="loading"]': {
-              backgroundColor: 'neutral.emphasis',
-              borderColor: 'neutral.emphasis',
-            },
-          }}
-          role="presentation"
-          data-variant={variant}
-        >
+    <div role="alert" className={classNames.ToastUI} data-dismissable={dismissible}>
+      <div role="presentation" className={classNames.ToastUI__wrapper} style={{height: height}}>
+        <div className={classNames.ToastUI__Icon} data-variant={variant}>
           {icon[variant]}
-        </Box>
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: dismissible ? 'auto 1fr' : '1fr',
-            alignItems: 'center',
-            gap: 3,
-            justifyContent: 'space-between',
-            borderBottomRightRadius: 2,
-            borderTopRightRadius: 2,
-            border: '1px solid',
-            borderColor: 'border.default',
-            borderInlineStart: 'none',
-            px: 3,
-            paddingRight: dismissible ? 2 : 3,
-          }}
-        >
-          <Box
+        </div>
+      </div>
+      <div>{body}</div>
+      {dismissible && (
+        <div className={classNames.ToastUI__wrapper} style={{height: height}}>
+          <IconButton
+            aria-label={dismissLabel}
+            icon={XIcon}
+            variant="invisible"
             sx={{
-              /* we margin to allow for margin collapsing when user-land uses as the children <Text as="p" /> */
-              marginY: 3,
+              color: 'var(--overlay-inverse-fgColor-default)',
+              '&:hover': {
+                backgroundColor: 'var(--button-invisible-bgColor-hover)',
+              },
+              '&:active': {
+                backgroundColor: 'var(--button-invisible-bgColor-active)',
+              },
             }}
-          >
-            {children}
-          </Box>
-          {dismissible && (
-            <IconButton
-              aria-label={dismissLabel}
-              icon={XIcon}
-              variant="invisible"
-              sx={{color: 'fg.default'}}
-              size="small"
-            ></IconButton>
-          )}
-        </Box>
-      </Box>
-    </Box>
+            size="small"
+          />
+        </div>
+      )}
+    </div>
   )
 }
 ToastUI.displayName = 'Toast'
@@ -124,17 +94,6 @@ export type ToastUIProps = {
    * @default false
    */
   dismissible?: boolean | undefined
-  /**
-   * Sets the role attribute of the toast, which is used by assistive technologies to communicate status to users.
-   *
-   * - "status" will not be read out of assistive technologies immediately, and won't interupt what the user is currently doing.
-   * - "alert" will be read out immediately, and will interupt what the user is currently doing. Because of this "alert" should be use sparingly.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
-   *
-   * @default status
-   */
-  role?: 'status' | 'alert' | undefined
 
   /**
    * The `aria-label` to use for the close button.

--- a/src/experimental/Toast/ToastUI.tsx
+++ b/src/experimental/Toast/ToastUI.tsx
@@ -1,0 +1,147 @@
+import React from 'react'
+import {CheckIcon, AlertIcon, StopIcon, InfoIcon, XIcon} from '@primer/octicons-react'
+
+import {Spinner, Box, IconButton} from '../..'
+
+const variants = ['default', 'success', 'attention', 'danger', 'loading'] as const
+
+const icon: Record<ToastVariants, React.ReactNode> = {
+  default: <InfoIcon size="small" />,
+  success: <CheckIcon size="small" />,
+  attention: <AlertIcon size="small" />,
+  danger: <StopIcon size="small" />,
+  loading: <Spinner size="small" />,
+}
+
+export const ToastUI = ({
+  dismissible = false,
+  variant = 'default',
+  role = 'status',
+  dismissLabel = 'Dismiss this message',
+  children,
+}: React.PropsWithChildren<ToastUIProps>) => {
+  if (__DEV__) {
+    // eslint-disable-next-line no-console
+    console.assert(
+      variants.includes(variant),
+      `The variant ${variant} is not supported. Use one of ${variants.join(', ')}`,
+    )
+  }
+
+  return (
+    <Box role={role} sx={{display: 'flex', justifyContent: 'flex-start'}}>
+      <Box
+        sx={{display: 'inline-flex', maxWidth: '450px', borderRadius: 2, boxShadow: 'shadow.large', overflow: 'hidden'}}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            justifyItems: 'center',
+            alignItems: 'center',
+            borderTopLeftRadius: 2,
+            borderBottomLeftRadius: 2,
+            border: '1px solid',
+            borderColor: 'border.default',
+            borderInlineEnd: 'none',
+            p: 3,
+            color: 'fg.onEmphasis',
+            '&[data-variant="default"]': {
+              backgroundColor: 'accent.emphasis',
+              borderColor: 'accent.emphasis',
+            },
+            '&[data-variant="success"]': {
+              backgroundColor: 'success.emphasis',
+              borderColor: 'success.emphasis',
+            },
+            '&[data-variant="attention"]': {
+              backgroundColor: 'attention.emphasis',
+              borderColor: 'attention.emphasis',
+            },
+            '&[data-variant="danger"]': {
+              backgroundColor: 'danger.emphasis',
+              borderColor: 'danger.emphasis',
+            },
+            '&[data-variant="loading"]': {
+              backgroundColor: 'neutral.emphasis',
+              borderColor: 'neutral.emphasis',
+            },
+          }}
+          role="presentation"
+          data-variant={variant}
+        >
+          {icon[variant]}
+        </Box>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: dismissible ? 'auto 1fr' : '1fr',
+            alignItems: 'center',
+            gap: 3,
+            justifyContent: 'space-between',
+            borderBottomRightRadius: 2,
+            borderTopRightRadius: 2,
+            border: '1px solid',
+            borderColor: 'border.default',
+            borderInlineStart: 'none',
+            px: 3,
+            paddingRight: dismissible ? 2 : 3,
+          }}
+        >
+          <Box
+            sx={{
+              /* we margin to allow for margin collapsing when user-land uses as the children <Text as="p" /> */
+              marginY: 3,
+            }}
+          >
+            {children}
+          </Box>
+          {dismissible && (
+            <IconButton
+              aria-label={dismissLabel}
+              icon={XIcon}
+              variant="invisible"
+              sx={{color: 'fg.default'}}
+              size="small"
+            ></IconButton>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+ToastUI.displayName = 'Toast'
+
+// --
+
+export type ToastUIProps = {
+  /**
+   * @default default
+   */
+  variant?: ToastVariants | undefined
+  /**
+   * Setting this to true will allow the user to dismiss this toast.
+   *
+   * @default false
+   */
+  dismissible?: boolean | undefined
+  /**
+   * Sets the role attribute of the toast, which is used by assistive technologies to communicate status to users.
+   *
+   * - "status" will not be read out of assistive technologies immediately, and won't interupt what the user is currently doing.
+   * - "alert" will be read out immediately, and will interupt what the user is currently doing. Because of this "alert" should be use sparingly.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
+   *
+   * @default status
+   */
+  role?: 'status' | 'alert' | undefined
+
+  /**
+   * The `aria-label` to use for the close button.
+   *
+   * @default Dismiss this message
+   */
+  dismissLabel?: string
+}
+
+export type ToastVariants = (typeof variants)[number]


### PR DESCRIPTION
GitHub is wanting to introduce a `<Toast />` Primer React component, to help with letting the user know about something.

This PR here simply introduces the underlying UI component, one that an end-user will not consume — hence the lack of re-export.

The intended api:

```tsx
import {ToastOutlet, Toast} from '@primer/react'

function MyProduct() {
  const [error, setError] = useState(null)

  return (
    <React.Fragment>
      <button onClick={() => setError('my mistake')}>Whoops</button>
      {error && <Toast variant="danger">{error}</Toast>} /* 👈 toast is an element */
    </React.Fragment>
  )
}

function App() {
  return (
    <React.Fragment>
      <MyProduct />
      <ToastOutlet /> /* 👈 where we will put the items */
    </React.Fragment>
  )
}
```

Since this element is rendered in the tree, we can update them over time like any stateful component, like "Closing issue 6/10" with a loading variant. Also, during SSR this can also be leveraged in place of `<Flash />`, as we can snapshot those toast messages mounted during SSR and display them to the user once we go to render.

Lots of benefits on this solution.

PoC on direction 👉 https://codesandbox.io/s/competent-khorana-27chtg?file=/src/App.js

> Will iterate now into building out the behaviours. Will do that against this branch, so it can all land in a single merge. Just raised to get some early eyes.

### Screenshots

![an example of a default toast message](https://github.com/primer/react/assets/599459/945eaa4c-4cca-4392-a983-c9792386681d)

### Merge checklist

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
