### PR TITLE
refactor(eslint): add pattern for importing from utils/ssr and move to useId

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -144,7 +144,13 @@ module.exports = {
                 message: 'Please use the `useId` hook from `src/hooks/useId.ts` instead',
               },
             ],
-            patterns: [],
+            patterns: [
+              {
+                group: ['**/utils/ssr'],
+                importNames: ['useSSRSafeId'],
+                message: 'Please use the `useId` hook from `src/hooks/useId.ts` instead',
+              },
+            ],
           },
         ],
       },

--- a/src/Autocomplete/AutocompleteMenu.tsx
+++ b/src/Autocomplete/AutocompleteMenu.tsx
@@ -6,7 +6,7 @@ import {useFocusZone} from '../hooks/useFocusZone'
 import {ComponentProps, MandateProps} from '../utils/types'
 import Box from '../Box'
 import Spinner from '../Spinner'
-import {useSSRSafeId} from '../utils/ssr'
+import {useId} from '../hooks/useId'
 import {AutocompleteContext} from './AutocompleteContext'
 import {PlusIcon} from '@primer/octicons-react'
 import VisuallyHidden from '../_VisuallyHidden'
@@ -146,7 +146,7 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
   const listContainerRef = useRef<HTMLDivElement>(null)
   const [highlightedItem, setHighlightedItem] = useState<T>()
   const [sortedItemIds, setSortedItemIds] = useState<Array<number | string>>(items.map(({id: itemId}) => itemId))
-  const generatedUniqueId = useSSRSafeId(id)
+  const generatedUniqueId = useId(id)
 
   const selectableItems = useMemo(
     () =>

--- a/src/FormControl/FormControl.tsx
+++ b/src/FormControl/FormControl.tsx
@@ -13,7 +13,7 @@ import {get} from '../constants'
 import InlineAutocomplete from '../drafts/InlineAutocomplete'
 import {useSlots} from '../hooks/useSlots'
 import {SxProp} from '../sx'
-import {useSSRSafeId} from '../utils/ssr'
+import {useId} from '../hooks/useId'
 import FormControlCaption from './_FormControlCaption'
 import FormControlLabel from './_FormControlLabel'
 import FormControlLeadingVisual from './_FormControlLeadingVisual'
@@ -67,7 +67,7 @@ const FormControl = React.forwardRef<HTMLDivElement, FormControlProps>(
     ]
     const choiceGroupContext = useContext(CheckboxOrRadioGroupContext)
     const disabled = choiceGroupContext.disabled || disabledProp
-    const id = useSSRSafeId(idProp)
+    const id = useId(idProp)
     const validationMessageId = slots.validation ? `${id}-validationMessage` : undefined
     const captionId = slots.caption ? `${id}-caption` : undefined
     const validationStatus = slots.validation?.props.variant

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,7 @@ export type {
 
 export {UnderlineNav as UnderlineNav2} from './UnderlineNav2'
 
+// eslint-disable-next-line no-restricted-imports
 export {SSRProvider, useSSRSafeId} from './utils/ssr'
 export {default as sx, merge} from './sx'
 export type {SxProp} from './sx'

--- a/src/internal/components/CheckboxOrRadioGroup/CheckboxOrRadioGroup.tsx
+++ b/src/internal/components/CheckboxOrRadioGroup/CheckboxOrRadioGroup.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import Box from '../../../Box'
 import ValidationAnimationContainer from '../ValidationAnimationContainer'
 import {get} from '../../../constants'
-import {useSSRSafeId} from '../../../utils/ssr'
+import {useId} from '../../../hooks/useId'
 import CheckboxOrRadioGroupCaption from './CheckboxOrRadioGroupCaption'
 import CheckboxOrRadioGroupLabel from './CheckboxOrRadioGroupLabel'
 import CheckboxOrRadioGroupValidation from './CheckboxOrRadioGroupValidation'
@@ -72,7 +72,7 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
   const captionChild = React.Children.toArray(children).find(child =>
     React.isValidElement(child) && child.type === CheckboxOrRadioGroupCaption ? child : null,
   )
-  const id = useSSRSafeId(idProp)
+  const id = useId(idProp)
   const validationMessageId = validationChild ? `${id}-validationMessage` : undefined
   const captionId = captionChild ? `${id}-caption` : undefined
 


### PR DESCRIPTION
Refactor usage of `useSSRSafeId` to `useId` and add an eslint rule to catch imports from `utils/ssr`

### Changelog

#### New

#### Changed

- Update eslint config to use a pattern for a restricted import rule for utils/ssr
- AutocompleteMenu now uses useId
- FormControl now uses useId
- CheckboxOrRadioGroup now uses useId

#### Removed