### PR TITLE
rm outlineButton from storybook

### DIFF
--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -30,7 +30,7 @@ Playground.argTypes = {
     control: {
       type: 'radio',
     },
-    options: ['default', 'primary', 'danger', 'invisible', 'outline'],
+    options: ['default', 'primary', 'danger', 'invisible'],
   },
   alignContent: {
     control: {

--- a/src/stories/deprecated/Button.stories.tsx
+++ b/src/stories/deprecated/Button.stories.tsx
@@ -1,15 +1,7 @@
 import React from 'react'
 import {Meta} from '@storybook/react'
 
-import {
-  Button,
-  ButtonClose,
-  ButtonDanger,
-  ButtonInvisible,
-  ButtonOutline,
-  ButtonPrimary,
-  ButtonTableList,
-} from '../../deprecated'
+import {Button, ButtonClose, ButtonDanger, ButtonInvisible, ButtonPrimary, ButtonTableList} from '../../deprecated'
 import {ButtonStyleProps} from 'styled-system'
 import {ButtonBaseProps} from '../../deprecated/Button/ButtonBase'
 type StrictButtonStyleProps = ButtonStyleProps & {variant: ButtonBaseProps['variant']}
@@ -48,10 +40,6 @@ defaultButton.args = {variant: 'medium'}
 // eslint-disable-next-line storybook/prefer-pascal-case
 export const dangerButton = (args: StrictButtonStyleProps) => <ButtonDanger {...args}>Danger Button</ButtonDanger>
 dangerButton.args = {variant: 'medium'}
-
-// eslint-disable-next-line storybook/prefer-pascal-case
-export const outlineButton = (args: StrictButtonStyleProps) => <ButtonOutline {...args}>Outline Button</ButtonOutline>
-outlineButton.args = {variant: 'medium'}
 
 // eslint-disable-next-line storybook/prefer-pascal-case
 export const primaryButton = (args: StrictButtonStyleProps) => <ButtonPrimary {...args}>Primary Button</ButtonPrimary>


### PR DESCRIPTION
### Changelog
- removed `outline` variant for `Button` from **storybook**

### Rollout strategy
No change to components.

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
