### PR TITLE
ci: update release tracking assignments

### DIFF
--- a/.github/workflows/assign_release_conductor.yml
+++ b/.github/workflows/assign_release_conductor.yml
@@ -13,39 +13,83 @@ jobs:
         with:
           node-version: 18
       - run: npm ci
-      - name: Fetch user from pagerduty schedule
+      - uses: ./.github/actions/pagerduty
         id: pagerduty
-        uses: actions/github-script@v5
         with:
-          script: |
-            const fetch = require('node-fetch');
-            const today = new Date().toISOString().slice(0, 10) // format: 2022-11-24
-            const url = `https://api.pagerduty.com/schedules/P3IIVC4?since=${today}&until=${today}`
-            const response = await fetch(url, {
-              headers: {
-               'Content-Type': 'application/json',
-               'Authorization': 'Token token=${{ secrets.PAGERDUTY_API_KEY_SID }}'
-              }
-            })
-            const data = await response.json()            
-            return data.schedule.final_schedule.rendered_schedule_entries[0].user.summary
-
-      - run: echo ${{ steps.pagerduty.outputs.result }} is release conductor
-
+          schedule-id: 'P3IIVC4'
+          token: ${{ secrets.PAGERDUTY_API_KEY_SID }}
+      - run: echo ${{ steps.pagerduty.outputs.user }} is release conductor
       - name: Add user as assignee and reviewer
         uses: actions/github-script@v6
+        env:
+          RELEASE_CONDUCTOR: ${{ steps.pagerduty.outputs.user }}
+          PREV_RELEASE_CONDUCTOR: ${{ steps.pagerduty.outputs.previous-schedule-user }}
         with:
           script: |
-            github.rest.issues.addAssignees({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              assignees: [${{ steps.pagerduty.outputs.result }}]
-            })
+            const { RELEASE_CONDUCTOR, PREV_RELEASE_CONDUCTOR } = process.env;
 
-            github.rest.pulls.requestReviewers({
-              pull_number: context.issue.number,
+            const { data: pull } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              reviewers: [${{ steps.pagerduty.outputs.result }}]
-            })
+              pull_number: context.pull.number,
+            });
+
+            // If the previous release conductor was added as an assignee, remove them
+            const hasPreviousAssignee = pull.assignees.find((assignee) => {
+              return assignee.login === PREV_RELEASE_CONDUCTOR;
+            });
+
+            if (hasPreviousAssignee) {
+              await github.rest.issues.removeAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.pull.number,
+                assignees: [PREV_RELEASE_CONDUCTOR],
+              });
+            }
+
+            // If the previous release conductor was added as a reviewer, remove them
+            const { data: requestedReviewers } = await github.rest.pulls.listRequestedReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const hasPreviousReviewer = requestedReviewers.users.find((user) => {
+              return user.login === PREV_RELEASE_CONDUCTOR;
+            });
+
+            if (hasPreviousReviewer) {
+              await github.rest.pulls.removeRequestedReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.pull.number,
+                reviewers: [PREV_RELEASE_CONDUCTOR],
+              });
+            }
+
+            // Add the current release conductor as an assignee if they are not currently assigned
+            const hasAssignee = pull.assignees.find((assignee) => {
+              return assignee.login === RELEASE_CONDUCTOR;
+            });
+            if (!hasAssignee) {
+              await github.rest.issues.addAssignees({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                assignees: [RELEASE_CONDUCTOR]
+              })
+            }
+
+            // Request the current release conductor as a reviewer if they are not currently requested
+            const hasReviewer = requestedReviewers.users.find((user) => {
+              return user.login === RELEASE_CONDUCTOR;
+            });
+
+            if (!hasReviewer) {
+              await github.rest.pulls.requestReviewers({
+                pull_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                reviewers: [RELEASE_CONDUCTOR]
+              })
+            }

--- a/.github/workflows/assign_release_conductor.yml
+++ b/.github/workflows/assign_release_conductor.yml
@@ -2,6 +2,12 @@ name: Assign Release Conductor
 
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      pull-request:
+        type: number
+        description: Pull Request Number
+        required: true
 
 jobs:
   assign-release-conductor:
@@ -22,16 +28,17 @@ jobs:
       - name: Add user as assignee and reviewer
         uses: actions/github-script@v6
         env:
+          PR_NUMBER: ${{ github.event.inputs.pull-request || github.event.pull_request.number }}
           RELEASE_CONDUCTOR: ${{ steps.pagerduty.outputs.user }}
           PREV_RELEASE_CONDUCTOR: ${{ steps.pagerduty.outputs.previous-schedule-user }}
         with:
           script: |
-            const { RELEASE_CONDUCTOR, PREV_RELEASE_CONDUCTOR } = process.env;
+            const { PR_NUMBER, RELEASE_CONDUCTOR, PREV_RELEASE_CONDUCTOR } = process.env;
 
             const { data: pull } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.pull.number,
+              pull_number: PR_NUMBER,
             });
 
             // If the previous release conductor was added as an assignee, remove them
@@ -43,7 +50,7 @@ jobs:
               await github.rest.issues.removeAssignees({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.pull.number,
+                issue_number: PR_NUMBER,
                 assignees: [PREV_RELEASE_CONDUCTOR],
               });
             }
@@ -52,7 +59,7 @@ jobs:
             const { data: requestedReviewers } = await github.rest.pulls.listRequestedReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: PR_NUMBER,
             });
             const hasPreviousReviewer = requestedReviewers.users.find((user) => {
               return user.login === PREV_RELEASE_CONDUCTOR;
@@ -62,7 +69,7 @@ jobs:
               await github.rest.pulls.removeRequestedReviewers({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: context.pull.number,
+                pull_number: PR_NUMBER,
                 reviewers: [PREV_RELEASE_CONDUCTOR],
               });
             }
@@ -73,9 +80,9 @@ jobs:
             });
             if (!hasAssignee) {
               await github.rest.issues.addAssignees({
-                issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
+                issue_number: PR_NUMBER,
                 assignees: [RELEASE_CONDUCTOR]
               })
             }
@@ -87,9 +94,9 @@ jobs:
 
             if (!hasReviewer) {
               await github.rest.pulls.requestReviewers({
-                pull_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
+                pull_number: PR_NUMBER,
                 reviewers: [RELEASE_CONDUCTOR]
               })
             }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Update our workflow for assigning the release conductor to the current Release Tracking Pull Request. This workflow now uses our shared pagerduty action and has been updated to remove  
 the previous release conductor from assignees/review requests.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update assign release conductor workflow to use pagerduty shared action
- Add workflow_dispatch for workflow for testing

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

None

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

Quick double check of the workflow to see if I messed anything up 😅 

I also added a workflow dispatch event for this to test it out before merging if the initial code looks okay!