### PR TITLE
Add changed components to the changesets

### DIFF
--- a/.changeset/four-bulldogs-hope.md
+++ b/.changeset/four-bulldogs-hope.md
@@ -3,3 +3,5 @@
 ---
 
 Renders docs.json markdown content
+
+<!-- Changed components: _none_ -->

--- a/.changeset/kind-eggs-cheer.md
+++ b/.changeset/kind-eggs-cheer.md
@@ -3,3 +3,5 @@
 ---
 
 Bug fix: ActionList item label weight and spacing if description exists
+
+<!-- Changed components: ActionList -->


### PR DESCRIPTION
I didn't realised [this PR](https://github.com/primer/react/pull/3441) didn't have changed components in the changeset because it is an old one. I enabled "Merge when ready" and updated the branch with the latest main. Although the changeset job failed it still merged the PR 🤷🏻‍♀️  So just adding changed components to its changeset. I also realised that https://github.com/primer/react/pull/3490 doesn't have changed components either so adding to that one as well.

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
