### PR TITLE
[Do not merge] SelectPanel2: Use Tooltip v2

### DIFF
--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -327,11 +327,11 @@ const SelectPanelHeader: React.FC<React.PropsWithChildren> = ({children, ...prop
         <Box>
           {/* Will not need tooltip after https://github.com/primer/react/issues/2008 */}
           {onClearSelection ? (
-            <Tooltip text="Clear selection" direction="s" onClick={onClearSelection}>
-              <IconButton type="button" variant="invisible" icon={FilterRemoveIcon} aria-label="Clear selection" />
+            <Tooltip text="Clear selection" type="label">
+              <IconButton type="button" variant="invisible" icon={FilterRemoveIcon} aria-label="Clear selection" onClick={onClearSelection} />
             </Tooltip>
           ) : null}
-          <Tooltip text="Close" direction="s">
+          <Tooltip text="Close" type="label">
             <IconButton type="button" variant="invisible" icon={XIcon} aria-label="Close" onClick={() => onCancel()} />
           </Tooltip>
         </Box>

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -8,7 +8,6 @@ import {
   IconButton,
   Heading,
   Box,
-  Tooltip,
   TextInput,
   TextInputProps,
   Spinner,
@@ -16,6 +15,7 @@ import {
   ActionListProps,
   Octicon,
 } from '../../../src/index'
+import {Tooltip} from '../../../src/drafts'
 import {ActionListContainerContext} from '../../../src/ActionList/ActionListContainerContext'
 import {useSlots} from '../../hooks/useSlots'
 import {useProvidedRefOrCreate, useId, useAnchoredPosition} from '../../hooks'


### PR DESCRIPTION
Easy peasy! Kudos to @broccolinisoup!

> [!WARNING]  
> We might want to wait until we adopt Tooltip v2 in TextInput.Action OR match the arrow design between the 2 Tooltips to make sure the Tooltips mach, will wait for @broccolinisoup's input on which direction to take

https://github.com/primer/react/assets/1863771/e4e26347-3b61-465d-b39f-4ac0cb5778ca

