### PR TITLE
Add banner to component docs with link to page in new docsite

### DIFF
--- a/docs/components/DeprecationBanner.js
+++ b/docs/components/DeprecationBanner.js
@@ -4,12 +4,9 @@ import {Note} from '@primer/gatsby-theme-doctocat'
 
 const DeprecationBanner = ({replacementUrl}) => {
   return (
-    <Note variant="warning" sx={{marginBottom: '40px'}}> 
-      This documentation is moving to a new home. Please update any link or bookmark that points to this page. The new content can be found{' '}
-      <GatsbyLink href={replacementUrl} >
-        here
-      </GatsbyLink>
-      .
+    <Note variant="warning" sx={{marginBottom: '40px'}}>
+      This documentation is moving to a new home. Please update any link or bookmark that points to this page. The new
+      content can be found <GatsbyLink href={replacementUrl}>here</GatsbyLink>.
     </Note>
   )
 }

--- a/docs/components/DeprecationBanner.js
+++ b/docs/components/DeprecationBanner.js
@@ -4,10 +4,9 @@ import {Note} from '@primer/gatsby-theme-doctocat'
 
 const DeprecationBanner = ({replacementUrl}) => {
   return (
-    <Note variant="warning" sx={{marginBottom: '40px'}}>
-      <strong>NOTE:</strong> The information on this page is moving to a new home. Please update your links and
-      bookmarks! The new content can be found{' '}
-      <GatsbyLink href={replacementUrl} target="_blank">
+    <Note variant="warning" sx={{marginBottom: '40px'}}> 
+      This documentation is moving to a new home. Please update any link or bookmark that points to this page. The new content can be found{' '}
+      <GatsbyLink href={replacementUrl} >
         here
       </GatsbyLink>
       .

--- a/docs/components/DeprecationBanner.js
+++ b/docs/components/DeprecationBanner.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import {Link as GatsbyLink} from 'gatsby'
+import {Note} from '@primer/gatsby-theme-doctocat'
+
+const DeprecationBanner = ({replacementUrl}) => {
+  return (
+    <Note variant="warning" sx={{marginBottom: '40px'}}>
+      <strong>NOTE:</strong> The information on this page is moving to a new home. Please update your links and
+      bookmarks! The new content can be found{' '}
+      <GatsbyLink href={replacementUrl} target="_blank">
+        here
+      </GatsbyLink>
+      .
+    </Note>
+  )
+}
+
+export default DeprecationBanner

--- a/docs/content/ActionList.mdx
+++ b/docs/content/ActionList.mdx
@@ -14,7 +14,7 @@ import {LinkIcon, AlertIcon, ArrowRightIcon} from '@primer/octicons-react'
 import InlineCode from '@primer/gatsby-theme-doctocat/src/components/inline-code'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/action-list/react`} />
+<DeprecationBanner replacementUrl={'/design/components/action-list/react'} />
 
 <Box sx={{border: '1px solid', borderColor: 'border.default', borderRadius: 2, padding: 6, marginBottom: 3}}>
   <ActionList sx={{width: 320}}>

--- a/docs/content/ActionList.mdx
+++ b/docs/content/ActionList.mdx
@@ -12,6 +12,9 @@ import data from '../../src/ActionList/ActionList.docs.json'
 import {ActionList, Avatar} from '@primer/react'
 import {LinkIcon, AlertIcon, ArrowRightIcon} from '@primer/octicons-react'
 import InlineCode from '@primer/gatsby-theme-doctocat/src/components/inline-code'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/action-list/react`} />
 
 <Box sx={{border: '1px solid', borderColor: 'border.default', borderRadius: 2, padding: 6, marginBottom: 3}}>
   <ActionList sx={{width: 320}}>

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -11,6 +11,9 @@ description: An ActionMenu is an ActionList-based component for creating a menu 
 import data from '../../src/ActionMenu/ActionMenu.docs.json'
 
 import {Box, Avatar, ActionList, ActionMenu} from '@primer/react'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/action-menu/react`} />
 
 <br />
 

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -13,7 +13,7 @@ import data from '../../src/ActionMenu/ActionMenu.docs.json'
 import {Box, Avatar, ActionList, ActionMenu} from '@primer/react'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/action-menu/react`} />
+<DeprecationBanner replacementUrl={'/design/components/action-menu/react'} />
 
 <br />
 

--- a/docs/content/AnchoredOverlay.mdx
+++ b/docs/content/AnchoredOverlay.mdx
@@ -8,6 +8,10 @@ storybook: '/react/storybook?path=/story/behaviors-anchoredoverlay--default-port
 
 import data from '../../src/AnchoredOverlay/AnchoredOverlay.docs.json'
 
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/anchored-overlay/react`} />
+
 An `AnchoredOverlay` provides an anchor that will open a floating overlay positioned relative to the anchor.
 The overlay can be opened and navigated using keyboard or mouse.
 

--- a/docs/content/AnchoredOverlay.mdx
+++ b/docs/content/AnchoredOverlay.mdx
@@ -10,7 +10,7 @@ import data from '../../src/AnchoredOverlay/AnchoredOverlay.docs.json'
 
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/anchored-overlay/react`} />
+<DeprecationBanner replacementUrl={'/design/components/anchored-overlay/react'} />
 
 An `AnchoredOverlay` provides an anchor that will open a floating overlay positioned relative to the anchor.
 The overlay can be opened and navigated using keyboard or mouse.

--- a/docs/content/Autocomplete.mdx
+++ b/docs/content/Autocomplete.mdx
@@ -9,6 +9,9 @@ storybook: '/react/storybook?path=/story/components-forms-autocomplete'
 
 import data from '../../src/Autocomplete/Autocomplete.docs.json'
 import {Autocomplete} from '@primer/react'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/autocomplete/react`} />
 
 The `Autocomplete` component is comprised of an `Autocomplete.Input` component that a user types into, and a `Autocomplete.Menu` component that displays the list of selectable values.
 

--- a/docs/content/Autocomplete.mdx
+++ b/docs/content/Autocomplete.mdx
@@ -11,7 +11,7 @@ import data from '../../src/Autocomplete/Autocomplete.docs.json'
 import {Autocomplete} from '@primer/react'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/autocomplete/react`} />
+<DeprecationBanner replacementUrl={'/design/components/autocomplete/react'} />
 
 The `Autocomplete` component is comprised of an `Autocomplete.Input` component that a user types into, and a `Autocomplete.Menu` component that displays the list of selectable values.
 

--- a/docs/content/Avatar.mdx
+++ b/docs/content/Avatar.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/Avatar
 ---
 
 import data from '../../src/Avatar/Avatar.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/avatar/react`} />
 
 import {Avatar, Box} from '@primer/react'
 

--- a/docs/content/Avatar.mdx
+++ b/docs/content/Avatar.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/Avatar
 import data from '../../src/Avatar/Avatar.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/avatar/react`} />
+<DeprecationBanner replacementUrl={'/design/components/avatar/react'} />
 
 import {Avatar, Box} from '@primer/react'
 

--- a/docs/content/Avatar.mdx
+++ b/docs/content/Avatar.mdx
@@ -6,11 +6,10 @@ source: https://github.com/primer/react/blob/main/src/Avatar
 ---
 
 import data from '../../src/Avatar/Avatar.docs.json'
+import {Avatar, Box} from '@primer/react'
 import DeprecationBanner from '../components/DeprecationBanner'
 
 <DeprecationBanner replacementUrl={'/design/components/avatar/react'} />
-
-import {Avatar, Box} from '@primer/react'
 
 ```js
 import {Avatar} from '@primer/react'

--- a/docs/content/AvatarPair.mdx
+++ b/docs/content/AvatarPair.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/AvatarPair
 import data from '../../src/AvatarPair/AvatarPair.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/avatar-pair/react`} />
+<DeprecationBanner replacementUrl={'/design/components/avatar-pair/react'} />
 
 ```js
 import {AvatarPair} from '@primer/react'

--- a/docs/content/AvatarPair.mdx
+++ b/docs/content/AvatarPair.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/AvatarPair
 ---
 
 import data from '../../src/AvatarPair/AvatarPair.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/avatar-pair/react`} />
 
 ```js
 import {AvatarPair} from '@primer/react'

--- a/docs/content/AvatarStack.mdx
+++ b/docs/content/AvatarStack.mdx
@@ -8,6 +8,9 @@ storybook: '/react/storybook?path=/story/components-avatarstack--default'
 ---
 
 import data from '../../src/AvatarStack/AvatarStack.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/avatar-stack/react`} />
 
 import {AvatarStack} from '@primer/react'
 

--- a/docs/content/AvatarStack.mdx
+++ b/docs/content/AvatarStack.mdx
@@ -10,7 +10,7 @@ storybook: '/react/storybook?path=/story/components-avatarstack--default'
 import data from '../../src/AvatarStack/AvatarStack.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/avatar-stack/react`} />
+<DeprecationBanner replacementUrl={'/design/components/avatar-stack/react'} />
 
 import {AvatarStack} from '@primer/react'
 

--- a/docs/content/AvatarStack.mdx
+++ b/docs/content/AvatarStack.mdx
@@ -8,11 +8,10 @@ storybook: '/react/storybook?path=/story/components-avatarstack--default'
 ---
 
 import data from '../../src/AvatarStack/AvatarStack.docs.json'
+import {AvatarStack} from '@primer/react'
 import DeprecationBanner from '../components/DeprecationBanner'
 
 <DeprecationBanner replacementUrl={'/design/components/avatar-stack/react'} />
-
-import {AvatarStack} from '@primer/react'
 
 ```js
 import {AvatarStack} from '@primer/react'

--- a/docs/content/Box.mdx
+++ b/docs/content/Box.mdx
@@ -9,7 +9,7 @@ source: https://github.com/primer/react/blob/main/src/Box.tsx
 import data from '../../src/Box/Box.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/box/react`} />
+<DeprecationBanner replacementUrl={'/design/components/box/react'} />
 
 ```js
 import {Box} from '@primer/react'

--- a/docs/content/Box.mdx
+++ b/docs/content/Box.mdx
@@ -7,6 +7,9 @@ source: https://github.com/primer/react/blob/main/src/Box.tsx
 ---
 
 import data from '../../src/Box/Box.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/box/react`} />
 
 ```js
 import {Box} from '@primer/react'

--- a/docs/content/BranchName.mdx
+++ b/docs/content/BranchName.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/BranchName/BranchName.tsx
 import data from '../../src/BranchName/BranchName.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/branch-name/react`} />
+<DeprecationBanner replacementUrl={'/design/components/branch-name/react'} />
 
 ```js
 import {BranchName} from '@primer/react'

--- a/docs/content/BranchName.mdx
+++ b/docs/content/BranchName.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/BranchName/BranchName.tsx
 ---
 
 import data from '../../src/BranchName/BranchName.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/branch-name/react`} />
 
 ```js
 import {BranchName} from '@primer/react'

--- a/docs/content/Breadcrumbs.mdx
+++ b/docs/content/Breadcrumbs.mdx
@@ -9,7 +9,7 @@ source: https://github.com/primer/react/blob/main/src/Breadcrumbs/Breadcrumbs.ts
 import data from '../../src/Breadcrumbs/Breadcrumbs.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/breadcrumbs/react`} />
+<DeprecationBanner replacementUrl={'/design/components/breadcrumbs/react'} />
 
 ```js
 import {Breadcrumbs} from '@primer/react'

--- a/docs/content/Breadcrumbs.mdx
+++ b/docs/content/Breadcrumbs.mdx
@@ -7,6 +7,9 @@ source: https://github.com/primer/react/blob/main/src/Breadcrumbs/Breadcrumbs.ts
 ---
 
 import data from '../../src/Breadcrumbs/Breadcrumbs.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/breadcrumbs/react`} />
 
 ```js
 import {Breadcrumbs} from '@primer/react'

--- a/docs/content/Button.mdx
+++ b/docs/content/Button.mdx
@@ -8,6 +8,9 @@ description: Use button for the main actions on a page or form.
 ---
 
 import data from '../../src/Button/Button.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/button/react`} />
 
 ```js
 import {Button} from '@primer/react'

--- a/docs/content/Button.mdx
+++ b/docs/content/Button.mdx
@@ -10,7 +10,7 @@ description: Use button for the main actions on a page or form.
 import data from '../../src/Button/Button.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/button/react`} />
+<DeprecationBanner replacementUrl={'/design/components/button/react'} />
 
 ```js
 import {Button} from '@primer/react'

--- a/docs/content/ButtonGroup.mdx
+++ b/docs/content/ButtonGroup.mdx
@@ -7,6 +7,9 @@ storybook: '/react/storybook?path=/story/components-buttongroup--default'
 ---
 
 import data from '../../src/ButtonGroup/ButtonGroup.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/button-group/react`} />
 
 ```js
 import {ButtonGroup} from '@primer/react'

--- a/docs/content/ButtonGroup.mdx
+++ b/docs/content/ButtonGroup.mdx
@@ -9,7 +9,7 @@ storybook: '/react/storybook?path=/story/components-buttongroup--default'
 import data from '../../src/ButtonGroup/ButtonGroup.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/button-group/react`} />
+<DeprecationBanner replacementUrl={'/design/components/button-group/react'} />
 
 ```js
 import {ButtonGroup} from '@primer/react'

--- a/docs/content/Checkbox.mdx
+++ b/docs/content/Checkbox.mdx
@@ -8,6 +8,9 @@ componentId: checkbox
 ---
 
 import data from '../../src/Checkbox/Checkbox.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/checkbox/react`} />
 
 ## Examples
 

--- a/docs/content/Checkbox.mdx
+++ b/docs/content/Checkbox.mdx
@@ -10,7 +10,7 @@ componentId: checkbox
 import data from '../../src/Checkbox/Checkbox.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/checkbox/react`} />
+<DeprecationBanner replacementUrl={'/design/components/checkbox/react'} />
 
 ## Examples
 

--- a/docs/content/CheckboxGroup.mdx
+++ b/docs/content/CheckboxGroup.mdx
@@ -11,6 +11,9 @@ import data from '../../src/CheckboxGroup/CheckboxGroup.docs.json'
 
 import {CheckboxGroup, Checkbox, Box} from '@primer/components'
 import {CheckIcon, XIcon, AlertIcon} from '@primer/octicons-react'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/checkbox-group/react`} />
 
 ## Examples
 

--- a/docs/content/CheckboxGroup.mdx
+++ b/docs/content/CheckboxGroup.mdx
@@ -13,7 +13,7 @@ import {CheckboxGroup, Checkbox, Box} from '@primer/components'
 import {CheckIcon, XIcon, AlertIcon} from '@primer/octicons-react'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/checkbox-group/react`} />
+<DeprecationBanner replacementUrl={'/design/components/checkbox-group/react'} />
 
 ## Examples
 

--- a/docs/content/CircleBadge.mdx
+++ b/docs/content/CircleBadge.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/CircleBadge
 import data from '../../src/CircleBadge/CircleBadge.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/circle-badge/react`} />
+<DeprecationBanner replacementUrl={'/design/components/circle-badge/react'} />
 
 ```js
 import {CircleBadge} from '@primer/react'

--- a/docs/content/CircleBadge.mdx
+++ b/docs/content/CircleBadge.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/CircleBadge
 ---
 
 import data from '../../src/CircleBadge/CircleBadge.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/circle-badge/react`} />
 
 ```js
 import {CircleBadge} from '@primer/react'

--- a/docs/content/CounterLabel.mdx
+++ b/docs/content/CounterLabel.mdx
@@ -9,7 +9,7 @@ source: https://github.com/primer/react/blob/main/src/CounterLabel/CounterLabel.
 import data from '../../src/CounterLabel/CounterLabel.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/counter-label/react`} />
+<DeprecationBanner replacementUrl={'/design/components/counter-label/react'} />
 
 ## Example
 

--- a/docs/content/CounterLabel.mdx
+++ b/docs/content/CounterLabel.mdx
@@ -7,6 +7,9 @@ source: https://github.com/primer/react/blob/main/src/CounterLabel/CounterLabel.
 ---
 
 import data from '../../src/CounterLabel/CounterLabel.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/counter-label/react`} />
 
 ## Example
 

--- a/docs/content/Details.mdx
+++ b/docs/content/Details.mdx
@@ -9,7 +9,7 @@ storybook: '/react/storybook/?path=/story/components-details--default'
 import data from '../../src/Details/Details.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/details/react`} />
+<DeprecationBanner replacementUrl={'/design/components/details/react'} />
 
 `Details` is a styled `details` element for use with the `useDetails` hook. The `useDetails` hook returns the `open` state, a `setOpen` function to manually change the open state, and **`getDetailsProps` which must be spread onto your `Details` element in order for `Details` to get receive the proper behaviors provided by the hook**. See [Kent Dodd's article on this pattern](https://kentcdodds.com/blog/how-to-give-rendering-control-to-users-with-prop-getters).
 

--- a/docs/content/Details.mdx
+++ b/docs/content/Details.mdx
@@ -7,6 +7,9 @@ storybook: '/react/storybook/?path=/story/components-details--default'
 ---
 
 import data from '../../src/Details/Details.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/details/react`} />
 
 `Details` is a styled `details` element for use with the `useDetails` hook. The `useDetails` hook returns the `open` state, a `setOpen` function to manually change the open state, and **`getDetailsProps` which must be spread onto your `Details` element in order for `Details` to get receive the proper behaviors provided by the hook**. See [Kent Dodd's article on this pattern](https://kentcdodds.com/blog/how-to-give-rendering-control-to-users-with-prop-getters).
 

--- a/docs/content/Dialog.mdx
+++ b/docs/content/Dialog.mdx
@@ -5,6 +5,9 @@ source: https://github.com/primer/react/blob/main/src/Dialog
 ---
 
 import data from '../../src/Dialog.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/dialog/react`} />
 
 The dialog component is used for all modals. It renders on top of the rest of the app with an overlay.
 

--- a/docs/content/Dialog.mdx
+++ b/docs/content/Dialog.mdx
@@ -7,7 +7,7 @@ source: https://github.com/primer/react/blob/main/src/Dialog
 import data from '../../src/Dialog.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/dialog/react`} />
+<DeprecationBanner replacementUrl={'/design/components/dialog/react'} />
 
 The dialog component is used for all modals. It renders on top of the rest of the app with an overlay.
 

--- a/docs/content/Flash.mdx
+++ b/docs/content/Flash.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/Flash
 ---
 
 import data from '../../src/Flash/Flash.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/flash/react`} />
 
 ```js
 import {Flash} from '@primer/react'

--- a/docs/content/Flash.mdx
+++ b/docs/content/Flash.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/Flash
 import data from '../../src/Flash/Flash.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/flash/react`} />
+<DeprecationBanner replacementUrl={'/design/components/flash/react'} />
 
 ```js
 import {Flash} from '@primer/react'

--- a/docs/content/FormControl.mdx
+++ b/docs/content/FormControl.mdx
@@ -9,8 +9,7 @@ storybook: '/react/storybook?path=/story/components-forms-autocomplete'
 
 import data from '../../src/FormControl/FormControl.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
-
-<DeprecationBanner replacementUrl={'/design/components/form-control/react'} />
+import {MarkGithubIcon} from '@primer/octicons-react'
 
 import {
   FormControl,
@@ -24,7 +23,8 @@ import {
   RadioGroup,
   Text,
 } from '@primer/react'
-import {MarkGithubIcon} from '@primer/octicons-react'
+
+<DeprecationBanner replacementUrl={'/design/components/form-control/react'} />
 
 ## Examples
 

--- a/docs/content/FormControl.mdx
+++ b/docs/content/FormControl.mdx
@@ -10,7 +10,7 @@ storybook: '/react/storybook?path=/story/components-forms-autocomplete'
 import data from '../../src/FormControl/FormControl.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/form-control/react`} />
+<DeprecationBanner replacementUrl={'/design/components/form-control/react'} />
 
 import {
   FormControl,

--- a/docs/content/FormControl.mdx
+++ b/docs/content/FormControl.mdx
@@ -8,6 +8,9 @@ storybook: '/react/storybook?path=/story/components-forms-autocomplete'
 ---
 
 import data from '../../src/FormControl/FormControl.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/form-control/react`} />
 
 import {
   FormControl,

--- a/docs/content/Header.mdx
+++ b/docs/content/Header.mdx
@@ -9,7 +9,7 @@ componentId: header
 import data from '../../src/Header/Header.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/header/react`} />
+<DeprecationBanner replacementUrl={'/design/components/header/react'} />
 
 ## Examples
 

--- a/docs/content/Header.mdx
+++ b/docs/content/Header.mdx
@@ -7,6 +7,9 @@ componentId: header
 ---
 
 import data from '../../src/Header/Header.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/header/react`} />
 
 ## Examples
 

--- a/docs/content/Heading.mdx
+++ b/docs/content/Heading.mdx
@@ -8,6 +8,9 @@ componentId: heading
 ---
 
 import data from '../../src/Heading/Heading.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/heading/react`} />
 
 The Heading component will render an html `h2` tag without any default styling. Other heading level elements `h1-h6` are available through use of the `as` prop (see [System Props](/system-props) for additional explanation). Please reference the [w3 recommendations for headings](https://www.w3.org/WAI/tutorials/page-structure/headings/) to ensure your headings provide an accessible experience for screen reader users.
 

--- a/docs/content/Heading.mdx
+++ b/docs/content/Heading.mdx
@@ -10,7 +10,7 @@ componentId: heading
 import data from '../../src/Heading/Heading.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/heading/react`} />
+<DeprecationBanner replacementUrl={'/design/components/heading/react'} />
 
 The Heading component will render an html `h2` tag without any default styling. Other heading level elements `h1-h6` are available through use of the `as` prop (see [System Props](/system-props) for additional explanation). Please reference the [w3 recommendations for headings](https://www.w3.org/WAI/tutorials/page-structure/headings/) to ensure your headings provide an accessible experience for screen reader users.
 

--- a/docs/content/IconButton.mdx
+++ b/docs/content/IconButton.mdx
@@ -10,7 +10,7 @@ description: An accessible button component with no text and only icon.
 import data from '../../src/Button/IconButton.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/icon-button/react`} />
+<DeprecationBanner replacementUrl={'/design/components/icon-button/react'} />
 
 ## Usage
 

--- a/docs/content/IconButton.mdx
+++ b/docs/content/IconButton.mdx
@@ -8,6 +8,9 @@ description: An accessible button component with no text and only icon.
 ---
 
 import data from '../../src/Button/IconButton.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/icon-button/react`} />
 
 ## Usage
 

--- a/docs/content/Label.mdx
+++ b/docs/content/Label.mdx
@@ -8,6 +8,9 @@ description: Use Label components to add contextual metadata to a design.
 ---
 
 import data from '../../src/Label/Label.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/label/react`} />
 
 ## Examples
 

--- a/docs/content/Label.mdx
+++ b/docs/content/Label.mdx
@@ -10,7 +10,7 @@ description: Use Label components to add contextual metadata to a design.
 import data from '../../src/Label/Label.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/label/react`} />
+<DeprecationBanner replacementUrl={'/design/components/label/react'} />
 
 ## Examples
 

--- a/docs/content/LabelGroup.mdx
+++ b/docs/content/LabelGroup.mdx
@@ -7,6 +7,9 @@ componentId: label_group
 ---
 
 import data from '../../src/LabelGroup/LabelGroup.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/label-group/react`} />
 
 ## Example
 

--- a/docs/content/LabelGroup.mdx
+++ b/docs/content/LabelGroup.mdx
@@ -9,7 +9,7 @@ componentId: label_group
 import data from '../../src/LabelGroup/LabelGroup.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/label-group/react`} />
+<DeprecationBanner replacementUrl={'/design/components/label-group/react'} />
 
 ## Example
 

--- a/docs/content/Link.mdx
+++ b/docs/content/Link.mdx
@@ -7,6 +7,9 @@ storybook: '/react/storybook/?path=/story/components-link--default'
 ---
 
 import data from '../../src/Link/Link.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/link/react`} />
 
 The Link component styles anchor tags with default hyperlink color cues and hover text decoration. `Link` is used for destinations, or moving from one page to another.
 

--- a/docs/content/Link.mdx
+++ b/docs/content/Link.mdx
@@ -9,7 +9,7 @@ storybook: '/react/storybook/?path=/story/components-link--default'
 import data from '../../src/Link/Link.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/link/react`} />
+<DeprecationBanner replacementUrl={'/design/components/link/react'} />
 
 The Link component styles anchor tags with default hyperlink color cues and hover text decoration. `Link` is used for destinations, or moving from one page to another.
 

--- a/docs/content/NavList.mdx
+++ b/docs/content/NavList.mdx
@@ -10,7 +10,7 @@ storybook: '/react/storybook/?path=/story/components-navlist--simple'
 import data from '../../src/NavList/NavList.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/nav-list/react`} />
+<DeprecationBanner replacementUrl={'/design/components/nav-list/react'} />
 
 ```js
 import {NavList} from '@primer/react'

--- a/docs/content/NavList.mdx
+++ b/docs/content/NavList.mdx
@@ -8,6 +8,9 @@ storybook: '/react/storybook/?path=/story/components-navlist--simple'
 ---
 
 import data from '../../src/NavList/NavList.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/nav-list/react`} />
 
 ```js
 import {NavList} from '@primer/react'

--- a/docs/content/Overlay.mdx
+++ b/docs/content/Overlay.mdx
@@ -10,7 +10,7 @@ storybook: '/react/storybook?path=/story/private-components-overlay--dropdown-ov
 import data from '../../src/Overlay/Overlay.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/overlay/react`} />
+<DeprecationBanner replacementUrl={'/design/components/overlay/react'} />
 
 ```js
 import {Overlay} from '@primer/react'

--- a/docs/content/Overlay.mdx
+++ b/docs/content/Overlay.mdx
@@ -8,6 +8,9 @@ storybook: '/react/storybook?path=/story/private-components-overlay--dropdown-ov
 ---
 
 import data from '../../src/Overlay/Overlay.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/overlay/react`} />
 
 ```js
 import {Overlay} from '@primer/react'

--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -9,6 +9,9 @@ a11yReviewed: true
 ---
 
 import data from '../../src/PageLayout/PageLayout.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/page-layout/react`} />
 
 ```js
 import {PageLayout} from '@primer/react'

--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -11,7 +11,7 @@ a11yReviewed: true
 import data from '../../src/PageLayout/PageLayout.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/page-layout/react`} />
+<DeprecationBanner replacementUrl={'/design/components/page-layout/react'} />
 
 ```js
 import {PageLayout} from '@primer/react'

--- a/docs/content/Pagehead.md
+++ b/docs/content/Pagehead.md
@@ -9,7 +9,7 @@ status: Alpha
 import data from '../../src/Pagehead/Pagehead.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/pagehead/react`} />
+<DeprecationBanner replacementUrl={'/design/components/pagehead/react'} />
 
 ```js
 import {Pagehead} from '@primer/react'

--- a/docs/content/Pagehead.md
+++ b/docs/content/Pagehead.md
@@ -7,6 +7,9 @@ status: Alpha
 ---
 
 import data from '../../src/Pagehead/Pagehead.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/pagehead/react`} />
 
 ```js
 import {Pagehead} from '@primer/react'

--- a/docs/content/Pagination.md
+++ b/docs/content/Pagination.md
@@ -12,7 +12,7 @@ import data from '../../src/Pagination/Pagination.docs.json'
 import State from '../components/State'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/pagination/react`} />
+<DeprecationBanner replacementUrl={'/design/components/pagination/react'} />
 
 ```js
 import {Pagination} from '@primer/react'

--- a/docs/content/Pagination.md
+++ b/docs/content/Pagination.md
@@ -10,6 +10,9 @@ status: Alpha
 import data from '../../src/Pagination/Pagination.docs.json'
 
 import State from '../components/State'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/pagination/react`} />
 
 ```js
 import {Pagination} from '@primer/react'

--- a/docs/content/PointerBox.mdx
+++ b/docs/content/PointerBox.mdx
@@ -9,7 +9,7 @@ source: https://github.com/primer/react/blob/main/src/PointerBox
 import data from '../../src/PointerBox/PointerBox.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/pointer-box/react`} />
+<DeprecationBanner replacementUrl={'/design/components/pointer-box/react'} />
 
 ## Examples
 

--- a/docs/content/PointerBox.mdx
+++ b/docs/content/PointerBox.mdx
@@ -7,6 +7,9 @@ source: https://github.com/primer/react/blob/main/src/PointerBox
 ---
 
 import data from '../../src/PointerBox/PointerBox.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/pointer-box/react`} />
 
 ## Examples
 

--- a/docs/content/Popover.md
+++ b/docs/content/Popover.md
@@ -7,6 +7,9 @@ source: https://github.com/primer/react/blob/main/src/Popover
 ---
 
 import data from '../../src/Popover/Popover.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/popover/react`} />
 
 ```js
 import {Popover} from '@primer/react'

--- a/docs/content/Popover.md
+++ b/docs/content/Popover.md
@@ -9,7 +9,7 @@ source: https://github.com/primer/react/blob/main/src/Popover
 import data from '../../src/Popover/Popover.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/popover/react`} />
+<DeprecationBanner replacementUrl={'/design/components/popover/react'} />
 
 ```js
 import {Popover} from '@primer/react'

--- a/docs/content/ProgressBar.mdx
+++ b/docs/content/ProgressBar.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/ProgressBar
 ---
 
 import data from '../../src/ProgressBar/ProgressBar.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/progress-bar/react`} />
 
 ```js
 import {ProgressBar} from '@primer/react'

--- a/docs/content/ProgressBar.mdx
+++ b/docs/content/ProgressBar.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/ProgressBar
 import data from '../../src/ProgressBar/ProgressBar.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/progress-bar/react`} />
+<DeprecationBanner replacementUrl={'/design/components/progress-bar/react'} />
 
 ```js
 import {ProgressBar} from '@primer/react'

--- a/docs/content/Radio.mdx
+++ b/docs/content/Radio.mdx
@@ -8,6 +8,9 @@ storybook: '/react/storybook?path=/story/components-forms-radiogroup'
 ---
 
 import data from '../../src/Radio/Radio.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/radio/react`} />
 
 ## Examples
 

--- a/docs/content/Radio.mdx
+++ b/docs/content/Radio.mdx
@@ -10,7 +10,7 @@ storybook: '/react/storybook?path=/story/components-forms-radiogroup'
 import data from '../../src/Radio/Radio.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/radio/react`} />
+<DeprecationBanner replacementUrl={'/design/components/radio/react'} />
 
 ## Examples
 

--- a/docs/content/RadioGroup.mdx
+++ b/docs/content/RadioGroup.mdx
@@ -13,7 +13,7 @@ import {RadioGroup, Radio, Box} from '@primer/components'
 import {CheckIcon, XIcon, AlertIcon} from '@primer/octicons-react'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/radio-group/react`} />
+<DeprecationBanner replacementUrl={'/design/components/radio-group/react'} />
 
 ## Examples
 

--- a/docs/content/RadioGroup.mdx
+++ b/docs/content/RadioGroup.mdx
@@ -11,6 +11,9 @@ import data from '../../src/RadioGroup/RadioGroup.docs.json'
 
 import {RadioGroup, Radio, Box} from '@primer/components'
 import {CheckIcon, XIcon, AlertIcon} from '@primer/octicons-react'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/radio-group/react`} />
 
 ## Examples
 

--- a/docs/content/RelativeTime.mdx
+++ b/docs/content/RelativeTime.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/RelativeTime
 import data from '../../src/RelativeTime/RelativeTime.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/relative-time/react`} />
+<DeprecationBanner replacementUrl={'/design/components/relative-time/react'} />
 
 ```js
 import {RelativeTime} from '@primer/react'

--- a/docs/content/RelativeTime.mdx
+++ b/docs/content/RelativeTime.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/RelativeTime
 ---
 
 import data from '../../src/RelativeTime/RelativeTime.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/relative-time/react`} />
 
 ```js
 import {RelativeTime} from '@primer/react'

--- a/docs/content/SegmentedControl.mdx
+++ b/docs/content/SegmentedControl.mdx
@@ -10,7 +10,7 @@ storybook: '/react/storybook/?path=/story/components-segmentedcontrol'
 import data from '../../src/SegmentedControl/SegmentedControl.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/segmented-control/react`} />
+<DeprecationBanner replacementUrl={'/design/components/segmented-control/react'} />
 
 <Note variant="warning">
 

--- a/docs/content/SegmentedControl.mdx
+++ b/docs/content/SegmentedControl.mdx
@@ -8,6 +8,9 @@ storybook: '/react/storybook/?path=/story/components-segmentedcontrol'
 ---
 
 import data from '../../src/SegmentedControl/SegmentedControl.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/segmented-control/react`} />
 
 <Note variant="warning">
 

--- a/docs/content/Select.mdx
+++ b/docs/content/Select.mdx
@@ -11,6 +11,9 @@ storybook: '/react/storybook?path=/story/components-forms-select--default'
 import data from '../../src/Select/Select.docs.json'
 
 import {Select, Text} from '@primer/react'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/select/react`} />
 
 ## Examples
 

--- a/docs/content/Select.mdx
+++ b/docs/content/Select.mdx
@@ -13,7 +13,7 @@ import data from '../../src/Select/Select.docs.json'
 import {Select, Text} from '@primer/react'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/select/react`} />
+<DeprecationBanner replacementUrl={'/design/components/select/react'} />
 
 ## Examples
 

--- a/docs/content/SelectPanel.mdx
+++ b/docs/content/SelectPanel.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/SelectPanel
 import data from '../../src/SelectPanel/SelectPanel.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/selectpanel/react`} />
+<DeprecationBanner replacementUrl={'/design/components/selectpanel/react'} />
 
 A `SelectPanel` provides an anchor that will open an overlay with a list of selectable items, and a text input to filter the selectable items
 

--- a/docs/content/SelectPanel.mdx
+++ b/docs/content/SelectPanel.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/SelectPanel
 ---
 
 import data from '../../src/SelectPanel/SelectPanel.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/selectpanel/react`} />
 
 A `SelectPanel` provides an anchor that will open an overlay with a list of selectable items, and a text input to filter the selectable items
 

--- a/docs/content/Spinner.mdx
+++ b/docs/content/Spinner.mdx
@@ -9,7 +9,7 @@ source: https://github.com/primer/react/blob/main/src/Spinner/Spinner.tsx
 import data from '../../src/Spinner/Spinner.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/spinner/react`} />
+<DeprecationBanner replacementUrl={'/design/components/spinner/react'} />
 
 ```jsx live
 <Spinner />

--- a/docs/content/Spinner.mdx
+++ b/docs/content/Spinner.mdx
@@ -7,6 +7,9 @@ source: https://github.com/primer/react/blob/main/src/Spinner/Spinner.tsx
 ---
 
 import data from '../../src/Spinner/Spinner.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/spinner/react`} />
 
 ```jsx live
 <Spinner />

--- a/docs/content/SplitPageLayout.mdx
+++ b/docs/content/SplitPageLayout.mdx
@@ -9,6 +9,9 @@ a11yReviewed: true
 ---
 
 import data from '../../src/SplitPageLayout/SplitPageLayout.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/split-page-layout/react`} />
 
 ```js
 import {SplitPageLayout} from '@primer/react'

--- a/docs/content/SplitPageLayout.mdx
+++ b/docs/content/SplitPageLayout.mdx
@@ -11,7 +11,7 @@ a11yReviewed: true
 import data from '../../src/SplitPageLayout/SplitPageLayout.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/split-page-layout/react`} />
+<DeprecationBanner replacementUrl={'/design/components/split-page-layout/react'} />
 
 ```js
 import {SplitPageLayout} from '@primer/react'

--- a/docs/content/StateLabel.mdx
+++ b/docs/content/StateLabel.mdx
@@ -9,7 +9,7 @@ source: https://github.com/primer/react/tree/main/src/StateLabel
 import data from '../../src/StateLabel/StateLabel.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/state-label/react`} />
+<DeprecationBanner replacementUrl={'/design/components/state-label/react'} />
 
 ## Examples
 

--- a/docs/content/StateLabel.mdx
+++ b/docs/content/StateLabel.mdx
@@ -7,6 +7,9 @@ source: https://github.com/primer/react/tree/main/src/StateLabel
 ---
 
 import data from '../../src/StateLabel/StateLabel.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/state-label/react`} />
 
 ## Examples
 

--- a/docs/content/SubNav.mdx
+++ b/docs/content/SubNav.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/SubNav
 import data from '../../src/SubNav/SubNav.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/subnav/react`} />
+<DeprecationBanner replacementUrl={'/design/components/subnav/react'} />
 
 Use the SubNav component for navigation on a dashboard-type interface with another set of navigation components above it. This helps distinguish navigation hierarchy.
 

--- a/docs/content/SubNav.mdx
+++ b/docs/content/SubNav.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/SubNav
 ---
 
 import data from '../../src/SubNav/SubNav.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/subnav/react`} />
 
 Use the SubNav component for navigation on a dashboard-type interface with another set of navigation components above it. This helps distinguish navigation hierarchy.
 

--- a/docs/content/TabNav.mdx
+++ b/docs/content/TabNav.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/TabNav
 import data from '../../src/TabNav/TabNav.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/tab-nav/react`} />
+<DeprecationBanner replacementUrl={'/design/components/tab-nav/react'} />
 
 To use TabNav with [react-router](https://github.com/ReactTraining/react-router) or
 [react-router-dom](https://www.npmjs.com/package/react-router-dom), pass

--- a/docs/content/TabNav.mdx
+++ b/docs/content/TabNav.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/TabNav
 ---
 
 import data from '../../src/TabNav/TabNav.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/tab-nav/react`} />
 
 To use TabNav with [react-router](https://github.com/ReactTraining/react-router) or
 [react-router-dom](https://www.npmjs.com/package/react-router-dom), pass

--- a/docs/content/Text.mdx
+++ b/docs/content/Text.mdx
@@ -7,6 +7,9 @@ source: https://github.com/primer/react/blob/main/src/Text
 ---
 
 import data from '../../src/Text/Text.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/text/react`} />
 
 The Text component is a wrapper component that will apply typography styles to the text inside.
 

--- a/docs/content/Text.mdx
+++ b/docs/content/Text.mdx
@@ -9,7 +9,7 @@ source: https://github.com/primer/react/blob/main/src/Text
 import data from '../../src/Text/Text.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/text/react`} />
+<DeprecationBanner replacementUrl={'/design/components/text/react'} />
 
 The Text component is a wrapper component that will apply typography styles to the text inside.
 

--- a/docs/content/TextInput.mdx
+++ b/docs/content/TextInput.mdx
@@ -7,6 +7,9 @@ storybook: '/react/storybook?path=/story/components-forms-textinput--default'
 ---
 
 import data from '../../src/TextInput/TextInput.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/text-input/react`} />
 
 TextInput is a form component to add default styling to the native text input.
 

--- a/docs/content/TextInput.mdx
+++ b/docs/content/TextInput.mdx
@@ -9,7 +9,7 @@ storybook: '/react/storybook?path=/story/components-forms-textinput--default'
 import data from '../../src/TextInput/TextInput.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/text-input/react`} />
+<DeprecationBanner replacementUrl={'/design/components/text-input/react'} />
 
 TextInput is a form component to add default styling to the native text input.
 

--- a/docs/content/Textarea.mdx
+++ b/docs/content/Textarea.mdx
@@ -10,6 +10,9 @@ storybook: '/react/storybook?path=/story/components-forms-textarea--textarea-sto
 import data from '../../src/Textarea/Textarea.docs.json'
 
 import {Textarea} from '@primer/react'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/textarea/react`} />
 
 <Box sx={{border: '1px solid', borderColor: 'border.default', borderRadius: 2, padding: 6, marginBottom: 3}}>
   <Textarea />

--- a/docs/content/Textarea.mdx
+++ b/docs/content/Textarea.mdx
@@ -12,7 +12,7 @@ import data from '../../src/Textarea/Textarea.docs.json'
 import {Textarea} from '@primer/react'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/textarea/react`} />
+<DeprecationBanner replacementUrl={'/design/components/textarea/react'} />
 
 <Box sx={{border: '1px solid', borderColor: 'border.default', borderRadius: 2, padding: 6, marginBottom: 3}}>
   <Textarea />

--- a/docs/content/Timeline.mdx
+++ b/docs/content/Timeline.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/Timeline
 import data from '../../src/Timeline/Timeline.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/timeline/react`} />
+<DeprecationBanner replacementUrl={'/design/components/timeline/react'} />
 
 The Timeline.Item component is used to display items on a vertical timeline, connected by Timeline.Badge elements.
 

--- a/docs/content/Timeline.mdx
+++ b/docs/content/Timeline.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/Timeline
 ---
 
 import data from '../../src/Timeline/Timeline.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/timeline/react`} />
 
 The Timeline.Item component is used to display items on a vertical timeline, connected by Timeline.Badge elements.
 

--- a/docs/content/ToggleSwitch.mdx
+++ b/docs/content/ToggleSwitch.mdx
@@ -8,6 +8,9 @@ storybook: '/react/storybook?path=/story/components-toggleswitch-examples--defau
 ---
 
 import data from '../../src/ToggleSwitch/ToggleSwitch.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/toggle-switch/react`} />
 
 ## Examples
 

--- a/docs/content/ToggleSwitch.mdx
+++ b/docs/content/ToggleSwitch.mdx
@@ -10,7 +10,7 @@ storybook: '/react/storybook?path=/story/components-toggleswitch-examples--defau
 import data from '../../src/ToggleSwitch/ToggleSwitch.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/toggle-switch/react`} />
+<DeprecationBanner replacementUrl={'/design/components/toggle-switch/react'} />
 
 ## Examples
 

--- a/docs/content/Token.mdx
+++ b/docs/content/Token.mdx
@@ -9,6 +9,9 @@ storybook: '/react/storybook?path=/story/components-token--default-token'
 
 import data from '../../src/Token/Token.docs.json'
 import {AvatarToken, IssueLabelToken, Token} from '@primer/react'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/token/react`} />
 
 The default `Token` can be used for most cases, but specialized token components are provided for specific use cases (see below for more info).
 

--- a/docs/content/Token.mdx
+++ b/docs/content/Token.mdx
@@ -11,7 +11,7 @@ import data from '../../src/Token/Token.docs.json'
 import {AvatarToken, IssueLabelToken, Token} from '@primer/react'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/token/react`} />
+<DeprecationBanner replacementUrl={'/design/components/token/react'} />
 
 The default `Token` can be used for most cases, but specialized token components are provided for specific use cases (see below for more info).
 

--- a/docs/content/Tooltip.mdx
+++ b/docs/content/Tooltip.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/Tooltip.tsx
 import data from '../../src/Tooltip.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/tooltip/react`} />
+<DeprecationBanner replacementUrl={'/design/components/tooltip/react'} />
 
 The Tooltip component adds a tooltip to add context to interactive elements on the page.
 

--- a/docs/content/Tooltip.mdx
+++ b/docs/content/Tooltip.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/Tooltip.tsx
 ---
 
 import data from '../../src/Tooltip.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/tooltip/react`} />
 
 The Tooltip component adds a tooltip to add context to interactive elements on the page.
 

--- a/docs/content/TreeView.mdx
+++ b/docs/content/TreeView.mdx
@@ -9,6 +9,9 @@ storybook: '/react/storybook?path=/story/components-treeview'
 ---
 
 import data from '../../src/TreeView/TreeView.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/tree-view/react`} />
 
 ```js
 import {TreeView} from '@primer/react'

--- a/docs/content/TreeView.mdx
+++ b/docs/content/TreeView.mdx
@@ -11,7 +11,7 @@ storybook: '/react/storybook?path=/story/components-treeview'
 import data from '../../src/TreeView/TreeView.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/tree-view/react`} />
+<DeprecationBanner replacementUrl={'/design/components/tree-view/react'} />
 
 ```js
 import {TreeView} from '@primer/react'

--- a/docs/content/Truncate.mdx
+++ b/docs/content/Truncate.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/blob/main/src/Truncate
 ---
 
 import data from '../../src/Truncate/Truncate.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/truncate/react`} />
 
 The Truncate component will shorten text with an ellipsis. Always add a `title` attribute to the truncated element so the full text remains accessible.
 

--- a/docs/content/Truncate.mdx
+++ b/docs/content/Truncate.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/blob/main/src/Truncate
 import data from '../../src/Truncate/Truncate.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/truncate/react`} />
+<DeprecationBanner replacementUrl={'/design/components/truncate/react'} />
 
 The Truncate component will shorten text with an ellipsis. Always add a `title` attribute to the truncated element so the full text remains accessible.
 

--- a/docs/content/UnderlineNav.mdx
+++ b/docs/content/UnderlineNav.mdx
@@ -6,6 +6,9 @@ source: https://github.com/primer/react/tree/main/src/UnderlineNav
 ---
 
 import data from '../../src/UnderlineNav/UnderlineNav.docs.json'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={`/design/components/underline-nav/react`} />
 
 Use the UnderlineNav component to style navigation with a minimal underlined selected state, typically used for navigation placed at the top of the page.
 

--- a/docs/content/UnderlineNav.mdx
+++ b/docs/content/UnderlineNav.mdx
@@ -8,7 +8,7 @@ source: https://github.com/primer/react/tree/main/src/UnderlineNav
 import data from '../../src/UnderlineNav/UnderlineNav.docs.json'
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={`/design/components/underline-nav/react`} />
+<DeprecationBanner replacementUrl={'/design/components/underline-nav/react'} />
 
 Use the UnderlineNav component to style navigation with a minimal underlined selected state, typically used for navigation placed at the top of the page.
 

--- a/docs/content/deprecated/Dropdown.md
+++ b/docs/content/deprecated/Dropdown.md
@@ -3,6 +3,10 @@ title: Dropdown
 status: Deprecated
 ---
 
+import DeprecationBanner from '../../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={'/design/deprecated-components/dropdown'} />
+
 ## Deprecation
 
 Use [ActionMenu](/ActionMenu) instead.

--- a/docs/content/deprecated/SelectMenu.md
+++ b/docs/content/deprecated/SelectMenu.md
@@ -3,6 +3,10 @@ title: SelectMenu
 status: Deprecated
 ---
 
+import DeprecationBanner from '../../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={'/design/deprecated-components/select-menu'} />
+
 ## Deprecation
 
 Use [ActionMenu](/ActionMenu) instead.

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -2,6 +2,10 @@
 title: Getting started
 ---
 
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={'/design/guides/development/react'} />
+
 ## Installation
 
 To get started using Primer React, install the package and its peer dependencies with your package manager of choice:

--- a/docs/content/status.mdx
+++ b/docs/content/status.mdx
@@ -4,6 +4,9 @@ description: Check the current status of Primer React components.
 ---
 
 import {ComponentStatuses} from '../src/component-statuses'
+import DeprecationBanner from '../components/DeprecationBanner'
+
+<DeprecationBanner replacementUrl={'/design/guides/status'} />
 
 <Note>
 


### PR DESCRIPTION
Describe your changes here.

Fixes https://github.com/github/primer/issues/2629

### Screenshots

![A screenshot of an old primer/react doc page for the ActionList component. A yellow banner appears under the header with a link to the new docsite.](https://github.com/primer/react/assets/575280/a55c7d27-03db-45b9-995d-a56bcf2fddab)

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
