### PR TITLE
ci(vrt): update docker image for VRT to v1.37

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -51,7 +51,7 @@ jobs:
           echo "pid=$pid" >> $GITHUB_OUTPUT
           sleep 5
       - name: Run VRT
-        uses: docker://mcr.microsoft.com/playwright:v1.36.0-jammy
+        uses: docker://mcr.microsoft.com/playwright:v1.37.0-jammy
         env:
           STORYBOOK_URL: 'http://172.17.0.1:6006'
         with:


### PR DESCRIPTION
Update the docker image for the VRT workflow to use the currently installed version of playwright in the project.