### PR TITLE
Add `aria-disabled` to inactive pagination buttons 

### DIFF
--- a/.changeset/grumpy-clocks-sell.md
+++ b/.changeset/grumpy-clocks-sell.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Adds `aria-disabled` to inactive pagination buttons.

--- a/src/DataTable/Pagination.tsx
+++ b/src/DataTable/Pagination.tsx
@@ -226,6 +226,7 @@ export function Pagination({
               className="TablePaginationAction"
               type="button"
               data-has-page={hasPreviousPage ? true : undefined}
+              aria-disabled={!hasPreviousPage ? true : undefined}
               onClick={() => {
                 if (!hasPreviousPage) {
                   return
@@ -306,6 +307,7 @@ export function Pagination({
               className="TablePaginationAction"
               type="button"
               data-has-page={hasNextPage ? true : undefined}
+              aria-disabled={!hasNextPage ? true : undefined}
               onClick={() => {
                 if (!hasNextPage) {
                   return


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/2734

Adds `aria-disabled` to "Next" and "Previous" buttons in `DataTable`. This allows AT to be informed of the button's state when it is inactive.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->
Added `aria-disabled` state to "Next" and "Previous" buttons when first or last page has been reached.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
