### PR TITLE
Fix `ActionListItem` border-radius on hover for `full` list variant

### DIFF
--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -93,7 +93,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       lineHeight: TEXT_ROW_HEIGHT,
       minHeight: 5,
       marginX: listVariant === 'inset' ? 2 : 0,
-      borderRadius: listVariant === 'inset' ? 2 : 0,
+      borderRadius: 2,
       transition: 'background 33.333ms linear',
       color: getVariantStyles(variant, disabled).color,
       cursor: 'pointer',


### PR DESCRIPTION
When ActionList is set to full variant, the border-radius is removed on items. I think this was either an oversight or we've since gone in another direction, but we don't have any designs (to my knowledge) where we want a full bleed on items.

### Screenshots

Please provide before/after screenshots for any visual changes

| Before | After |
| -- | -- |
| <img width="198" alt="Action list item hover state before update" src="https://github.com/primer/react/assets/18661030/52dfccea-d5d9-44c2-9c36-8d427f591a76"> | -- |


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
