### PR TITLE
Remove extra space at beginning of `AvatarStack` rendered output

### DIFF
--- a/src/AvatarStack/AvatarStack.tsx
+++ b/src/AvatarStack/AvatarStack.tsx
@@ -245,7 +245,7 @@ const AvatarStack = ({children, alignRight, disableExpand, size, sx: sxProp = de
 
   return (
     <AvatarStackWrapper count={count} className={wrapperClassNames} sx={avatarStackSx}>
-      <Box className={bodyClassNames}> {transformChildren(children)}</Box>
+      <Box className={bodyClassNames}>{transformChildren(children)}</Box>
     </AvatarStackWrapper>
   )
 }


### PR DESCRIPTION
Describe your changes here.

Closes # (type the issue number after # if applicable; otherwise remove this line)

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
