### PR TITLE
Fix duplicate heading to resolve duplicate IDs

### DIFF
--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -318,7 +318,7 @@ Each component may be labeled through either `aria-label` or `aria-labelledby` i
 - [WCAG, ARIA11 Technique](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA11)
 - [MDN, Landmark roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role)
 
-### `PageLayout.Pane`
+### `PageLayout.Pane` as landmark
 
 The `PageLayout.Pane` component does not provide a default landmark role as the
 content of this component may have different roles. When using this component,


### PR DESCRIPTION
Closes #2926

### Screenshots

`PageLayout.Pane` was a heading used more than once on a single page. In order to avoid conflict between identical `id`s generated for each of these sections, I updated one of the section headings to be more specific. No other visual changes.

### Merge checklist

- [x] Added/updated documentation
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
