### PR TITLE
NavList: Fix when subNav opens automatically and shows current indicator

### DIFF
--- a/.changeset/tiny-numbers-sip.md
+++ b/.changeset/tiny-numbers-sip.md
@@ -1,0 +1,7 @@
+---
+"@primer/react": patch
+---
+
+NavList: Fix when subNav opens automatically and shows current indicator
+
+<!-- Changed components: NavList -->

--- a/src/NavList/NavList.stories.tsx
+++ b/src/NavList/NavList.stories.tsx
@@ -143,4 +143,50 @@ export const WithNextJSLink = () => (
   </PageLayout>
 )
 
+export const WithReloads: Story = () => {
+  // eslint-disable-next-line ssr-friendly/no-dom-globals-in-react-fc
+  const location = window.location
+
+  const storyId = new URLSearchParams(location.search).get('id')
+  const urlBase = `${location.origin + location.pathname}?id=${storyId}`
+  const itemId = new URLSearchParams(location.search).get('itemId')
+
+  return (
+    <>
+      <PageLayout>
+        <PageLayout.Pane position="start">
+          <NavList>
+            <NavList.Item href={`${urlBase}&itemId=1`} aria-current={itemId === '1' ? 'page' : 'false'}>
+              Item 1
+            </NavList.Item>
+            <NavList.Item>
+              Item 2
+              <NavList.SubNav>
+                <NavList.Item href={`${urlBase}&itemId=2.1`} aria-current={itemId === '2.1' ? 'page' : 'false'}>
+                  Sub item 2.1
+                </NavList.Item>
+                <NavList.Item href={`${urlBase}&itemId=2.2`} aria-current={itemId === '2.2' ? 'page' : 'false'}>
+                  Sub item 2.2
+                </NavList.Item>
+              </NavList.SubNav>
+            </NavList.Item>
+            <NavList.Item>
+              Item 3
+              <NavList.SubNav>
+                <NavList.Item href={`${urlBase}&itemId=3.1`} aria-current={itemId === '3.1' ? 'page' : 'false'}>
+                  Sub item 3.1
+                </NavList.Item>
+                <NavList.Item href={`${urlBase}&itemId=3.2`} aria-current={itemId === '3.2' ? 'page' : 'false'}>
+                  Sub item 3.2
+                </NavList.Item>
+              </NavList.SubNav>
+            </NavList.Item>
+          </NavList>
+        </PageLayout.Pane>
+        <PageLayout.Content></PageLayout.Content>
+      </PageLayout>
+    </>
+  )
+}
+
 export default meta

--- a/src/NavList/NavList.tsx
+++ b/src/NavList/NavList.tsx
@@ -116,8 +116,10 @@ function ItemWithSubNav({children, subNav, depth, sx: sxProp = defaultSxProp}: I
   useIsomorphicLayoutEffect(() => {
     if (subNavRef.current) {
       // Check if SubNav contains current item
-      const currentItem = subNavRef.current.querySelector('[aria-current]')
-      if (currentItem && currentItem.getAttribute('aria-current') !== 'false') {
+      // valid values: page, step, location, date, time, true and false
+      const currentItem = subNavRef.current.querySelector('[aria-current]:not([aria-current=false])')
+
+      if (currentItem) {
         setContainsCurrentItem(true)
         setIsOpen(true)
       }


### PR DESCRIPTION
- Fix part of https://github.com/primer/react/issues/3564 (not completely because it might not work for soft navigation)

Before: If the second item is selected, NavList does not open the subNav automatically and does not show current indicator at the subNav level when folded

https://github.com/primer/react/assets/1863771/05908fa1-52e5-4973-a8bd-00e82839efad

After: If the second item is selected, NavList does open subNav automatically and shows the current indicator at the subNav level

https://github.com/primer/react/assets/1863771/c9ac1294-7369-4918-a37c-c5f8f7ee151f

#### Implementation detail

While we did check for `aria-current !== false`, we did this for the first element with `aria-current`, which could be the one with `aria-current=false` :)

Changing the selector to exclude false value takes care of this.

```diff
- subNavRef.current.querySelector('[aria-current]')
+ subNavRef.current.querySelector('[aria-current]:not([aria-current=false])')
```