### PR TITLE
docs(contributors): add ADR 018

### DIFF
--- a/contributor-docs/adrs/adr-009-interaction-tests.md
+++ b/contributor-docs/adrs/adr-009-interaction-tests.md
@@ -1,5 +1,8 @@
 # ADR 009: Use Interaction testing in storybook to maintain components
 
+> **Warning**
+> This ADR is superceded by [`ADR 018`](./adr-018-interaction-tests-revisited.md)
+
 ## Status
 
 | Stage    | Status |

--- a/contributor-docs/adrs/adr-018-interaction-tests-revisited.md
+++ b/contributor-docs/adrs/adr-018-interaction-tests-revisited.md
@@ -1,0 +1,36 @@
+# ADR 018: Interaction testing (revisited)
+
+## Status
+
+| Stage    | Status |
+| -------- | ------ |
+| Approved | 🚧     |
+| Adopted  | 🚧     |
+
+## Context
+
+> **Note**
+> This ADR supercedes [`ADR 009`](./adr-009-interaction-tests.md)
+
+We author tests using a combination of Jest and Playwright. Typically, Jest is
+used for unit and integration tests and Playwright is used for Visual Regression
+Tests against our Storybook.
+
+In `ADR 009`, we proposed using Storybook's [`play`
+functions](https://storybook.js.org/docs/react/writing-stories/play-function) as
+the recommended way to author tests that require tests based on user
+interactions. In this ADR, we would like to revisit this decision.
+
+## Decision
+
+For tests involving interaction, use Playwright to visit a storybook story and
+interact with the component directly. This will allow for easy integration with
+Visual Regression Testing and our automated accessibility testing (through axe).
+In order to perform interactions, use [actions from
+Playwright](https://playwright.dev/docs/input).
+
+### Impact
+
+The impact of this decision is minimal as we only have one example of
+interaction stories, `UnderlineNav.interactions.stories.tsx`, and it has
+corresponding tests in Playwright.


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/2823

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Add ADR 018 which supercedes ADR 009 around interaction testing. We no longer use Chromatic and instead prefer Playwright for authoring interaction tests.

Let me know if this is a good flow to use when updating an ADR! I wasn't sure what the exact flow was so I ended up just adding a new ADR with this decision.

Also feel free to provide any feedback if this approach is incorrect or merits a larger discussion! 


