### PR TITLE
memoize context value in ActionList.List

### DIFF
--- a/.changeset/nasty-carpets-help.md
+++ b/.changeset/nasty-carpets-help.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+ActionList: memoize context value in ActionList.List

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useMemo} from 'react'
 import {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 import styled from 'styled-components'
 import sx, {SxProp, merge} from '../sx'
@@ -63,16 +63,20 @@ export const List = React.forwardRef<HTMLUListElement, ActionListProps>(
 
     const ariaLabelledBy = slots.heading ? slots.heading.props.id ?? headingId : listLabelledBy
 
+    // If we don't memoize the context object, every child will rerender on every render even if memoized
+    const context = useMemo(
+      () => ({
+        variant,
+        selectionVariant: selectionVariant || containerSelectionVariant,
+        showDividers,
+        role: role || listRole,
+        headingId,
+      }),
+      [variant, selectionVariant, containerSelectionVariant, showDividers, role, listRole, headingId],
+    )
+
     return (
-      <ListContext.Provider
-        value={{
-          variant,
-          selectionVariant: selectionVariant || containerSelectionVariant,
-          showDividers,
-          role: role || listRole,
-          headingId,
-        }}
-      >
+      <ListContext.Provider value={context}>
         {slots.heading}
         <ListBox
           sx={merge(styles, sxProp as SxProp)}


### PR DESCRIPTION
### Changelog

#### Changed

We now memoize the internal context value in ActionList.List. This prevents unnecessary rerenders.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [X] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
