### PR TITLE
Delete changeset/changelog for change in story file

### DIFF
--- a/.changeset/ten-schools-provide.md
+++ b/.changeset/ten-schools-provide.md
@@ -1,7 +1,0 @@
----
-'@primer/react': patch
----
-
-SelectPanel anchors should have aria-haspopup="dialog"
-
-<!-- Changed components: SelectPanel -->


### PR DESCRIPTION
Introduced in https://github.com/primer/react/pull/3636, we usually don't add changelog for storybook files because it might mislead developers reading the changelog.

For example, [from release tracking](https://github.com/primer/react/pull/3847):

```
@primer/react@35.32.2

Patch Changes
- #3636 Thanks (author) - SelectPanel anchors should have aria-haspopup="dialog" 
```

This looks like SelectPanel anchors will render `aria-haspopup=dialog`, which sounds totally finebut we updated an example in storybook, not the component.

Removing the changelog to avoid confusion.