### PR TITLE
refactor Dialog to use <dialog> internally

### DIFF
--- a/.changeset/little-dryers-sort.md
+++ b/.changeset/little-dryers-sort.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+Dialog now uses <dialog>
+
+<!-- Changed components: Dialog -->

--- a/src/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/ConfirmationDialog/ConfirmationDialog.tsx
@@ -156,6 +156,7 @@ async function confirm(themeProps: ThemeProviderProps, options: ConfirmOptions):
     const root = createRoot(hostElement)
     const onClose: ConfirmationDialogProps['onClose'] = gesture => {
       root.unmount()
+
       if (gesture === 'confirm') {
         resolve(true)
       } else {

--- a/src/utils/test-helpers.tsx
+++ b/src/utils/test-helpers.tsx
@@ -18,3 +18,12 @@ global.CSS = {
 }
 
 global.TextEncoder = TextEncoder
+
+// Dialog showModal isn't implemented in JSDOM https://github.com/jsdom/jsdom/issues/3294
+global.HTMLDialogElement.prototype.showModal = jest.fn(function mock(this: HTMLDialogElement) {
+  // eslint-disable-next-line no-invalid-this
+  this.open = true
+  // eslint-disable-next-line no-invalid-this
+  const element: HTMLElement | null = this.querySelector('[autofocus]')
+  element?.focus()
+})


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Refs https://github.com/github/primer/issues/2531

This changes `Dialog` to use the `<dialog>` element internally, which allows us to delete a fair amount of code and should resolve some bugs and complexity we have with the current dialog.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->
`Dialog` now uses native `<dialog>` under the hood.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
