### PR TITLE
Update assign_release_conductor.yml

### DIFF
--- a/.github/workflows/assign_release_conductor.yml
+++ b/.github/workflows/assign_release_conductor.yml
@@ -59,7 +59,7 @@ jobs:
             const { data: requestedReviewers } = await github.rest.pulls.listRequestedReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: PR_NUMBER,
+              pull_number: PR_NUMBER,
             });
             const hasPreviousReviewer = requestedReviewers.users.find((user) => {
               return user.login === PREV_RELEASE_CONDUCTOR;


### PR DESCRIPTION
This is a quick follow-up to the PR that recently changed this workflow. It changes `issue_number` to `pull_number` for `listRequestedReviewers` 😅 