### PR TITLE
chore(build): update rollup config to ignore use client warnings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -119,6 +119,15 @@ const baseConfig = {
       // plugins are defined in postcss.config.js
     }),
   ],
+  onwarn(warning, defaultHandler) {
+    // Dependencies or modules may use "use client" as an indicator for React
+    // Server Components that this module should only be loaded on the client.
+    if (warning.code === 'MODULE_LEVEL_DIRECTIVE' && warning.message.includes('use client')) {
+      return
+    }
+
+    defaultHandler(warning)
+  },
 }
 
 export default [


### PR DESCRIPTION
Add an `onwarn` handler to our rollup config to ignore `'use client'` warnings that appear in our project dependencies. This approach seems to be mirrored in other ecosystems for this situation, the approach here was inspired by Vite.