### PR TITLE
Draft components are under 'drafts' folder not 'draft'

### DIFF
--- a/script/components-json/build.ts
+++ b/script/components-json/build.ts
@@ -40,7 +40,7 @@ const components = docsFiles.map(docsFilepath => {
 
   // Get the story name prefix for the default story id
   const storyPrefix = {
-    draft: 'draft-',
+    draft: 'drafts-',
     experimental: 'experimental-',
     deprecated: 'deprecated-',
     alpha: '',


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

Following up with [the PR](https://github.com/primer/react/pull/3682) that updates default story ids for components, since the 35.30 is out, I had a chance to test it on [primer.style/design](https://primer.style/design/components/blankslate/react) and unfortunately made a typo 🤦‍♀️ The draft components are under `drafts` folder not `draft` - This PR updates this. 

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

[Story prefix](https://github.com/primer/react/blob/6d0ee1614ac2aec9a42fe06f9e068db91a62b557/script/components-json/build.ts#L42) for the draft status components changed from `draft` to `drafts`  

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

I was thinking no changeset as this is docs related update but as a reviewer if you think this should go in the changeset, it would be a patch. 

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan


### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
Testing is not super straightforward but what I did was
- copy the content of the [component.json file](https://unpkg.com/@primer/react@0.0.0-20230921013923/generated/components.json) that is generated in the latest canary build
-  add a new file in the [design repo](https://github.com/primer/design) in my local called `generated-components.json`
- comment out [the line that fetches the content](https://github.com/primer/design/blob/main/gatsby-node.esm.js#L242) from the last stable primer react release
- add this line instead `const content = JSON.parse(fs.readFileSync('generated-components.json', 'utf8'))`
- restart the server 🎉 

I can confirm that I was able to see the draft stories on my local test.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
