### PR TITLE
ci: update ci workflow to remove app token requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,17 +245,8 @@ jobs:
   build-components-json:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.PRIVATE_KEY }}
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
-          token: ${{ steps.generate_token.outputs.token }}
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Update the `build-components-json` job to no longer require an app token. This step is no longer needed as we do not need to commit a generated `components.json` file back to a PR. Instead, this step should validate and report errors if the format is incorrect.

Removing this requirement for the app token means that this step will not fail on PRs from forks or PRs from apps like dependabot.