### PR TITLE
feat(codemods): add codemod for updating imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 coverage/
 dist/
 lib/
+!codemods/lib/
 lib-esm/
 css/
 public/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 .changeset
 dist
 lib
+!codemods/lib/**
 lib-esm
 storybook-static
 docs/.cache

--- a/codemods/.eslintignore
+++ b/codemods/.eslintignore
@@ -1,0 +1,1 @@
+__testfixtures__

--- a/codemods/.eslintrc.js
+++ b/codemods/.eslintrc.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  rules: {
+    'github/array-foreach': 'off',
+  },
+}

--- a/codemods/.eslintrc.json
+++ b/codemods/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "github/array-foreach": 0
-  }
-}

--- a/codemods/lib/__tests__/changeImportSource.test.js
+++ b/codemods/lib/__tests__/changeImportSource.test.js
@@ -1,0 +1,104 @@
+import { defineInlineTest } from 'jscodeshift/dist/testUtils';
+import { changeImportSource } from '../changeImportSource';
+import { setupPreserveLeadingComments } from '../preserveLeadingComments';
+
+function defaultTransform(file, api, options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  const preserveLeadingComments = setupPreserveLeadingComments(j, root);
+
+  changeImportSource(j, root, {
+    name: 'TreeView',
+    from: '@primer/react/drafts',
+    to: '@primer/react'
+  });
+
+  preserveLeadingComments();
+
+  return root.toSource(options.printOptions ?? {});
+}
+
+const transformOptions = {
+  printOptions: {
+    quote: 'single',
+  },
+};
+
+defineInlineTest(
+  defaultTransform,
+  transformOptions,
+`
+import { TreeView } from '@primer/react/drafts';
+`,
+`
+import { TreeView } from '@primer/react';
+`,
+  'moves the import from the source to the target ImportDeclaration'
+);
+
+defineInlineTest(
+  defaultTransform,
+  transformOptions,
+`
+import { TreeView as PrimerTreeView } from '@primer/react/drafts';
+`,
+`
+import { TreeView as PrimerTreeView } from '@primer/react';
+`,
+  'supports remapped imports'
+);
+
+
+defineInlineTest(
+  defaultTransform,
+  transformOptions,
+`
+// Comment
+import { TreeView } from '@primer/react/drafts';
+`,
+`
+// Comment
+import { TreeView } from '@primer/react';
+`,
+  'preserves leading comments'
+);
+
+defineInlineTest(
+  defaultTransform,
+  transformOptions,
+`
+import { TreeView } from '@primer/react/drafts';
+import { Box } from '@primer/react';
+`,
+`
+import { Box, TreeView } from '@primer/react';
+`,
+  'adds to existing ImportDeclaration'
+);
+
+defineInlineTest(
+  defaultTransform,
+  transformOptions,
+`
+import fs from 'node:fs';
+import { TreeView } from '@primer/react/drafts';
+`,
+`
+import { TreeView } from '@primer/react';
+import fs from 'node:fs';
+`,
+  'replaces import declaration location'
+)
+defineInlineTest(
+  defaultTransform,
+  transformOptions,
+`
+import fs from 'node:fs';
+import path from 'node:path';
+`,
+`
+import fs from 'node:fs';
+import path from 'node:path';
+`,
+  'no changes if import is not available'
+);;

--- a/codemods/lib/changeImportSource.js
+++ b/codemods/lib/changeImportSource.js
@@ -1,0 +1,130 @@
+function changeImportSource(j, root, options) {
+  const { name, from, to } = options;
+  // Changes is a mapping of `imported` values to their `local` values. For
+  // example, someone may import `Link` but remaps it to `PrimerLink`
+  //
+  // Example:
+  // Map(
+  //   'Link' => ['PrimerLink'],
+  // )
+  const changes = new Map();
+
+  root.find(j.ImportDeclaration, {
+    source: {
+      value: from,
+    },
+  }).forEach((path) => {
+    // Iterate through every ImportSpecifier that matches the given `name` of
+    // the import that we're changing. Add the name of the import to our list of
+    // changes and remove the ImportSpecifier
+    j(path).find(j.ImportSpecifier, {
+      imported: {
+        name,
+      },
+    }).forEach((specifierPath) => {
+      const imported = specifierPath.value.imported.name;
+      if (!changes.has(imported)) {
+        changes.set(imported, []);
+      }
+      changes.get(imported).push(specifierPath.value.local.name);
+      j(specifierPath).remove();
+    });
+
+    // If the ImportDeclaration is empty (has no specifiers), remove it
+    const specifiers = j(path).find(j.ImportSpecifier);
+    if (specifiers.length === 0) {
+      j(path).remove();
+    }
+  });
+
+  if (changes.size === 0) {
+    return;
+  }
+
+  // If we have no ImportDeclaration's, create one at the top of the file.
+  // Note: make sure to preserve leading comments in the transformer that uses
+  // this utility function
+  if (root.find(j.ImportDeclaration).length === 0) {
+    root.find(j.Program).get('body', 0).insertBefore(
+      j.importDeclaration(Array.from(changes).flatMap(([imported, locals]) => {
+        return locals.map((local) => {
+          return j.importSpecifier(j.identifier(imported), j.identifier(local));
+        });
+      }), j.stringLiteral('@primer/react'))
+    );
+    return;
+  }
+
+  // Look for import declarations that match the given `to` ImportDeclaration
+  // source
+  const matchingImportDeclarations = root.find(j.ImportDeclaration, {
+    source: {
+      value: to,
+    },
+  });
+
+  // If none exist, try to insert the ImportDeclaration for `to` in alphabetical
+  // order
+  if (matchingImportDeclarations.length === 0) {
+    const importDeclarations = root.find(j.ImportDeclaration);
+    const order = [
+      ...importDeclarations.nodes().map((node) => {
+        return node.source.value;
+      }),
+      to,
+    ].sort((a, b) => {
+      return a.localeCompare(b);
+    });
+    const insertionIndex = order.indexOf(to);
+    const specifiers = Array.from(changes).flatMap(([imported, locals]) => {
+      return locals.map(local => {
+        return j.importSpecifier(j.identifier(imported), j.identifier(local));
+      });
+    });
+
+    if (insertionIndex === 0) {
+      importDeclarations.at(0).insertBefore(
+        j.importDeclaration(specifiers, j.stringLiteral(to)),
+      );
+    } else {
+      importDeclarations.at(insertionIndex - 1).insertAfter(
+        j.importDeclaration(specifiers, j.stringLiteral(to)),
+      );
+    }
+
+    return;
+  }
+
+  // If one exists, try to add the specifier in alphabetical order
+  matchingImportDeclarations.at(0).forEach((path) => {
+    const specifiers = path.value.specifiers.map((specifier) => {
+      return specifier.imported.name;
+    });
+    const order = [...specifiers, ...Array.from(changes.keys())].sort((a, b) => {
+      return a.localeCompare(b);
+    });
+
+    for (const [imported, locals] of changes) {
+      const insertionIndex = order.indexOf(imported);
+      const specifiers = locals.map(local => {
+        return j.importSpecifier(j.identifier(imported), j.identifier(local));
+      });
+
+      // The `change` should be at the front of the list
+      if (insertionIndex === 0) {
+        j(path).find(j.ImportSpecifier).at(0).insertBefore(
+          specifiers
+        );
+      } else {
+        // The `change` should be after an item in the list
+        j(path).find(j.ImportSpecifier).at(insertionIndex - 1).insertAfter(
+          specifiers
+        );
+      }
+    }
+  });
+}
+
+module.exports = {
+  changeImportSource,
+};

--- a/codemods/lib/format.js
+++ b/codemods/lib/format.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const prettier = require('prettier');
+const config = prettier.resolveConfig.sync(process.cwd());
+
+function format(file, source) {
+  return prettier.format(source, {
+    ...config,
+    filepath: file.path,
+  });
+}
+
+module.exports = {
+  format,
+};

--- a/codemods/lib/preserveLeadingComments.js
+++ b/codemods/lib/preserveLeadingComments.js
@@ -1,0 +1,22 @@
+'use strict';
+
+function setupPreserveLeadingComments(j, root) {
+  const getFirstNode = () => {
+    return root.find(j.Program).get('body', 0).node
+  }
+  // Save the comments attached to the first node
+  const firstNode = getFirstNode()
+  const {comments} = firstNode
+
+  return () => {
+    // If the first node has been modified or deleted, reattach the comments
+    const firstNode2 = getFirstNode()
+    if (firstNode2 !== firstNode) {
+      firstNode2.comments = comments
+    }
+  }
+}
+
+module.exports = {
+  setupPreserveLeadingComments,
+};

--- a/codemods/v36/__testfixtures__/update-imports.input.js
+++ b/codemods/v36/__testfixtures__/update-imports.input.js
@@ -1,0 +1,2 @@
+import {SplitPageLayout, TreeView, UnderlineNav} from '@primer/react/drafts'
+import {FilteredList, FilteredSearch} from '@primer/react'

--- a/codemods/v36/__testfixtures__/update-imports.output.js
+++ b/codemods/v36/__testfixtures__/update-imports.output.js
@@ -1,0 +1,2 @@
+import {SplitPageLayout, TreeView, UnderlineNav} from '@primer/react'
+import {FilteredList, FilteredSearch} from '@primer/react/deprecated'

--- a/codemods/v36/__tests__/update-imports.test.js
+++ b/codemods/v36/__tests__/update-imports.test.js
@@ -1,0 +1,8 @@
+const {defineTest} = require('jscodeshift/dist/testUtils')
+
+defineTest(__dirname, 'update-imports', {
+  printOptions: {
+    quote: 'single',
+    objectCurlySpacing: false,
+  },
+})

--- a/codemods/v36/update-imports.js
+++ b/codemods/v36/update-imports.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const {changeImportSource} = require('../lib/changeImportSource')
+const {setupPreserveLeadingComments} = require('../lib/preserveLeadingComments')
+const {format} = require('../lib/format')
+
+const draftsToMain = new Set(['SplitPageLayout', 'TreeView', 'UnderlineNav'])
+const mainToDeprecated = new Set(['FilteredList', 'FilteredSearch'])
+
+function transform(file, api) {
+  const j = api.jscodeshift
+  const root = j(file.source)
+  const preserveLeadingComments = setupPreserveLeadingComments(j, root)
+
+  for (const name of draftsToMain) {
+    changeImportSource(j, root, {
+      name,
+      from: '@primer/react/drafts',
+      to: '@primer/react',
+    })
+  }
+
+  for (const name of mainToDeprecated) {
+    changeImportSource(j, root, {
+      name,
+      from: '@primer/react',
+      to: '@primer/react/deprecated',
+    })
+  }
+
+  preserveLeadingComments()
+
+  return format(file, root.toSource())
+}
+
+module.exports = transform
+module.exports.parser = 'tsx'


### PR DESCRIPTION
Add a `v36/update-imports.js` codemod for changing the imports for the v36 release. This also includes some helpers to make working with codemods a little easier, in particular for formatting and preserving leading comments.

This is currently being run against: https://github.com/github/github/pull/282480 to update the imports for `@primer/react` in v36.