### PR TITLE
Update `useSyntheticChange` to only call `execCommand` if input is focused

### DIFF
--- a/.changeset/tame-foxes-tan.md
+++ b/.changeset/tame-foxes-tan.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Fix `MarkdownEditor` file uploads inserting the URL into the wrong input when an overlay is open

--- a/src/drafts/hooks/useSyntheticChange.ts
+++ b/src/drafts/hooks/useSyntheticChange.ts
@@ -94,7 +94,7 @@ export const useSyntheticChange = ({inputRef, fallbackEventHandler}: UseSyntheti
       const input = inputRef.current
       if (!input) return
 
-      input.focus() // the input must be focused to execute execCommand
+      input.focus()
 
       const replaceRange = replaceRange_ ?? [
         input.selectionStart ?? input.value.length,
@@ -113,6 +113,10 @@ export const useSyntheticChange = ({inputRef, fallbackEventHandler}: UseSyntheti
       // but it's a deprecated API and there's no alternative. It also doesn't work in test environments
       let execCommandResult = false
       try {
+        // There is no guarantee the input is focused even after calling `focus()` on it. For example, the focus could
+        // be trapped by an overlay. In that case we must prevent the change from happening in some unexpected target.
+        if (document.activeElement !== input) throw new Error('Input must be focused to use execCommand')
+
         // expand selection to the whole range and replace it with the new value
         input.setSelectionRange(replaceRange[0], replaceRange[1])
         execCommandResult =


### PR DESCRIPTION
`useSyntheticChange` powers all updates to the `MarkdownEditor` textarea under the hood. Using this hook instead of directly updating the input value allows us to preserve the caret position and browser undo stack. However, it uses `execCommand` which has all sorts of gotchas since it essentially just simulates the user typing in the input. This means the input needs to be focused, which is fine because it usually is when you are editing Markdown.

When uploading a file, the delay between interaction and update may be significant. In this case, the user might have started working on something else. For example, they might have opened a dialog which activated a focus trap. Then we can't pull focus into the editor, so we can't use `execCommand` to update the input.

Currently in this case we still call `execCommand`, unexpectedly updating whatever input _is_ focused instead. This is obviously not great since it means we may insert file URLs into random spots. So instead, this PR updated the hook to ensure the input is focused before trying to call `execCommand`. If not, it falls back to the already-available fallback method of directly updating the input.

Closes https://github.com/primer/react/issues/3548

### Merge checklist

- ~~[ ] Added/updated tests~~
  - This change cannot be tested because `execCommand` is not available in JSDom so we always use the fallback method in the test suite anyway.
- ~~[ ] Added/updated documentation~~
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
