### PR TITLE
Tooltip2: Make the text prop required 

### DIFF
--- a/.changeset/young-trees-move.md
+++ b/.changeset/young-trees-move.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Tooltip2: make the text prop required

--- a/src/drafts/Tooltip/Tooltip.docs.json
+++ b/src/drafts/Tooltip/Tooltip.docs.json
@@ -13,6 +13,7 @@
     },
     {
       "name": "text",
+      "required": true,
       "type": "string",
       "description": "The text to be displayed in the tooltip"
     },

--- a/src/drafts/Tooltip/Tooltip.playground.stories.tsx
+++ b/src/drafts/Tooltip/Tooltip.playground.stories.tsx
@@ -18,10 +18,10 @@ export default {
 export const Playground: StoryFn = args => {
   // this is a hack to remove the `type` prop from the args because for this example type label is not a valid choice and violates accessibility
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const {type, ...rest} = args
+  const {text, type, ...rest} = args
   return (
     <Box sx={{p: 6}}>
-      <Tooltip type="description" {...rest}>
+      <Tooltip text={text} type="description" {...rest}>
         <Button>Delete</Button>
       </Tooltip>
     </Box>

--- a/src/drafts/Tooltip/Tooltip.tsx
+++ b/src/drafts/Tooltip/Tooltip.tsx
@@ -126,7 +126,7 @@ type TooltipDirection = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w'
 export type TooltipProps = React.PropsWithChildren<
   {
     direction?: TooltipDirection
-    text?: string
+    text: string
     type?: 'label' | 'description'
   } & SxProp &
     ComponentProps<typeof StyledTooltip>

--- a/src/drafts/Tooltip/__tests__/Tooltip.test.tsx
+++ b/src/drafts/Tooltip/__tests__/Tooltip.test.tsx
@@ -5,7 +5,7 @@ import {render as HTMLRender} from '@testing-library/react'
 import theme from '../../../theme'
 import {Button, ActionMenu, ActionList, ThemeProvider, SSRProvider, BaseStyles} from '../../../'
 
-const TooltipComponent = (props: TooltipProps) => (
+const TooltipComponent = (props: Omit<TooltipProps, 'text'> & {text?: string}) => (
   <Tooltip text="Tooltip text" {...props}>
     <Button>Button Text</Button>
   </Tooltip>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

Update `text` prop from being optional to required. 

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->
This is technically a breaking change but because Tooltip is still experimental, breaking API changes are expected. 
- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
