### PR TITLE
Remove `jsx-a11y/click-events-have-key-events` and `jsx-a11y/no-static-element-interactions` disables

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
@@ -7,9 +7,13 @@ import {Placeholder} from '@primer/react/Placeholder'
 import React from 'react'
 import State from '../../../components/State'
 
-const ReactRouterLink = ({to, ...props}) => {
+const ReactRouterLink = ({to, children, ...props}) => {
   // eslint-disable-next-line jsx-a11y/anchor-has-content
-  return <a href={to} {...props} />
+  return (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  )
 }
 
 // Exclude octicons-react's default export because it's deprecated

--- a/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
@@ -8,7 +8,6 @@ import React from 'react'
 import State from '../../../components/State'
 
 const ReactRouterLink = ({to, children, ...props}) => {
-  // eslint-disable-next-line jsx-a11y/anchor-has-content
   return (
     <a href={to} {...props}>
       {children}

--- a/src/TreeView/TreeView.test.tsx
+++ b/src/TreeView/TreeView.test.tsx
@@ -853,7 +853,7 @@ describe('Keyboard interactions', () => {
   describe('Enter', () => {
     it('calls onSelect function if provided and checks if the item has been selected', () => {
       const onSelect = jest.fn()
-      const {getByRole, debug} = renderWithTheme(
+      const {getByRole} = renderWithTheme(
         <TreeView aria-label="Test tree">
           <TreeView.Item id="parent-1" onSelect={onSelect}>
             Parent 1
@@ -881,7 +881,6 @@ describe('Keyboard interactions', () => {
           </TreeView.Item>
         </TreeView>,
       )
-      debug()
       const itemChild = getByRole('treeitem', {name: 'Child2'})
 
       act(() => {
@@ -1174,9 +1173,8 @@ describe('State', () => {
       )
     }
 
-    const {getByRole, debug} = renderWithTheme(<TestTree />)
+    const {getByRole} = renderWithTheme(<TestTree />)
 
-    debug()
     const parent = getByRole('treeitem', {name: 'Parent'})
     const child = getByRole('treeitem', {name: 'Child'})
 

--- a/src/TreeView/TreeView.test.tsx
+++ b/src/TreeView/TreeView.test.tsx
@@ -851,21 +851,42 @@ describe('Keyboard interactions', () => {
   })
 
   describe('Enter', () => {
-    it('calls onSelect function if provided', () => {
+    it('calls onSelect function if provided and checks if the item has been selected', () => {
       const onSelect = jest.fn()
-      const {getByRole} = renderWithTheme(
+      const {getByRole, debug} = renderWithTheme(
         <TreeView aria-label="Test tree">
-          <TreeView.Item id="item" onSelect={onSelect}>
-            Item
+          <TreeView.Item id="parent-1" onSelect={onSelect}>
+            Parent 1
+            <TreeView.SubTree>
+              <TreeView.Item id="child-1" onSelect={onSelect}>
+                Child 1
+              </TreeView.Item>
+            </TreeView.SubTree>
+          </TreeView.Item>
+          <TreeView.Item id="parent-2" onSelect={onSelect} expanded>
+            Parent 2
+            <TreeView.SubTree>
+              <TreeView.Item id="child-2" onSelect={onSelect}>
+                Child2
+              </TreeView.Item>
+            </TreeView.SubTree>
+          </TreeView.Item>
+          <TreeView.Item id="parent-3" onSelect={onSelect}>
+            Parent 3
+            <TreeView.SubTree>
+              <TreeView.Item id="child-3" onSelect={onSelect}>
+                Child 3
+              </TreeView.Item>
+            </TreeView.SubTree>
           </TreeView.Item>
         </TreeView>,
       )
-
-      const item = getByRole('treeitem')
+      debug()
+      const itemChild = getByRole('treeitem', {name: 'Child2'})
 
       act(() => {
         // Focus first item
-        item.focus()
+        itemChild.focus()
       })
 
       // Press Enter
@@ -1153,8 +1174,9 @@ describe('State', () => {
       )
     }
 
-    const {getByRole} = renderWithTheme(<TestTree />)
+    const {getByRole, debug} = renderWithTheme(<TestTree />)
 
+    debug()
     const parent = getByRole('treeitem', {name: 'Parent'})
     const child = getByRole('treeitem', {name: 'Child'})
 

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -453,8 +453,19 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
             event.stopPropagation()
           }}
           onBlur={() => setIsFocused(false)}
+          onClick={event => {
+            if (onSelect) {
+              onSelect(event)
+            } else {
+              toggle(event)
+            }
+          }}
+          onAuxClick={event => {
+            if (onSelect && event.button === 1) {
+              onSelect(event)
+            }
+          }}
         >
-          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
           <div
             className="PRIVATE_TreeView-item-container"
             style={{
@@ -463,35 +474,17 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
               contentVisibility: containIntrinsicSize ? 'auto' : undefined,
               containIntrinsicSize,
             }}
-            onClick={event => {
-              if (onSelect) {
-                onSelect(event)
-              } else {
-                toggle(event)
-              }
-            }}
-            onAuxClick={event => {
-              if (onSelect && event.button === 1) {
-                onSelect(event)
-              }
-            }}
           >
             <div style={{gridArea: 'spacer', display: 'flex'}}>
               <LevelIndicatorLines level={level} />
             </div>
             {hasSubTree ? (
-              // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
               <div
                 className={clsx(
                   'PRIVATE_TreeView-item-toggle',
                   onSelect && 'PRIVATE_TreeView-item-toggle--hover',
                   level === 1 && 'PRIVATE_TreeView-item-toggle--end',
                 )}
-                onClick={event => {
-                  if (onSelect) {
-                    toggle(event)
-                  }
-                }}
               >
                 {isExpanded ? <ChevronDownIcon size={12} /> : <ChevronRightIcon size={12} />}
               </div>

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -479,12 +479,22 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
               <LevelIndicatorLines level={level} />
             </div>
             {hasSubTree ? (
+              // This lint rule is disabled due to the guidelines in the `TreeView` api docs.
+              // https://github.com/github/primer/blob/main/apis/tree-view-api.md#the-expandcollapse-chevron-toggle
+              // This has specific advice that the chevron be available only to pointer event.
+              // If they take up a button role, they become unnecessary and numerous tab stops.
+              // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
               <div
                 className={clsx(
                   'PRIVATE_TreeView-item-toggle',
                   onSelect && 'PRIVATE_TreeView-item-toggle--hover',
                   level === 1 && 'PRIVATE_TreeView-item-toggle--end',
                 )}
+                onClick={event => {
+                  if (onSelect) {
+                    toggle(event)
+                  }
+                }}
               >
                 {isExpanded ? <ChevronDownIcon size={12} /> : <ChevronRightIcon size={12} />}
               </div>

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -395,6 +395,7 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
             } else {
               toggle(event)
             }
+            event.stopPropagation()
             break
           case 'ArrowRight':
             // Ignore if modifier keys are pressed
@@ -459,11 +460,13 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
             } else {
               toggle(event)
             }
+            event.stopPropagation()
           }}
           onAuxClick={event => {
             if (onSelect && event.button === 1) {
               onSelect(event)
             }
+            event.stopPropagation()
           }}
         >
           <div


### PR DESCRIPTION


Closes https://github.com/github/primer/issues/2793

### Problem

In the `treeView` component, the structure looks like

```
li(treeItem) [keydown, focus, blur]
- div(container) [onClick, onAuxClick]
-- div(levelIndicator)
-- div(subtree chevron) [onClick]
-- content
```
Right now we have multiple`onClick` events on `div` tags which are non-interactive elements with no `treeitem` role on them as well. This needs to be managed using the eslint disables as mentioned in the issue title

### Solution

My solution is to convert above to below structure and move all the event handlers to the `treeitem` role `li` tag.
```
li(treeItem) [keydown, focus, blur, onClick, onAuxClick]
- div(container) 
-- div(levelIndicator)
-- div(subtree chevron)
-- content
```

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

I have tested this in storybook and it seems to unproblematic.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
