### PR TITLE
docs(getting-started.md): install v5 of styled-components

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -12,10 +12,10 @@ To get started using Primer React, install the package and its peer dependencies
 
 ```bash
 # with npm
-npm install @primer/react react react-dom styled-components
+npm install @primer/react react react-dom styled-components@5
 
 # with yarn
-yarn add @primer/react react react-dom styled-components
+yarn add @primer/react react react-dom styled-components@5
 ```
 
 You can now import Primer React from the main package module:


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

The latest version of styled-components is v6. But peer dependencies of @primer/react requires v4 or v5. I just went through the getting started docs and ran into the problem: https://primer.style/react/getting-started. It's a bad first impression for someone new to Primer

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

n/a just a documentation update

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
