### PR TITLE
refactor(Button): add support for React.ReactNode for slot props

### DIFF
--- a/.changeset/odd-goats-compare.md
+++ b/.changeset/odd-goats-compare.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Add support for React.ReactNode to leadingVisual, trailingVisual, and trailingAction for Button components

--- a/src/Button/Button.features.stories.tsx
+++ b/src/Button/Button.features.stories.tsx
@@ -12,9 +12,9 @@ export const Danger = () => <Button variant="danger">Danger</Button>
 
 export const Invisible = () => <Button variant="invisible">Invisible</Button>
 
-export const LeadingVisual = () => <Button leadingVisual={HeartIcon}>Leading visual</Button>
+export const LeadingVisual = () => <Button leadingVisual={<HeartIcon />}>Leading visual</Button>
 
-export const TrailingVisual = () => <Button trailingVisual={EyeIcon}>Trailing visual</Button>
+export const TrailingVisual = () => <Button trailingVisual={<EyeIcon />}>Trailing visual</Button>
 
 export const TrailingCounter = () => {
   const [count, setCount] = useState(0)

--- a/src/Button/ButtonBase.tsx
+++ b/src/Button/ButtonBase.tsx
@@ -1,4 +1,5 @@
 import React, {ComponentPropsWithRef, forwardRef, useMemo} from 'react'
+import {isValidElementType} from 'react-is'
 import {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 import Box from '../Box'
 import {BetterSystemStyleObject, merge} from '../sx'
@@ -76,7 +77,7 @@ const ButtonBase = forwardRef(
             <Box as="span" data-component="buttonContent" sx={getAlignContentSize(alignContent)}>
               {LeadingVisual && (
                 <Box as="span" data-component="leadingVisual" sx={{...iconWrapStyles}}>
-                  <LeadingVisual />
+                  {isValidElementType(LeadingVisual) ? <LeadingVisual /> : LeadingVisual}
                 </Box>
               )}
               {children && <span data-component="text">{children}</span>}
@@ -86,13 +87,13 @@ const ButtonBase = forwardRef(
                 </Box>
               ) : TrailingVisual ? (
                 <Box as="span" data-component="trailingVisual" sx={{...iconWrapStyles}}>
-                  <TrailingVisual />
+                  {isValidElementType(TrailingVisual) ? <TrailingVisual /> : TrailingVisual}
                 </Box>
               ) : null}
             </Box>
             {TrailingAction && (
               <Box as="span" data-component="trailingAction" sx={{...iconWrapStyles}}>
-                <TrailingAction />
+                {isValidElementType(TrailingAction) ? <TrailingAction /> : TrailingAction}
               </Box>
             )}
           </>

--- a/src/Button/LinkButton.features.stories.tsx
+++ b/src/Button/LinkButton.features.stories.tsx
@@ -25,13 +25,13 @@ export const Invisible = () => (
 )
 
 export const LeadingVisual = () => (
-  <Button as="a" href="/" leadingVisual={HeartIcon}>
+  <Button as="a" href="/" leadingVisual={<HeartIcon />}>
     Leading visual
   </Button>
 )
 
 export const TrailingVisual = () => (
-  <Button as="a" href="/" trailingVisual={EyeIcon}>
+  <Button as="a" href="/" trailingVisual={<EyeIcon />}>
     Trailing visual
   </Button>
 )

--- a/src/Button/types.ts
+++ b/src/Button/types.ts
@@ -52,17 +52,17 @@ export type ButtonProps = {
   /**
    * The leading visual which comes before the button content
    */
-  leadingVisual?: React.ElementType | null
+  leadingVisual?: React.ReactNode | React.ElementType | null
 
   /**
    * The trailing visual which comes after the button content
    */
-  trailingVisual?: React.ElementType | null
+  trailingVisual?: React.ReactNode | React.ElementType | null
 
   /**
    * Trailing action appears to the right of the trailing visual and is always locked to the end
    */
-  trailingAction?: React.ElementType | null
+  trailingAction?: React.ReactNode | React.ElementType | null
 
   children?: React.ReactNode
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/2457

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Update `leadingVisual`, `trailingVisual`, and `trailingAction` to support `React.ReactNode` in addition to the existing `React.ElementType`. This change also updates the examples to use `React.ReactNode` as this will be the recommended practice (and potentially the only option) moving forward.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Extend type for `leadingVisual`, `trailingVisual`, and `trailingAction` to include `React.ReactNode`
- Update docs for button components to use `React.ReactNode`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->


- [x] Minor release

This is an additive change that teams can move to over time and is potentially an opportunity for codemods.

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Verify that there is no loss of functionality with the changes to types and how these slots are rendered
- Would also love your feedback on how we're checking for element types with the `react-is` package and if there would be a better way to support this 👀 