### PR TITLE
chore(dependencies): Upgrade `@primer/octicons-react` to v19.7.0

### DIFF
--- a/.changeset/lazy-bees-train.md
+++ b/.changeset/lazy-bees-train.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': minor
+---
+
+Octicons: Upgrade react-octicons to v19.7.0
+
+<!-- Changed components: _none_ -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@github/relative-time-element": "^4.1.2",
         "@lit-labs/react": "^2.0.1",
         "@primer/behaviors": "^1.3.4",
-        "@primer/octicons-react": "^19.3.0",
+        "@primer/octicons-react": "^19.7.0",
         "@primer/primitives": "^7.11.11",
         "@react-aria/ssr": "^3.5.0",
         "@styled-system/css": "^5.1.5",
@@ -6038,9 +6038,9 @@
       }
     },
     "node_modules/@primer/octicons-react": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.3.0.tgz",
-      "integrity": "sha512-LCCer1Roc5WGYy5FZcByniuUOJKla7i+9TaPeL95G+KIXhisuyWbTIy5DbiW/EWYMWvfCUQe6u71zZKVNeHjyg==",
+      "version": "19.7.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.7.0.tgz",
+      "integrity": "sha512-KzB7P+Ew3ud/ua61tQFkTvdS2aIfKUMsT/uHUCvIzfHTcB49xD1MIoQLAwoshiEH4M+aLLGFNCLfBC/xTIH8vw==",
       "engines": {
         "node": ">=8"
       },

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@github/relative-time-element": "^4.1.2",
     "@lit-labs/react": "^2.0.1",
     "@primer/behaviors": "^1.3.4",
-    "@primer/octicons-react": "^19.3.0",
+    "@primer/octicons-react": "^19.7.0",
     "@primer/primitives": "^7.11.11",
     "@react-aria/ssr": "^3.5.0",
     "@styled-system/css": "^5.1.5",


### PR DESCRIPTION
Updates the `@primer/octicons-react` to v19.7.0

Changelog since the last upgrade:
- [v19.7.0](https://github.com/primer/octicons/releases/tag/v19.7.0)
- [v19.6.0](https://github.com/primer/octicons/releases/tag/v19.6.0)
- [v19.5.0](https://github.com/primer/octicons/releases/tag/v19.5.0)
- [v19.4.0](https://github.com/primer/octicons/releases/tag/v19.4.0)




### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
