### PR TITLE
Fix MarkdownEditor focus variable usage and border bottom missing

### DIFF
--- a/src/drafts/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/drafts/MarkdownEditor/MarkdownEditor.tsx
@@ -403,7 +403,7 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(
                 '&: focus-within':
                   view === 'edit'
                     ? {
-                        outline: '2px solid var(--borderColor-accent-emphasis)',
+                        outline: theme => `2px solid ${theme.colors.accent.emphasis}`,
                       }
                     : {},
                 ...sx,
@@ -424,12 +424,28 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(
                 }}
                 as="header"
               >
-                <Box sx={{ml: '-1px', mt: '-1px', display: 'flex', alignItems: 'flex-end'}}>
+                <Box
+                  sx={{
+                    ml: '-1px',
+                    mt: '-1px',
+                    display: 'flex',
+                    alignItems: 'flex-end',
+                    flexGrow: 1,
+                    flexBasis: 0,
+                  }}
+                >
                   <ViewSwitch
                     selectedView={view}
                     onViewSelect={setView}
                     disabled={fileHandler?.uploadProgress !== undefined}
                     onLoadPreview={loadPreview}
+                  />
+                  <Box
+                    sx={{
+                      borderBottom: '1px solid',
+                      borderBottomColor: 'border.subtle',
+                      flexGrow: 1,
+                    }}
                   />
                 </Box>
 


### PR DESCRIPTION
Fixes an issue with MarkdownEditor's focus token usage that wasn't picked up causing focus to not be visible part of https://github.com/primer/react/pull/3901 as well as an issue that caused the borderBottom for the Preview tab to not be visible. 

## Before: 

https://github.com/primer/react/assets/4548309/03fb79e2-d28b-4045-b72f-5e4d04f00624

##After:

https://github.com/primer/react/assets/4548309/9b75adaa-03c2-410d-97b3-558a85131c7d



### Changelog

#### Changed

- Fetched the right token using the `theme` function, as the variable itself seems like it's no longer available
- Added styles to make sure the Preview tab has a `borderBottom`

### Rollout strategy

- [x] Patch release (if possible still part of https://github.com/primer/react/pull/3901)
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

Head to http://127.0.0.1:6006/?path=/story/drafts-components-markdowneditor--playground and focus the text area or navigate to the Preview tab

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
- [ ] Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
