### PR TITLE
Jdrush89/fix dialog escape

### DIFF
--- a/.changeset/long-walls-sparkle.md
+++ b/.changeset/long-walls-sparkle.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+Fix dialog bug where escape would move focus when dialog was closed
+
+<!-- Changed components: _none_ -->

--- a/src/__tests__/Dialog.test.tsx
+++ b/src/__tests__/Dialog.test.tsx
@@ -137,4 +137,15 @@ describe('Dialog', () => {
     const triggerButton = getByTestId('trigger-button')
     expect(document.activeElement).toEqual(triggerButton)
   })
+
+  it('Returns focus to returnFocusRef on escape', async () => {
+    const {getByTestId, queryByTestId} = HTMLRender(<Component />)
+
+    expect(getByTestId('inner')).toBeTruthy()
+    fireEvent.keyDown(document.body, {key: 'Escape'})
+
+    expect(queryByTestId('inner')).toBeNull()
+    const triggerButton = getByTestId('trigger-button')
+    expect(document.activeElement).toEqual(triggerButton)
+  })
 })

--- a/src/hooks/useDialog.ts
+++ b/src/hooks/useDialog.ts
@@ -115,10 +115,12 @@ function useDialog({
 
   useOnEscapePress(
     (event: KeyboardEvent) => {
-      onDismiss()
-      event.preventDefault()
+      if (isOpen) {
+        onDismiss()
+        event.preventDefault()
+      }
     },
-    [onDismiss],
+    [isOpen, onDismiss],
   )
 
   return {getDialogProps}


### PR DESCRIPTION
Having a dialog on the page would register the escape handler which would not only preventDefault on the escape key presses, but also move focus when the dialog was closed. Adding a check before doing this to make sure a dialog is actually open.

Closes #3686 

### Screenshots

N/A

### Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation
- [X] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [X] Tested in Chrome
- [X] Tested in Firefox
- [X] Tested in Safari
- [X] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
