### PR TITLE
Show border when there's only one avatar in an AvatarStack

### DIFF
--- a/.changeset/tame-rockets-compete.md
+++ b/.changeset/tame-rockets-compete.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fix inconsistent border treatment when there is one avatar in an AvatarStack

--- a/src/AvatarStack/AvatarStack.features.stories.tsx
+++ b/src/AvatarStack/AvatarStack.features.stories.tsx
@@ -88,3 +88,9 @@ export const CustomSizeOnChildrenResponsive = () => (
     />
   </AvatarStack>
 )
+
+export const WithSingleAvatar = () => (
+  <AvatarStack>
+    <Avatar alt="Primer logo" src="https://avatars.githubusercontent.com/primer" />
+  </AvatarStack>
+)

--- a/src/AvatarStack/AvatarStack.stories.tsx
+++ b/src/AvatarStack/AvatarStack.stories.tsx
@@ -25,6 +25,12 @@ export const Default = () => (
   </AvatarStack>
 )
 
+export const WithSingleAvatar = () => (
+  <AvatarStack>
+    <Avatar alt="Primer logo" src="https://avatars.githubusercontent.com/primer" />
+  </AvatarStack>
+)
+
 export const Playground: Story<Args> = args => (
   <AvatarStack size={parseSizeFromArgs(args)} alignRight={args.alignRight} disableExpand={args.disableExpand}>
     <Avatar alt="Primer logo" src="https://avatars.githubusercontent.com/primer" />

--- a/src/AvatarStack/AvatarStack.stories.tsx
+++ b/src/AvatarStack/AvatarStack.stories.tsx
@@ -25,12 +25,6 @@ export const Default = () => (
   </AvatarStack>
 )
 
-export const WithSingleAvatar = () => (
-  <AvatarStack>
-    <Avatar alt="Primer logo" src="https://avatars.githubusercontent.com/primer" />
-  </AvatarStack>
-)
-
 export const Playground: Story<Args> = args => (
   <AvatarStack size={parseSizeFromArgs(args)} alignRight={args.alignRight} disableExpand={args.disableExpand}>
     <Avatar alt="Primer logo" src="https://avatars.githubusercontent.com/primer" />

--- a/src/AvatarStack/AvatarStack.tsx
+++ b/src/AvatarStack/AvatarStack.tsx
@@ -137,7 +137,7 @@ const AvatarStackWrapper = styled.span<StyledAvatarStackWrapperProps>`
       margin-left: ${get('space.1')};
       opacity: 100%;
       visibility: visible;
-      box-shadow: 0 0 0 4px ${props => (props.count === 1 ? get('colors.avatar.border') : get('colors.canvas.default'))};
+      ${props => (props.count === 1 ? '' : `box-shadow: 0 0 0 4px ${get('colors.canvas.default')};`)}
       transition:
         margin 0.2s ease-in-out,
         opacity 0.2s ease-in-out,

--- a/src/AvatarStack/AvatarStack.tsx
+++ b/src/AvatarStack/AvatarStack.tsx
@@ -46,7 +46,8 @@ const AvatarStackWrapper = styled.span<StyledAvatarStackWrapperProps>`
     flex-shrink: 0;
     height: var(--avatar-stack-size);
     width: var(--avatar-stack-size);
-    box-shadow: 0 0 0 var(--avatar-border-width) ${get('colors.canvas.default')};
+    box-shadow: 0 0 0 var(--avatar-border-width)
+      ${props => (props.count === 1 ? get('colors.avatar.border') : get('colors.canvas.default'))};
     position: relative;
     overflow: hidden;
 
@@ -136,7 +137,8 @@ const AvatarStackWrapper = styled.span<StyledAvatarStackWrapperProps>`
       margin-left: ${get('space.1')};
       opacity: 100%;
       visibility: visible;
-      box-shadow: 0 0 0 4px ${get('colors.canvas.default')};
+      box-shadow: 0 0 0 var(--avatar-border-width)
+        ${props => (props.count === 1 ? get('colors.avatar.border') : get('colors.canvas.default'))};
       transition:
         margin 0.2s ease-in-out,
         opacity 0.2s ease-in-out,

--- a/src/AvatarStack/AvatarStack.tsx
+++ b/src/AvatarStack/AvatarStack.tsx
@@ -137,8 +137,7 @@ const AvatarStackWrapper = styled.span<StyledAvatarStackWrapperProps>`
       margin-left: ${get('space.1')};
       opacity: 100%;
       visibility: visible;
-      box-shadow: 0 0 0 var(--avatar-border-width)
-        ${props => (props.count === 1 ? get('colors.avatar.border') : get('colors.canvas.default'))};
+      box-shadow: 0 0 0 4px ${props => (props.count === 1 ? get('colors.avatar.border') : get('colors.canvas.default'))};
       transition:
         margin 0.2s ease-in-out,
         opacity 0.2s ease-in-out,

--- a/src/__tests__/__snapshots__/AvatarStack.test.tsx.snap
+++ b/src/__tests__/__snapshots__/AvatarStack.test.tsx.snap
@@ -122,9 +122,12 @@ exports[`Avatar renders consistently 1`] = `
   margin-left: 4px;
   opacity: 100%;
   visibility: visible;
-  box-shadow: 0 0 0 4px #ffffff;
   -webkit-transition: margin 0.2s ease-in-out,opacity 0.2s ease-in-out,visibility 0.2s ease-in-out,box-shadow 0.1s ease-in-out;
   transition: margin 0.2s ease-in-out,opacity 0.2s ease-in-out,visibility 0.2s ease-in-out,box-shadow 0.1s ease-in-out;
+}
+
+.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover .pc-AvatarItem box-shadow:0 0 0 4px function (props) {
+  return: (0,_core.get)(props.theme,path,fallback);
 }
 
 .c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover .pc-AvatarItem:first-child {
@@ -284,9 +287,12 @@ exports[`Avatar respects alignRight props 1`] = `
   margin-left: 4px;
   opacity: 100%;
   visibility: visible;
-  box-shadow: 0 0 0 4px #ffffff;
   -webkit-transition: margin 0.2s ease-in-out,opacity 0.2s ease-in-out,visibility 0.2s ease-in-out,box-shadow 0.1s ease-in-out;
   transition: margin 0.2s ease-in-out,opacity 0.2s ease-in-out,visibility 0.2s ease-in-out,box-shadow 0.1s ease-in-out;
+}
+
+.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover .pc-AvatarItem box-shadow:0 0 0 4px function (props) {
+  return: (0,_core.get)(props.theme,path,fallback);
 }
 
 .c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover .pc-AvatarItem:first-child {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/3716

This PR updates `AvatarStack` to show a border when there is only one avatar in the stack, making it consistent with the appearance of the `Avatar` component. This is especially obvious when using a high-contrast theme.

| Before | After |
|--------|--------|
| <img width="42" alt="before (invisible border)" src="https://github.com/primer/react/assets/431533/f1a78977-434c-465b-95b8-6d3899b12387"> | <img width="44" alt="after (visible border)" src="https://github.com/primer/react/assets/431533/33d64758-d75f-45f8-bef2-17b73eab1f8c"> | 

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
- [ ] Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
