### PR TITLE
Honor `disableExpand` on right-aligned avatar stacks

### DIFF
--- a/src/AvatarStack/AvatarStack.tsx
+++ b/src/AvatarStack/AvatarStack.tsx
@@ -116,7 +116,7 @@ const AvatarStackWrapper = styled.span<StyledAvatarStackWrapperProps>`
     .pc-AvatarStackBody {
       flex-direction: row-reverse;
 
-      &:hover {
+      &:not(.pc-AvatarStack--disableExpand):hover {
         .pc-AvatarItem {
           margin-right: ${get('space.1')}!important;
           margin-left: 0 !important;


### PR DESCRIPTION
Adding the `.pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover` rule on the right-aligned stacks. The snapshot tests are correct! The `:not` check was missing for this one case in the component.

### Screenshots

Please provide before/after screenshots for any visual changes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
