### PR TITLE
avoid creating a div on every render in portal

### DIFF
--- a/.changeset/weak-balloons-search.md
+++ b/.changeset/weak-balloons-search.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Portal avoids useless createElement

--- a/src/Portal/Portal.tsx
+++ b/src/Portal/Portal.tsx
@@ -65,14 +65,18 @@ export const Portal: React.FC<React.PropsWithChildren<PortalProps>> = ({
   onMount,
   containerName: _containerName,
 }) => {
-  const hostElement = document.createElement('div')
+  const elementRef = React.useRef<HTMLDivElement | null>(null)
+  if (!elementRef.current) {
+    const div = document.createElement('div')
+    // Portaled content should get their own stacking context so they don't interfere
+    // with each other in unexpected ways. One should never find themselves tempted
+    // to change the zIndex to a value other than "1".
+    div.style.position = 'relative'
+    div.style.zIndex = '1'
+    elementRef.current = div
+  }
 
-  // Portaled content should get their own stacking context so they don't interfere
-  // with each other in unexpected ways. One should never find themselves tempted
-  // to change the zIndex to a value other than "1".
-  hostElement.style.position = 'relative'
-  hostElement.style.zIndex = '1'
-  const elementRef = React.useRef(hostElement)
+  const element = elementRef.current
 
   useLayoutEffect(() => {
     let containerName = _containerName
@@ -87,7 +91,6 @@ export const Portal: React.FC<React.PropsWithChildren<PortalProps>> = ({
         `Portal container '${_containerName}' is not yet registered. Container must be registered with registerPortal before use.`,
       )
     }
-    const element = elementRef.current
     parentElement.appendChild(element)
     onMount?.()
 
@@ -95,7 +98,7 @@ export const Portal: React.FC<React.PropsWithChildren<PortalProps>> = ({
       parentElement.removeChild(element)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [elementRef])
+  }, [element])
 
-  return createPortal(children, elementRef.current)
+  return createPortal(children, element)
 }


### PR DESCRIPTION
### Changelog

Portal avoids `createElement` call on every render

#### New

<!-- List of things added in this PR -->

#### Changed

Portal

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
