### PR TITLE
Revert "chore(deps): bump @lit-labs/react from 1.1.1 to 2.0.1 (#3652)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@github/markdown-toolbar-element": "^2.1.0",
         "@github/paste-markdown": "^1.4.0",
         "@github/relative-time-element": "^4.1.2",
-        "@lit-labs/react": "^2.0.1",
+        "@lit-labs/react": "^1.1.1",
         "@primer/behaviors": "^1.3.4",
         "@primer/octicons-react": "^19.7.0",
         "@primer/primitives": "^7.11.11",
@@ -5729,12 +5729,9 @@
       "dev": true
     },
     "node_modules/@lit-labs/react": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-2.0.1.tgz",
-      "integrity": "sha512-Nj+XB3HamqaWefN91lpFPJaqjJ78XzGkPWCedB4jyH22GBFEenpE9A/h8B/2dnIGXtNtd9D/RFpUdQ/dBtWFqA==",
-      "peerDependencies": {
-        "@types/react": "17 || 18"
-      }
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA=="
     },
     "node_modules/@manypkg/find-root": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@github/markdown-toolbar-element": "^2.1.0",
     "@github/paste-markdown": "^1.4.0",
     "@github/relative-time-element": "^4.1.2",
-    "@lit-labs/react": "^2.0.1",
+    "@lit-labs/react": "^1.1.1",
     "@primer/behaviors": "^1.3.4",
     "@primer/octicons-react": "^19.7.0",
     "@primer/primitives": "^7.11.11",

--- a/src/RelativeTime/RelativeTime.tsx
+++ b/src/RelativeTime/RelativeTime.tsx
@@ -5,13 +5,7 @@ import {createComponent} from '@lit-labs/react'
 import {ComponentProps} from '../utils/types'
 import sx from '../sx'
 
-const RelativeTime = styled(
-  createComponent({
-    react: React,
-    tagName: 'relative-time',
-    elementClass: RelativeTimeElement,
-  }),
-)(sx)
+const RelativeTime = styled(createComponent(React, 'relative-time', RelativeTimeElement))(sx)
 
 export type RelativeTimeProps = ComponentProps<typeof RelativeTime>
 export default RelativeTime

--- a/src/__tests__/__snapshots__/RelativeTime.test.tsx.snap
+++ b/src/__tests__/__snapshots__/RelativeTime.test.tsx.snap
@@ -3,6 +3,5 @@
 exports[`RelativeTime renders consistently 1`] = `
 <relative-time
   class=""
-  suppressHydrationWarning={true}
 />
 `;


### PR DESCRIPTION
This reverts commit 440829c0a8d450c20075b5e8da32b3ed1e359271.

This change unfortunately impacts anyone who uses the `lib` entrypoint as we compile the `@lit-labs/react` package into a CommonJS format which collapses the `exports` field in that package's `package.json` file.

This file is important because it specifies which entrypoints to use for the browser versus node. When that information is lost, it will attempt to run the code intended for the browser in a Node.js environment which causes errors like `useLayoutEffect`.

I'm unsure how to best address this so wanted to roll back and then come back with a plan for this work.