### PR TITLE
Tooltip v2: Update tooltip draft id and add to the `primer.style/react` navigation

### DIFF
--- a/docs/content/drafts/Tooltip.mdx
+++ b/docs/content/drafts/Tooltip.mdx
@@ -2,6 +2,7 @@
 componentId: tooltip_v2
 title: Tooltip v2
 status: Draft
+source: https://github.com/primer/react/blob/main/src/drafts/Tooltip.tsx
 ---
 
 import data from '../../../src/drafts/Tooltip/Tooltip.docs.json'

--- a/docs/content/drafts/Tooltip.mdx
+++ b/docs/content/drafts/Tooltip.mdx
@@ -1,7 +1,7 @@
 ---
-componentId: tooltip
-title: Tooltip
-status: Alpha
+componentId: tooltip_v2
+title: Tooltip v2
+status: Draft
 ---
 
 import data from '../../../src/drafts/Tooltip/Tooltip.docs.json'

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -160,6 +160,8 @@
   children:
     - title: Dialog v2
       url: /drafts/Dialog
+    - title: Hidden
+      url: /drafts/Hidden
     - title: InlineAutocomplete
       url: /drafts/InlineAutocomplete
     - title: MarkdownEditor
@@ -170,8 +172,8 @@
       url: /drafts/UnderlineNav2
     - title: PageHeader
       url: /drafts/PageHeader
-    - title: Hidden
-      url: /drafts/Hidden
+    - title: Tooltip v2
+      url: /drafts/Tooltip
 - title: Deprecated
   children:
     - title: ActionList (legacy)

--- a/src/drafts/Tooltip/Tooltip.docs.json
+++ b/src/drafts/Tooltip/Tooltip.docs.json
@@ -1,6 +1,6 @@
 {
   "id": "tooltip_v2",
-  "name": "Tooltip v2",
+  "name": "Tooltip",
   "status": "draft",
   "a11yReviewed": false,
   "stories": [],

--- a/src/drafts/Tooltip/Tooltip.docs.json
+++ b/src/drafts/Tooltip/Tooltip.docs.json
@@ -1,6 +1,6 @@
 {
-  "id": "tooltip",
-  "name": "Tooltip",
+  "id": "tooltip_v2",
+  "name": "Tooltip v2",
   "status": "draft",
   "a11yReviewed": false,
   "stories": [],


### PR DESCRIPTION
<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

#### New

<!-- List of things added in this PR -->


#### Changed

<!-- List of things changed in this PR -->
The component id of tooltip and tooltip v2 are the same. Tooltip v2 component details end up overriding the tooltip v1's.  You can see the [generated/components.json](https://unpkg.com/@primer/react@35.31.0/generated/components.json) data has one tooltip (id is `tooltip` but it has draft tooltip's data.) This is wrong. I updated the draft tooltips data to be unique. 

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->
No changeset requires.
- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->


### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
