### PR TITLE
Remove Storybook autodocs

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -48,6 +48,6 @@ module.exports = {
     },
   },
   docs: {
-    autodocs: true,
+    autodocs: false,
   },
 }


### PR DESCRIPTION
This disables the `autodocs` feature in Storybook 7. I feel like its not adding any value and instead adds clutter?

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
