### PR TITLE
Bug fix: ActionList item label weight and spacing if description exists

### DIFF
--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -221,7 +221,9 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
                     id={labelId}
                     sx={{
                       flexGrow: slots.description && slots.description.props.variant !== 'block' ? 0 : 1,
-                      fontWeight: slots.description && slots.description.props.variant !== 'block' ? 'bold' : 'normal',
+                      fontWeight: slots.description ? 'bold' : 'normal',
+                      marginBlockEnd:
+                        slots.description && slots.description.props.variant !== 'inline' ? '4px' : undefined,
                     }}
                   >
                     {childrenWithoutSlots}


### PR DESCRIPTION
The item label should be bold is there's a description. I think this likely broke at some point recently. Also fixed the spacing between rows.

### Screenshots

| Before | After |
| -- | -- |
| <img width="238" alt="Action list with description before fix" src="https://github.com/primer/react/assets/18661030/adc4e935-e9a3-40fd-9f5f-b42461e170d1"> | <img width="172" alt="Action list with description after fix" src="https://github.com/primer/react/assets/18661030/dd3f8a87-7346-47f1-af94-ea4f037460c4"> |
| <img width="219" alt="Action list with description before fix" src="https://github.com/primer/react/assets/18661030/16ea84a5-533a-40a5-ab6d-72feb56cec6b"> | <img width="213" alt="Action list with description after fix" src="https://github.com/primer/react/assets/18661030/19094323-1692-46d2-8e84-984cb136ee39"> |


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
