### PR TITLE
bs/return focus dialog actionlist item

### DIFF
--- a/src/ActionMenu/ActionMenu.examples.stories.tsx
+++ b/src/ActionMenu/ActionMenu.examples.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useState, useRef} from 'react'
 import {Box, ActionMenu, ActionList, Button, IconButton} from '../'
 import {
   GearIcon,
@@ -14,6 +14,7 @@ import {
   CheckIcon,
   CopyIcon,
 } from '@primer/octicons-react'
+import Dialog from '../Dialog'
 
 export default {
   title: 'Components/ActionMenu/Examples',
@@ -184,6 +185,67 @@ export const CustomAnchor = () => (
     </ActionMenu.Overlay>
   </ActionMenu>
 )
+
+export const OpenDialogFromMenuItem = () => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const closeDialog = () => setIsDialogOpen(false)
+  const buttonRef = React.useRef(null)
+  return (
+    <>
+      <IconButton
+        ref={buttonRef}
+        icon={KebabHorizontalIcon}
+        aria-label="Open menu"
+        onClick={() => setIsOpen(!isOpen)}
+      />
+      <ActionMenu open={isOpen} anchorRef={buttonRef} onOpenChange={value => setIsOpen(value)}>
+        <ActionMenu.Overlay width="medium">
+          <ActionList>
+            <ActionList.Item onSelect={() => setIsDialogOpen(true)}>
+              <ActionList.LeadingVisual>
+                <IssueOpenedIcon />
+              </ActionList.LeadingVisual>
+              Change Issue Type
+            </ActionList.Item>
+            <ActionList.Item onSelect={() => alert('Copy link clicked')}>
+              Copy link
+              <ActionList.TrailingVisual>⌘C</ActionList.TrailingVisual>
+            </ActionList.Item>
+            <ActionList.Item onSelect={() => alert('Quote reply clicked')}>
+              Quote reply
+              <ActionList.TrailingVisual>⌘Q</ActionList.TrailingVisual>
+            </ActionList.Item>
+            <ActionList.Item onSelect={() => alert('Edit comment clicked')}>
+              Edit comment
+              <ActionList.TrailingVisual>⌘E</ActionList.TrailingVisual>
+            </ActionList.Item>
+            <ActionList.Divider />
+            <ActionList.Item variant="danger" onSelect={() => alert('Delete file clicked')}>
+              Delete file
+              <ActionList.TrailingVisual>⌘D</ActionList.TrailingVisual>
+            </ActionList.Item>
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+
+      <Dialog
+        returnFocusRef={buttonRef}
+        isOpen={isDialogOpen}
+        onDismiss={() => {
+          closeDialog()
+        }}
+      >
+        <Dialog.Header id="header-id">Title</Dialog.Header>
+        some content
+        <Box display="flex" mt={3} justifyContent="flex-end">
+          <Button sx={{mr: 1}}>Cancel</Button>
+          <Button variant="danger">Delete</Button>
+        </Box>
+      </Dialog>
+    </>
+  )
+}
 
 export const MixedSelection = () => {
   const [selectedIndex, setSelectedIndex] = React.useState<number | null>(1)

--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {SelectPanel} from './SelectPanel'
 import {ActionList, ActionMenu, Avatar, Box, Button, Flash} from '../../../src/index'
-import {ArrowRightIcon, AlertIcon, EyeIcon, GitBranchIcon, TriangleDownIcon} from '@primer/octicons-react'
+import {ArrowRightIcon, AlertIcon, EyeIcon, GitBranchIcon, TriangleDownIcon, TagIcon} from '@primer/octicons-react'
 import data from './mock-data'
 
 const getCircle = (color: string) => (
@@ -776,6 +776,37 @@ export const GOpenFromMenu = () => {
           ))}
         </ActionList>
         <SelectPanel.Footer />
+      </SelectPanel>
+    </>
+  )
+}
+
+export const IInstantSelectionVariant = () => {
+  const [selectedTag, setSelectedTag] = React.useState<string>()
+
+  const onSubmit = () => {
+    if (!selectedTag) return
+    data.ref = selectedTag // pretending to persist changes
+  }
+
+  const itemsToShow = data.tags
+
+  return (
+    <>
+      <h1>Instant selection variant</h1>
+
+      <SelectPanel title="Choose a tag" selectionVariant="instant" onSubmit={onSubmit} defaultOpen>
+        {/* @ts-ignore todo */}
+        <SelectPanel.Button leadingIcon={TagIcon}>{selectedTag || 'Choose a tag'}</SelectPanel.Button>
+
+        <ActionList>
+          {itemsToShow.map(tag => (
+            <ActionList.Item key={tag.id} onSelect={() => setSelectedTag(tag.id)} selected={selectedTag === tag.id}>
+              {tag.name}
+            </ActionList.Item>
+          ))}
+        </ActionList>
+        {/* no footer */}
       </SelectPanel>
     </>
   )

--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -795,7 +795,7 @@ export const IInstantSelectionVariant = () => {
     <>
       <h1>Instant selection variant</h1>
 
-      <SelectPanel title="Choose a tag" selectionVariant="instant" onSubmit={onSubmit} defaultOpen>
+      <SelectPanel title="Choose a tag" selectionVariant="instant" onSubmit={onSubmit} height="medium" defaultOpen>
         {/* @ts-ignore todo */}
         <SelectPanel.Button leadingIcon={TagIcon}>{selectedTag || 'Choose a tag'}</SelectPanel.Button>
 
@@ -806,7 +806,9 @@ export const IInstantSelectionVariant = () => {
             </ActionList.Item>
           ))}
         </ActionList>
-        {/* no footer */}
+        <SelectPanel.Footer>
+          <SelectPanel.SecondaryButton>Edit tags</SelectPanel.SecondaryButton>
+        </SelectPanel.Footer>
       </SelectPanel>
     </>
   )

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -57,15 +57,19 @@ const SelectPanel = props => {
     if (props.open === undefined) setInternalOpen(false)
     if (typeof props.onCancel === 'function') props.onCancel()
   }
-  // @ts-ignore todo
-  const onInternalSubmit = event => {
-    event.preventDefault()
+
+  const onInternalSubmit = (event?: React.SyntheticEvent) => {
+    event?.preventDefault() // there is no event with selectionVariant=instant
     if (props.open === undefined) setInternalOpen(false)
     if (typeof props.onSubmit === 'function') props.onSubmit(event)
   }
 
   const onInternalClearSelection = () => {
     if (typeof props.onSubmit === 'function') props.onClearSelection()
+  }
+
+  const internalAfterSelect = () => {
+    if (props.selectionVariant === 'instant') onInternalSubmit()
   }
 
   /* Search/Filter */
@@ -127,7 +131,9 @@ const SelectPanel = props => {
                   container: 'SelectPanel',
                   listRole: 'listbox',
                   selectionAttribute: 'aria-selected',
-                  selectionVariant: props.selectionVariant || 'multiple',
+                  selectionVariant:
+                    props.selectionVariant === 'instant' ? 'single' : props.selectionVariant || 'multiple',
+                  afterSelect: internalAfterSelect,
                 }}
               >
                 {childrenInBody}

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -13,6 +13,7 @@ import {
   AnchoredOverlayProps,
   Spinner,
   Text,
+  ActionListProps,
 } from '../../../src/index'
 import {ActionListContainerContext} from '../../../src/ActionList/ActionListContainerContext'
 import {useSlots} from '../../hooks/useSlots'
@@ -25,12 +26,14 @@ const SelectPanelContext = React.createContext<{
   onClearSelection: undefined | (() => void)
   searchQuery: string
   setSearchQuery: () => void
+  selectionVariant: ActionListProps['selectionVariant'] | 'instant'
 }>({
   title: '',
   onCancel: () => {},
   onClearSelection: undefined,
   searchQuery: '',
   setSearchQuery: () => {},
+  selectionVariant: 'multiple',
 })
 
 // @ts-ignore todo
@@ -101,6 +104,7 @@ const SelectPanel = props => {
             searchQuery,
             // @ts-ignore todo
             setSearchQuery,
+            selectionVariant: props.selectionVariant,
           }}
         >
           <Box
@@ -250,7 +254,15 @@ const SelectPanelSearchInput = props => {
 SelectPanel.SearchInput = SelectPanelSearchInput
 
 const SelectPanelFooter = ({...props}) => {
-  const {onCancel} = React.useContext(SelectPanelContext)
+  const {onCancel, selectionVariant} = React.useContext(SelectPanelContext)
+
+  const hidePrimaryActions = selectionVariant === 'instant'
+
+  if (hidePrimaryActions && !props.children) {
+    // nothing to render
+    // todo: we can inform them the developer footer will render nothing
+    return null
+  }
 
   return (
     <Box
@@ -262,15 +274,18 @@ const SelectPanelFooter = ({...props}) => {
         borderColor: 'border.default',
       }}
     >
-      <div>{props.children}</div>
-      <Box sx={{display: 'flex', gap: 2}}>
-        <Button size="small" type="button" onClick={() => onCancel()}>
-          Cancel
-        </Button>
-        <Button size="small" type="submit" variant="primary">
-          Save
-        </Button>
-      </Box>
+      <Box sx={{flexGrow: hidePrimaryActions ? 1 : 0}}>{props.children}</Box>
+
+      {hidePrimaryActions ? null : (
+        <Box sx={{display: 'flex', gap: 2}}>
+          <Button size="small" type="button" onClick={() => onCancel()}>
+            Cancel
+          </Button>
+          <Button size="small" type="submit" variant="primary">
+            Save
+          </Button>
+        </Box>
+      )}
     </Box>
   )
 }
@@ -278,7 +293,7 @@ SelectPanel.Footer = SelectPanelFooter
 
 // @ts-ignore todo
 SelectPanel.SecondaryButton = props => {
-  return <Button {...props} size="small" type="button" />
+  return <Button {...props} size="small" type="button" block />
 }
 // SelectPanel.SecondaryLink = props => {
 //   return <a {...props}>{props.children}</a>

--- a/src/drafts/SelectPanel2/mock-data.ts
+++ b/src/drafts/SelectPanel2/mock-data.ts
@@ -922,7 +922,9 @@ const data = {
     {id: 'dependabot/markdownlint-github-0.4.1', name: 'dependabot/markdownlint-github-0.4.1'},
   ],
   tags: [
-    {id: 'v35.29.0', name: 'v35.29.0', trailingInfo: 'Latest'},
+    {id: 'v35.31.0', name: 'v35.31.0', trailingInfo: 'Latest'},
+    {id: 'v35.30.0', name: 'v35.30.0'},
+    {id: 'v35.29.0', name: 'v35.29.0'},
     {id: 'v35.28.0', name: 'v35.28.0'},
     {id: 'v35.27.1', name: 'v35.27.1'},
     {id: 'v35.27.0', name: 'v35.27.0'},


### PR DESCRIPTION
- add instant variant example
- secondary action only
- Add an example to open a dialog from action menu and return focus to the menu trigger not the dialog

<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
