### PR TITLE
Fix MarkdownEditor fullHeight support

### DIFF
--- a/.changeset/gorgeous-dolphins-compare.md
+++ b/.changeset/gorgeous-dolphins-compare.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fix MarkdownEditor fullHeight support

--- a/src/drafts/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/drafts/MarkdownEditor/MarkdownEditor.tsx
@@ -373,7 +373,7 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(
         <fieldset
           aria-disabled={disabled /* if we set disabled={true}, we can't enable the buttons that should be enabled */}
           aria-describedby={describedBy ? `${descriptionId} ${describedBy}` : descriptionId}
-          style={{appearance: 'none', border: 'none', minInlineSize: 'auto'}}
+          style={{appearance: 'none', border: 'none', minInlineSize: 'auto', height: fullHeight ? '100%' : undefined}}
         >
           <FormattingTools ref={formattingToolsRef} forInputId={id} />
           <div style={{display: 'none'}}>{childrenWithoutSlots}</div>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

#### Changed

Currently, the MarkdownEditor's fullHeight prop doesn't take effect because the height change isn't applied to the outermost container element (`<fieldset>`). The PR fixes the issue by applying full height style to the the container element. 

Storybook has also been updated for demo purpose.


(Demo screen recording: after the fix, the MarkdownEditor correctly resizes to full height when fullHeight is turned on)


https://github.com/primer/react/assets/1556390/813c9ee5-45eb-4433-a902-91749eb2d60f



### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge


