### PR TITLE
Remove `main` landmark from PageLayout.Content.

### DIFF
--- a/.changeset/angry-beds-itch.md
+++ b/.changeset/angry-beds-itch.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+PageLayout.Content no longer renders as `main` by default. Instead, developers may add a `main` landmark within `Pagelayout.Content` themselves.
+
+<!-- Changed components: PageLayout -->

--- a/src/PageLayout/PageLayout.test.tsx
+++ b/src/PageLayout/PageLayout.test.tsx
@@ -23,7 +23,9 @@ describe('PageLayout', () => {
       <ThemeProvider>
         <PageLayout>
           <PageLayout.Header>Header</PageLayout.Header>
-          <PageLayout.Content>Content</PageLayout.Content>
+          <PageLayout.Content>
+            <main aria-label="Content">Content</main>
+          </PageLayout.Content>
           <PageLayout.Pane>Pane</PageLayout.Pane>
           <PageLayout.Footer>Footer</PageLayout.Footer>
         </PageLayout>
@@ -131,7 +133,7 @@ describe('PageLayout', () => {
     )
 
     expect(screen.getByRole('banner')).toHaveAccessibleName('Header')
-    expect(screen.getByRole('main')).toHaveAccessibleName('Content')
+    expect(screen.getByLabelText('Content')).toHaveAccessibleName('Content')
     expect(screen.getByRole('contentinfo')).toHaveAccessibleName('Footer')
   })
 
@@ -154,7 +156,7 @@ describe('PageLayout', () => {
     )
 
     expect(screen.getByRole('banner')).toHaveAccessibleName('header')
-    expect(screen.getByRole('main')).toHaveAccessibleName('content')
+    expect(screen.getByLabelText('content')).toBeInTheDocument()
     expect(screen.getByRole('contentinfo')).toHaveAccessibleName('footer')
   })
 

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -421,7 +421,6 @@ const Content: React.FC<React.PropsWithChildren<PageLayoutContentProps>> = ({
 
   return (
     <Box
-      as="main"
       aria-label={label}
       aria-labelledby={labelledBy}
       sx={merge<BetterSystemStyleObject>(

--- a/src/PageLayout/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/PageLayout/__snapshots__/PageLayout.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`PageLayout renders condensed layout 1`] = `
       <div
         class="c5"
       >
-        <main
+        <div
           class="c6"
         >
           <div
@@ -213,7 +213,7 @@ exports[`PageLayout renders condensed layout 1`] = `
           <div
             class=""
           />
-        </main>
+        </div>
         <div
           class="c8"
         >
@@ -493,7 +493,7 @@ exports[`PageLayout renders default layout 1`] = `
       <div
         class="c5"
       >
-        <main
+        <div
           class="c6"
         >
           <div
@@ -502,12 +502,16 @@ exports[`PageLayout renders default layout 1`] = `
           <div
             class="c7"
           >
-            Content
+            <main
+              aria-label="Content"
+            >
+              Content
+            </main>
           </div>
           <div
             class=""
           />
-        </main>
+        </div>
         <div
           class="c8"
         >
@@ -787,7 +791,7 @@ exports[`PageLayout renders pane in different position when narrow 1`] = `
       <div
         class="c5"
       >
-        <main
+        <div
           class="c6"
         >
           <div
@@ -801,7 +805,7 @@ exports[`PageLayout renders pane in different position when narrow 1`] = `
           <div
             class=""
           />
-        </main>
+        </div>
         <div
           class="c8"
         >
@@ -1081,7 +1085,7 @@ exports[`PageLayout renders with dividers 1`] = `
       <div
         class="c5"
       >
-        <main
+        <div
           class="c6"
         >
           <div
@@ -1095,7 +1099,7 @@ exports[`PageLayout renders with dividers 1`] = `
           <div
             class=""
           />
-        </main>
+        </div>
         <div
           class="c8"
         >

--- a/src/SplitPageLayout/__snapshots__/SplitPageLayout.test.tsx.snap
+++ b/src/SplitPageLayout/__snapshots__/SplitPageLayout.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`SplitPageLayout renders default layout 1`] = `
       <div
         class="c5"
       >
-        <main
+        <div
           class="c6"
         >
           <div
@@ -248,7 +248,7 @@ exports[`SplitPageLayout renders default layout 1`] = `
           <div
             class=""
           />
-        </main>
+        </div>
         <div
           class="c8"
         >


### PR DESCRIPTION
Reintroducing these changes which were introduced in https://github.com/primer/react/pull/3154, but were reverted.

Closes https://github.com/github/primer/issues/1586

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [X] Added/updated tests
- [X] Added/updated documentation
- [X] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [X] Tested in Chrome
- [X] Tested in Firefox
- [X] Tested in Safari
- [X] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
