### PR TITLE
Rename status "drafts" to "experimental"

### DIFF
--- a/script/components-json/component.schema.json
+++ b/script/components-json/component.schema.json
@@ -63,7 +63,7 @@
     "status": {
       "type": "string",
       "description": "The status of the component.",
-      "enum": ["draft", "alpha", "beta", "stable", "deprecated"]
+      "enum": ["draft", "experimental", "alpha", "beta", "stable", "deprecated"]
     },
     "a11yReviewed": {
       "type": "boolean",

--- a/src/Blankslate/Blankslate.docs.json
+++ b/src/Blankslate/Blankslate.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "blankslate",
   "name": "Blankslate",
-  "status": "draft",
+  "status": "experimental",
   "a11yReviewed": false,
   "stories": [],
   "props": [

--- a/src/DataTable/DataTable.docs.json
+++ b/src/DataTable/DataTable.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "data_table",
   "name": "DataTable",
-  "status": "draft",
+  "status": "experimental",
   "a11yReviewed": false,
   "stories": [
     {

--- a/src/Dialog/Dialog.docs.json
+++ b/src/Dialog/Dialog.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "drafts_dialog",
   "name": "Dialog",
-  "status": "draft",
+  "status": "experimental",
   "a11yReviewed": false,
   "stories": [],
   "props": [

--- a/src/Hidden/Hidden.docs.json
+++ b/src/Hidden/Hidden.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "drafts_hidden",
   "name": "Hidden",
-  "status": "draft",
+  "status": "experimental",
   "a11yReviewed": false,
   "stories": [],
   "props": [

--- a/src/PageHeader/PageHeader.docs.json
+++ b/src/PageHeader/PageHeader.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "drafts_page_header",
   "name": "PageHeader",
-  "status": "draft",
+  "status": "experimental",
   "a11yReviewed": false,
   "stories": [],
   "props": [

--- a/src/UnderlineNav/UnderlineNav.docs.json
+++ b/src/UnderlineNav/UnderlineNav.docs.json
@@ -1,7 +1,7 @@
 {
-  "id": "drafts_underline_nav2",
+  "id": "experimental_underline_nav2",
   "name": "UnderlineNav",
-  "status": "draft",
+  "status": "experimental",
   "a11yReviewed": true,
   "stories": [],
   "props": [

--- a/src/drafts/Button2/Button.docs.json
+++ b/src/drafts/Button2/Button.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "drafts_button",
   "name": "Button2",
-  "status": "draft",
+  "status": "experimental",
   "a11yReviewed": false,
   "stories": [],
   "props": [

--- a/src/drafts/InlineAutocomplete/InlineAutocomplete.docs.json
+++ b/src/drafts/InlineAutocomplete/InlineAutocomplete.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "drafts_inline_autocomplete",
   "name": "InlineAutocomplete",
-  "status": "draft",
+  "status": "experimental",
   "a11yReviewed": false,
   "stories": [],
   "props": [

--- a/src/drafts/MarkdownEditor/MarkdownEditor.docs.json
+++ b/src/drafts/MarkdownEditor/MarkdownEditor.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "drafts_markdown_editor",
   "name": "MarkdownEditor",
-  "status": "draft",
+  "status": "experimental",
   "a11yReviewed": false,
   "stories": [],
   "props": [

--- a/src/drafts/MarkdownViewer/MarkdownViewer.docs.json
+++ b/src/drafts/MarkdownViewer/MarkdownViewer.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "drafts_markdown_viewer",
   "name": "MarkdownViewer",
-  "status": "draft",
+  "status": "experimental",
   "a11yReviewed": false,
   "stories": [],
   "props": [

--- a/src/drafts/Tooltip/Tooltip.docs.json
+++ b/src/drafts/Tooltip/Tooltip.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "tooltip_v2",
   "name": "Tooltip",
-  "status": "draft",
+  "status": "experimental",
   "a11yReviewed": false,
   "stories": [],
   "props": [


### PR DESCRIPTION
One tiny part of implementing [ADR 010: Merge drafts status into experimental](https://github.com/primer/react/blob/main/contributor-docs/adrs/adr-010-drafts-are-experimental.md#adr-010-merge-drafts-status-into-experimental). 

This would update https://primer.style/guides/status

- Matching doctocat PR: https://github.com/primer/design/pull/652

