### PR TITLE
ci: remove storybook deployment from preview for forks

### DIFF
--- a/.github/workflows/deploy_preview_forks.yml
+++ b/.github/workflows/deploy_preview_forks.yml
@@ -49,34 +49,3 @@ jobs:
         uses: actions/deploy-pages@v3
         with:
           preview: true
-
-  deploy-storybook:
-    name: Preview Storybook
-    if: ${{ github.repository != github.event.pull_request.head.repo.full_name }}
-    needs: deploy-preview
-    permissions:
-      deployments: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: chrnorm/deployment-action@v2.0.5
-        name: Create GitHub deployment for storybook
-        id: storybook
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          environment: storybook-preview-${{ github.event.number }}
-          environment_url: '${{ needs.deploy-preview.outputs.deployment_url }}/storybook'
-      - name: Update storybook deployment status (success)
-        if: success()
-        uses: chrnorm/deployment-status@v2.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          environment-url: '${{ needs.deploy-preview.outputs.deployment_url }}/storybook'
-          state: 'success'
-          deployment-id: ${{ steps.storybook.outputs.deployment_id }}
-      - name: Update storybook deployment status (failure)
-        if: failure()
-        uses: chrnorm/deployment-status@v2.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          state: 'failure'
-          deployment-id: ${{ steps.storybook.outputs.deployment_id }}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

When updating our `deploy_preview_forks` workflow, I tried to include the storybook custom deployment but unfortunately that doesn't work as the pull request does not have a valid ref to create a deployment.

This PR removes that behavior (and restores the original behavior in the workflow)

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Remove storybook deployment from `deploy_preview_forks`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->


- [x] None; if selected, include a brief description as to why
