### PR TITLE
upgrade popover-polyfill to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@github/paste-markdown": "^1.4.0",
         "@github/relative-time-element": "^4.1.2",
         "@lit-labs/react": "^1.1.1",
-        "@oddbird/popover-polyfill": "0.2.3",
+        "@oddbird/popover-polyfill": "^0.3.1",
         "@primer/behaviors": "^1.3.4",
         "@primer/octicons-react": "^19.8.0",
         "@primer/primitives": "^7.11.11",
@@ -6164,9 +6164,9 @@
       }
     },
     "node_modules/@oddbird/popover-polyfill": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.2.3.tgz",
-      "integrity": "sha512-XDK+V/gUeE4NEsWp79eVzhlK3wuVcRDJuaas63qo0IJLJpyOLHqycJLFYvuq8kebgT1nl87P3sbSb5ZN6Vyf5g=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.1.tgz",
+      "integrity": "sha512-Ne0e4L0Yo++NyNVpsrY+u1fK9xlBjwDqOj+neQQpaa4zsXhDDj/OSHuODhgbHI6YrwhA4XvgWMiFuhkBOAo1Bw=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -6343,6 +6343,12 @@
         "@oddbird/popover-polyfill": "^0.2.1",
         "@primer/behaviors": "^1.3.4"
       }
+    },
+    "node_modules/@primer/view-components/node_modules/@oddbird/popover-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.2.3.tgz",
+      "integrity": "sha512-XDK+V/gUeE4NEsWp79eVzhlK3wuVcRDJuaas63qo0IJLJpyOLHqycJLFYvuq8kebgT1nl87P3sbSb5ZN6Vyf5g==",
+      "dev": true
     },
     "node_modules/@radix-ui/number": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@github/paste-markdown": "^1.4.0",
     "@github/relative-time-element": "^4.1.2",
     "@lit-labs/react": "^1.1.1",
-    "@oddbird/popover-polyfill": "0.2.3",
+    "@oddbird/popover-polyfill": "^0.3.1",
     "@primer/behaviors": "^1.3.4",
     "@primer/octicons-react": "^19.8.0",
     "@primer/primitives": "^7.11.11",


### PR DESCRIPTION
### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

Upgrade `@oddbird/popover-polyfill` to `0.3.2`.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
