### PR TITLE
SelectPanel2: Add option to use external anchor

### DIFF
--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -660,31 +660,23 @@ export const FExternalAnchor = () => {
 }
 
 export const GOpenFromMenu = () => {
-  const initialSelectedLabels = data.issue.labelIds // mock initial state: has selected labels
-  const [selectedLabelIds, setSelectedLabelIds] = React.useState<string[]>(initialSelectedLabels)
-
   /* Selection */
-  const onLabelSelect = (labelId: string) => {
-    if (!selectedLabelIds.includes(labelId)) setSelectedLabelIds([...selectedLabelIds, labelId])
-    else setSelectedLabelIds(selectedLabelIds.filter(id => id !== labelId))
+
+  const [selectedEvents, setSelectedEvents] = React.useState<string[]>([])
+
+  const onEventSelect = (event: string) => {
+    if (!selectedEvents.includes(event)) setSelectedEvents([...selectedEvents, event])
+    else setSelectedEvents(selectedEvents.filter(name => name !== event))
   }
 
   const onSubmit = () => {
-    data.issue.labelIds = selectedLabelIds // pretending to persist changes
+    data.issue.labelIds = selectedEvents // pretending to persist changes
 
     // eslint-disable-next-line no-console
     console.log('form submitted')
   }
 
-  const sortingFn = (itemA: {id: string}, itemB: {id: string}) => {
-    const initialSelectedIds = data.issue.labelIds
-    if (initialSelectedIds.includes(itemA.id) && initialSelectedIds.includes(itemB.id)) return 1
-    else if (initialSelectedIds.includes(itemA.id)) return -1
-    else if (initialSelectedIds.includes(itemB.id)) return 1
-    else return 1
-  }
-
-  const itemsToShow = data.labels.sort(sortingFn)
+  const itemsToShow = ['Issues', 'Pull requests', 'Releases', 'Discussions', 'Security alerts']
 
   const [selectPanelOpen, setSelectPanelOpen] = React.useState(false)
   const buttonRef = React.useRef<HTMLButtonElement>(null)
@@ -737,7 +729,7 @@ export const GOpenFromMenu = () => {
       </ActionMenu>
 
       <SelectPanel
-        title="Select labels"
+        title="Custom"
         open={selectPanelOpen}
         anchorRef={buttonRef}
         onSubmit={() => {
@@ -745,17 +737,12 @@ export const GOpenFromMenu = () => {
           onSubmit()
         }}
         onCancel={() => setSelectPanelOpen(false)}
+        height="medium"
       >
         <SelectPanel.ActionList>
-          {itemsToShow.map(label => (
-            <ActionList.Item
-              key={label.id}
-              onSelect={() => onLabelSelect(label.id)}
-              selected={selectedLabelIds.includes(label.id)}
-            >
-              <ActionList.LeadingVisual>{getCircle(label.color)}</ActionList.LeadingVisual>
-              {label.name}
-              <ActionList.Description variant="block">{label.description}</ActionList.Description>
+          {itemsToShow.map(item => (
+            <ActionList.Item key={item} onSelect={() => onEventSelect(item)} selected={selectedEvents.includes(item)}>
+              {item}
             </ActionList.Item>
           ))}
         </SelectPanel.ActionList>

--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {SelectPanel} from './SelectPanel'
-import {ActionList, Avatar, Box, Button} from '../../../src/index'
-import {GitBranchIcon, TriangleDownIcon} from '@primer/octicons-react'
+import {ActionList, ActionMenu, Avatar, Box, Button} from '../../../src/index'
+import {ArrowRightIcon, EyeIcon, GitBranchIcon, TriangleDownIcon} from '@primer/octicons-react'
 import data from './mock-data'
 
 const getCircle = (color: string) => (
@@ -571,6 +571,181 @@ export const EMinimal = () => {
         {/* @ts-ignore todo */}
         <SelectPanel.Button>Assign label</SelectPanel.Button>
 
+        <SelectPanel.ActionList>
+          {itemsToShow.map(label => (
+            <ActionList.Item
+              key={label.id}
+              onSelect={() => onLabelSelect(label.id)}
+              selected={selectedLabelIds.includes(label.id)}
+            >
+              <ActionList.LeadingVisual>{getCircle(label.color)}</ActionList.LeadingVisual>
+              {label.name}
+              <ActionList.Description variant="block">{label.description}</ActionList.Description>
+            </ActionList.Item>
+          ))}
+        </SelectPanel.ActionList>
+      </SelectPanel>
+    </>
+  )
+}
+
+export const FExternalAnchor = () => {
+  const initialSelectedLabels = data.issue.labelIds // mock initial state: has selected labels
+  const [selectedLabelIds, setSelectedLabelIds] = React.useState<string[]>(initialSelectedLabels)
+
+  /* Selection */
+  const onLabelSelect = (labelId: string) => {
+    if (!selectedLabelIds.includes(labelId)) setSelectedLabelIds([...selectedLabelIds, labelId])
+    else setSelectedLabelIds(selectedLabelIds.filter(id => id !== labelId))
+  }
+
+  const onSubmit = () => {
+    data.issue.labelIds = selectedLabelIds // pretending to persist changes
+
+    // eslint-disable-next-line no-console
+    console.log('form submitted')
+  }
+
+  const sortingFn = (itemA: {id: string}, itemB: {id: string}) => {
+    const initialSelectedIds = data.issue.labelIds
+    if (initialSelectedIds.includes(itemA.id) && initialSelectedIds.includes(itemB.id)) return 1
+    else if (initialSelectedIds.includes(itemA.id)) return -1
+    else if (initialSelectedIds.includes(itemB.id)) return 1
+    else return 1
+  }
+
+  const itemsToShow = data.labels.sort(sortingFn)
+
+  const anchorRef = React.useRef<HTMLButtonElement>(null)
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <>
+      <h1>With External Anchor</h1>
+      <p>
+        To use an external anchor, pass an `anchorRef` to `SelectPanel`. You would also need to control the `open` state
+        with `onSubmit` and `onCancel`
+      </p>
+
+      <Button ref={anchorRef} variant="primary" onClick={() => setOpen(!open)}>
+        Assign label
+      </Button>
+
+      <SelectPanel
+        title="Select labels"
+        anchorRef={anchorRef}
+        open={open} // this needs to be set with the button
+        onSubmit={() => {
+          setOpen(false) // close on submit
+          onSubmit()
+        }}
+        onCancel={() => setOpen(false)} // close on cancel
+      >
+        <SelectPanel.ActionList>
+          {itemsToShow.map(label => (
+            <ActionList.Item
+              key={label.id}
+              onSelect={() => onLabelSelect(label.id)}
+              selected={selectedLabelIds.includes(label.id)}
+            >
+              <ActionList.LeadingVisual>{getCircle(label.color)}</ActionList.LeadingVisual>
+              {label.name}
+              <ActionList.Description variant="block">{label.description}</ActionList.Description>
+            </ActionList.Item>
+          ))}
+        </SelectPanel.ActionList>
+      </SelectPanel>
+    </>
+  )
+}
+
+export const GOpenFromMenu = () => {
+  const initialSelectedLabels = data.issue.labelIds // mock initial state: has selected labels
+  const [selectedLabelIds, setSelectedLabelIds] = React.useState<string[]>(initialSelectedLabels)
+
+  /* Selection */
+  const onLabelSelect = (labelId: string) => {
+    if (!selectedLabelIds.includes(labelId)) setSelectedLabelIds([...selectedLabelIds, labelId])
+    else setSelectedLabelIds(selectedLabelIds.filter(id => id !== labelId))
+  }
+
+  const onSubmit = () => {
+    data.issue.labelIds = selectedLabelIds // pretending to persist changes
+
+    // eslint-disable-next-line no-console
+    console.log('form submitted')
+  }
+
+  const sortingFn = (itemA: {id: string}, itemB: {id: string}) => {
+    const initialSelectedIds = data.issue.labelIds
+    if (initialSelectedIds.includes(itemA.id) && initialSelectedIds.includes(itemB.id)) return 1
+    else if (initialSelectedIds.includes(itemA.id)) return -1
+    else if (initialSelectedIds.includes(itemB.id)) return 1
+    else return 1
+  }
+
+  const itemsToShow = data.labels.sort(sortingFn)
+
+  const [selectPanelOpen, setSelectPanelOpen] = React.useState(false)
+  const buttonRef = React.useRef<HTMLButtonElement>(null)
+
+  return (
+    <>
+      <h1>Open from ActionMenu</h1>
+      <p>
+        To open SelectPanel from a menu, you would need to use an external anchor and pass `anchorRef` to `SelectPanel`.
+        You would also need to control the `open` state with `onSubmit` and `onCancel`.
+        <br />
+        <br />
+        Important: Pass the same `anchorRef` to both ActionMenu and SelectPanel, otherwise the SelectPanel would not be
+        visible.
+      </p>
+
+      <ActionMenu anchorRef={buttonRef}>
+        <ActionMenu.Button leadingVisual={EyeIcon} ref={buttonRef}>
+          Unwatch
+        </ActionMenu.Button>
+        <ActionMenu.Overlay width="medium">
+          <ActionList selectionVariant="single">
+            <ActionList.Item>
+              Participating and @mentions
+              <ActionList.Description variant="block">
+                Only receive notifications from this repository when participating or @mentioned.
+              </ActionList.Description>
+            </ActionList.Item>
+            <ActionList.Item selected={true}>
+              All activity
+              <ActionList.Description variant="block">
+                Notified of all notifications on this repository.
+              </ActionList.Description>
+            </ActionList.Item>
+            <ActionList.Item>
+              Ignore
+              <ActionList.Description variant="block">Never be notified.</ActionList.Description>
+            </ActionList.Item>
+            <ActionList.Item onSelect={() => setSelectPanelOpen(true)}>
+              Custom
+              <ActionList.TrailingVisual>
+                <ArrowRightIcon />
+              </ActionList.TrailingVisual>
+              <ActionList.Description variant="block">
+                Select events you want to be notified of in addition to participating and @mentions.
+              </ActionList.Description>
+            </ActionList.Item>
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+
+      <SelectPanel
+        title="Select labels"
+        open={selectPanelOpen}
+        anchorRef={buttonRef}
+        onSubmit={() => {
+          setSelectPanelOpen(false)
+          onSubmit()
+        }}
+        onCancel={() => setSelectPanelOpen(false)}
+      >
         <SelectPanel.ActionList>
           {itemsToShow.map(label => (
             <ActionList.Item

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../src/index'
 import {useSlots} from '../../hooks/useSlots'
 import {ClearIcon} from './tmp-ClearIcon'
+import {useProvidedRefOrCreate} from '../../hooks'
 
 const SelectPanelContext = React.createContext<{
   title: string
@@ -35,7 +36,7 @@ const SelectPanelContext = React.createContext<{
 
 // @ts-ignore todo
 const SelectPanel = props => {
-  const anchorRef = React.useRef<HTMLButtonElement>(null)
+  const anchorRef = useProvidedRefOrCreate(props.anchorRef)
 
   // 🚨 Hack for good API!
   // we strip out Anchor from children and pass it to AnchoredOverlay to render
@@ -49,19 +50,18 @@ const SelectPanel = props => {
     return child
   })
 
-  // TODO: defaultOpen is not for debugging, I don't intend to make
-  // it part of the API
-  const [open, setOpen] = React.useState(props.defaultOpen)
+  const [internalOpen, setInternalOpen] = React.useState(props.defaultOpen)
+  // sync open state
+  React.useEffect(() => setInternalOpen(props.open), [props.open])
 
   const onInternalClose = () => {
-    setOpen(false)
-
+    if (props.open === 'undefined') setInternalOpen(false)
     if (typeof props.onCancel === 'function') props.onCancel()
   }
   // @ts-ignore todo
   const onInternalSubmit = event => {
     event.preventDefault()
-    setOpen(false)
+    if (props.open === 'undefined') setInternalOpen(false)
     if (typeof props.onSubmit === 'function') props.onSubmit(event)
   }
 
@@ -77,10 +77,11 @@ const SelectPanel = props => {
   return (
     <>
       <AnchoredOverlay
+        // @ts-ignore todo
         anchorRef={anchorRef}
         renderAnchor={renderAnchor}
-        open={open}
-        onOpen={() => setOpen(true)}
+        open={internalOpen}
+        onOpen={() => setInternalOpen(true)}
         onClose={onInternalClose}
         width="medium"
         height="large"

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -83,8 +83,8 @@ const SelectPanel = props => {
         open={internalOpen}
         onOpen={() => setInternalOpen(true)}
         onClose={onInternalClose}
-        width="medium"
-        height="large"
+        width={props.width || 'medium'}
+        height={props.height || 'large'}
         focusZoneSettings={{bindKeys: FocusKeys.Tab}}
       >
         {/* TODO: Keyboard navigation of actionlist should be arrow keys


### PR DESCRIPTION
There are a bunch of use cases where you'd need to open a SelectPanel with an external anchor

For example, here's an example from memex where the anchor is a row cell:

<img height="400" alt="clicking a row cell opens a SelectPanel to switch milestones" src="https://github.com/primer/react/assets/1863771/062bbc67-2a19-492b-91e5-ee5aab8cabc0">

&nbsp;

Another example, here's a SelectPanel that opens from an action in ActionMenu:

https://github.com/primer/react/assets/1863771/78daf150-52f1-44c8-9853-116e08a8da19

