### PR TITLE
Update release-schedule.yml

### DIFF
--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -6,7 +6,7 @@ on:
         type: boolean
         description: 'Run in dry mode. This option will disable creating and closing issues'
   schedule:
-    - cron: '30 15 * * MON'
+    - cron: '30 16 * * MON'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update our release schedule to run at the end of a release schedule (16:30 GMT+0000). Currently it's running too soon which is causing the timing problems

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Change CRON trigger of `release-schedule.yml`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

None

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Verify that the CRON will run at 16:30 GMT+0000 every Monday