### PR TITLE
SelectPanel2: Remove instant sorting in stories

### DIFF
--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -9,13 +9,30 @@ const getCircle = (color: string) => (
 )
 
 export const AControlled = () => {
-  const [filteredLabels, setFilteredLabels] = React.useState(data.labels)
-
-  // const initialSelectedLabels: string[] = [] // initial state: no labels
-  const initialSelectedLabels = data.issue.labelIds // initial state: has labels
-
+  const initialSelectedLabels = data.issue.labelIds // mock initial state: has selected labels
   const [selectedLabelIds, setSelectedLabelIds] = React.useState<string[]>(initialSelectedLabels)
 
+  /* Selection */
+  const onLabelSelect = (labelId: string) => {
+    if (!selectedLabelIds.includes(labelId)) setSelectedLabelIds([...selectedLabelIds, labelId])
+    else setSelectedLabelIds(selectedLabelIds.filter(id => id !== labelId))
+  }
+
+  const onClearSelection = () => {
+    // soft set, does not save until submit
+    setSelectedLabelIds([])
+  }
+
+  const onSubmit = (event: {preventDefault: () => void}) => {
+    event.preventDefault() // coz form submit, innit
+    data.issue.labelIds = selectedLabelIds // pretending to persist changes
+
+    // eslint-disable-next-line no-console
+    console.log('form submitted')
+  }
+
+  /* Filtering */
+  const [filteredLabels, setFilteredLabels] = React.useState(data.labels)
   const [query, setQuery] = React.useState('')
 
   // TODO: should this be baked-in
@@ -40,25 +57,7 @@ export const AControlled = () => {
     }
   }
 
-  const onLabelSelect = (labelId: string) => {
-    if (!selectedLabelIds.includes(labelId)) setSelectedLabelIds([...selectedLabelIds, labelId])
-    else setSelectedLabelIds(selectedLabelIds.filter(id => id !== labelId))
-  }
-
-  const onClearSelection = () => {
-    // soft set, does not save until submit
-    setSelectedLabelIds([])
-  }
-
-  const onSubmit = (event: {preventDefault: () => void}) => {
-    event.preventDefault() // coz form submit, innit
-    data.issue.labelIds = selectedLabelIds // pretending to persist changes
-
-    // eslint-disable-next-line no-console
-    console.log('form submitted')
-  }
-
-  const labelsToShow = query ? filteredLabels : data.labels
+  const itemsToShow = query ? filteredLabels : data.labels
 
   return (
     <>
@@ -95,8 +94,10 @@ export const AControlled = () => {
           <SelectPanel.SearchInput onChange={onSearchInputChange} />
         </SelectPanel.Header>
         <SelectPanel.ActionList>
-          {labelsToShow.length > 1 ? (
-            labelsToShow.map(label => (
+          {itemsToShow.length === 0 ? (
+            <SelectPanel.EmptyMessage>No labels found for &quot;{query}&quot;</SelectPanel.EmptyMessage>
+          ) : (
+            itemsToShow.map(label => (
               <ActionList.Item
                 key={label.id}
                 onSelect={() => onLabelSelect(label.id)}
@@ -107,8 +108,6 @@ export const AControlled = () => {
                 <ActionList.Description variant="block">{label.description}</ActionList.Description>
               </ActionList.Item>
             ))
-          ) : (
-            <SelectPanel.EmptyMessage>No labels found for &quot;{query}&quot;</SelectPanel.EmptyMessage>
           )}
         </SelectPanel.ActionList>
         <SelectPanel.Footer>

--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -57,7 +57,15 @@ export const AControlled = () => {
     }
   }
 
-  const itemsToShow = query ? filteredLabels : data.labels
+  const sortingFn = (itemA: {id: string}, itemB: {id: string}) => {
+    const initialSelectedIds = data.issue.labelIds
+    if (initialSelectedIds.includes(itemA.id) && initialSelectedIds.includes(itemB.id)) return 1
+    else if (initialSelectedIds.includes(itemA.id)) return -1
+    else if (initialSelectedIds.includes(itemB.id)) return 1
+    else return 1
+  }
+
+  const itemsToShow = query ? filteredLabels : data.labels.sort(sortingFn)
 
   return (
     <>

--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -153,6 +153,7 @@ export const BWithSuspendedList = () => {
 const SuspendedActionList: React.FC<{query: string}> = ({query}) => {
   const fetchedData: typeof data = use(getData({key: 'suspended-action-list'}))
 
+  /* Selection */
   const initialSelectedLabels: string[] = fetchedData.issue.labelIds
   const [selectedLabelIds, setSelectedLabelIds] = React.useState<string[]>(initialSelectedLabels)
 
@@ -161,13 +162,7 @@ const SuspendedActionList: React.FC<{query: string}> = ({query}) => {
     else setSelectedLabelIds(selectedLabelIds.filter(id => id !== labelId))
   }
 
-  const sortingFn = (labelA: {id: string}, labelB: {id: string}) => {
-    if (selectedLabelIds.includes(labelA.id) && selectedLabelIds.includes(labelB.id)) return 1
-    else if (selectedLabelIds.includes(labelA.id)) return -1
-    else if (selectedLabelIds.includes(labelB.id)) return 1
-    else return 1
-  }
-
+  /* Filtering */
   const filteredLabels = fetchedData.labels
     .map(label => {
       if (label.name.toLowerCase().startsWith(query)) return {priority: 1, label}
@@ -178,11 +173,14 @@ const SuspendedActionList: React.FC<{query: string}> = ({query}) => {
     .filter(result => result.priority > 0)
     .map(result => result.label)
 
+  const itemsToShow = query ? filteredLabels : data.labels
+
   return (
     <SelectPanel.ActionList>
-      {/* slightly different view for search results view and list view */}
-      {query ? (
-        filteredLabels.map(label => (
+      {itemsToShow.length === 0 ? (
+        <SelectPanel.EmptyMessage>No labels found for &quot;{query}&quot;</SelectPanel.EmptyMessage>
+      ) : (
+        itemsToShow.map(label => (
           <ActionList.Item
             key={label.id}
             onSelect={() => onLabelSelect(label.id)}
@@ -193,28 +191,6 @@ const SuspendedActionList: React.FC<{query: string}> = ({query}) => {
             <ActionList.Description variant="block">{label.description}</ActionList.Description>
           </ActionList.Item>
         ))
-      ) : (
-        <>
-          {fetchedData.labels.sort(sortingFn).map((label, index) => {
-            const nextLabel = fetchedData.labels.sort(sortingFn)[index + 1]
-            const showDivider = selectedLabelIds.includes(label.id) && !selectedLabelIds.includes(nextLabel?.id)
-
-            return (
-              <>
-                <ActionList.Item
-                  key={label.id}
-                  onSelect={() => onLabelSelect(label.id)}
-                  selected={selectedLabelIds.includes(label.id)}
-                >
-                  <ActionList.LeadingVisual>{getCircle(label.color)}</ActionList.LeadingVisual>
-                  {label.name}
-                  <ActionList.Description variant="block">{label.description}</ActionList.Description>
-                </ActionList.Item>
-                {showDivider ? <ActionList.Divider /> : null}
-              </>
-            )
-          })}
-        </>
       )}
     </SelectPanel.ActionList>
   )

--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -328,12 +328,26 @@ export const DAsyncSearchWithUseTransition = () => {
     startTransition(() => setQuery(query))
   }
 
+  /* Selection */
+  const initialAssigneeIds: string[] = data.issue.assigneeIds
+  const [selectedUserIds, setSelectedUserIds] = React.useState<string[]>(initialAssigneeIds)
+  const onUserSelect = (userId: string) => {
+    if (!selectedUserIds.includes(userId)) setSelectedUserIds([...selectedUserIds, userId])
+    else setSelectedUserIds(selectedUserIds.filter(id => id !== userId))
+  }
+
+  const onSubmit = () => {
+    data.issue.assigneeIds = selectedUserIds // pretending to persist changes
+    // eslint-disable-next-line no-console
+    console.log('form submitted')
+  }
+
   return (
     <>
       <h1>Async search with useTransition</h1>
       <p>Fetching items on every keystroke search (like github users)</p>
 
-      <SelectPanel defaultOpen={true}>
+      <SelectPanel defaultOpen={true} onSubmit={onSubmit}>
         {/* @ts-ignore todo */}
         <SelectPanel.Button>Select assignees</SelectPanel.Button>
         <SelectPanel.Header>
@@ -342,7 +356,13 @@ export const DAsyncSearchWithUseTransition = () => {
         </SelectPanel.Header>
 
         <React.Suspense fallback={<SelectPanel.Loading>Fetching users...</SelectPanel.Loading>}>
-          <SearchableUserList query={query} showLoading={isPending} />
+          <SearchableUserList
+            query={query}
+            showLoading={isPending}
+            initialAssigneeIds={initialAssigneeIds}
+            selectedUserIds={selectedUserIds}
+            onUserSelect={onUserSelect}
+          />
           <SelectPanel.Footer />
         </React.Suspense>
       </SelectPanel>

--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -11,8 +11,8 @@ const getCircle = (color: string) => (
 export const AControlled = () => {
   const [filteredLabels, setFilteredLabels] = React.useState(data.labels)
 
-  const initialSelectedLabels: string[] = [] // initial state: no labels
-  // const initialSelectedLabels = data.issue.labelIds // initial state: has labels
+  // const initialSelectedLabels: string[] = [] // initial state: no labels
+  const initialSelectedLabels = data.issue.labelIds // initial state: has labels
 
   const [selectedLabelIds, setSelectedLabelIds] = React.useState<string[]>(initialSelectedLabels)
 
@@ -58,25 +58,14 @@ export const AControlled = () => {
     console.log('form submitted')
   }
 
-  const sortingFn = (labelA: {id: string}, labelB: {id: string}) => {
-    /* Important! This sorting is only for initial selected ids, not for subsequent changes!
-      deterministic sorting for better UX: don't change positions with other selected items.
-
-      TODO: should this sorting be baked-in OR we only validate + warn OR do nothing
-      need to either own or accept the selection state to make that automatic
-      OR provide a API for sorting in ActionList like sort by key or sort fn
-    */
-    if (selectedLabelIds.includes(labelA.id) && selectedLabelIds.includes(labelB.id)) return 1
-    else if (selectedLabelIds.includes(labelA.id)) return -1
-    else if (selectedLabelIds.includes(labelB.id)) return 1
-    else return 1
-  }
+  const labelsToShow = query ? filteredLabels : data.labels
 
   return (
     <>
       <h1>Controlled SelectPanel</h1>
 
       <SelectPanel
+        defaultOpen
         // onSubmit and onCancel feel out of place here instead of the footer,
         // but cancel can be called from 4 different actions - Cancel button, X iconbutton up top, press escape key, click outside
         // also, what if there is no footer? onSubmit is maybe not needed, but we need to put the onCancel callback somewhere.
@@ -106,50 +95,20 @@ export const AControlled = () => {
           <SelectPanel.SearchInput onChange={onSearchInputChange} />
         </SelectPanel.Header>
         <SelectPanel.ActionList>
-          {/* slightly different view for search results view and list view */}
-          {query ? (
-            filteredLabels.length > 1 ? (
-              filteredLabels.map(label => (
-                <ActionList.Item
-                  key={label.id}
-                  onSelect={() => onLabelSelect(label.id)}
-                  selected={selectedLabelIds.includes(label.id)}
-                >
-                  <ActionList.LeadingVisual>{getCircle(label.color)}</ActionList.LeadingVisual>
-                  {label.name}
-                  <ActionList.Description variant="block">{label.description}</ActionList.Description>
-                </ActionList.Item>
-              ))
-            ) : (
-              <SelectPanel.EmptyMessage>No labels found for &quot;{query}&quot;</SelectPanel.EmptyMessage>
-            )
+          {labelsToShow.length > 1 ? (
+            labelsToShow.map(label => (
+              <ActionList.Item
+                key={label.id}
+                onSelect={() => onLabelSelect(label.id)}
+                selected={selectedLabelIds.includes(label.id)}
+              >
+                <ActionList.LeadingVisual>{getCircle(label.color)}</ActionList.LeadingVisual>
+                {label.name}
+                <ActionList.Description variant="block">{label.description}</ActionList.Description>
+              </ActionList.Item>
+            ))
           ) : (
-            <>
-              {data.labels.sort(sortingFn).map((label, index) => {
-                /* 
-                  we want to render a divider between the group of selected and unselected items.
-                  kinda hack: if this is the last item that is selected, render an divider after it
-                  TODO: can this be cleaner?
-                */
-                const nextLabel = data.labels.sort(sortingFn)[index + 1]
-                const showDivider = selectedLabelIds.includes(label.id) && !selectedLabelIds.includes(nextLabel?.id)
-
-                return (
-                  <>
-                    <ActionList.Item
-                      key={label.id}
-                      onSelect={() => onLabelSelect(label.id)}
-                      selected={selectedLabelIds.includes(label.id)}
-                    >
-                      <ActionList.LeadingVisual>{getCircle(label.color)}</ActionList.LeadingVisual>
-                      {label.name}
-                      <ActionList.Description variant="block">{label.description}</ActionList.Description>
-                    </ActionList.Item>
-                    {showDivider ? <ActionList.Divider /> : null}
-                  </>
-                )
-              })}
-            </>
+            <SelectPanel.EmptyMessage>No labels found for &quot;{query}&quot;</SelectPanel.EmptyMessage>
           )}
         </SelectPanel.ActionList>
         <SelectPanel.Footer>

--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -231,35 +231,33 @@ export const CAsyncSearchWithSuspenseKey = () => {
   )
 }
 
+/* 
+  `data` is already pre-fetched with the issue 
+  `users` are fetched async on search
+*/
 const SearchableUserList: React.FC<{query: string; showLoading?: boolean}> = ({query, showLoading = false}) => {
-  // issue `data` is already pre-fetched
   const repository = {collaborators: data.collaborators}
-  // `users` are fetched async on search
-  const filteredUsers: typeof data.users = query ? use(queryUsers({query})) : []
 
+  /* Selection */
   const initialSelectedUsers: string[] = data.issue.assigneeIds
   const [selectedUserIds, setSelectedUserIds] = React.useState<string[]>(initialSelectedUsers)
-
   const onUserSelect = (userId: string) => {
     if (!selectedUserIds.includes(userId)) setSelectedUserIds([...selectedUserIds, userId])
     else setSelectedUserIds(selectedUserIds.filter(id => id !== userId))
   }
 
-  const sortingFn = (userA: {id: string}, userB: {id: string}) => {
-    if (selectedUserIds.includes(userA.id) && selectedUserIds.includes(userB.id)) return 1
-    else if (selectedUserIds.includes(userA.id)) return -1
-    else if (selectedUserIds.includes(userB.id)) return 1
-    else return 1
-  }
+  /* Filtering */
+  const filteredUsers: typeof data.users = query ? use(queryUsers({query})) : []
 
-  // only used with useTransition example
   if (showLoading) return <SelectPanel.Loading>Search for users...</SelectPanel.Loading>
+  const itemsToShow = query ? filteredUsers : repository.collaborators
 
-  /* slightly different view for search results view and list view */
-  if (query) {
-    return (
-      <SelectPanel.ActionList>
-        {filteredUsers.map(user => (
+  return (
+    <SelectPanel.ActionList>
+      {itemsToShow.length === 0 ? (
+        <SelectPanel.EmptyMessage>No users found for &quot;{query}&quot;</SelectPanel.EmptyMessage>
+      ) : (
+        itemsToShow.map(user => (
           <ActionList.Item
             key={user.id}
             onSelect={() => onUserSelect(user.id)}
@@ -271,42 +269,17 @@ const SearchableUserList: React.FC<{query: string; showLoading?: boolean}> = ({q
             {user.login}
             <ActionList.Description>{user.name}</ActionList.Description>
           </ActionList.Item>
-        ))}
-      </SelectPanel.ActionList>
-    )
-  } else {
-    return (
-      <SelectPanel.ActionList>
-        {repository.collaborators.sort(sortingFn).map((user, index) => {
-          // tiny bit of additional logic to show divider
-          const nextUser = repository.collaborators.sort(sortingFn)[index + 1]
-          const showDivider = selectedUserIds.includes(user.id) && !selectedUserIds.includes(nextUser?.id)
-          return (
-            <>
-              <ActionList.Item
-                key={user.id}
-                onSelect={() => onUserSelect(user.id)}
-                selected={selectedUserIds.includes(user.id)}
-              >
-                <ActionList.LeadingVisual>
-                  <Avatar src={`https://github.com/${user.login}.png`} />
-                </ActionList.LeadingVisual>
-                {user.login}
-                <ActionList.Description>{user.name}</ActionList.Description>
-              </ActionList.Item>
-              {showDivider ? <ActionList.Divider /> : null}
-            </>
-          )
-        })}
-      </SelectPanel.ActionList>
-    )
-  }
+        ))
+      )}
+    </SelectPanel.ActionList>
+  )
 }
 
+/* 
+  `data` is already pre-fetched with the issue 
+  `users` are fetched async on search
+*/
 export const DAsyncSearchWithUseTransition = () => {
-  // issue `data` is already pre-fetched
-  // `users` are fetched async on search
-
   const [isPending, startTransition] = React.useTransition()
 
   const [query, setQuery] = React.useState('')
@@ -340,7 +313,7 @@ export const DAsyncSearchWithUseTransition = () => {
 export const TODO1Uncontrolled = () => {
   /* features to implement:
      1. search
-     2. sort + divider
+     2. sort
      3. selection
      4. clear selection
      5. different results view

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -58,6 +58,7 @@ const SelectPanel = props => {
   }
   // @ts-ignore todo
   const onInternalSubmit = event => {
+    event.preventDefault()
     setOpen(false)
     if (typeof props.onSubmit === 'function') props.onSubmit(event)
   }

--- a/src/drafts/SelectPanel2/mock-data.ts
+++ b/src/drafts/SelectPanel2/mock-data.ts
@@ -1,7 +1,7 @@
 const data = {
   issue: {
     labelIds: ['MDU6TGFiZWw4Mzk2MzgxMTU=', 'MDU6TGFiZWw4Mzk2MzgxMjE='],
-    assigneeIds: [],
+    assigneeIds: ['MDQ6VXNlcjQxNzI2OA=='],
   },
   collaborators: [
     {

--- a/src/drafts/SelectPanel2/work-log.md
+++ b/src/drafts/SelectPanel2/work-log.md
@@ -37,12 +37,16 @@
 
 ## Implementation notes
 
-1. [Next for Sid] Improve divider logic in stories (we don't need 2 branches, instead a ConditionalDivider component or a showDividerAtIndex variable) (we don't even need it anymore, + also leave a comment in the code to the issue where we decided not to do it)
 1. Is there a way to absorb divider logic, right now it's the application's responsibility
-1. Add controlled state for `open` (use cases: 1. fetch data when opened, 2. nested menus, 3. keep panel open till it's saved: https://github.com/github/primer/issues/2403)
+1. Add controlled state for `open` (use cases: 1. fetch data when opened, 2. nested menus
+1. keep panel open till it's saved: https://github.com/github/primer/issues/2403)
 1. We probably (need to check) should not even render Overlay contents until it's opened
-1. Add SelectPanel.EmptyMessage to all stories
-1. SelectPanel.Overlay
-1. The flicker in story with useTransition is unfortunate, is there already a way to add a minimum time to avoid this (debounce)? and is it possible/ergonomic to bake that in the component or should it be delegated to the application
+1. SelectPanel.Overlay API
 1. I think it's nice that there is a `<SelectPanel.Footer>` because you can wrap it in suspense along with the search results
 1. Need to make Save and Cancel optional (selectionVariant="instant"?)
+
+### Stories
+
+1. [Next for Sid] Improve divider logic in stories (we don't need 2 branches, instead a ConditionalDivider component or a showDividerAtIndex variable) (we don't even need it anymore, + also leave a comment in the code to the issue where we decided not to do it)
+1. Add SelectPanel.EmptyMessage to all stories
+1. The flicker in story with useTransition is unfortunate, is there already a way to add a minimum time to avoid this (debounce)? and is it possible/ergonomic to bake that in the component or should it be delegated to the application


### PR DESCRIPTION
- Implements part of https://github.com/github/primer/issues/2644

Items should not move when selecting elements. From Chelsea:

> the selection of items and should stay put until saved and the dialog reopened to bring the selected items to the top. The reverse is also true. Deselected items should not shift list position until saved and reopened

&nbsp;

Note: This PR removes the divider and does not implement the [second part of #2644](https://github.com/github/primer/issues/2644#issuecomment-1716368920) (when the input filter is emptied, selected items should be moved to the top). Keeping [#2644](https://github.com/github/primer/issues/2644#issuecomment-1716368920) open until I add that.

&nbsp;

| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/primer/react/assets/1863771/c7b65b3f-40ca-439b-870a-16f9af63ac21">  | <video src="https://github.com/primer/react/assets/1863771/5639ee63-26ae-4808-937d-f3d99bb2c51f">|