### PR TITLE
fix(sx): support Primer colors for `border*Color` properties

### DIFF
--- a/.changeset/angry-boats-wash.md
+++ b/.changeset/angry-boats-wash.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+Include `border*Color` properties in sx to support named Primer colors
+
+<!-- Changed components: _none_ -->

--- a/src/sx.ts
+++ b/src/sx.ts
@@ -1,10 +1,12 @@
 import css, {SystemCssProperties, SystemStyleObject} from '@styled-system/css'
 import {ThemeColorPaths, ThemeShadowPaths} from './theme'
-import {ColorProps, ShadowProps} from 'styled-system'
+import {ColorProps, BorderColorProps, ShadowProps} from 'styled-system'
 import merge from 'deepmerge'
 
 export type BetterCssProperties = {
   [K in keyof SystemCssProperties]: K extends keyof ColorProps
+    ? ThemeColorPaths | SystemCssProperties[K]
+    : K extends keyof BorderColorProps
     ? ThemeColorPaths | SystemCssProperties[K]
     : K extends keyof ShadowProps
     ? ThemeShadowPaths | SystemCssProperties[K]


### PR DESCRIPTION
Closes #3618

### Screenshots

Before

![Screenshot of Box component code](https://github.com/primer/react/assets/39992/339934c4-4937-4c95-9c50-1e1d134e4050)

After

![Screenshot of Box component code](https://github.com/primer/react/assets/39992/a752e44c-c8e5-4abb-b694-3287265a1578)

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
