### PR TITLE
ci: update vrt-runner to use docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,6 @@ jobs:
         run: npm ci
       - name: Build storybook
         run: npx storybook build
-      - name: Install browsers
-        run: npx playwright install --with-deps
       - name: Run storybook
         id: storybook
         run: |
@@ -171,7 +169,11 @@ jobs:
           echo "pid=$pid" >> $GITHUB_OUTPUT
           sleep 5
       - name: Run VRT
-        run: npx playwright test --grep @vrt --shard="${{ matrix.shard }}/${{ strategy.job-total }}"
+        uses: docker://mcr.microsoft.com/playwright:v1.36.0-jammy
+        env:
+          STORYBOOK_URL: 'http://172.17.0.1:6006'
+        with:
+          args: npx playwright test --grep @vrt --shard="${{ matrix.shard }}/${{ strategy.job-total }}"
       - name: Stop storybook
         run: kill ${{ steps.storybook.outputs.pid }}
       - name: Upload report

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@changesets/changelog-github": "0.4.8",
         "@github/markdownlint-github": "^0.3.0",
         "@github/prettier-config": "0.0.6",
-        "@playwright/test": "1.32.0",
+        "@playwright/test": "1.36.0",
         "@primer/css": "^21.0.1",
         "@rollup/plugin-babel": "6.0.3",
         "@rollup/plugin-commonjs": "25.0.0",
@@ -5009,34 +5009,34 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
-      "integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.0.tgz",
+      "integrity": "sha512-yN+fvMYtiyLFDCQos+lWzoX4XW3DNuaxjBu68G0lkgLgC6BP+m/iTxJQoSicz/x2G5EsrqlZTqTIP9sTgLQerg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.32.0"
+        "playwright-core": "1.36.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
-      "integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.0.tgz",
+      "integrity": "sha512-7RTr8P6YJPAqB+8j5ATGHqD6LvLLM39sYVNsslh78g8QeLcBs5750c6+msjrHUwwGt+kEbczBj1XB22WMwn+WA==",
       "dev": true,
       "bin": {
-        "playwright": "cli.js"
+        "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@primer/behaviors": {
@@ -34687,8 +34687,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/property-information": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "@changesets/changelog-github": "0.4.8",
     "@github/markdownlint-github": "^0.3.0",
     "@github/prettier-config": "0.0.6",
-    "@playwright/test": "1.32.0",
+    "@playwright/test": "1.36.0",
     "@primer/css": "^21.0.1",
     "@rollup/plugin-babel": "6.0.3",
     "@rollup/plugin-commonjs": "25.0.0",

--- a/script/test-e2e
+++ b/script/test-e2e
@@ -6,5 +6,5 @@ docker run --rm \
   --network host \
   -v $(pwd):/workspace \
   -w /workspace \
-  -it mcr.microsoft.com/playwright:v1.32.0-focal \
+  -it mcr.microsoft.com/playwright:v1.36.0-jammy \
   /bin/bash -c "npm install && STORYBOOK_URL=http://host.docker.internal:6006 npx playwright test $@"


### PR DESCRIPTION
Update `@playwright/test` and its usage in Docker and in CI. In CI, this removes the step where we install browsers and instead uses a docker image. This change helps to:

- Remove the install browsers step which can take up to 2min to complete
- In the happy path, this docker image should be cached and downloaded quickly
- When no cache is available, this step should mirror the performance of the typical browser install step

This change also updates the docker image used locally so that we can replicate tests in CI and in development.