### PR TITLE
Only show tooltip on :focus-visible, not :focus

### DIFF
--- a/src/drafts/Tooltip/Tooltip.tsx
+++ b/src/drafts/Tooltip/Tooltip.tsx
@@ -281,6 +281,8 @@ export const Tooltip = React.forwardRef(
                 child.props.onBlur?.(event)
               },
               onFocus: (event: React.FocusEvent) => {
+                // only show tooltip on :focus-visible, not on :focus
+                if (!event.target.matches(':focus-visible')) return;
                 openTooltip()
                 child.props.onFocus?.(event)
               },

--- a/src/drafts/Tooltip/Tooltip.tsx
+++ b/src/drafts/Tooltip/Tooltip.tsx
@@ -282,7 +282,7 @@ export const Tooltip = React.forwardRef(
               },
               onFocus: (event: React.FocusEvent) => {
                 // only show tooltip on :focus-visible, not on :focus
-                if (!event.target.matches(':focus-visible')) return;
+                if (!event.target.matches(':focus-visible')) return
                 openTooltip()
                 child.props.onFocus?.(event)
               },


### PR DESCRIPTION
- Closes https://github.com/github/primer/issues/2926