### PR TITLE
ci(vrt): update snapshots workflow to use create-github-app-token

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
Update our `update-snapshots` workflow to use the new `actions-create-github-app-token` action 🥳 Hopefully this is a drop-in replacement for the existing action 🤞 