### PR TITLE
fix(ButtonBase): remove leading, trailing props from being spread onto base butotn

### DIFF
--- a/src/Button/ButtonBase.tsx
+++ b/src/Button/ButtonBase.tsx
@@ -11,6 +11,10 @@ import {defaultSxProp} from '../utils/defaultSxProp'
 const ButtonBase = forwardRef(
   ({children, as: Component = 'button', sx: sxProp = defaultSxProp, ...props}, forwardedRef): JSX.Element => {
     const {
+      leadingIcon,
+      leadingVisual,
+      trailingIcon,
+      trailingVisual,
       trailingAction: TrailingAction,
       icon: Icon,
       variant = 'default',
@@ -19,8 +23,8 @@ const ButtonBase = forwardRef(
       block = false,
       ...rest
     } = props
-    const LeadingVisual = props.leadingVisual ?? props.leadingIcon
-    const TrailingVisual = props.trailingVisual ?? props.trailingIcon
+    const LeadingVisual = leadingVisual ?? leadingIcon
+    const TrailingVisual = trailingVisual ?? trailingIcon
 
     const innerRef = React.useRef<HTMLButtonElement>(null)
     useRefObjectAsForwardedRef(forwardedRef, innerRef)


### PR DESCRIPTION
Addresses a current release blocker where leading, trailing props were not being spread onto the base button causing an "unknown DOM attribute" warning from React.

### Changelog

#### New

#### Changed

- Add `leadingIcon`, `leadingVisual`, `trailingIcon`, and `trailingVisual` to destructure list for ButtonBase props

#### Removed