### PR TITLE
Revert "Add aria-selected value to ActionList.Item."

### DIFF
--- a/.changeset/wise-boxes-peel.md
+++ b/.changeset/wise-boxes-peel.md
@@ -3,3 +3,5 @@
 ---
 
 Revert "Add aria-selected value to ActionList.Item."
+
+<!-- Changed components: ActionList -->

--- a/.changeset/wise-boxes-peel.md
+++ b/.changeset/wise-boxes-peel.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Revert "Add aria-selected value to ActionList.Item."

--- a/src/ActionList/ActionList.test.tsx
+++ b/src/ActionList/ActionList.test.tsx
@@ -42,6 +42,7 @@ function SingleSelectListStory(): JSX.Element {
           key={index}
           role="option"
           selected={index === selectedIndex}
+          aria-selected={index === selectedIndex}
           onSelect={() => setSelectedIndex(index)}
           disabled={project.disabled}
         >

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -220,7 +220,6 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
           ref={forwardedRef}
           sx={merge<BetterSystemStyleObject>(styles, sxProp)}
           data-variant={variant === 'danger' ? variant : undefined}
-          aria-selected={containerProps.role === 'option' ? selected : undefined}
           {...containerProps}
           {...props}
         >


### PR DESCRIPTION
This reverts commit `242c634`.

There was some disagreement about how ActionList items should announce if they're selected or not. There's a functional difference between an item being "selected" (the user is currently focused on it) and "checked" (the option was previously chosen and is active). We want to communicate the former, but the `aria-selected` attribute is the incorrect way to do this.

This should not impact anything major in dotcom, as both changes were internal to the component, and did not require any changes by consumers.