### PR TITLE
Default stories for Page header do not link correctly.

### DIFF
--- a/src/PageHeader/PageHeader.docs.json
+++ b/src/PageHeader/PageHeader.docs.json
@@ -3,7 +3,11 @@
   "name": "PageHeader",
   "status": "draft",
   "a11yReviewed": false,
-  "stories": [],
+  "stories": [
+    {
+      "id": "drafts-components-pageheader--default"
+    }
+  ],
   "props": [
     {
       "name": "aria-label",


### PR DESCRIPTION
- Currently the default storybook stories for [pageheader](https://primer.style/design/components/page-header/react) do not link correctly.
- Added stories in `PageHeader.docs.json` so that it link the storybook stories correctly.
- Changes in docs so skipping changeset.

Closes #3669 