### PR TITLE
Docs: Tweak responsive example, add generated css

### DIFF
--- a/docs/content/overriding-styles.mdx
+++ b/docs/content/overriding-styles.mdx
@@ -40,14 +40,38 @@ Just like [values passed to system props](https://styled-system.com/responsive-s
 
 ```jsx live
 <Box
-  sx={{
-    display: ['flex', 'flex', 'block', 'block'],
+ sx={{
+    backgroundColor: ['danger.emphasis', 'accent.emphasis', 'done.emphasis', 'open.emphasis', 'attention.emphasis'],
+    color: 'fg.onEmphasis',
     borderRadius: 2,
-    padding: 2,
+    padding: 2
   }}
 >
-  Responsive background color
+  Resize window to see responsive background color
 </Box>
+```
+
+This generates the css equivalent of:
+
+```css
+.Box {
+  background-color: var(--bgColor-danger-emphasis); /* default, smaller than sm */
+  color: rgb(255, 255, 255);
+  border-radius: 6px;
+  padding: 8px;
+}
+@media screen and (min-width: 544px) { // sm
+  .Box { background-color: var(--bgColor-accent-emphasis); }
+}
+@media screen and (min-width: 768px) { // md
+  .Box { background-color: var(--bgColor-done-emphasis); }
+}
+@media screen and (min-width: 1012px) { // lg
+  .Box { background-color: var(--bgColor-open-emphasis); }
+}
+@media screen and (min-width: 1280px) { // xlarge
+  .Box { background-color: var(--bgColor-attention-emphasis); }
+}
 ```
 
 ## Nesting, pseudo-classes, and pseudo-elements

--- a/docs/content/overriding-styles.mdx
+++ b/docs/content/overriding-styles.mdx
@@ -48,7 +48,7 @@ Values in the `sx` prop can be provided as arrays to provide responsive styling.
       'danger.emphasis', // large     (min-width: 1012px)
       'attention.emphasis', // xlarge (min-width: 1280px)
     ],
-    padding: [2, 4],
+    padding: [2, 2, 4],
     color: 'fg.onEmphasis',
     borderRadius: 2,
   }}
@@ -69,12 +69,13 @@ This generates the following CSS:
 @media screen and (min-width: 544px /* small */) {
   .Box-hsdYAF {
     background-color: var(--bgColor-done-emphasis);
-    padding: 16px;
+    padding: 8px;
   }
 }
 @media screen and (min-width: 768px /* medium */) {
   .Box-hsdYAF {
     background-color: var(--bgColor-accent-emphasis);
+    padding: 16px;
   }
 }
 @media screen and (min-width: 1012px /* large */) {

--- a/docs/content/overriding-styles.mdx
+++ b/docs/content/overriding-styles.mdx
@@ -36,15 +36,21 @@ This example demonstrates applying a bottom border to `Heading`, a component tha
 
 ## Responsive values
 
-Just like [values passed to system props](https://styled-system.com/responsive-styles), values in the `sx` prop can be provided as arrays to provide responsive styling.
+Values in the `sx` prop can be provided as arrays to provide responsive styling.
 
 ```jsx live
 <Box
   sx={{
-    backgroundColor: ['danger.emphasis', 'accent.emphasis', 'done.emphasis', 'open.emphasis', 'attention.emphasis'],
+    backgroundColor: [
+      'open.emphasis', // default
+      'done.emphasis', // small       (min-width: 544px)
+      'accent.emphasis', // medium    (min-width: 768px)
+      'danger.emphasis', // large     (min-width: 1012px)
+      'attention.emphasis', // xlarge (min-width: 1280px)
+    ],
+    padding: [2, 4],
     color: 'fg.onEmphasis',
     borderRadius: 2,
-    padding: 2,
   }}
 >
   Resize window to see responsive background color
@@ -55,24 +61,25 @@ This generates the following CSS:
 
 ```css
 .Box-hsdYAF {
-  background-color: var(--bgColor-danger-emphasis); /* default, smaller than sm */
-  color: rgb(255, 255, 255);
-  border-radius: 6px;
+  background-color: var(--bgColor-open-emphasis); /* default */
   padding: 8px;
+  color: var(--fgColor-onEmphasis);
+  border-radius: 6px;
 }
-@media screen and (min-width: 544px /* sm */) {
+@media screen and (min-width: 544px /* small */) {
+  .Box-hsdYAF {
+    background-color: var(--bgColor-done-emphasis);
+    padding: 16px;
+  }
+}
+@media screen and (min-width: 768px /* medium */) {
   .Box-hsdYAF {
     background-color: var(--bgColor-accent-emphasis);
   }
 }
-@media screen and (min-width: 768px /* md */) {
+@media screen and (min-width: 1012px /* large */) {
   .Box-hsdYAF {
-    background-color: var(--bgColor-done-emphasis);
-  }
-}
-@media screen and (min-width: 1012px /* lg */) {
-  .Box-hsdYAF {
-    background-color: var(--bgColor-open-emphasis);
+    background-color: var(--bgColor-danger-emphasis);
   }
 }
 @media screen and (min-width: 1280px /* xlarge */) {

--- a/docs/content/overriding-styles.mdx
+++ b/docs/content/overriding-styles.mdx
@@ -40,37 +40,45 @@ Just like [values passed to system props](https://styled-system.com/responsive-s
 
 ```jsx live
 <Box
- sx={{
+  sx={{
     backgroundColor: ['danger.emphasis', 'accent.emphasis', 'done.emphasis', 'open.emphasis', 'attention.emphasis'],
     color: 'fg.onEmphasis',
     borderRadius: 2,
-    padding: 2
+    padding: 2,
   }}
 >
   Resize window to see responsive background color
 </Box>
 ```
 
-This generates the css equivalent of:
+This generates the following CSS:
 
 ```css
-.Box {
+.Box-hsdYAF {
   background-color: var(--bgColor-danger-emphasis); /* default, smaller than sm */
   color: rgb(255, 255, 255);
   border-radius: 6px;
   padding: 8px;
 }
-@media screen and (min-width: 544px) { // sm
-  .Box { background-color: var(--bgColor-accent-emphasis); }
+@media screen and (min-width: 544px /* sm */) {
+  .Box-hsdYAF {
+    background-color: var(--bgColor-accent-emphasis);
+  }
 }
-@media screen and (min-width: 768px) { // md
-  .Box { background-color: var(--bgColor-done-emphasis); }
+@media screen and (min-width: 768px /* md */) {
+  .Box-hsdYAF {
+    background-color: var(--bgColor-done-emphasis);
+  }
 }
-@media screen and (min-width: 1012px) { // lg
-  .Box { background-color: var(--bgColor-open-emphasis); }
+@media screen and (min-width: 1012px /* lg */) {
+  .Box-hsdYAF {
+    background-color: var(--bgColor-open-emphasis);
+  }
 }
-@media screen and (min-width: 1280px) { // xlarge
-  .Box { background-color: var(--bgColor-attention-emphasis); }
+@media screen and (min-width: 1280px /* xlarge */) {
+  .Box-hsdYAF {
+    background-color: var(--bgColor-attention-emphasis);
+  }
 }
 ```
 


### PR DESCRIPTION
Inspired by a [message on slack (GitHub only)](https://github.slack.com/archives/CSGAVNZ19/p1700173976284559), it's not super obvious what the responsive syntax means.

Added the generated css next to the example for clarity

Preview: https://primer-63b8bdee13-13348165.drafts.github.io/overriding-styles#responsive-values