### PR TITLE
Fix MarkdownEditor preview button incorrectly triggered form submit event

### DIFF
--- a/.changeset/red-points-give.md
+++ b/.changeset/red-points-give.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fix MarkdownEditor preview button incorrectly triggered form submit event

--- a/packages/react/src/drafts/MarkdownEditor/MarkdownEditor.test.tsx
+++ b/packages/react/src/drafts/MarkdownEditor/MarkdownEditor.test.tsx
@@ -782,6 +782,23 @@ describe('MarkdownEditor', () => {
       expect(getViewSwitch()).not.toBeDisabled()
     })
 
+    it('does not trigger form submit event', async () => {
+      const onSubmit = jest.fn(e => e.preventDefault())
+
+      const {getViewSwitch} = await render(
+        <form onSubmit={onSubmit}>
+          <UncontrolledEditor />
+        </form>,
+      )
+
+      fireEvent.click(getViewSwitch())
+      await act(async () => {
+        await new Promise(process.nextTick)
+      })
+
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+
     describe('fetching', () => {
       it('prefetches the preview when the view switch is focused', async () => {
         const renderPreviewMock = jest.fn()

--- a/packages/react/src/drafts/MarkdownEditor/_ViewSwitch.tsx
+++ b/packages/react/src/drafts/MarkdownEditor/_ViewSwitch.tsx
@@ -37,6 +37,7 @@ export const ViewSwitch = ({selectedView, onViewSelect, onLoadPreview, disabled}
         <TabNav.Link
           {...sharedProps}
           as="button"
+          type="button"
           selected={selectedView === 'edit'}
           disabled={disabled}
           sx={{cursor: 'pointer', color: selectedView === 'edit' ? 'fg.default' : 'fg.muted', borderTopLeftRadius: 1}}
@@ -46,6 +47,7 @@ export const ViewSwitch = ({selectedView, onViewSelect, onLoadPreview, disabled}
         <TabNav.Link
           {...sharedProps}
           as="button"
+          type="button"
           selected={selectedView === 'preview'}
           disabled={disabled}
           sx={{


### PR DESCRIPTION
<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

When the `MarkdownEditor` was placed inside a form:

```jsx
<form>
   <MarkdownEditor />
</form>
```

The preview tab button of the MarkdownEditor would unintentionally trigger the form submit event when clicked, as the button element, by default, has a submit type.

> The missing value default and invalid value default are the Submit Button state.
> [HTML Standard - the button element](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element)

This PR fixes this issue by explicitly setting the `type` attribute of the Preview/Write button to be `button`.

```html
<button type="button" role="tab" aria-selected="true" tabindex="0">Write</button>
<button type="button" role="tab" aria-selected="false" tabindex="-1">Preview</button>
```


#### Changed

- The "Preview" and "Write" button elements would have attributed `type="button"` set.


### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan


### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
