### PR TITLE
Wrap generating e2e script into async func

### DIFF
--- a/script/generate-e2e-tests.js
+++ b/script/generate-e2e-tests.js
@@ -1521,15 +1521,17 @@ const components = new Map([
   ],
 ])
 
-for (const [component, info] of components) {
-  const filepath = path.join(E2E_DIR, path.format({name: `${component}.test`, ext: '.ts'}))
+async function generateE2ETests() {
+  try {
+    for (const [component, info] of components) {
+      const filepath = path.join(E2E_DIR, path.format({name: `${component}.test`, ext: '.ts'}))
 
-  if (fs.existsSync(filepath)) {
-    continue
-  }
+      if (fs.existsSync(filepath)) {
+        continue
+      }
 
-  const stories = info.stories.map(story => {
-    return `test.describe('${story.name}', () => {
+      const stories = info.stories.map(story => {
+        return `test.describe('${story.name}', () => {
   for (const theme of themes) {
     test.describe(theme, () => {
       test('default @vrt', async ({page}) => {
@@ -1556,9 +1558,9 @@ for (const [component, info] of components) {
     });
   }
 })`
-  })
+      })
 
-  const source = recast.parse(`import {test, expect} from '@playwright/test'
+      const source = recast.parse(`import {test, expect} from '@playwright/test'
 import {visit} from '../test-helpers/storybook'
 import {themes} from '../test-helpers/themes'
 
@@ -1566,10 +1568,18 @@ test.describe('${component}', () => {
   ${stories.join('\n\n')}
 })`)
 
-  const {code} = recast.print(source)
-  const formatted = prettier.format(code, {
-    parser: 'typescript',
-    ...prettierConfig,
-  })
-  fs.writeFileSync(filepath, formatted, 'utf8')
+      const {code} = recast.print(source)
+
+      const formatted = await prettier.format(code, {
+        parser: 'typescript',
+        ...prettierConfig,
+      })
+      fs.writeFileSync(filepath, formatted, 'utf8')
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(error)
+  }
 }
+
+generateE2ETests()


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

Running the `script/generate-e2e-tests.js` throws an error due to prettier.format retuning a Promise object, not string. ([docs reference](https://prettier.io/docs/en/api.html#prettierformatsource-options))

```
node:internal/fs/utils:905
  throw new ERR_INVALID_ARG_TYPE(
  ^

TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Promise
    at Object.writeFileSync (node:fs:2314:5)
    at Object.<anonymous> (/Users/broccolinisoup/GitHub/DesignSystems/react/script/generate-e2e-tests.js:1605:6)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:86:12)
    at node:internal/main/run_main_module:23:47 {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

I wrapped the code into an async function and awaiting the prettier.format. Let me know if there is a better way to do it!

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

Could be test adding a new item to the `components` array with an id and story name to check if the script generates a test file. 

<!-- Describe any specific details to help reviewers test or review this Pull Request -->



Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
