### PR TITLE
chore: leverage `clsx` for our conditional class names

### DIFF
--- a/contributor-docs/adrs/adr-017-css.md
+++ b/contributor-docs/adrs/adr-017-css.md
@@ -73,8 +73,8 @@ The other reasons for change are to utilise css variables for theming and improv
 Code example:
 
 ```jsx
-import classNames from './ActionList.module.css'
 import clsx from 'clsx'
+import classNames from './ActionList.module.css'
 
 const Button = ({className, sx, ...props}}) => {
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/styled-system": "^5.1.12",
         "@types/styled-system__css": "^5.0.16",
         "@types/styled-system__theme-get": "^5.0.1",
-        "classnames": "^2.3.1",
+        "clsx": "^1.2.1",
         "color2k": "^2.0.0",
         "deepmerge": "^4.2.2",
         "focus-visible": "^5.2.0",
@@ -18805,11 +18805,6 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
-    "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
-    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -18994,6 +18989,14 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@types/styled-system": "^5.1.12",
     "@types/styled-system__css": "^5.0.16",
     "@types/styled-system__theme-get": "^5.0.1",
-    "classnames": "^2.3.1",
+    "clsx": "^1.2.1",
     "color2k": "^2.0.0",
     "deepmerge": "^4.2.2",
     "focus-visible": "^5.2.0",

--- a/src/AvatarStack/AvatarStack.tsx
+++ b/src/AvatarStack/AvatarStack.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames'
+import clsx from 'clsx'
 import React from 'react'
 import styled from 'styled-components'
 import {get} from '../constants'
@@ -120,7 +120,7 @@ const transformChildren = (children: React.ReactNode) => {
     if (!React.isValidElement(child)) return child
     return React.cloneElement(child, {
       ...child.props,
-      className: classnames(child.props.className, 'pc-AvatarItem'),
+      className: clsx(child.props.className, 'pc-AvatarItem'),
     })
   })
 }
@@ -132,7 +132,7 @@ export type AvatarStackProps = {
 
 const AvatarStack = ({children, alignRight, sx: sxProp}: AvatarStackProps) => {
   const count = React.Children.count(children)
-  const wrapperClassNames = classnames({
+  const wrapperClassNames = clsx({
     'pc-AvatarStack--two': count === 2,
     'pc-AvatarStack--three-plus': count > 2,
     'pc-AvatarStack--right': alignRight,

--- a/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames'
+import clsx from 'clsx'
 import {To} from 'history'
 import React from 'react'
 import styled from 'styled-components'
@@ -60,7 +60,7 @@ type StyledBreadcrumbsItemProps = {
 
 const BreadcrumbsItem = styled.a.attrs<StyledBreadcrumbsItemProps>(props => ({
   activeClassName: typeof props.to === 'string' ? 'selected' : undefined,
-  className: classnames(props.selected && SELECTED_CLASS, props.className),
+  className: clsx(props.selected && SELECTED_CLASS, props.className),
   'aria-current': props.selected ? 'page' : null,
 }))<StyledBreadcrumbsItemProps>`
   color: ${get('colors.accent.fg')};

--- a/src/DataTable/Table.tsx
+++ b/src/DataTable/Table.tsx
@@ -1,5 +1,5 @@
 import {SortAscIcon, SortDescIcon} from '@primer/octicons-react'
-import cx from 'classnames'
+import clsx from 'clsx'
 import React from 'react'
 import styled, {keyframes} from 'styled-components'
 import Box from '../Box'
@@ -274,7 +274,7 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(function Table(
         {...rest}
         aria-labelledby={labelledby}
         data-cell-padding={cellPadding}
-        className={cx('Table', className)}
+        className={clsx('Table', className)}
         role="table"
         ref={ref}
         style={{'--grid-template-columns': gridTemplateColumns} as React.CSSProperties}
@@ -407,7 +407,7 @@ function TableCell({align, className, children, scope, ...rest}: TableCellProps)
   const role = scope ? 'rowheader' : 'cell'
 
   return (
-    <BaseComponent {...rest} className={cx('TableCell', className)} scope={scope} role={role} data-cell-align={align}>
+    <BaseComponent {...rest} className={clsx('TableCell', className)} scope={scope} role={role} data-cell-align={align}>
       {children}
     </BaseComponent>
   )

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames'
+import clsx from 'clsx'
 import styled from 'styled-components'
 import {get} from '../constants'
 import sx, {SxProp} from '../sx'
@@ -26,7 +26,7 @@ type StyledPopoverProps = {
 
 const Popover = styled.div.attrs<StyledPopoverProps>(({className, caret = 'top'}) => {
   return {
-    className: classnames(className, `caret-pos--${caret}`),
+    className: clsx(className, `caret-pos--${caret}`),
   }
 })<StyledPopoverProps>`
   position: ${props => (props.relative ? 'relative' : 'absolute')};

--- a/src/SideNav.tsx
+++ b/src/SideNav.tsx
@@ -7,7 +7,7 @@ import Box from './Box'
 import {ComponentProps} from './utils/types'
 import Link from './Link'
 import React from 'react'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import sx, {SxProp} from './sx'
 
 type SideNavBaseProps = {
@@ -20,7 +20,7 @@ type SideNavBaseProps = {
 
 function SideNavBase({variant = 'normal', className, bordered, children, 'aria-label': ariaLabel}: SideNavBaseProps) {
   const variantClassName = variant === 'lightweight' ? 'lightweight' : 'normal'
-  const newClassName = classnames(className, `variant-${variantClassName}`)
+  const newClassName = clsx(className, `variant-${variantClassName}`)
 
   return (
     <Box

--- a/src/SubNav/SubNav.tsx
+++ b/src/SubNav/SubNav.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames'
+import clsx from 'clsx'
 import {To} from 'history'
 import React from 'react'
 import styled from 'styled-components'
@@ -41,7 +41,7 @@ export type SubNavProps = {
 } & ComponentProps<typeof SubNavBase>
 
 function SubNav({actions, className, children, label, ...rest}: SubNavProps) {
-  const classes = classnames(className, 'SubNav')
+  const classes = clsx(className, 'SubNav')
   return (
     <SubNavBase className={classes} aria-label={label} {...rest}>
       <div className="SubNav-body">{children}</div>
@@ -64,7 +64,7 @@ type StyledSubNavLinkProps = {
 
 const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
   activeClassName: typeof props.to === 'string' ? 'selected' : undefined,
-  className: classnames(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
+  className: clsx(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
 }))<StyledSubNavLinkProps>`
   padding-left: ${get('space.3')};
   padding-right: ${get('space.3')};

--- a/src/TabNav/TabNav.tsx
+++ b/src/TabNav/TabNav.tsx
@@ -1,5 +1,5 @@
 import {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import {To} from 'history'
 import React, {useRef, useState} from 'react'
 import styled from 'styled-components'
@@ -82,7 +82,7 @@ export type TabNavLinkProps = React.DetailedHTMLProps<React.HTMLAttributes<HTMLA
 
 const TabNavLink = styled.a.attrs<TabNavLinkProps>(props => ({
   activeClassName: typeof props.to === 'string' ? 'selected' : undefined,
-  className: classnames(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
+  className: clsx(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
   role: 'tab',
   'aria-selected': !!props.selected,
   tabIndex: -1,

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -1,7 +1,7 @@
 import React, {MouseEventHandler, useCallback, useState} from 'react'
 import {isValidElementType} from 'react-is'
 import {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
-import classnames from 'classnames'
+import clsx from 'clsx'
 
 import TextInputInnerVisualSlot from '../internal/components/TextInputInnerVisualSlot'
 import {useProvidedRefOrCreate} from '../hooks'
@@ -85,7 +85,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
     const [isInputFocused, setIsInputFocused] = useState<boolean>(false)
     const inputRef = useProvidedRefOrCreate(ref as React.RefObject<HTMLInputElement>)
     // this class is necessary to style FilterSearch, plz no touchy!
-    const wrapperClasses = classnames(className, 'TextInput-wrapper')
+    const wrapperClasses = clsx(className, 'TextInput-wrapper')
     const showLeadingLoadingIndicator =
       loading && (loaderPosition === 'leading' || Boolean(LeadingVisual && loaderPosition !== 'trailing'))
     const showTrailingLoadingIndicator =

--- a/src/Timeline/Timeline.tsx
+++ b/src/Timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames'
+import clsx from 'clsx'
 import React from 'react'
 import styled, {css} from 'styled-components'
 import Box from '../Box'
@@ -27,7 +27,7 @@ const Timeline = styled.div<{clipSidebar?: boolean} & SxProp>`
 type StyledTimelineItemProps = {condensed?: boolean} & SxProp
 
 const TimelineItem = styled.div.attrs<StyledTimelineItemProps>(props => ({
-  className: classnames('Timeline-Item', props.className),
+  className: clsx('Timeline-Item', props.className),
 }))<StyledTimelineItemProps>`
   display: flex;
   position: relative;

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames'
+import clsx from 'clsx'
 import React from 'react'
 import styled from 'styled-components'
 import {get} from './constants'
@@ -245,7 +245,7 @@ export type TooltipProps = {
 } & ComponentProps<typeof TooltipBase>
 
 function Tooltip({direction = 'n', children, className, text, noDelay, align, wrap, ...rest}: TooltipProps) {
-  const classes = classnames(
+  const classes = clsx(
     className,
     `tooltipped-${direction}`,
     align && `tooltipped-align-${align}-2`,

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -4,7 +4,7 @@ import {
   FileDirectoryFillIcon,
   FileDirectoryOpenFillIcon,
 } from '@primer/octicons-react'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import React, {useCallback, useEffect} from 'react'
 import styled, {keyframes} from 'styled-components'
 import {ConfirmationDialog} from '../Dialog/ConfirmationDialog'
@@ -482,7 +482,7 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
             {hasSubTree ? (
               // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
               <div
-                className={classnames(
+                className={clsx(
                   'PRIVATE_TreeView-item-toggle',
                   onSelect && 'PRIVATE_TreeView-item-toggle--hover',
                   level === 1 && 'PRIVATE_TreeView-item-toggle--end',

--- a/src/UnderlineNav/UnderlineNav.tsx
+++ b/src/UnderlineNav/UnderlineNav.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames'
+import clsx from 'clsx'
 import {To} from 'history'
 import React from 'react'
 import styled from 'styled-components'
@@ -50,7 +50,7 @@ export type UnderlineNavProps = {
 } & ComponentProps<typeof UnderlineNavBase>
 
 function UnderlineNav({actions, className, align, children, full, label, theme, ...rest}: UnderlineNavProps) {
-  const classes = classnames(
+  const classes = clsx(
     className,
     'PRC-UnderlineNav',
     align && `PRC-UnderlineNav--${align}`,
@@ -71,7 +71,7 @@ type StyledUnderlineNavLinkProps = {
 
 const UnderlineNavLink = styled.a.attrs<StyledUnderlineNavLinkProps>(props => ({
   activeClassName: typeof props.to === 'string' ? 'selected' : undefined,
-  className: classnames(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
+  className: clsx(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
 }))<StyledUnderlineNavLinkProps>`
   padding: ${get('space.3')} ${get('space.2')};
   margin-right: ${get('space.3')};

--- a/src/deprecated/SelectMenu/SelectMenuTab.tsx
+++ b/src/deprecated/SelectMenu/SelectMenuTab.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames'
+import clsx from 'clsx'
 import React, {useContext, useEffect} from 'react'
 import styled, {css} from 'styled-components'
 import {get} from '../../constants'
@@ -72,7 +72,7 @@ const SelectMenuTab = ({tabName = '', index, className, onClick, ...rest}: Selec
   return (
     <StyledTab
       role="tab"
-      className={classnames('SelectMenuTab', className)}
+      className={clsx('SelectMenuTab', className)}
       aria-selected={isSelected}
       onClick={handleClick}
       {...rest}

--- a/src/drafts/CSSComponent/index.tsx
+++ b/src/drafts/CSSComponent/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import merge from 'classnames'
+import clsx from 'clsx'
 import classNames from './component.module.css'
 
 export const Component: React.FC<React.HTMLProps<HTMLDivElement>> = ({className, ...props}) => {
-  return <div className={merge(classNames.component, className)} {...props} />
+  return <div className={clsx(classNames.component, className)} {...props} />
 }


### PR DESCRIPTION
Let's move to `clsx` as outlined in the css ADR. A lighter [more performant](https://github.com/lukeed/clsx/tree/master/bench) conditional class names library.

This will make authoring our styles with css-modules an absolute breeze.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
