### PR TITLE
Add aria-disabled to the storybooks to highlight issues

### DIFF
--- a/src/Button/Button.features.stories.tsx
+++ b/src/Button/Button.features.stories.tsx
@@ -62,6 +62,7 @@ export const TrailingAction = () => <Button trailingAction={TriangleDownIcon}>Tr
 export const Block = () => <Button block>Default</Button>
 
 export const Disabled = () => <Button disabled>Default</Button>
+export const AriaDisabled = () => <Button aria-disabled>Default</Button>
 
 export const Inactive = () => (
   <Button variant="primary" inactive>

--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -26,6 +26,12 @@ Playground.argTypes = {
       type: 'boolean',
     },
   },
+  'aria-disabled': {
+    control: {
+      type: 'radio',
+    },
+    options: [false, true, 'true', 'false'],
+  },
   inactive: {
     control: {
       type: 'boolean',
@@ -55,6 +61,7 @@ Playground.argTypes = {
 Playground.args = {
   block: false,
   size: 'medium',
+  'aria-disabled': undefined,
   disabled: false,
   inactive: false,
   variant: 'default',


### PR DESCRIPTION
Hi, so during my investigation I added `aria-disabled` to the `Button` component and found a couple of styling issues
- `aria-disabled='false'` and `aria-disabled='true'` are treated the same. aria-disabled='false' should not add disabled styles to the button


![Image](https://github.com/primer/react/assets/417268/59b0fa6d-bdda-4bbb-9a4a-3facd47135c2)


- Invisible button does not respect `aria-disabled` values at all


![Image](https://github.com/primer/react/assets/417268/4ab515ee-ac29-44c6-8456-41131ad2b79e)

