### PR TITLE
fix(PageLayout): restore main landmark

### DIFF
--- a/.changeset/friendly-shirts-protect.md
+++ b/.changeset/friendly-shirts-protect.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+Restore default main landmark in PageLayout.Content
+
+<!-- Changed components: PageLayout, SplitPageLayout -->

--- a/src/PageLayout/PageLayout.test.tsx
+++ b/src/PageLayout/PageLayout.test.tsx
@@ -23,9 +23,7 @@ describe('PageLayout', () => {
       <ThemeProvider>
         <PageLayout>
           <PageLayout.Header>Header</PageLayout.Header>
-          <PageLayout.Content>
-            <main aria-label="Content">Content</main>
-          </PageLayout.Content>
+          <PageLayout.Content>Content</PageLayout.Content>
           <PageLayout.Pane>Pane</PageLayout.Pane>
           <PageLayout.Footer>Footer</PageLayout.Footer>
         </PageLayout>
@@ -133,7 +131,7 @@ describe('PageLayout', () => {
     )
 
     expect(screen.getByRole('banner')).toHaveAccessibleName('Header')
-    expect(screen.getByLabelText('Content')).toHaveAccessibleName('Content')
+    expect(screen.getByRole('main')).toHaveAccessibleName('Content')
     expect(screen.getByRole('contentinfo')).toHaveAccessibleName('Footer')
   })
 
@@ -156,7 +154,7 @@ describe('PageLayout', () => {
     )
 
     expect(screen.getByRole('banner')).toHaveAccessibleName('header')
-    expect(screen.getByLabelText('content')).toBeInTheDocument()
+    expect(screen.getByRole('main')).toHaveAccessibleName('content')
     expect(screen.getByRole('contentinfo')).toHaveAccessibleName('footer')
   })
 
@@ -200,6 +198,17 @@ describe('PageLayout', () => {
       fireEvent.mouseUp(divider)
       const finalWidth = (pane as HTMLElement).style.getPropertyValue('--pane-width')
       expect(finalWidth).not.toEqual(initialWidth)
+    })
+  })
+
+  describe('PageLayout.Content', () => {
+    it('should support a custom element type with the `as` prop', () => {
+      const {container} = render(
+        <PageLayout.Content as="div">
+          <main>Content</main>
+        </PageLayout.Content>,
+      )
+      expect(container.firstChild?.nodeName).toEqual('DIV')
     })
   })
 })

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -386,6 +386,12 @@ Header.displayName = 'PageLayout.Header'
 
 export type PageLayoutContentProps = {
   /**
+   * Provide an optional element type for the outermost element rendered by the component.
+   * @default 'main'
+   */
+  as?: React.ElementType
+
+  /**
    * A unique label for the rendered main landmark
    */
   'aria-label'?: React.AriaAttributes['aria-label']
@@ -408,6 +414,7 @@ const contentWidths = {
 }
 
 const Content: React.FC<React.PropsWithChildren<PageLayoutContentProps>> = ({
+  as = 'main',
   'aria-label': label,
   'aria-labelledby': labelledBy,
   width = 'full',
@@ -421,6 +428,7 @@ const Content: React.FC<React.PropsWithChildren<PageLayoutContentProps>> = ({
 
   return (
     <Box
+      as={as}
       aria-label={label}
       aria-labelledby={labelledBy}
       sx={merge<BetterSystemStyleObject>(

--- a/src/PageLayout/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/PageLayout/__snapshots__/PageLayout.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`PageLayout renders condensed layout 1`] = `
       <div
         class="c5"
       >
-        <div
+        <main
           class="c6"
         >
           <div
@@ -213,7 +213,7 @@ exports[`PageLayout renders condensed layout 1`] = `
           <div
             class=""
           />
-        </div>
+        </main>
         <div
           class="c8"
         >
@@ -493,7 +493,7 @@ exports[`PageLayout renders default layout 1`] = `
       <div
         class="c5"
       >
-        <div
+        <main
           class="c6"
         >
           <div
@@ -502,16 +502,12 @@ exports[`PageLayout renders default layout 1`] = `
           <div
             class="c7"
           >
-            <main
-              aria-label="Content"
-            >
-              Content
-            </main>
+            Content
           </div>
           <div
             class=""
           />
-        </div>
+        </main>
         <div
           class="c8"
         >
@@ -791,7 +787,7 @@ exports[`PageLayout renders pane in different position when narrow 1`] = `
       <div
         class="c5"
       >
-        <div
+        <main
           class="c6"
         >
           <div
@@ -805,7 +801,7 @@ exports[`PageLayout renders pane in different position when narrow 1`] = `
           <div
             class=""
           />
-        </div>
+        </main>
         <div
           class="c8"
         >
@@ -1085,7 +1081,7 @@ exports[`PageLayout renders with dividers 1`] = `
       <div
         class="c5"
       >
-        <div
+        <main
           class="c6"
         >
           <div
@@ -1099,7 +1095,7 @@ exports[`PageLayout renders with dividers 1`] = `
           <div
             class=""
           />
-        </div>
+        </main>
         <div
           class="c8"
         >

--- a/src/SplitPageLayout/__snapshots__/SplitPageLayout.test.tsx.snap
+++ b/src/SplitPageLayout/__snapshots__/SplitPageLayout.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`SplitPageLayout renders default layout 1`] = `
       <div
         class="c5"
       >
-        <div
+        <main
           class="c6"
         >
           <div
@@ -248,7 +248,7 @@ exports[`SplitPageLayout renders default layout 1`] = `
           <div
             class=""
           />
-        </div>
+        </main>
         <div
           class="c8"
         >


### PR DESCRIPTION
Follow-up to: https://github.com/primer/react/pull/3675

Currently, we have teams in a couple of situations where either:

- A team makes use of a `main` landmark and therefore runs into the duplicate landmark violation
- A team uses the default `main` landmark from `PageLayout.Content`

When removing the `main` landmark, teams in the latter are impacted. In this PR, we introduce an `as` prop to allow for teams in the first example to change the semantics of this component to `as="div"` as they already have a `main` defined.

## Rollout

This is an incremental rollout strategy if our ideal here is to remove `main` as a landmark from `PageLayout.Content`. With this path, we could swap teams to use `as="div"` before removing the `main` support and also dropping `as="div"`