### PR TITLE
Make resize vertical splitter keyboard accessible

### DIFF
--- a/.changeset/proud-dingos-occur.md
+++ b/.changeset/proud-dingos-occur.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Make resize vertical splitter keyboard accessible

--- a/src/PageLayout/PageLayout.test.tsx
+++ b/src/PageLayout/PageLayout.test.tsx
@@ -191,7 +191,7 @@ describe('PageLayout', () => {
       const pane = placeholder.parentNode
       const initialWidth = (pane as HTMLElement).style.getPropertyValue('--pane-width')
 
-      const divider = await screen.findByRole('separator')
+      const divider = await screen.findByRole('slider')
       // Moving divider should resize pane.
       fireEvent.mouseDown(divider)
       fireEvent.mouseMove(divider)

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -30,7 +30,7 @@ const PageLayoutContext = React.createContext<{
   padding: keyof typeof SPACING_MAP
   rowGap: keyof typeof SPACING_MAP
   columnGap: keyof typeof SPACING_MAP
-  paneRef?: React.RefObject<HTMLDivElement>
+  paneRef: React.RefObject<HTMLDivElement>
   enableStickyPane?: (top: number | string) => void
   disableStickyPane?: () => void
   contentTopRef?: (node?: Element | null | undefined) => void
@@ -39,6 +39,7 @@ const PageLayoutContext = React.createContext<{
   padding: 'normal',
   rowGap: 'normal',
   columnGap: 'normal',
+  paneRef: {current: null},
 })
 
 // ----------------------------------------------------------------------------
@@ -240,11 +241,11 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
   const [currentWidth, setCurrentWidth] = React.useState(0)
 
   React.useEffect(() => {
-    if (paneRef?.current !== null) {
-      const paneStyles = getComputedStyle(paneRef?.current as Element)
+    if (paneRef.current !== null) {
+      const paneStyles = getComputedStyle(paneRef.current as Element)
       const maxPaneWidthDiffPixels = paneStyles.getPropertyValue('--pane-max-width-diff')
       const minWidthPixels = paneStyles.getPropertyValue('--pane-min-width')
-      const paneWidth = paneRef?.current.getBoundingClientRect().width
+      const paneWidth = paneRef.current.getBoundingClientRect().width
       const maxPaneWidthDiff = Number(maxPaneWidthDiffPixels.split('px')[0])
       const minPaneWidth = Number(minWidthPixels.split('px')[0])
       const viewportWidth = window.innerWidth
@@ -315,7 +316,7 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
       window.removeEventListener('mouseup', handleDragEnd)
       document.body.removeAttribute('data-page-layout-dragging')
     }
-  }, [isDragging, isKeyboardDrag])
+  }, [isDragging, isKeyboardDrag, currentWidth, minWidth, maxWidth])
 
   return (
     <Box
@@ -655,9 +656,7 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
 
     const isHidden = useResponsiveValue(responsiveHidden, false)
 
-    const {rowGap, columnGap, enableStickyPane, disableStickyPane} = React.useContext(PageLayoutContext)
-    let {paneRef} = React.useContext(PageLayoutContext)
-    paneRef = paneRef || useRef<HTMLDivElement>(null)
+    const {rowGap, columnGap, enableStickyPane, disableStickyPane, paneRef} = React.useContext(PageLayoutContext)
 
     React.useEffect(() => {
       if (sticky) {
@@ -787,7 +786,7 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
           }}
           // Ensure `paneWidth` state and actual pane width are in sync when the drag ends
           onDragEnd={() => {
-            const paneRect = paneRef?.current?.getBoundingClientRect()
+            const paneRect = paneRef.current?.getBoundingClientRect()
             if (!paneRect) return
             updatePaneWidth(paneRect.width)
           }}

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -314,6 +314,8 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
     return () => {
       window.removeEventListener('mousemove', handleDrag)
       window.removeEventListener('mouseup', handleDragEnd)
+      window.removeEventListener('keydown', handleKeyDrag)
+      window.removeEventListener('keyup', handleKeyDragEnd)
       document.body.removeAttribute('data-page-layout-dragging')
     }
   }, [isDragging, isKeyboardDrag, currentWidth, minWidth, maxWidth])

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -357,7 +357,12 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
               onDragStart?.()
             }}
             onKeyDown={event => {
-              if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+              if (
+                event.key === 'ArrowLeft' ||
+                event.key === 'ArrowRight' ||
+                event.key === 'ArrowUp' ||
+                event.key === 'ArrowDown'
+              ) {
                 setIsKeyboardDrag(true)
                 onDragStart?.()
               }

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -278,10 +278,10 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
 
     function handleKeyDrag(event: KeyboardEvent) {
       let delta = 0
-      // Hardcoded a delta for every key press to move the splitter. Should I perhaps expose this as a prop?
-      if (event.key === 'ArrowLeft' && currentWidth > minWidth) {
+      // https://github.com/github/accessibility/issues/5101#issuecomment-1822870655
+      if ((event.key === 'ArrowLeft' || event.key === 'ArrowDown') && currentWidth > minWidth) {
         delta = -3
-      } else if (event.key === 'ArrowRight' && currentWidth < maxWidth) {
+      } else if ((event.key === 'ArrowRight' || event.key === 'ArrowUp') && currentWidth < maxWidth) {
         delta = 3
       } else {
         return
@@ -349,7 +349,6 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
             aria-label="Draggable pane splitter"
             aria-valuemin={minWidth}
             aria-valuemax={maxWidth}
-            aria-orientation="vertical"
             aria-valuenow={currentWidth}
             aria-valuetext={`Pane width ${currentWidth} pixels`}
             tabIndex={0}

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -345,7 +345,7 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
                 bg: isDragging || isKeyboardDrag ? 'accent.fg' : 'neutral.muted',
               },
             }}
-            role="separator"
+            role="slider"
             aria-label="Draggable splitter"
             aria-valuemin={minWidth}
             aria-valuemax={maxWidth}

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useRef} from 'react'
 import {createGlobalStyle} from 'styled-components'
 import Box from '../Box'
 import {useId} from '../hooks/useId'
@@ -10,7 +10,6 @@ import {Theme} from '../ThemeProvider'
 import {canUseDOM} from '../utils/environment'
 import {useOverflow} from '../internal/hooks/useOverflow'
 import {warning} from '../utils/warning'
-import VisuallyHidden from '../_VisuallyHidden'
 import {useStickyPaneHeight} from './useStickyPaneHeight'
 
 const REGION_ORDER = {
@@ -31,6 +30,7 @@ const PageLayoutContext = React.createContext<{
   padding: keyof typeof SPACING_MAP
   rowGap: keyof typeof SPACING_MAP
   columnGap: keyof typeof SPACING_MAP
+  paneRef?: React.RefObject<HTMLDivElement>
   enableStickyPane?: (top: number | string) => void
   disableStickyPane?: () => void
   contentTopRef?: (node?: Element | null | undefined) => void
@@ -76,6 +76,8 @@ const Root: React.FC<React.PropsWithChildren<PageLayoutProps>> = ({
   const {rootRef, enableStickyPane, disableStickyPane, contentTopRef, contentBottomRef, stickyPaneHeight} =
     useStickyPaneHeight()
 
+  const paneRef = useRef<HTMLDivElement>(null)
+
   const [slots, rest] = useSlots(children, slotsConfig ?? {header: Header, footer: Footer})
 
   return (
@@ -88,6 +90,7 @@ const Root: React.FC<React.PropsWithChildren<PageLayoutProps>> = ({
         disableStickyPane,
         contentTopRef,
         contentBottomRef,
+        paneRef,
       }}
     >
       <Box
@@ -197,7 +200,7 @@ const verticalDividerVariants = {
 type DraggableDividerProps = {
   draggable?: boolean
   onDragStart?: () => void
-  onDrag?: (delta: number) => void
+  onDrag?: (delta: number, isKeyboard: boolean) => void
   onDragEnd?: () => void
   onDoubleClick?: () => void
 }
@@ -224,10 +227,33 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
   sx = {},
 }) => {
   const [isDragging, setIsDragging] = React.useState(false)
+  const [isKeyboardDrag, setIsKeyboardDrag] = React.useState(false)
   const responsiveVariant = useResponsiveValue(variant, 'none')
 
   const stableOnDrag = React.useRef(onDrag)
   const stableOnDragEnd = React.useRef(onDragEnd)
+
+  const {paneRef} = React.useContext(PageLayoutContext)
+
+  const [minWidth, setMinWidth] = React.useState(0)
+  const [maxWidth, setMaxWidth] = React.useState(0)
+  const [currentWidth, setCurrentWidth] = React.useState(0)
+
+  React.useEffect(() => {
+    if (paneRef?.current !== null) {
+      const paneStyles = getComputedStyle(paneRef?.current as Element)
+      const maxPaneWidthDiffPixels = paneStyles.getPropertyValue('--pane-max-width-diff')
+      const minWidthPixels = paneStyles.getPropertyValue('--pane-min-width')
+      const paneWidth = paneRef?.current.getBoundingClientRect().width
+      const maxPaneWidthDiff = Number(maxPaneWidthDiffPixels.split('px')[0])
+      const minPaneWidth = Number(minWidthPixels.split('px')[0])
+      const viewportWidth = window.innerWidth
+      const maxPaneWidth = viewportWidth > maxPaneWidthDiff ? viewportWidth - maxPaneWidthDiff : viewportWidth
+      setMinWidth(minPaneWidth)
+      setMaxWidth(maxPaneWidth)
+      setCurrentWidth(paneWidth || 0)
+    }
+  }, [paneRef, isKeyboardDrag, isDragging])
 
   React.useEffect(() => {
     stableOnDrag.current = onDrag
@@ -239,7 +265,7 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
 
   React.useEffect(() => {
     function handleDrag(event: MouseEvent) {
-      stableOnDrag.current?.(event.movementX)
+      stableOnDrag.current?.(event.movementX, false)
       event.preventDefault()
     }
 
@@ -249,14 +275,38 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
       event.preventDefault()
     }
 
+    function handleKeyDrag(event: KeyboardEvent) {
+      let delta = 0
+      // Hardcoded a delta for every key press to move the splitter. Should I perhaps expose this as a prop?
+      if (event.key === 'ArrowLeft' && currentWidth > minWidth) {
+        delta = -3
+      } else if (event.key === 'ArrowRight' && currentWidth < maxWidth) {
+        delta = 3
+      } else {
+        return
+      }
+      setCurrentWidth(currentWidth + delta)
+      stableOnDrag.current?.(delta, true)
+      event.preventDefault()
+    }
+
+    function handleKeyDragEnd(event: KeyboardEvent) {
+      setIsKeyboardDrag(false)
+      stableOnDragEnd.current?.()
+      event.preventDefault()
+    }
     // TODO: Support touch events
-    if (isDragging) {
+    if (isDragging || isKeyboardDrag) {
       window.addEventListener('mousemove', handleDrag)
+      window.addEventListener('keydown', handleKeyDrag)
       window.addEventListener('mouseup', handleDragEnd)
+      window.addEventListener('keyup', handleKeyDragEnd)
       document.body.setAttribute('data-page-layout-dragging', 'true')
     } else {
       window.removeEventListener('mousemove', handleDrag)
       window.removeEventListener('mouseup', handleDragEnd)
+      window.removeEventListener('keydown', handleKeyDrag)
+      window.removeEventListener('keyup', handleKeyDragEnd)
       document.body.removeAttribute('data-page-layout-dragging')
     }
 
@@ -265,7 +315,7 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
       window.removeEventListener('mouseup', handleDragEnd)
       document.body.removeAttribute('data-page-layout-dragging')
     }
-  }, [isDragging])
+  }, [isDragging, isKeyboardDrag])
 
   return (
     <Box
@@ -286,16 +336,29 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
               position: 'absolute',
               inset: '0 -2px',
               cursor: 'col-resize',
-              bg: isDragging ? 'accent.fg' : 'transparent',
+              bg: isDragging || isKeyboardDrag ? 'accent.fg' : 'transparent',
               transitionDelay: '0.1s',
               '&:hover': {
-                bg: isDragging ? 'accent.fg' : 'neutral.muted',
+                bg: isDragging || isKeyboardDrag ? 'accent.fg' : 'neutral.muted',
               },
             }}
             role="separator"
+            aria-label="Draggable splitter"
+            aria-valuemin={minWidth}
+            aria-valuemax={maxWidth}
+            aria-orientation="vertical"
+            aria-valuenow={currentWidth}
+            aria-valuetext={`Pane width ${currentWidth} pixels`}
+            tabIndex={0}
             onMouseDown={() => {
               setIsDragging(true)
               onDragStart?.()
+            }}
+            onKeyDown={event => {
+              if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+                setIsKeyboardDrag(true)
+                onDragStart?.()
+              }
             }}
             onDoubleClick={onDoubleClick}
           />
@@ -593,6 +656,8 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
     const isHidden = useResponsiveValue(responsiveHidden, false)
 
     const {rowGap, columnGap, enableStickyPane, disableStickyPane} = React.useContext(PageLayoutContext)
+    let {paneRef} = React.useContext(PageLayoutContext)
+    paneRef = paneRef || useRef<HTMLDivElement>(null)
 
     React.useEffect(() => {
       if (sticky) {
@@ -637,54 +702,9 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
       }
     }
 
-    const paneRef = React.useRef<HTMLDivElement>(null)
     useRefObjectAsForwardedRef(forwardRef, paneRef)
 
-    const [minPercent, setMinPercent] = React.useState(0)
-    const [maxPercent, setMaxPercent] = React.useState(0)
     const hasOverflow = useOverflow(paneRef)
-
-    const measuredRef = React.useCallback(() => {
-      if (paneRef.current !== null) {
-        const maxPaneWidthDiffPixels = getComputedStyle(paneRef.current as Element).getPropertyValue(
-          '--pane-max-width-diff',
-        )
-        const paneWidth = paneRef.current.getBoundingClientRect().width
-        const maxPaneWidthDiff = Number(maxPaneWidthDiffPixels.split('px')[0])
-        const viewportWidth = window.innerWidth
-        const maxPaneWidth = viewportWidth > maxPaneWidthDiff ? viewportWidth - maxPaneWidthDiff : viewportWidth
-
-        const minPercent = Math.round((100 * minWidth) / viewportWidth)
-        setMinPercent(minPercent)
-
-        const maxPercent = Math.round((100 * maxPaneWidth) / viewportWidth)
-        setMaxPercent(maxPercent)
-
-        const widthPercent = Math.round((100 * paneWidth) / viewportWidth)
-        setWidthPercent(widthPercent.toString())
-      }
-    }, [paneRef, minWidth])
-
-    const [widthPercent, setWidthPercent] = React.useState('')
-    const [prevPercent, setPrevPercent] = React.useState('')
-
-    const handleWidthFormSubmit = (event: React.FormEvent<HTMLElement>) => {
-      event.preventDefault()
-      let percent = Number(widthPercent)
-      if (Number.isNaN(percent)) {
-        percent = Number(prevPercent) || minPercent
-      } else if (percent > maxPercent) {
-        percent = maxPercent
-      } else if (percent < minPercent) {
-        percent = minPercent
-      }
-
-      setWidthPercent(percent.toString())
-      // Cache previous valid percent.
-      setPrevPercent(percent.toString())
-
-      updatePaneWidth((percent / 100) * window.innerWidth)
-    }
 
     const paneId = useId(id)
 
@@ -706,7 +726,6 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
 
     return (
       <Box
-        ref={measuredRef}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         sx={(theme: any) =>
           merge<BetterSystemStyleObject>(
@@ -756,14 +775,19 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
           // If pane is resizable, the divider should be draggable
           draggable={resizable}
           sx={{[position === 'end' ? 'marginRight' : 'marginLeft']: SPACING_MAP[columnGap]}}
-          onDrag={delta => {
+          onDrag={(delta, isKeyboard = false) => {
             // Get the number of pixels the divider was dragged
-            const deltaWithDirection = position === 'end' ? -delta : delta
+            let deltaWithDirection
+            if (isKeyboard) {
+              deltaWithDirection = delta
+            } else {
+              deltaWithDirection = position === 'end' ? -delta : delta
+            }
             updatePaneWidth(paneWidth + deltaWithDirection)
           }}
           // Ensure `paneWidth` state and actual pane width are in sync when the drag ends
           onDragEnd={() => {
-            const paneRect = paneRef.current?.getBoundingClientRect()
+            const paneRect = paneRef?.current?.getBoundingClientRect()
             if (!paneRect) return
             updatePaneWidth(paneRect.width)
           }}
@@ -798,32 +822,6 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
           {...(id && {id: paneId})}
         >
           {children}
-          {resizable && (
-            // eslint-disable-next-line github/a11y-no-visually-hidden-interactive-element
-            <VisuallyHidden>
-              <form onSubmit={handleWidthFormSubmit}>
-                <label htmlFor={`${paneId}-width-input`}>Pane width</label>
-                <p id={`${paneId}-input-hint`}>
-                  Use a value between {minPercent}% and {maxPercent}%
-                </p>
-                <input
-                  id={`${paneId}-width-input`}
-                  aria-describedby={`${paneId}-input-hint`}
-                  name="pane-width"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
-                  value={widthPercent}
-                  autoCorrect="off"
-                  autoComplete="off"
-                  type="text"
-                  onChange={event => {
-                    setWidthPercent(event.target.value)
-                  }}
-                />
-                <button type="submit">Change width</button>
-              </form>
-            </VisuallyHidden>
-          )}
         </Box>
       </Box>
     )

--- a/src/PageLayout/PageLayout.tsx
+++ b/src/PageLayout/PageLayout.tsx
@@ -346,7 +346,7 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
               },
             }}
             role="slider"
-            aria-label="Draggable splitter"
+            aria-label="Draggable pane splitter"
             aria-valuemin={minWidth}
             aria-valuemax={maxWidth}
             aria-orientation="vertical"


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/2810

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Context

Earlier [guidance for SplitPageLayout accessibility](https://github.com/primer/react/pull/2593) was to create a visually hidden form with range input to determine the position of the splitter. However this hidden form swallows the focus when tabbing through the page layout. 


#### New

The proposed change here is to follow [Window Splitter a11y guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) and support keyboard navigation on the vertical splitter.


https://github.com/primer/react/assets/417268/1100611d-ae34-4b79-a63f-15403a9e012f


### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

Tab through the `Resizable Pane` storybook under `PageLayout.features.stories` and navigate to focus on the vertical splitter. Use the left and right arrow keys to move it sideways. Use Voiceover to here the announcement on current pane width updated with every move.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
