### PR TITLE
remove role=table from table

### DIFF
--- a/src/DataTable/Table.tsx
+++ b/src/DataTable/Table.tsx
@@ -276,7 +276,6 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(function Table(
         aria-labelledby={labelledby}
         data-cell-padding={cellPadding}
         className={clsx('Table', className)}
-        role="table"
         ref={ref}
         style={{'--grid-template-columns': gridTemplateColumns} as React.CSSProperties}
       />


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Refs #3845 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

This removes `role=table` from our `<Table>` component, as it is redundant. `<table>` elements already have an implicit role of `table`, so setting `role=table` does nothing.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->
Removed `role=table` for `<table>` elements.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
