### PR TITLE
Fix ActionList.Item width for `full` variant

### DIFF
--- a/.changeset/plenty-bats-shop.md
+++ b/.changeset/plenty-bats-shop.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+ActionList: Fixes the width of items for the full variant

--- a/.changeset/plenty-bats-shop.md
+++ b/.changeset/plenty-bats-shop.md
@@ -3,3 +3,5 @@
 ---
 
 ActionList: Fixes the width of items for the full variant
+
+<!-- Changed components: ActionList -->

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -103,7 +103,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       appearance: 'none',
       background: 'unset',
       border: 'unset',
-      width: 'calc(100% - 16px)',
+      width: listVariant === 'inset' ? 'calc(100% - 16px)' : '100%',
       fontFamily: 'unset',
       textAlign: 'unset',
       marginY: 'unset',


### PR DESCRIPTION
Describe your changes here.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6512a3c</samp>

This pull request fixes the width issue of the `ActionList.Item` component in the `@primer/react` package. It adds a conditional width style based on the `listVariant` prop and updates the changeset file for a patch release.

### Screenshots

| Before | After |
|--------|--------|
| <img width="990" alt="screenshot-fb2AVLWx-000579@2x" src="https://github.com/primer/react/assets/175638/5b52239e-263b-4cc1-9899-7d43d12a2eee"> | <img width="982" alt="screenshot-lhsQOHpJ-000580@2x" src="https://github.com/primer/react/assets/175638/036358ba-a07a-471c-99bd-7e2bd8326be8"> |

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
