### PR TITLE
refactor(types): update type exports to prevent missing exports warnings

### DIFF
--- a/.changeset/grumpy-maps-shave.md
+++ b/.changeset/grumpy-maps-shave.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+Update type exports to prevent missing export warnings
+
+<!-- Changed components: _none_ -->

--- a/src/Avatar/index.ts
+++ b/src/Avatar/index.ts
@@ -1,1 +1,2 @@
-export {default, AvatarProps} from './Avatar'
+export {default} from './Avatar'
+export type {AvatarProps} from './Avatar'

--- a/src/AvatarPair/index.ts
+++ b/src/AvatarPair/index.ts
@@ -1,1 +1,2 @@
-export {default, AvatarPairProps} from './AvatarPair'
+export {default} from './AvatarPair'
+export type {AvatarPairProps} from './AvatarPair'

--- a/src/AvatarStack/index.ts
+++ b/src/AvatarStack/index.ts
@@ -1,1 +1,2 @@
-export {default, AvatarStackProps} from './AvatarStack'
+export {default} from './AvatarStack'
+export type {AvatarStackProps} from './AvatarStack'

--- a/src/Blankslate/index.tsx
+++ b/src/Blankslate/index.tsx
@@ -1,1 +1,2 @@
-export {default as Blankslate, BlankslateProps} from './Blankslate'
+export {default as Blankslate} from './Blankslate'
+export type {BlankslateProps} from './Blankslate'

--- a/src/Box/index.ts
+++ b/src/Box/index.ts
@@ -1,1 +1,2 @@
-export {default, BoxProps} from './Box'
+export {default} from './Box'
+export type {BoxProps} from './Box'

--- a/src/BranchName/index.ts
+++ b/src/BranchName/index.ts
@@ -1,1 +1,2 @@
-export {default, BranchNameProps} from './BranchName'
+export {default} from './BranchName'
+export type {BranchNameProps} from './BranchName'

--- a/src/Breadcrumbs/index.ts
+++ b/src/Breadcrumbs/index.ts
@@ -1,8 +1,2 @@
-export {
-  default,
-  Breadcrumb,
-  BreadcrumbsProps,
-  BreadcrumbProps,
-  BreadcrumbsItemProps,
-  BreadcrumbItemProps,
-} from './Breadcrumbs'
+export {default, Breadcrumb} from './Breadcrumbs'
+export type {BreadcrumbsProps, BreadcrumbProps, BreadcrumbsItemProps, BreadcrumbItemProps} from './Breadcrumbs'

--- a/src/ButtonGroup/index.ts
+++ b/src/ButtonGroup/index.ts
@@ -1,1 +1,2 @@
-export {default, ButtonGroupProps} from './ButtonGroup'
+export {default} from './ButtonGroup'
+export type {ButtonGroupProps} from './ButtonGroup'

--- a/src/Checkbox/index.ts
+++ b/src/Checkbox/index.ts
@@ -1,1 +1,2 @@
-export {default, CheckboxProps} from './Checkbox'
+export {default} from './Checkbox'
+export type {CheckboxProps} from './Checkbox'

--- a/src/CircleBadge/index.ts
+++ b/src/CircleBadge/index.ts
@@ -1,1 +1,2 @@
-export {default, CircleBadgeProps, CircleBadgeIconProps} from './CircleBadge'
+export {default} from './CircleBadge'
+export type {CircleBadgeProps, CircleBadgeIconProps} from './CircleBadge'

--- a/src/CircleOcticon/index.ts
+++ b/src/CircleOcticon/index.ts
@@ -1,1 +1,2 @@
-export {default, CircleOcticonProps} from './CircleOcticon'
+export {default} from './CircleOcticon'
+export type {CircleOcticonProps} from './CircleOcticon'

--- a/src/CounterLabel/index.ts
+++ b/src/CounterLabel/index.ts
@@ -1,1 +1,2 @@
-export {default, CounterLabelProps} from './CounterLabel'
+export {default} from './CounterLabel'
+export type {CounterLabelProps} from './CounterLabel'

--- a/src/Details/index.ts
+++ b/src/Details/index.ts
@@ -1,1 +1,2 @@
-export {default, DetailsProps} from './Details'
+export {default} from './Details'
+export type {DetailsProps} from './Details'

--- a/src/FilterList/index.ts
+++ b/src/FilterList/index.ts
@@ -1,1 +1,2 @@
-export {default, FilterListProps, FilterListItemProps} from './FilterList'
+export {default} from './FilterList'
+export type {FilterListProps, FilterListItemProps} from './FilterList'

--- a/src/FilteredSearch/index.ts
+++ b/src/FilteredSearch/index.ts
@@ -1,1 +1,2 @@
-export {default, FilteredSearchProps} from './FilteredSearch'
+export {default} from './FilteredSearch'
+export type {FilteredSearchProps} from './FilteredSearch'

--- a/src/Flash/index.ts
+++ b/src/Flash/index.ts
@@ -1,1 +1,2 @@
-export {default, FlashProps} from './Flash'
+export {default} from './Flash'
+export type {FlashProps} from './Flash'

--- a/src/Header/index.ts
+++ b/src/Header/index.ts
@@ -1,1 +1,2 @@
-export {default, HeaderProps, HeaderItemProps, HeaderLinkProps} from './Header'
+export {default} from './Header'
+export type {HeaderProps, HeaderItemProps, HeaderLinkProps} from './Header'

--- a/src/Heading/index.ts
+++ b/src/Heading/index.ts
@@ -1,1 +1,2 @@
-export {default, HeadingProps} from './Heading'
+export {default} from './Heading'
+export type {HeadingProps} from './Heading'

--- a/src/LabelGroup/index.ts
+++ b/src/LabelGroup/index.ts
@@ -1,1 +1,2 @@
-export {default, LabelGroupProps} from './LabelGroup'
+export {default} from './LabelGroup'
+export type {LabelGroupProps} from './LabelGroup'

--- a/src/Link/index.ts
+++ b/src/Link/index.ts
@@ -1,1 +1,2 @@
-export {default, LinkProps} from './Link'
+export {default} from './Link'
+export type {LinkProps} from './Link'

--- a/src/Octicon/index.ts
+++ b/src/Octicon/index.ts
@@ -1,1 +1,2 @@
-export {default, OcticonProps} from './Octicon'
+export {default} from './Octicon'
+export type {OcticonProps} from './Octicon'

--- a/src/Overlay/index.ts
+++ b/src/Overlay/index.ts
@@ -1,1 +1,2 @@
-export {default, OverlayProps} from './Overlay'
+export {default} from './Overlay'
+export type {OverlayProps} from './Overlay'

--- a/src/Pagehead/index.ts
+++ b/src/Pagehead/index.ts
@@ -1,1 +1,2 @@
-export {default, PageheadProps} from './Pagehead'
+export {default} from './Pagehead'
+export type {PageheadProps} from './Pagehead'

--- a/src/PointerBox/index.ts
+++ b/src/PointerBox/index.ts
@@ -1,1 +1,2 @@
-export {default, PointerBoxProps} from './PointerBox'
+export {default} from './PointerBox'
+export type {PointerBoxProps} from './PointerBox'

--- a/src/Popover/index.ts
+++ b/src/Popover/index.ts
@@ -1,1 +1,2 @@
-export {default, PopoverProps, PopoverContentProps} from './Popover'
+export {default} from './Popover'
+export type {PopoverProps, PopoverContentProps} from './Popover'

--- a/src/Radio/index.ts
+++ b/src/Radio/index.ts
@@ -1,1 +1,2 @@
-export {default, RadioProps} from './Radio'
+export {default} from './Radio'
+export type {RadioProps} from './Radio'

--- a/src/Spinner/index.ts
+++ b/src/Spinner/index.ts
@@ -1,1 +1,2 @@
-export {default, SpinnerProps} from './Spinner'
+export {default} from './Spinner'
+export type {SpinnerProps} from './Spinner'

--- a/src/StateLabel/index.ts
+++ b/src/StateLabel/index.ts
@@ -1,1 +1,2 @@
-export {default, StateLabelProps} from './StateLabel'
+export {default} from './StateLabel'
+export type {StateLabelProps} from './StateLabel'

--- a/src/StyledOcticon/index.ts
+++ b/src/StyledOcticon/index.ts
@@ -1,1 +1,2 @@
-export {default, StyledOcticonProps} from './StyledOcticon'
+export {default} from './StyledOcticon'
+export type {StyledOcticonProps} from './StyledOcticon'

--- a/src/SubNav/index.ts
+++ b/src/SubNav/index.ts
@@ -1,1 +1,2 @@
-export {default, SubNavProps, SubNavLinkProps, SubNavLinksProps} from './SubNav'
+export {default} from './SubNav'
+export type {SubNavProps, SubNavLinkProps, SubNavLinksProps} from './SubNav'

--- a/src/TabNav/index.ts
+++ b/src/TabNav/index.ts
@@ -1,1 +1,2 @@
-export {default, TabNavProps, TabNavLinkProps} from './TabNav'
+export {default} from './TabNav'
+export type {TabNavProps, TabNavLinkProps} from './TabNav'

--- a/src/Text/index.ts
+++ b/src/Text/index.ts
@@ -1,1 +1,2 @@
-export {default, TextProps} from './Text'
+export {default} from './Text'
+export type {TextProps} from './Text'

--- a/src/TextInput/index.ts
+++ b/src/TextInput/index.ts
@@ -1,1 +1,2 @@
-export {default, TextInputProps, TextInputNonPassthroughProps} from './TextInput'
+export {default} from './TextInput'
+export type {TextInputProps, TextInputNonPassthroughProps} from './TextInput'

--- a/src/TextInputWithTokens/index.ts
+++ b/src/TextInputWithTokens/index.ts
@@ -1,1 +1,2 @@
-export {default, TextInputWithTokensProps} from './TextInputWithTokens'
+export {default} from './TextInputWithTokens'
+export type {TextInputWithTokensProps} from './TextInputWithTokens'

--- a/src/Textarea/index.ts
+++ b/src/Textarea/index.ts
@@ -1,1 +1,2 @@
-export {default, TextareaProps, DEFAULT_TEXTAREA_COLS, DEFAULT_TEXTAREA_RESIZE, DEFAULT_TEXTAREA_ROWS} from './Textarea'
+export {default, DEFAULT_TEXTAREA_COLS, DEFAULT_TEXTAREA_RESIZE, DEFAULT_TEXTAREA_ROWS} from './Textarea'
+export type {TextareaProps} from './Textarea'

--- a/src/Timeline/index.ts
+++ b/src/Timeline/index.ts
@@ -1,5 +1,5 @@
-export {
-  default,
+export {default} from './Timeline'
+export type {
   TimelineProps,
   TimelineItemsProps,
   TimelineBadgeProps,

--- a/src/ToggleSwitch/index.ts
+++ b/src/ToggleSwitch/index.ts
@@ -1,1 +1,2 @@
-export {default, ToggleSwitchProps} from './ToggleSwitch'
+export {default} from './ToggleSwitch'
+export type {ToggleSwitchProps} from './ToggleSwitch'

--- a/src/Truncate/index.ts
+++ b/src/Truncate/index.ts
@@ -1,1 +1,2 @@
-export {default, TruncateProps} from './Truncate'
+export {default} from './Truncate'
+export type {TruncateProps} from './Truncate'

--- a/src/UnderlineNav/index.ts
+++ b/src/UnderlineNav/index.ts
@@ -1,1 +1,2 @@
-export {default, UnderlineNavProps, UnderlineNavLinkProps} from './UnderlineNav'
+export {default} from './UnderlineNav'
+export type {UnderlineNavProps, UnderlineNavLinkProps} from './UnderlineNav'


### PR DESCRIPTION
We were getting missing import warnings in both Gatsby and in Webpack due to the way types were being exported in component entrypoints. This PR updates the way we export types to use the explicit `export type` syntax to avoid this missing export warning.