### PR TITLE
Fix Dialog button spacing

### DIFF
--- a/.changeset/curly-games-smoke.md
+++ b/.changeset/curly-games-smoke.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Update the spacing for buttons in the footer of a Dialog.

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -375,7 +375,7 @@ const Footer = styled.div<SxProp>`
   flex-shrink: 0;
 
   button {
-    margin-left: ${get('space.1')};
+    margin-left: ${get('space.2')};
     &:first-child {
       margin-left: 0;
     }

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -371,17 +371,9 @@ const Footer = styled.div<SxProp>`
   display: flex;
   flex-flow: wrap;
   justify-content: flex-end;
+  gap: ${get('space.2')};
   z-index: 1;
   flex-shrink: 0;
-
-  button {
-    margin-left: ${get('space.2')};
-    &:first-child {
-      margin-left: 0;
-    }
-  }
-
-  ${sx};
 `
 
 const buttonTypes = {


### PR DESCRIPTION
### Changelog

#### Changed

Changes dialog footer button spacing from 4px to 8px as is standard

##### Before
![image](https://github.com/primer/react/assets/6905903/414a71f5-15be-4e80-aaf1-212540884f2d)

##### After
<img width="568" alt="image" src="https://github.com/primer/react/assets/6905903/83decc15-f77b-43d7-a906-be851c5f3b30">



### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
