### PR TITLE
chore(deps-dev): bump `primer-changesets-cli` to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,7 @@
         "micromark-extension-mdxjs": "1.0.1",
         "postcss-custom-properties-fallback": "^1.0.2",
         "prettier": "2.8.8",
-        "primer-changesets-cli": "2.1.0",
+        "primer-changesets-cli": "2.2.0",
         "react": "18.2.0",
         "react-dnd": "14.0.4",
         "react-dnd-html5-backend": "14.0.2",
@@ -34898,9 +34898,9 @@
       }
     },
     "node_modules/primer-changesets-cli": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/primer-changesets-cli/-/primer-changesets-cli-2.1.0.tgz",
-      "integrity": "sha512-yu3Qk9XqpqruBcKn2uv2yvbHO5hYYwaSrcQOq1R9DliwQc2snZWB6jdOZJ0zip1KcvOaHzUNPSFiUlmPoxxU2A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/primer-changesets-cli/-/primer-changesets-cli-2.2.0.tgz",
+      "integrity": "sha512-xfptqA9bI5aG40VrOk52XwgYVmnht2gwGl1rysEojzxfNzTz0zBTqs1ro0s9RhoXu9IAk7MJx+nAtkjMxLHf4w==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.20.1",

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "micromark-extension-mdxjs": "1.0.1",
     "postcss-custom-properties-fallback": "^1.0.2",
     "prettier": "2.8.8",
-    "primer-changesets-cli": "2.1.0",
+    "primer-changesets-cli": "2.2.0",
     "react": "18.2.0",
     "react-dnd": "14.0.4",
     "react-dnd-html5-backend": "14.0.2",


### PR DESCRIPTION
This versions supports `_none_` as valid option for changed components
