### PR TITLE
generate default story id based on the component status

### DIFF
--- a/script/components-json/build.ts
+++ b/script/components-json/build.ts
@@ -14,6 +14,7 @@ import outputSchema from './output.schema.json'
 // Only includes fields we use in this script
 type Component = {
   name: string
+  status: 'draft' | 'experimental' | 'alpha' | 'beta' | 'stable' | 'deprecated'
   stories: Array<{id: string; code?: string}>
 }
 
@@ -37,8 +38,17 @@ const components = docsFiles.map(docsFilepath => {
   // Example: src/components/Box/Box.docs.json -> src/components/Box/Box.stories.tsx
   const defaultStoryFilepath = docsFilepath.replace(/\.docs\.json$/, '.stories.tsx')
 
+  // Get the story name prefix for the default story id
+  const storyPrefix = {
+    draft: 'draft-',
+    experimental: 'experimental-',
+    deprecated: 'deprecated-',
+    alpha: '',
+    beta: '',
+    stable: '',
+  }
   // Get the default story id
-  const defaultStoryId = `components-${String(docs.name).toLowerCase()}--default`
+  const defaultStoryId = `${storyPrefix[docs.status]}components-${String(docs.name).toLowerCase()}--default`
 
   // Get source code for default story
   const {Default: defaultStoryCode} = getStorySourceCode(defaultStoryFilepath)


### PR DESCRIPTION
[BlankSlate](https://primer.style/design/components/blankslate/react) and [PageHeader](https://primer.style/design/components/page-header/react) component stories are broken in https://primer.style/design because the default stories are always rendered as `components-<componentname>--default` and doesn't take component status into account. For draft components, our default story id is `draft-components-<componentname>--default`. This PR adds this logic into it.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
