### PR TITLE
Set initial sort order of DataTable based on initialSortColumn and initialSortDirection props

### DIFF
--- a/.changeset/eleven-cooks-wonder.md
+++ b/.changeset/eleven-cooks-wonder.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Set initial sort order of DataTable based on `initialSortColumn` and `initialSortDirection` props

--- a/src/DataTable/DataTable.stories.tsx
+++ b/src/DataTable/DataTable.stories.tsx
@@ -215,6 +215,7 @@ export const Playground = (args: DataTableProps<UniqueRow> & ColWidthArgTypes) =
             minWidth: args.minColWidth0,
             maxWidth: args.maxColWidth0,
             align,
+            sortBy: 'alphanumeric',
           },
           {
             header: 'Type',
@@ -237,6 +238,7 @@ export const Playground = (args: DataTableProps<UniqueRow> & ColWidthArgTypes) =
             minWidth: args.minColWidth2,
             maxWidth: args.maxColWidth2,
             align,
+            sortBy: 'datetime',
           },
           {
             header: 'Dependabot',
@@ -323,6 +325,20 @@ Playground.argTypes = {
     type: {
       name: 'enum',
       value: ['condensed', 'normal', 'spacious'],
+    },
+  },
+  initialSortColumn: {
+    control: {
+      type: 'text',
+    },
+  },
+  initialSortDirection: {
+    control: {
+      type: 'radio',
+    },
+    type: {
+      name: 'enum',
+      value: ['ASC', 'DESC'],
     },
   },
   ...getColumnWidthArgTypes(5),

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -39,9 +39,7 @@ export type DataTableProps<Data extends UniqueRow> = {
   columns: Array<Column<Data>>
 
   /**
-   * Provide the id or field of the column by which the table is sorted. When
-   * using this `prop`, the input data must be sorted by this column in
-   * ascending order
+   * Provide the id or field of the column that the table should be sorted by
    */
   initialSortColumn?: ObjectPaths<Data> | string | number
 

--- a/src/DataTable/__tests__/DataTable.test.tsx
+++ b/src/DataTable/__tests__/DataTable.test.tsx
@@ -301,14 +301,14 @@ describe('DataTable', () => {
               },
             ]}
             initialSortColumn="value"
-            initialSortDirection="ASC"
+            initialSortDirection="DESC"
           />,
         )
 
         const header = screen.getByRole('columnheader', {
           name: 'Value',
         })
-        expect(header).toHaveAttribute('aria-sort', 'ascending')
+        expect(header).toHaveAttribute('aria-sort', 'descending')
 
         const rows = screen
           .getAllByRole('row')
@@ -319,7 +319,7 @@ describe('DataTable', () => {
             const cell = getByRole(row, 'cell')
             return cell.textContent
           })
-        expect(rows).toEqual(['1', '2', '3'])
+        expect(rows).toEqual(['3', '2', '1'])
       })
 
       it('should set the default sort state if `initialSortColumn` is provided', () => {
@@ -500,9 +500,9 @@ describe('DataTable', () => {
           return cells
         })
         expect(rows).toEqual([
-          ['a', 'c'],
-          ['b', 'b'],
           ['c', 'a'],
+          ['b', 'b'],
+          ['a', 'c'],
         ])
       })
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #3951

### Note

I spotted the above issue and thought I'd take a look at the implementation. This is my first contribution to this repo and I hope I'm not treading on any toes by picking this up and raising a PR! I was keen to have a look at how the design system was structured, as well as how the tooling worked, and I thought picking up an issue would be a good way to dig into that. Again, hope you don't mind this PR out of the blue! 🙂

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

This PR modifies the behaviour of the `initialSortColumn` and `initialSortDirection` props of the DataTable component. Previously, I believe they were only used to _describe_ the sorting of the intial data provided by the implementor. Now, they can be used to _set_ how the initial data should be sorted.

Eg, if the DataTable is rendered as follows:

```tsx
<DataTable
  data={[
    { id: 1, fieldOne: 'a', fieldTwo: 'c' },
    { id: 2, fieldOne: 'b', fieldTwo: 'b' },
    { id: 3, fieldOne: 'c', fieldTwo: 'a' },
  ]}
  columns={[
    {
      header: 'Field One',
      field: 'fieldOne',
      sortBy: true
    },
    {
      header: 'Field Two',
      field: 'fieldTwo'
    },
  ]}
  initialSortColumn="fieldOne"
  initialSortDirection="DESC"
/>
```

Then the rendered table will now be sorted like this:

| Field One ↓ | Field Two |
| --- | --- |
| c | a |
| b | b |
| a | c |

Note that the sorting of the resulting table is different to the sorting of the provided data, as the sorting is now defined by the `initialSortColumn` and `initialSortDirection` props. Previously, the table would be sorted in the same way as the initial data regardless of what `initialSortColumn` and `initialSortDirection` were set to.

Since I've modified the implementation and removed the manual tracking of `rowOrder` and `prevData` in favour of recalculating the sorted data any time the `data`, `columns`, and `sortByColumns` props change, I'd recommend that the implementor memoizes `columns` and `data` before passing them into the DataTable component. This could be seen as best practise anyway, but it might be worth documenting it explicitly. How/where would you recommend documenting this?

This may not be the direction you want to go with these props (in which case let me know what the desired behaviour should be and I'll modify the PR appropriately) however this seemed to match the desired functionality described in #3951

#### Changed

- `initialSortColumn` and `initialSortDirection` props now set the initial sort state of the DataTable component.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

Modify the `initialSortColumn` and `initialSortDirection` props in the DataTable component's _Playground_ story and hit the remount button in the top left. Note that when the table mounts, the sort order should match the specified column and direction.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
- [ ] Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

⬆️ This isn't something I have access to.

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
