### PR TITLE
SelectPanel2: Make room for custom elements in Header

### DIFF
--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -503,7 +503,7 @@ export const TODO4WithFilterButtons = () => {
     }
   }
 
-  const [selectedTab, setSelectedTab] = React.useState<'branches' | 'tags'>('branches')
+  const [selectedFilter, setSelectedFilter] = React.useState<'branches' | 'tags'>('branches')
 
   const onLabelSelect = (labelId: string) => {
     if (!selectedLabelIds.includes(labelId)) setSelectedLabelIds([...selectedLabelIds, labelId])
@@ -553,15 +553,15 @@ export const TODO4WithFilterButtons = () => {
           <Box id="filters" sx={{display: 'flex'}}>
             <Button
               variant="invisible"
-              sx={{fontWeight: selectedTab === 'tags' ? 'semibold' : 'normal', color: 'fg.default'}}
-              onClick={() => setSelectedTab('branches')}
+              sx={{fontWeight: selectedFilter === 'tags' ? 'semibold' : 'normal', color: 'fg.default'}}
+              onClick={() => setSelectedFilter('branches')}
             >
               Branches <Button.Counter>{20}</Button.Counter>
             </Button>
             <Button
               variant="invisible"
-              sx={{fontWeight: selectedTab === 'tags' ? 'semibold' : 'normal', color: 'fg.default'}}
-              onClick={() => setSelectedTab('tags')}
+              sx={{fontWeight: selectedFilter === 'tags' ? 'semibold' : 'normal', color: 'fg.default'}}
+              onClick={() => setSelectedFilter('tags')}
             >
               Tags <Button.Counter>{8}</Button.Counter>
             </Button>
@@ -587,16 +587,16 @@ export const TODO4WithFilterButtons = () => {
             )
           ) : (
             <>
-              {data[selectedTab].sort(sortingFn).map(branch => {
+              {data[selectedFilter].sort(sortingFn).map(item => {
                 return (
                   <>
                     <ActionList.Item
-                      key={branch.id}
-                      onSelect={() => onLabelSelect(branch.id)}
-                      selected={selectedLabelIds.includes(branch.id)}
+                      key={item.id}
+                      onSelect={() => onLabelSelect(item.id)}
+                      selected={selectedLabelIds.includes(item.id)}
                     >
-                      {branch.name}
-                      <ActionList.TrailingVisual>{branch.trailingInfo}</ActionList.TrailingVisual>
+                      {item.name}
+                      <ActionList.TrailingVisual>{item.trailingInfo}</ActionList.TrailingVisual>
                     </ActionList.Item>
                   </>
                 )

--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -530,7 +530,7 @@ export const TODO4WithFilterButtons = () => {
 
   return (
     <>
-      <h1>With Filter Buttons in Header</h1>
+      <h1>With Filter Buttons</h1>
 
       <SelectPanel
         defaultOpen

--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {SelectPanel} from './SelectPanel'
-import {ActionList, Avatar, Box} from '../../../src/index'
+import {ActionList, Avatar, Box, Button} from '../../../src/index'
+import {GitBranchIcon, TriangleDownIcon} from '@primer/octicons-react'
 import data from './mock-data'
 
 const getCircle = (color: string) => (
@@ -467,6 +468,149 @@ export const TODO3NoCustomisation = () => {
     <>
       <h1>TODO: Without any customisation</h1>
       <p>Address after TODO: Uncontrolled</p>
+    </>
+  )
+}
+
+export const TODO4WithFilterButtons = () => {
+  const [filteredLabels, setFilteredLabels] = React.useState(data.branches)
+
+  const initialSelectedLabels: string[] = ['main']
+
+  // TODO: Single selection doesn't need an array
+  const [selectedLabelIds, setSelectedLabelIds] = React.useState<string[]>(initialSelectedLabels)
+
+  const [query, setQuery] = React.useState('')
+
+  const onSearchInputChange = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const query = event.currentTarget.value
+    setQuery(query)
+
+    if (query === '') setFilteredLabels(data.labels)
+    else {
+      // TODO: should probably add a highlight for matching text
+      setFilteredLabels(
+        data.labels
+          .map(label => {
+            if (label.name.toLowerCase().startsWith(query)) return {priority: 1, label}
+            else if (label.name.toLowerCase().includes(query)) return {priority: 2, label}
+            else if (label.description?.toLowerCase().includes(query)) return {priority: 3, label}
+            else return {priority: -1, label}
+          })
+          .filter(result => result.priority > 0)
+          .map(result => result.label),
+      )
+    }
+  }
+
+  const [selectedTab, setSelectedTab] = React.useState<'branches' | 'tags'>('branches')
+
+  const onLabelSelect = (labelId: string) => {
+    if (!selectedLabelIds.includes(labelId)) setSelectedLabelIds([...selectedLabelIds, labelId])
+    else setSelectedLabelIds(selectedLabelIds.filter(id => id !== labelId))
+  }
+
+  const onSubmit = (event: {preventDefault: () => void}) => {
+    event.preventDefault() // coz form submit, innit
+    data.issue.labelIds = selectedLabelIds // pretending to persist changes
+
+    // eslint-disable-next-line no-console
+    console.log('form submitted')
+  }
+
+  const sortingFn = (branchA: {id: string}, branchB: {id: string}) => {
+    /* Important! This sorting is only for initial selected ids, not for subsequent changes!
+      deterministic sorting for better UX: don't change positions with other selected items.
+    */
+    if (selectedLabelIds.includes(branchA.id) && selectedLabelIds.includes(branchB.id)) return 1
+    else if (selectedLabelIds.includes(branchA.id)) return -1
+    else if (selectedLabelIds.includes(branchB.id)) return 1
+    else return 1
+  }
+
+  return (
+    <>
+      <h1>With Filter Buttons in Header</h1>
+
+      <SelectPanel
+        defaultOpen
+        onSubmit={onSubmit}
+        onCancel={() => {
+          // eslint-disable-next-line no-console
+          console.log('panel was closed')
+        }}
+      >
+        {/* TODO: the ref types don't match here, use useProvidedRefOrCreate */}
+        {/* @ts-ignore todo */}
+        <SelectPanel.Button leadingIcon={GitBranchIcon} trailingIcon={TriangleDownIcon}>
+          main
+        </SelectPanel.Button>
+
+        <SelectPanel.Header>
+          <SelectPanel.Heading>Switch branches/tags</SelectPanel.Heading>
+          <SelectPanel.SearchInput onChange={onSearchInputChange} sx={{marginBottom: 2}} />
+
+          <Box id="filters" sx={{display: 'flex'}}>
+            <Button
+              variant="invisible"
+              sx={{fontWeight: selectedTab === 'tags' ? 'semibold' : 'normal', color: 'fg.default'}}
+              onClick={() => setSelectedTab('branches')}
+            >
+              Branches <Button.Counter>{20}</Button.Counter>
+            </Button>
+            <Button
+              variant="invisible"
+              sx={{fontWeight: selectedTab === 'tags' ? 'semibold' : 'normal', color: 'fg.default'}}
+              onClick={() => setSelectedTab('tags')}
+            >
+              Tags <Button.Counter>{8}</Button.Counter>
+            </Button>
+          </Box>
+        </SelectPanel.Header>
+
+        <SelectPanel.ActionList selectionVariant="single">
+          {/* slightly different view for search results view and list view */}
+          {query ? (
+            filteredLabels.length > 1 ? (
+              filteredLabels.map(label => (
+                <ActionList.Item
+                  key={label.id}
+                  onSelect={() => onLabelSelect(label.id)}
+                  selected={selectedLabelIds.includes(label.id)}
+                >
+                  {label.name}
+                  <ActionList.TrailingVisual>{label.trailingInfo}</ActionList.TrailingVisual>
+                </ActionList.Item>
+              ))
+            ) : (
+              <SelectPanel.EmptyMessage>No labels found for &quot;{query}&quot;</SelectPanel.EmptyMessage>
+            )
+          ) : (
+            <>
+              {data[selectedTab].sort(sortingFn).map(branch => {
+                return (
+                  <>
+                    <ActionList.Item
+                      key={branch.id}
+                      onSelect={() => onLabelSelect(branch.id)}
+                      selected={selectedLabelIds.includes(branch.id)}
+                    >
+                      {branch.name}
+                      <ActionList.TrailingVisual>{branch.trailingInfo}</ActionList.TrailingVisual>
+                    </ActionList.Item>
+                  </>
+                )
+              })}
+            </>
+          )}
+        </SelectPanel.ActionList>
+        <SelectPanel.Footer>
+          {/* TODO: Can't disable Cancel and Save yet */}
+          <SelectPanel.SecondaryButton as="a" href="/branches">
+            See all branches
+          </SelectPanel.SecondaryButton>
+        </SelectPanel.Footer>
+      </SelectPanel>
     </>
   )
 }

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -12,6 +12,7 @@ import {
   TextInput,
   AnchoredOverlayProps,
   ActionList,
+  ActionListProps,
   Spinner,
   Text,
 } from '../../../src/index'
@@ -192,8 +193,7 @@ const SelectPanelSearchInput = props => {
 }
 SelectPanel.SearchInput = SelectPanelSearchInput
 
-// TODO: type this with ActionList props
-const SelectPanelActionList: React.FC<React.PropsWithChildren> = props => {
+const SelectPanelActionList: React.FC<React.PropsWithChildren<ActionListProps>> = props => {
   /* features to implement for uncontrolled:
      1. select
      2. sort

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -103,7 +103,7 @@ const SelectPanelButton = React.forwardRef((props, anchorRef) => {
 SelectPanel.Button = SelectPanelButton
 
 const SelectPanelHeader: React.FC<React.PropsWithChildren> = ({children, ...props}) => {
-  const [slots] = useSlots(children, {
+  const [slots, childrenWithoutSlots] = useSlots(children, {
     heading: SelectPanelHeading,
     searchInput: SelectPanelSearchInput,
   })
@@ -125,6 +125,7 @@ const SelectPanelHeader: React.FC<React.PropsWithChildren> = ({children, ...prop
         </Box>
       </Box>
       {slots.searchInput}
+      {childrenWithoutSlots}
     </Box>
   )
 }

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -19,9 +19,14 @@ import {
 import {useSlots} from '../../hooks/useSlots'
 import {ClearIcon} from './tmp-ClearIcon'
 
-const SelectPanelContext = React.createContext({
+const SelectPanelContext = React.createContext<{
+  onCancel: () => void
+  onClearSelection: undefined | (() => void)
+  searchQuery: string
+  setSearchQuery: () => void
+}>({
   onCancel: () => {},
-  onClearSelection: () => {},
+  onClearSelection: undefined,
   searchQuery: '',
   setSearchQuery: () => {},
 })
@@ -82,7 +87,7 @@ const SelectPanel = props => {
         <SelectPanelContext.Provider
           value={{
             onCancel: onInternalClose,
-            onClearSelection: onInternalClearSelection,
+            onClearSelection: props.onClearSelection ? onInternalClearSelection : undefined,
             searchQuery,
             // @ts-ignore todo
             setSearchQuery,
@@ -117,9 +122,11 @@ const SelectPanelHeader: React.FC<React.PropsWithChildren> = ({children, ...prop
         {slots.heading}
         <Box>
           {/* Will not need tooltip after https://github.com/primer/react/issues/2008 */}
-          <Tooltip text="Clear selection" direction="s" onClick={onClearSelection}>
-            <IconButton type="button" variant="invisible" icon={ClearIcon} aria-label="Clear selection" />
-          </Tooltip>
+          {onClearSelection ? (
+            <Tooltip text="Clear selection" direction="s" onClick={onClearSelection}>
+              <IconButton type="button" variant="invisible" icon={ClearIcon} aria-label="Clear selection" />
+            </Tooltip>
+          ) : null}
           <Tooltip text="Close" direction="s">
             <IconButton type="button" variant="invisible" icon={XIcon} aria-label="Close" onClick={() => onCancel()} />
           </Tooltip>

--- a/src/drafts/SelectPanel2/mock-data.ts
+++ b/src/drafts/SelectPanel2/mock-data.ts
@@ -909,6 +909,27 @@ const data = {
       login: 'tylerjohnst',
     },
   ],
+  branches: [
+    {id: 'main', name: 'main', trailingInfo: 'Default'},
+    {id: 'b', name: 'next-major'},
+    {id: 'c', name: 'changeset-release/main'},
+    {id: 'd', name: 'changeset-release/next-major'},
+    {id: 'e', name: 'selectpanel-2'},
+    {id: 'f', name: 'bs/actionlist-heading'},
+    {id: 'g', name: 'refactor/support-alt-names'},
+    {id: 'h', name: 'fix/update-action-list'},
+    {id: 'i', name: 'dependabot/markdownlint-github-0.4.1'},
+  ],
+  tags: [
+    {id: 'a', name: 'v35.29.0', trailingInfo: 'Latest'},
+    {id: 'b', name: 'v35.28.0'},
+    {id: 'c', name: 'v35.27.1'},
+    {id: 'd', name: 'v35.27.0'},
+    {id: 'e', name: 'v35.26.1'},
+    {id: 'f', name: 'v35.26.0'},
+    {id: 'g', name: 'v35.0.0'},
+    {id: 'h', name: 'v34.0.0'},
+  ],
 }
 
 export default data

--- a/src/drafts/SelectPanel2/work-log.md
+++ b/src/drafts/SelectPanel2/work-log.md
@@ -32,6 +32,7 @@
 1. where do you say `selectionVariant="single"` on the ActionList or on SelectPanel? what all does it change? should we not use ActionMenu for that anymore?
 1. when you do not add a `<SelectPanel.Footer>`, should we add it for you? 😈 = it's present by default, you can only choose to modify the secondary action
 1. Can we automate empty message? We do need some information from the context, so maybe not entirely. Can we add a default that can be customised.
+1. Checkbox in secondary action, should secondary action be an open slot?
 
 ## Implementation notes
 
@@ -43,3 +44,4 @@
 1. SelectPanel.Overlay
 1. The flicker in story with useTransition is unfortunate, is there already a way to add a minimum time to avoid this (debounce)? and is it possible/ergonomic to bake that in the component or should it be delegated to the application
 1. I think it's nice that there is a `<SelectPanel.Footer>` because you can wrap it in suspense along with the search results
+1. Need to make Save and Cancel optional (selectionVariant="instant"?)

--- a/src/drafts/SelectPanel2/work-log.md
+++ b/src/drafts/SelectPanel2/work-log.md
@@ -19,6 +19,7 @@
 
 1. How strongly does Maxime feel about adding count of changes in the submit button? (he had it in his prototype)
 1. Should we highlight matching text for filter results, especially because we search across title and description (example: https://github.com/primer/react/assets/1863771/d8d2d6e1-4075-4096-bc8a-db46e9b69351)
+1. Should clearSelection always be optional, or only missing/optional when selectionVariant=single
 
 ## API decisions still to make
 


### PR DESCRIPTION
- Closes https://github.com/github/primer/issues/2613
- Implements ideas tested in https://github.com/primer/react/pull/3731
- Part of https://github.com/github/primer/issues/2396
- Accessibility guidance for "Tabs" / Filter buttons: https://github.com/github/accessibility/issues/4156#issuecomment-1701473661

Decision:

Instead of creating a `SelectPanel.Tabs` component, we are opening up some space in `SelectPanel.Header` for ItemPicker to utilise. The promise here is that ItemPicker would be the first (and maybe only) user of drafts/SelectPanel for a while. This way, we can learn from usage in dotcom and see if we want to bake some decisions / add constraints to this open slot in `SelectPanel.Header`


API:

```diff
<SelectPanel>

  <SelectPanel.Header>
    <SelectPanel.SearchInput/>

+   {/*  children without slots in header */}
+   <Box sx={{display:'flex'}}>
+     <Button variant="invisible">Branches</Button>
+     <Button variant="invisible">Tags</Button>
+   </Box>
+   {/*  end open children */}
  </SelectPanel.Header>

  {/*  list, actions, etc */}

</SelectPanel>
```