### PR TITLE
SelectPanel(draft): move selected items to top on reopen

### DIFF
--- a/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -556,19 +556,27 @@ export const EMinimal = () => {
     else return 1
   }
 
-  const itemsToShow = data.labels.sort(sortingFn)
+  const [sortedLabels, setSortedLabels] = React.useState([])
 
   return (
     <>
       <h1>Minimal SelectPanel</h1>
 
-      <SelectPanel title="Select labels" defaultOpen onSubmit={onSubmit}>
+      <SelectPanel
+        title="Select labels"
+        defaultOpen
+        onSubmit={onSubmit}
+        onOpen={() => {
+          // console.log('onOpen')
+          setSortedLabels(data.labels.sort(sortingFn))
+        }}
+      >
         {/* TODO: the ref types don't match here, use useProvidedRefOrCreate */}
         {/* @ts-ignore todo */}
         <SelectPanel.Button>Assign label</SelectPanel.Button>
 
         <ActionList>
-          {itemsToShow.map(label => (
+          {sortedLabels.map(label => (
             <ActionList.Item
               key={label.id}
               onSelect={() => onLabelSelect(label.id)}

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -52,6 +52,10 @@ const SelectPanel = props => {
   // sync open state
   React.useEffect(() => setInternalOpen(props.open), [props.open])
 
+  const onInternalOpen = () => {
+    if (props.open === undefined) setInternalOpen(true)
+    if (typeof props.onOpen === 'function') props.onOpen()
+  }
   const onInternalClose = () => {
     if (props.open === undefined) setInternalOpen(false)
     if (typeof props.onCancel === 'function') props.onCancel()
@@ -79,7 +83,7 @@ const SelectPanel = props => {
         anchorRef={anchorRef}
         renderAnchor={renderAnchor}
         open={internalOpen}
-        onOpen={() => setInternalOpen(true)}
+        onOpen={onInternalOpen}
         onClose={onInternalClose}
         width={props.width || 'medium'}
         height={props.height || 'large'}

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -53,7 +53,7 @@ const SelectPanel = props => {
   React.useEffect(() => setInternalOpen(props.open), [props.open])
 
   const onInternalOpen = () => {
-    if (props.open === undefined) setInternalOpen(true)
+    setInternalOpen(true)
     if (typeof props.onOpen === 'function') props.onOpen()
   }
   const onInternalClose = () => {


### PR DESCRIPTION
Work in progress. It's something that @dusave and I tried to figure out while working on a new internal component. Our understanding is that while items should not be re-sorted while the user interacts with the list, the selected items should be moved to the top when the panel is closed and opened again. But we couldn't figure out how to do it.

Dustin suggested to add an `onOpen` callback but I couldn't get it to work even with that, but I might have missed something?

/cc @siddharthkp

<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
