### PR TITLE
Sync color mode prior to subscribing in ThemeProvider

### DIFF
--- a/.changeset/fresh-hotels-begin.md
+++ b/.changeset/fresh-hotels-begin.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Sync theme in effect

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -160,15 +160,20 @@ function useSystemColorMode() {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const media = window?.matchMedia?.('(prefers-color-scheme: dark)')
 
+    function matchesMediaToColorMode(matches: boolean) {
+      return matches ? 'night' : 'day'
+    }
+
     function handleChange(event: MediaQueryListEvent) {
       const isNight = event.matches
-      setSystemColorMode(isNight ? 'night' : 'day')
+      setSystemColorMode(matchesMediaToColorMode(isNight))
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (media) {
       // just in case the preference changed before the event listener was attached
-      setSystemColorMode(media.matches ? 'night' : 'day')
+      const isNight = media.matches
+      setSystemColorMode(matchesMediaToColorMode(isNight))
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (media.addEventListener !== undefined) {
         media.addEventListener('change', handleChange)

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -167,6 +167,8 @@ function useSystemColorMode() {
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (media) {
+      // just in case the preference changed before the event listener was attached
+      setSystemColorMode(media.matches ? 'night' : 'day')
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (media.addEventListener !== undefined) {
         media.addEventListener('change', handleChange)


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

related to https://github.com/github/issues/issues/8432

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

Ensure theme syncs between initial render and setting up listeners in useEffect. This should handle the unlikely but possible scenario that in between initial render and the effect, the user's preference for theme color has changed. This team is not large, but potentially happens for users who use automatic theme switching based on time/schedule

#### New

<!-- List of things added in this PR -->

#### Changed

ThemeProvider setColorMode gets called when setting up subscription

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

It's not super straightforward to validate, but generally, when setting up subscriptions in an efffect, it's important to ensure that the time between render and the effect was accounted for.

In this case, I believe that occasionally when this effect occurs far enough after that initial render, the match state can change prior to listening to the change event, leading to some ui tearing. 

see: `useSyncExternalStore`'s shim implementation (which is basically a subscription to an event) - https://github.com/facebook/react/blob/40f653d13c363c6f81b13de67ce391991fb1f870/packages/use-sync-external-store/src/useSyncExternalStoreShimClient.js#L103-L122

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
