### PR TITLE
Update Button.docs.json

### DIFF
--- a/src/Button/Button.docs.json
+++ b/src/Button/Button.docs.json
@@ -19,13 +19,13 @@
     },
     {
       "name": "variant",
-      "type": "| 'default'\n| 'primary'\n| 'danger'\n| 'outline'\n| 'invisible'",
+      "type": "'default'\n| 'primary'\n| 'danger'\n| 'invisible'",
       "defaultValue": "'default'",
       "description": "Change the visual style of the button."
     },
     {
       "name": "size",
-      "type": "| 'small'\n| 'medium'\n| 'large'",
+      "type": "'small'\n| 'medium'\n| 'large'",
       "defaultValue": "'medium'"
     },
     {


### PR DESCRIPTION
Remove `outline` from button docs

### Changelog

#### Removed

This PR removes the `outline` option from the button docs.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

**Docs only update**

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
