### PR TITLE
docs: update side-nav to include data table

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -154,6 +154,8 @@
       url: /UnderlineNav
 - title: Drafts
   children:
+    - title: DataTable
+      url: /drafts/DataTable
     - title: Dialog v2
       url: /drafts/Dialog
     - title: Hidden


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Update side-nav in local docs to list DataTable under the Drafts section.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `nav.yml` within the Gatsby docs for PRC

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

None

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Verify in the deploy preview that DataTable shows up in the side nav and is navigable