### PR TITLE
test(e2e): use @prettier/sync for e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/react",
-  "version": "36.4.0",
+  "version": "36.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/react",
-      "version": "36.4.0",
+      "version": "36.5.0",
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.1.5",

--- a/script/generate-e2e-tests.js
+++ b/script/generate-e2e-tests.js
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs')
 const path = require('node:path')
-const prettier = require('prettier')
+const prettier = require('@prettier/sync')
 const prettierConfig = require('@github/prettier-config')
 const recast = require('recast')
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Uses `@prettier/sync` instead of `prettier` for formatting as the `format` method is now async in later versions of `prettier`.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `script/generate-e2e-tests.js` to use `@prettier/sync`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->


- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Verify you can run this script locally 😅 