### PR TITLE
build(deps): bump `primer-changesets-cli` to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,7 @@
         "micromark-extension-mdxjs": "1.0.1",
         "postcss-custom-properties-fallback": "^1.0.2",
         "prettier": "2.8.8",
-        "primer-changesets-cli": "2.2.0",
+        "primer-changesets-cli": "2.2.1",
         "react": "18.2.0",
         "react-dnd": "14.0.4",
         "react-dnd-html5-backend": "14.0.2",
@@ -34898,9 +34898,9 @@
       }
     },
     "node_modules/primer-changesets-cli": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/primer-changesets-cli/-/primer-changesets-cli-2.2.0.tgz",
-      "integrity": "sha512-xfptqA9bI5aG40VrOk52XwgYVmnht2gwGl1rysEojzxfNzTz0zBTqs1ro0s9RhoXu9IAk7MJx+nAtkjMxLHf4w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/primer-changesets-cli/-/primer-changesets-cli-2.2.1.tgz",
+      "integrity": "sha512-k+/gXOw+2+Bwve1ZaquQII1eqOn/S7hzrNWYZ0nCF/ZD+4/LIPe7ekRpDFwcUT3ufWlN3HRXkAX+7CDL7KSd3A==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.20.1",

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "micromark-extension-mdxjs": "1.0.1",
     "postcss-custom-properties-fallback": "^1.0.2",
     "prettier": "2.8.8",
-    "primer-changesets-cli": "2.2.0",
+    "primer-changesets-cli": "2.2.1",
     "react": "18.2.0",
     "react-dnd": "14.0.4",
     "react-dnd-html5-backend": "14.0.2",


### PR DESCRIPTION
With this pull request, running `npx changeset` will run `npm run build:components.json` before trying to load component names from `generated/components.json`

<img width="808" alt="screenshot of terminal showing the new behavior of npx changeset" src="https://github.com/gr2m/primer-changesets-cli/assets/39992/410e90ef-7934-4fb3-9d71-3f2c1bbad996">
