### PR TITLE
fix(DataTable): Fix pagination step generation when `defaultPageIndex` is provided

### DIFF
--- a/.changeset/bright-cougars-switch.md
+++ b/.changeset/bright-cougars-switch.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+DataTable: fix incorrect pagination steps when defaultPageIndex is provided
+
+<!-- Changed components: DataTable -->

--- a/src/DataTable/DataTable.features.stories.tsx
+++ b/src/DataTable/DataTable.features.stories.tsx
@@ -1525,6 +1525,86 @@ export const WithPagination = () => {
   )
 }
 
+export const WithPaginationUsingDefaultPageIndex = () => {
+  const pageSize = 10
+  const [pageIndex, setPageIndex] = React.useState(0)
+  const start = pageIndex * pageSize
+  const end = start + pageSize
+  const rows = repos.slice(start, end)
+
+  return (
+    <Table.Container>
+      <Table.Title as="h2" id="repositories">
+        Repositories
+      </Table.Title>
+      <Table.Subtitle as="p" id="repositories-subtitle">
+        A subtitle could appear here to give extra context to the data.
+      </Table.Subtitle>
+      <DataTable
+        aria-labelledby="repositories"
+        aria-describedby="repositories-subtitle"
+        data={rows}
+        columns={[
+          {
+            header: 'Repository',
+            field: 'name',
+            rowHeader: true,
+          },
+          {
+            header: 'Type',
+            field: 'type',
+            renderCell: row => {
+              return <Label>{uppercase(row.type)}</Label>
+            },
+          },
+          {
+            header: 'Updated',
+            field: 'updatedAt',
+            renderCell: row => {
+              return <RelativeTime date={new Date(row.updatedAt)} />
+            },
+          },
+          {
+            header: 'Dependabot',
+            field: 'securityFeatures.dependabot',
+            renderCell: row => {
+              return row.securityFeatures.dependabot.length > 0 ? (
+                <LabelGroup>
+                  {row.securityFeatures.dependabot.map(feature => {
+                    return <Label key={feature}>{uppercase(feature)}</Label>
+                  })}
+                </LabelGroup>
+              ) : null
+            },
+          },
+          {
+            header: 'Code scanning',
+            field: 'securityFeatures.codeScanning',
+            renderCell: row => {
+              return row.securityFeatures.codeScanning.length > 0 ? (
+                <LabelGroup>
+                  {row.securityFeatures.codeScanning.map(feature => {
+                    return <Label key={feature}>{uppercase(feature)}</Label>
+                  })}
+                </LabelGroup>
+              ) : null
+            },
+          },
+        ]}
+      />
+      <Table.Pagination
+        aria-label="Pagination for Repositories"
+        pageSize={pageSize}
+        totalCount={repos.length}
+        onChange={({pageIndex}) => {
+          setPageIndex(pageIndex)
+        }}
+        defaultPageIndex={49}
+      />
+    </Table.Container>
+  )
+}
+
 export const WithNetworkError = () => {
   const pageSize = 10
   const [pageIndex, setPageIndex] = React.useState(0)

--- a/src/DataTable/Pagination.tsx
+++ b/src/DataTable/Pagination.tsx
@@ -108,7 +108,7 @@ const StyledPagination = styled.nav`
         .TablePaginationSteps[data-hidden-viewport-ranges*='${viewportRangeKey}'] > *:first-child {
           margin-inline-end: 0;
         }
-        
+
         .TablePaginationSteps[data-hidden-viewport-ranges*='${viewportRangeKey}'] > *:last-child {
           margin-inline-start: 0;
         }
@@ -260,17 +260,23 @@ export function Pagination({
               </Page>
             </Step>
           ) : null}
+          {hasLeadingTruncation ? <TruncationStep key="truncation-0" /> : null}
           {pageCount > 2
             ? Array.from({length: truncatedPageCount}).map((_, i) => {
-                if (i === 0 && hasLeadingTruncation) {
-                  return <TruncationStep key={`truncation-${i}`} />
+                let page = offsetStartIndex + i
+
+                // In order to prevent the loop from adding steps that go beyond the maximum number of pages,
+                // we must reset the `page` offset to start from the very first step after the leading truncation
+                if (hasLeadingTruncation && !hasTrailingTruncation) {
+                  // The last page is always visible, so we need to remove that from consideration
+                  const pagesAvailableToTruncate = pageCount - 1
+                  const firstTruncatedPageFromEnd = pagesAvailableToTruncate - truncatedPageCount
+
+                  if (page >= firstTruncatedPageFromEnd) {
+                    page = firstTruncatedPageFromEnd + i
+                  }
                 }
 
-                if (i === truncatedPageCount - 1 && hasTrailingTruncation) {
-                  return <TruncationStep key={`truncation-${i}`} />
-                }
-
-                const page = offsetStartIndex + i
                 return (
                   <Step key={i}>
                     <Page
@@ -288,6 +294,7 @@ export function Pagination({
                 )
               })
             : null}
+          {hasTrailingTruncation ? <TruncationStep key="truncation-1" /> : null}
           {pageCount > 1 ? (
             <Step>
               <Page

--- a/src/DataTable/__tests__/Pagination.test.tsx
+++ b/src/DataTable/__tests__/Pagination.test.tsx
@@ -23,6 +23,18 @@ describe('Table.Pagination', () => {
     expect(getCurrentPage()).toEqual(getLastPage())
   })
 
+  it('should select the correct page with `defaultPageIndex`', () => {
+    render(<Pagination aria-label="Pagination" defaultPageIndex={4} pageSize={10} totalCount={100} />)
+    const expectedPage = getPages().filter(p => p.textContent?.includes('5'))[0]
+    expect(getCurrentPage()).toEqual(expectedPage)
+  })
+
+  it('should show the expected steps when `defaultPageIndex` is provided', () => {
+    render(<Pagination aria-label="Pagination" defaultPageIndex={6} pageSize={10} totalCount={100} />)
+    const pages = getPages().map(p => p.textContent?.replace(/[a-z]|\s+/gi, ''))
+    expect(pages).toEqual(['1…', '3', '4', '5', '6', '7', '8', '9', '10'])
+  })
+
   it('should warn if `defaultPageIndex` is not a valid `pageIndex`', () => {
     const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
     render(<Pagination aria-label="Pagination" defaultPageIndex={4} pageSize={25} totalCount={100} />)

--- a/src/DataTable/__tests__/Pagination.test.tsx
+++ b/src/DataTable/__tests__/Pagination.test.tsx
@@ -32,7 +32,7 @@ describe('Table.Pagination', () => {
   it('should show the expected steps when `defaultPageIndex` is provided', () => {
     render(<Pagination aria-label="Pagination" defaultPageIndex={6} pageSize={10} totalCount={100} />)
     const pages = getPages().map(p => p.textContent?.replace(/[a-z]|\s+/gi, ''))
-    expect(pages).toEqual(['1…', '3', '4', '5', '6', '7', '8', '9', '10'])
+    expect(pages).toEqual(['1…', '4', '5', '6', '7', '8', '9', '10'])
   })
 
   it('should warn if `defaultPageIndex` is not a valid `pageIndex`', () => {
@@ -234,6 +234,12 @@ describe('Table.Pagination', () => {
 
       expect(previousStep).toHaveAttribute('aria-hidden', 'true')
       expect(previousStep).toHaveTextContent('…')
+    })
+
+    it('should not have more than 7 pages when leading and trailing truncation are present', () => {
+      render(<Pagination aria-label="Test label" defaultPageIndex={49} pageSize={10} totalCount={1000} />)
+      const pages = getPages()
+      expect(pages).toHaveLength(7)
     })
   })
 })


### PR DESCRIPTION
Closes https://github.com/primer/react/issues/3856

This PR fixes a bug in DataTable's pagination where providing a `defaultPageIndex` would sometimes create unexpected steps. 

Here's the before/after when given the following props (attempting to pre-select the 5th page):

```jsx
<Table.Pagination
  pageSize={10}
  totalCount={100}
  defaultPageIndex={4}
/>
```

| Before | After |
|--------|--------|
| <img width="516" alt="before" src="https://github.com/primer/react/assets/431533/575b0b82-30fb-4b09-bfc2-b70c12d653f4"> |  <img width="516" alt="after" src="https://github.com/primer/react/assets/431533/e357817a-b602-4a9e-a89f-da1ed42657f1"> | 

There were two problems that needed to be fixed here:

1. When leading truncation is present, the generated steps would be off by one. To fix this, the leading and trailing truncation elements were moved out of the step creation loop
2. When given a starting index that is within the truncation limit of the last page (usually 7 steps), the loop generating steps would add more steps than there are pages (causing the appearance of "page 11" in the example above)

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

- Fix occasional incorrect pagination steps being shown when `defaultPageIndex` is provided

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
