### PR TITLE
ci: fix Add to inbox workflow

### DIFF
--- a/.github/workflows/add_to_inbox.yml
+++ b/.github/workflows/add_to_inbox.yml
@@ -27,7 +27,7 @@ jobs:
           gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
             mutation($project:ID!,$issue:ID!) {
               addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
-                projectNextItem {
+                item {
                   id
                 }
               }


### PR DESCRIPTION
resolves error

> Field 'projectNextItem' doesn't exist on type 'AddProjectV2ItemByIdPayload'

Example: https://github.com/primer/react/actions/runs/5871756061/job/15921876081#step:3:17

### Screenshots

n/a

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
