### PR TITLE
Re-introduce removing aria-hidden=true from spans with required asterisk (#3320)

### DIFF
--- a/.changeset/pink-beds-fetch.md
+++ b/.changeset/pink-beds-fetch.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Remove `aria-hidden=true` from `span`s with required asterisk

--- a/src/__tests__/deprecated/InputField.test.tsx
+++ b/src/__tests__/deprecated/InputField.test.tsx
@@ -6,6 +6,7 @@ import InputField from '../../deprecated/InputField'
 expect.extend(toHaveNoViolations)
 
 const TEXTINPUTFIELD_LABEL_TEXT = 'Name'
+const TEXTINPUTFIELD_LABEL_TEXT_WITH_ASTERISK = 'Name *'
 const TEXTINPUTFIELD_CAPTION_TEXT = 'Hint: your first name'
 const TEXTINPUTFIELD_SUCCESS_TEXT = 'This name is valid'
 const TEXTINPUTFIELD_ERROR_TEXT = 'This name is invalid'
@@ -66,7 +67,7 @@ describe('InputField', () => {
         </SSRProvider>,
       )
 
-      const input = getByRole('textbox', {name: TEXTINPUTFIELD_LABEL_TEXT})
+      const input = getByRole('textbox', {name: TEXTINPUTFIELD_LABEL_TEXT_WITH_ASTERISK})
 
       expect(input.getAttribute('required')).not.toBeNull()
     })

--- a/src/internal/components/InputLabel.tsx
+++ b/src/internal/components/InputLabel.tsx
@@ -55,7 +55,7 @@ const InputLabel: React.FC<React.PropsWithChildren<Props>> = ({
       {required ? (
         <Box display="flex" as="span">
           <Box mr={1}>{children}</Box>
-          <span aria-hidden="true">*</span>
+          <span>*</span>
         </Box>
       ) : (
         children


### PR DESCRIPTION
Describe your changes here.

See https://github.com/primer/react/pull/3439 and https://github.com/primer/react/pull/3320... 😅 

I got all dotcom CI green with the Primer canary version from this PR installed, so I _think_ this time around, this commit finally won't cause any issues for the next Primer release 🤞 

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
