### PR TITLE
Add 'display' text size to PRC theme

### DIFF
--- a/.changeset/rotten-meals-obey.md
+++ b/.changeset/rotten-meals-obey.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Adds 'display' text size to PRC theme. This size is described in our [typography documentation](https://primer.style/design/foundations/typography#headings), but was never added to our React theme.

--- a/.changeset/rotten-meals-obey.md
+++ b/.changeset/rotten-meals-obey.md
@@ -3,3 +3,5 @@
 ---
 
 Adds 'display' text size to PRC theme. This size is described in our [typography documentation](https://primer.style/design/foundations/typography#headings), but was never added to our React theme.
+
+<!-- Changed components: _none_ -->

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -43,7 +43,7 @@ const sizes = {
   xlarge: '1280px',
 }
 
-const fontSizes = ['12px', '14px', '16px', '20px', '24px', '32px', '40px', '48px']
+const fontSizes = ['12px', '14px', '16px', '20px', '24px', '32px', '40px', '48px', '56px']
 
 const space = ['0', '4px', '8px', '16px', '24px', '32px', '40px', '48px', '64px', '80px', '96px', '112px', '128px']
 


### PR DESCRIPTION
Adds the display text size to the theme. This size is mentioned here: https://primer.style/design/foundations/typography#headings

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
