### PR TITLE
Fix: Typo on Primer CSS link in 'getting-started.md'

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -95,7 +95,7 @@ export default () => (
 )
 ```
 
-This will apply the same `color`, `font-family`, and `line-height` styles to the `<body>` as [Primer CSS's base styles](https://github.com/primer/css/blob/master/src/base/base.scss#L15-L20).
+This will apply the same `color`, `font-family`, and `line-height` styles to the `<body>` as [Primer CSS's base styles](https://github.com/primer/css/blob/main/src/base/base.scss#L15-L20).
 
 ## Static CSS rendering
 


### PR DESCRIPTION
Fixed a typo where the link redirecting to Primer CSS default branch was `master` but was renamed to `main`.

### Screenshots

N/A other than the message box not appearing on Github when arriving on the repository.

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
