### PR TITLE
Take the listing html structure back to its original structure

### DIFF
--- a/src/UnderlineNav2/UnderlineNav.tsx
+++ b/src/UnderlineNav2/UnderlineNav.tsx
@@ -310,18 +310,7 @@ export const UnderlineNav = forwardRef(
           ref={navRef}
         >
           <NavigationList sx={ulStyles} ref={listRef} role="list">
-            {listItems.map(listItem => {
-              return (
-                <Box
-                  key={listItem.props.children}
-                  as="li"
-                  sx={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}
-                >
-                  {listItem}
-                </Box>
-              )
-            })}
-
+            {listItems}
             {menuItems.length > 0 && (
               <MoreMenuListItem ref={moreMenuRef}>
                 {!onlyMenuVisible && <Box sx={getDividerStyle(theme)}></Box>}

--- a/src/UnderlineNav2/UnderlineNavItem.tsx
+++ b/src/UnderlineNav2/UnderlineNavItem.tsx
@@ -114,43 +114,45 @@ export const UnderlineNavItem = forwardRef(
     )
 
     return (
-      <Link
-        ref={ref}
-        as={Component}
-        href={href}
-        aria-current={ariaCurrent}
-        onKeyDown={keyDownHandler}
-        onClick={clickHandler}
-        sx={merge<BetterSystemStyleObject>(getLinkStyles(theme, ariaCurrent), sxProp as SxProp)}
-        {...props}
-      >
-        {iconsVisible && Icon && (
-          <Box as="span" data-component="icon" sx={iconWrapStyles}>
-            <Icon />
-          </Box>
-        )}
-        {children && (
-          <Box
-            as="span"
-            data-component="text"
-            data-content={children}
-            sx={Boolean(ariaCurrent) && ariaCurrent !== 'false' ? {fontWeight: 600} : {}}
-          >
-            {children}
-          </Box>
-        )}
-        {loadingCounters ? (
-          <Box as="span" data-component="counter" sx={counterStyles}>
-            <LoadingCounter />
-          </Box>
-        ) : (
-          counter !== undefined && (
-            <Box as="span" data-component="counter" sx={counterStyles}>
-              <CounterLabel>{counter}</CounterLabel>
+      <Box as="li" sx={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
+        <Link
+          ref={ref}
+          as={Component}
+          href={href}
+          aria-current={ariaCurrent}
+          onKeyDown={keyDownHandler}
+          onClick={clickHandler}
+          sx={merge<BetterSystemStyleObject>(getLinkStyles(theme, ariaCurrent), sxProp as SxProp)}
+          {...props}
+        >
+          {iconsVisible && Icon && (
+            <Box as="span" data-component="icon" sx={iconWrapStyles}>
+              <Icon />
             </Box>
-          )
-        )}
-      </Link>
+          )}
+          {children && (
+            <Box
+              as="span"
+              data-component="text"
+              data-content={children}
+              sx={Boolean(ariaCurrent) && ariaCurrent !== 'false' ? {fontWeight: 600} : {}}
+            >
+              {children}
+            </Box>
+          )}
+          {loadingCounters ? (
+            <Box as="span" data-component="counter" sx={counterStyles}>
+              <LoadingCounter />
+            </Box>
+          ) : (
+            counter !== undefined && (
+              <Box as="span" data-component="counter" sx={counterStyles}>
+                <CounterLabel>{counter}</CounterLabel>
+              </Box>
+            )
+          )}
+        </Link>
+      </Box>
     )
   },
 ) as PolymorphicForwardRefComponent<'a', UnderlineNavItemProps>


### PR DESCRIPTION
When running integration tests at dotcom, found out that [the select issue fix](https://github.com/primer/react/pull/3361) introduces some changes that was breaking `UnderlineNav` usages. ([Error log (GitHub stuff only link)](https://github.com/github/github/actions/runs/5617713828/job/15222242848))

It is mainly the HTML re-structure I made [here](https://github.com/primer/react/pull/3361/files#r1266304085).

Relying on the implementation details on the consumer side for the `key` prop for iteration causing some issues.  I was expecting `linkItem.props.children` to always have a value however for custom components like below, there is no children passed. So taking the HTML structure back to its origin where we don't need to manually extract the key value from the UnderlineNav children components, so that the iteration all will be on the consumer side.


```jsx
function OverviewFileTab({
  tabName,
  tabId,
  icon,
  selectedTab,
  setSelectedTab,
}: {
  tabName: string
  tabId: string
  icon: FunctionComponent<IconProps>
  selectedTab: string
  setSelectedTab: (tab: string) => void
}) {
  return (
    <UnderlineNav.Item
      as="button"
      icon={icon}
      aria-current={selectedTab === tabId ? 'page' : undefined}
      onSelect={ev => {
        setSelectedTab(tabId)
        ev.preventDefault()
      }}
      sx={{backgroundColor: 'unset', border: 'none'}}
    >
      {tabName}
    </UnderlineNav.Item>
  )
}

const licenses = [
  {
    path: 'LICENSE',
    tabName: 'License',
  },
  {
    path: 'package.json',
    tabName: 'package.json',
  },
  {
    path: 'README.md',
    tabName: 'README.md',
  },
]

export const TabTypeExample = () => {
  const [selectedTab, setSelectedTab] = React.useState('LICENSE')

  return (
    <UnderlineNav aria-label="Repository">
      {licenses.map(({tabName, path}) => (
        <OverviewFileTab
          key={path}
          tabName={tabName}
          tabId={path}
          icon={LawIcon}
          selectedTab={selectedTab}
          setSelectedTab={setSelectedTab}
        />
      ))}
    </UnderlineNav>
  )
}
```

Closes # (type the issue number after # if applicable; otherwise remove this line)

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
