### PR TITLE
ci: update changesets action to build generated/components.json

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -10,4 +10,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      # This step generates the generated/components.json file expected by the
+      # validator action
+      - name: Build
+        run: npm run build
       - uses: gr2m/primer-release-changesets-validator-action@v1


### PR DESCRIPTION
Update the changesets validate job to build the project before running the validator action so that the `generated/components.json` file is available.