### PR TITLE
Move `DataTable` header creation to before updating sort order

### DIFF
--- a/.changeset/slimy-foxes-wash.md
+++ b/.changeset/slimy-foxes-wash.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Fix issue in DataTable so that sort order is determined after column headers are created

--- a/src/DataTable/useTable.ts
+++ b/src/DataTable/useTable.ts
@@ -71,15 +71,6 @@ export function useTable<Data extends UniqueRow>({
     }
   }
 
-  // Update the row order and apply the current sort column to the incoming data
-  if (data !== prevData) {
-    setPrevData(data)
-    setRowOrder(data)
-    if (sortByColumn) {
-      sortRows(sortByColumn)
-    }
-  }
-
   const headers = columns.map(column => {
     const id = column.id ?? column.field
     if (id === undefined) {
@@ -101,6 +92,15 @@ export function useTable<Data extends UniqueRow>({
       },
     }
   })
+
+  // Update the row order and apply the current sort column to the incoming data
+  if (data !== prevData) {
+    setPrevData(data)
+    setRowOrder(data)
+    if (sortByColumn) {
+      sortRows(sortByColumn)
+    }
+  }
 
   /**
    * Sort the input row data by the given header


### PR DESCRIPTION
This PR fixes a bug where `sortRows` may be [called](https://github.com/primer/react/blob/4b0622e59ffa0b7708a1ec33fe63c914fd3765bc/src/DataTable/useTable.ts#L79) before `headers` is [initialized](https://github.com/primer/react/blob/4b0622e59ffa0b7708a1ec33fe63c914fd3765bc/src/DataTable/useTable.ts#L83).  `sortRows` filters headers on [this line](https://github.com/primer/react/blob/4b0622e59ffa0b7708a1ec33fe63c914fd3765bc/src/DataTable/useTable.ts#L123). I just moved the code block up to avoid this issue.

### Changelog

#### New

NA

#### Changed

- Moved header initialization before applying sort order and direction

#### Removed

NA

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

Tried a few different iterations of unit tests but I couldn't get one that definitively proved the issue.  However, in my own usage of the component, I found that it seems to be related to state change in some way.  This is the error that I was seeing:

<img width="530" alt="console error emitted by DataTable" src="https://github.com/primer/react/assets/13154238/2dbbe1b8-1ebd-40d6-a34b-c5a0b6b49d2a">

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
