### PR TITLE
Update hover styles for ActionList item

### DIFF
--- a/.changeset/dry-zoos-love.md
+++ b/.changeset/dry-zoos-love.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Update hover styles for ActionList item

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -125,7 +125,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
         ':hover:not([aria-disabled])': {
           backgroundColor: `actionListItem.${variant}.hoverBg`,
           color: getVariantStyles(variant, disabled).hoverColor,
-          boxShadow: `inset 0 0 0 max(1px, 0.0625rem) ${theme?.colors.border.muted}`,
+          boxShadow: `inset 0 0 0 max(1px, 0.0625rem) ${theme?.colors.actionListItem.default.activeBorder}`,
         },
         '&:focus-visible, > a:focus-visible': {
           outline: 'none',

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -125,6 +125,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
         ':hover:not([aria-disabled])': {
           backgroundColor: `actionListItem.${variant}.hoverBg`,
           color: getVariantStyles(variant, disabled).hoverColor,
+          boxShadow: `inset 0 0 0 max(1px, 0.0625rem) ${theme?.colors.border.muted}` ,
         },
         '&:focus-visible, > a:focus-visible': {
           outline: 'none',

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -125,7 +125,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
         ':hover:not([aria-disabled])': {
           backgroundColor: `actionListItem.${variant}.hoverBg`,
           color: getVariantStyles(variant, disabled).hoverColor,
-          boxShadow: `inset 0 0 0 max(1px, 0.0625rem) ${theme?.colors.border.muted}` ,
+          boxShadow: `inset 0 0 0 max(1px, 0.0625rem) ${theme?.colors.border.muted}`,
         },
         '&:focus-visible, > a:focus-visible': {
           outline: 'none',

--- a/src/NavList/__snapshots__/NavList.test.tsx.snap
+++ b/src/NavList/__snapshots__/NavList.test.tsx.snap
@@ -248,7 +248,7 @@ exports[`NavList renders a simple list 1`] = `
   .c2:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
-    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) rgba(0,0,0,0);
   }
 
   .c2:focus-visible,
@@ -274,7 +274,7 @@ exports[`NavList renders a simple list 1`] = `
   .c6:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
-    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) rgba(0,0,0,0);
   }
 
   .c6:focus-visible,
@@ -660,7 +660,7 @@ exports[`NavList renders with groups 1`] = `
   .c6:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
-    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) rgba(0,0,0,0);
   }
 
   .c6:focus-visible,
@@ -686,7 +686,7 @@ exports[`NavList renders with groups 1`] = `
   .c10:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
-    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) rgba(0,0,0,0);
   }
 
   .c10:focus-visible,
@@ -1149,7 +1149,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
   .c10:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
-    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) rgba(0,0,0,0);
   }
 
   .c10:focus-visible,
@@ -1175,7 +1175,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
   .c3:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
-    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) rgba(0,0,0,0);
   }
 
   .c3:focus-visible,
@@ -1633,7 +1633,7 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
   .c10:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
-    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) rgba(0,0,0,0);
   }
 
   .c10:focus-visible,
@@ -1659,7 +1659,7 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
   .c3:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
-    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) rgba(0,0,0,0);
   }
 
   .c3:focus-visible,

--- a/src/NavList/__snapshots__/NavList.test.tsx.snap
+++ b/src/NavList/__snapshots__/NavList.test.tsx.snap
@@ -248,6 +248,7 @@ exports[`NavList renders a simple list 1`] = `
   .c2:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
   }
 
   .c2:focus-visible,
@@ -273,6 +274,7 @@ exports[`NavList renders a simple list 1`] = `
   .c6:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
   }
 
   .c6:focus-visible,
@@ -658,6 +660,7 @@ exports[`NavList renders with groups 1`] = `
   .c6:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
   }
 
   .c6:focus-visible,
@@ -683,6 +686,7 @@ exports[`NavList renders with groups 1`] = `
   .c10:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
   }
 
   .c10:focus-visible,
@@ -1145,6 +1149,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
   .c10:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
   }
 
   .c10:focus-visible,
@@ -1170,6 +1175,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
   .c3:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
   }
 
   .c3:focus-visible,
@@ -1627,6 +1633,7 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
   .c10:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
   }
 
   .c10:focus-visible,
@@ -1652,6 +1659,7 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
   .c3:hover:not([aria-disabled]) {
     background-color: rgba(208,215,222,0.32);
     color: #1F2328;
+    box-shadow: inset 0 0 0 max(1px,0.0625rem) hsla(210,18%,87%,1);
   }
 
   .c3:focus-visible,


### PR DESCRIPTION
Closes #2479 

In dark high contrast theme, the `ActionMenu` shows no hover color since the hover color and the menu overlay color are the same in this particular theme. However, if we refer to the `view_components` implementation, we see that they have a hover shadow as well which does the job pretty well in this theme. I've added the same shadow styles to `ActionListItem`. This looks great as the fix for our bug without regressing during other cases.

### Before

https://github.com/primer/react/assets/417268/a3c339cb-3365-4083-837f-58d4feccdf66

### After


https://github.com/primer/react/assets/417268/33f9189c-6b39-4bf9-9e93-f44e0178853d



### Note

This fixes Light High contrast mode ActionItems as well.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
