### PR TITLE
ci: update release-schedule.yml

### DIFF
--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -6,7 +6,7 @@ on:
         type: boolean
         description: 'Run in dry mode. This option will disable creating and closing issues'
   schedule:
-    - cron: '30 13 * * MON'
+    - cron: '30 15 * * MON'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Update our release schedule to run at 15:30 GMT+0 which is when our schedule switches between the previous and next conductors.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update CRON job to run at 15:30 GMT+0 every Monday

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

None

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Verify that the CRON job says what I think 😅 lol