### PR TITLE
feat(npm): move deprecated components in v36 to deprecated

### DIFF
--- a/.changeset/tough-pillows-glow.md
+++ b/.changeset/tough-pillows-glow.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': minor
+---
+
+The UnderlineNav, FilterList, and FilteredSearch components will be deprecated in v36 and have been moved to the deprecated entrypoint. To use the new UnderlineNav, migrate to the component available in drafts.
+
+<!-- Changed components: FilterList, FilteredSearch, UnderlineNav -->

--- a/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -117,6 +117,8 @@ exports[`@primer/react/decprecated should not update exports without a semver ch
   "Dropdown",
   "DropdownButton",
   "DropdownMenu",
+  "FilterList",
+  "FilteredSearch",
   "Fixed",
   "Flex",
   "FormGroup",
@@ -128,6 +130,7 @@ exports[`@primer/react/decprecated should not update exports without a semver ch
   "Relative",
   "SelectMenu",
   "Sticky",
+  "UnderlineNav",
 ]
 `;
 

--- a/src/deprecated/index.ts
+++ b/src/deprecated/index.ts
@@ -72,3 +72,11 @@ export type {
   ButtonCloseProps,
 } from './Button'
 // end of v35.0.0
+
+// Deprecated in v36
+export {default as FilterList} from '../FilterList'
+export type {FilterListProps, FilterListItemProps} from '../FilterList'
+export {default as FilteredSearch} from '../FilteredSearch'
+export type {FilteredSearchProps} from '../FilteredSearch'
+export {default as UnderlineNav} from '../UnderlineNav'
+export type {UnderlineNavProps, UnderlineNavLinkProps} from '../UnderlineNav'


### PR DESCRIPTION
Part of: https://github.com/github/primer/issues/2628

Add components deprecated for v35 to deprecated entrypoint in v35 so that we can migrate teams before the v36 release.