### PR TITLE
Fix missing selection attributes in ActionList items

### DIFF
--- a/.changeset/rare-jeans-rush.md
+++ b/.changeset/rare-jeans-rush.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fix missing `aria-selected` & `aria-checked` attributes in ActionList items

--- a/src/ActionList/ActionList.test.tsx
+++ b/src/ActionList/ActionList.test.tsx
@@ -44,7 +44,6 @@ function SingleSelectListStory(): JSX.Element {
           key={index}
           role="option"
           selected={index === selectedIndex}
-          aria-selected={index === selectedIndex}
           onSelect={() => setSelectedIndex(index)}
           disabled={project.disabled}
           inactiveText={project.inactiveText}

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -101,14 +101,16 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
     const itemSelectionAttribute: ActionListProps['selectionAttribute'] = selectionAttribute || listSelectionAttribute
 
     /** Infer item role based on the container */
-    let itemRole: ActionListItemProps['role']
+    let inferredItemRole: ActionListItemProps['role']
     if (container === 'ActionMenu') {
-      if (selectionVariant === 'single') itemRole = 'menuitemradio'
-      else if (selectionVariant === 'multiple') itemRole = 'menuitemcheckbox'
-      else itemRole = 'menuitem'
+      if (selectionVariant === 'single') inferredItemRole = 'menuitemradio'
+      else if (selectionVariant === 'multiple') inferredItemRole = 'menuitemcheckbox'
+      else inferredItemRole = 'menuitem'
     } else if (container === 'SelectPanel' && listRole === 'listbox') {
-      if (selectionVariant !== undefined) itemRole = 'option'
+      if (selectionVariant !== undefined) inferredItemRole = 'option'
     }
+
+    const itemRole = role || inferredItemRole
 
     const {theme} = useTheme()
 
@@ -248,11 +250,11 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
         ? [blockDescriptionId, inactiveWarningId].join(' ')
         : inactiveWarningId,
       ...(itemSelectionAttribute && {[itemSelectionAttribute]: selected}),
-      role: role || itemRole,
+      role: itemRole,
       id: itemId,
     }
 
-    const containerProps = _PrivateItemWrapper ? {role: role || itemRole ? 'none' : undefined} : menuItemProps
+    const containerProps = _PrivateItemWrapper ? {role: itemRole ? 'none' : undefined} : menuItemProps
 
     const wrapperProps = _PrivateItemWrapper ? menuItemProps : {}
 

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -74,7 +74,6 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       role: listRole,
       showDividers,
       selectionVariant: listSelectionVariant,
-      selectionAttribute: listSelectionAttribute,
     } = React.useContext(ListContext)
     const {selectionVariant: groupSelectionVariant} = React.useContext(GroupContext)
     const {container, afterSelect, selectionAttribute} = React.useContext(ActionListContainerContext)
@@ -98,8 +97,6 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       ? groupSelectionVariant
       : listSelectionVariant
 
-    const itemSelectionAttribute: ActionListProps['selectionAttribute'] = selectionAttribute || listSelectionAttribute
-
     /** Infer item role based on the container */
     let inferredItemRole: ActionListItemProps['role']
     if (container === 'ActionMenu') {
@@ -111,6 +108,13 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
     }
 
     const itemRole = role || inferredItemRole
+
+    /** Infer the proper selection attribute based on the item's role */
+    let inferredSelectionAttribute: 'aria-selected' | 'aria-checked' | undefined
+    if (itemRole === 'menuitemradio' || itemRole === 'menuitemcheckbox') inferredSelectionAttribute = 'aria-checked'
+    else if (itemRole === 'option') inferredSelectionAttribute = 'aria-selected'
+
+    const itemSelectionAttribute = selectionAttribute || inferredSelectionAttribute
 
     const {theme} = useTheme()
 

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -239,6 +239,10 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
 
     const ItemWrapper = _PrivateItemWrapper || React.Fragment
 
+    // only apply aria-selected and aria-checked to selectable items
+    const selectableRoles = ['menuitemradio', 'menuitemcheckbox', 'option']
+    const includeSelectionAttribute = itemSelectionAttribute && itemRole && selectableRoles.includes(itemRole)
+
     const menuItemProps = {
       onClick: clickHandler,
       onKeyPress: keyPressHandler,
@@ -249,7 +253,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       'aria-describedby': slots.blockDescription
         ? [blockDescriptionId, inactiveWarningId].join(' ')
         : inactiveWarningId,
-      ...(itemSelectionAttribute && {[itemSelectionAttribute]: selected}),
+      ...(includeSelectionAttribute && {[itemSelectionAttribute]: selected}),
       role: itemRole,
       id: itemId,
     }

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -74,6 +74,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       role: listRole,
       showDividers,
       selectionVariant: listSelectionVariant,
+      selectionAttribute: listSelectionAttribute,
     } = React.useContext(ListContext)
     const {selectionVariant: groupSelectionVariant} = React.useContext(GroupContext)
     const {container, afterSelect, selectionAttribute} = React.useContext(ActionListContainerContext)
@@ -96,6 +97,8 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
     const selectionVariant: ActionListProps['selectionVariant'] = groupSelectionVariant
       ? groupSelectionVariant
       : listSelectionVariant
+
+    const itemSelectionAttribute: ActionListProps['selectionAttribute'] = selectionAttribute || listSelectionAttribute
 
     /** Infer item role based on the container */
     let itemRole: ActionListItemProps['role']
@@ -244,7 +247,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       'aria-describedby': slots.blockDescription
         ? [blockDescriptionId, inactiveWarningId].join(' ')
         : inactiveWarningId,
-      ...(selectionAttribute && {[selectionAttribute]: selected}),
+      ...(itemSelectionAttribute && {[itemSelectionAttribute]: selected}),
       role: role || itemRole,
       id: itemId,
     }

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -26,10 +26,15 @@ export type ActionListProps = React.PropsWithChildren<{
    * The ARIA role describing the function of `List` component. `listbox` or `menu` are a common values.
    */
   role?: AriaRole
+
+  selectionAttribute?: 'aria-selected' | 'aria-checked'
 }> &
   SxProp
 
-type ContextProps = Pick<ActionListProps, 'variant' | 'selectionVariant' | 'showDividers' | 'role'> & {
+type ContextProps = Pick<
+  ActionListProps,
+  'variant' | 'selectionVariant' | 'showDividers' | 'role' | 'selectionAttribute'
+> & {
   headingId?: string
 }
 
@@ -58,19 +63,23 @@ export const List = React.forwardRef<HTMLUListElement, ActionListProps>(
     const {
       listRole,
       listLabelledBy,
+      selectionAttribute,
       selectionVariant: containerSelectionVariant, // TODO: Remove after DropdownMenu2 deprecation
     } = React.useContext(ActionListContainerContext)
 
     const ariaLabelledBy = slots.heading ? slots.heading.props.id ?? headingId : listLabelledBy
+    const listSelectionVariant = selectionVariant || containerSelectionVariant
+    const defaultSelectionAttribute = listSelectionVariant === 'multiple' ? 'aria-checked' : 'aria-selected'
 
     return (
       <ListContext.Provider
         value={{
           variant,
-          selectionVariant: selectionVariant || containerSelectionVariant,
+          selectionVariant: listSelectionVariant,
           showDividers,
           role: role || listRole,
           headingId,
+          selectionAttribute: selectionAttribute || defaultSelectionAttribute,
         }}
       >
         {slots.heading}

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -26,15 +26,10 @@ export type ActionListProps = React.PropsWithChildren<{
    * The ARIA role describing the function of `List` component. `listbox` or `menu` are a common values.
    */
   role?: AriaRole
-
-  selectionAttribute?: 'aria-selected' | 'aria-checked'
 }> &
   SxProp
 
-type ContextProps = Pick<
-  ActionListProps,
-  'variant' | 'selectionVariant' | 'showDividers' | 'role' | 'selectionAttribute'
-> & {
+type ContextProps = Pick<ActionListProps, 'variant' | 'selectionVariant' | 'showDividers' | 'role'> & {
   headingId?: string
 }
 
@@ -63,13 +58,11 @@ export const List = React.forwardRef<HTMLUListElement, ActionListProps>(
     const {
       listRole,
       listLabelledBy,
-      selectionAttribute,
       selectionVariant: containerSelectionVariant, // TODO: Remove after DropdownMenu2 deprecation
     } = React.useContext(ActionListContainerContext)
 
     const ariaLabelledBy = slots.heading ? slots.heading.props.id ?? headingId : listLabelledBy
     const listSelectionVariant = selectionVariant || containerSelectionVariant
-    const defaultSelectionAttribute = listSelectionVariant === 'multiple' ? 'aria-checked' : 'aria-selected'
 
     return (
       <ListContext.Provider
@@ -79,7 +72,6 @@ export const List = React.forwardRef<HTMLUListElement, ActionListProps>(
           showDividers,
           role: role || listRole,
           headingId,
-          selectionAttribute: selectionAttribute || defaultSelectionAttribute,
         }}
       >
         {slots.heading}

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -62,13 +62,12 @@ export const List = React.forwardRef<HTMLUListElement, ActionListProps>(
     } = React.useContext(ActionListContainerContext)
 
     const ariaLabelledBy = slots.heading ? slots.heading.props.id ?? headingId : listLabelledBy
-    const listSelectionVariant = selectionVariant || containerSelectionVariant
 
     return (
       <ListContext.Provider
         value={{
           variant,
-          selectionVariant: listSelectionVariant,
+          selectionVariant: selectionVariant || containerSelectionVariant,
           showDividers,
           role: role || listRole,
           headingId,

--- a/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -789,6 +789,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
       >
         <li
           aria-labelledby="0--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="0"
           id="0"
@@ -819,6 +820,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
         </li>
         <li
           aria-labelledby="1--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="1"
           id="1"
@@ -849,6 +851,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
         </li>
         <li
           aria-labelledby="2--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="2"
           id="2"
@@ -879,6 +882,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
         </li>
         <li
           aria-labelledby="3--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="3"
           id="3"
@@ -909,6 +913,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
         </li>
         <li
           aria-labelledby="4--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="4"
           id="4"
@@ -939,6 +944,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
         </li>
         <li
           aria-labelledby="5--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="5"
           id="5"
@@ -969,6 +975,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
         </li>
         <li
           aria-labelledby="6--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="6"
           id="6"
@@ -999,6 +1006,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
         </li>
         <li
           aria-labelledby="7--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="7"
           id="7"
@@ -1029,6 +1037,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
         </li>
         <li
           aria-labelledby="20--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="20"
           id="20"
@@ -1059,6 +1068,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
         </li>
         <li
           aria-labelledby="21--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="21"
           id="21"
@@ -1089,6 +1099,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
         </li>
         <li
           aria-labelledby="add-new-item--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="add-new-item"
           id="add-new-item"
@@ -1512,6 +1523,7 @@ exports[`snapshots renders a multiselect input 1`] = `
       >
         <li
           aria-labelledby="0--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="0"
           id="0"
@@ -1542,6 +1554,7 @@ exports[`snapshots renders a multiselect input 1`] = `
         </li>
         <li
           aria-labelledby="1--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="1"
           id="1"
@@ -1572,6 +1585,7 @@ exports[`snapshots renders a multiselect input 1`] = `
         </li>
         <li
           aria-labelledby="2--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="2"
           id="2"
@@ -1602,6 +1616,7 @@ exports[`snapshots renders a multiselect input 1`] = `
         </li>
         <li
           aria-labelledby="3--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="3"
           id="3"
@@ -1632,6 +1647,7 @@ exports[`snapshots renders a multiselect input 1`] = `
         </li>
         <li
           aria-labelledby="4--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="4"
           id="4"
@@ -1662,6 +1678,7 @@ exports[`snapshots renders a multiselect input 1`] = `
         </li>
         <li
           aria-labelledby="5--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="5"
           id="5"
@@ -1692,6 +1709,7 @@ exports[`snapshots renders a multiselect input 1`] = `
         </li>
         <li
           aria-labelledby="6--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="6"
           id="6"
@@ -1722,6 +1740,7 @@ exports[`snapshots renders a multiselect input 1`] = `
         </li>
         <li
           aria-labelledby="7--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="7"
           id="7"
@@ -1752,6 +1771,7 @@ exports[`snapshots renders a multiselect input 1`] = `
         </li>
         <li
           aria-labelledby="20--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="20"
           id="20"
@@ -1782,6 +1802,7 @@ exports[`snapshots renders a multiselect input 1`] = `
         </li>
         <li
           aria-labelledby="21--label "
+          aria-selected={false}
           className="c2 c3"
           data-id="21"
           id="21"
@@ -2329,6 +2350,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
       >
         <li
           aria-labelledby="0--label "
+          aria-selected={true}
           className="c2 c3"
           data-id="0"
           id="0"
@@ -2359,6 +2381,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
         </li>
         <li
           aria-labelledby="1--label "
+          aria-selected={true}
           className="c2 c3"
           data-id="1"
           id="1"
@@ -2389,6 +2412,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
         </li>
         <li
           aria-labelledby="2--label "
+          aria-selected={true}
           className="c2 c3"
           data-id="2"
           id="2"
@@ -2419,6 +2443,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
         </li>
         <li
           aria-labelledby="3--label "
+          aria-selected={false}
           className="c2 c8"
           data-id="3"
           id="3"
@@ -2449,6 +2474,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
         </li>
         <li
           aria-labelledby="4--label "
+          aria-selected={false}
           className="c2 c8"
           data-id="4"
           id="4"
@@ -2479,6 +2505,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
         </li>
         <li
           aria-labelledby="5--label "
+          aria-selected={false}
           className="c2 c8"
           data-id="5"
           id="5"
@@ -2509,6 +2536,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
         </li>
         <li
           aria-labelledby="6--label "
+          aria-selected={false}
           className="c2 c8"
           data-id="6"
           id="6"
@@ -2539,6 +2567,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
         </li>
         <li
           aria-labelledby="7--label "
+          aria-selected={false}
           className="c2 c8"
           data-id="7"
           id="7"
@@ -2569,6 +2598,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
         </li>
         <li
           aria-labelledby="20--label "
+          aria-selected={false}
           className="c2 c8"
           data-id="20"
           id="20"
@@ -2599,6 +2629,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
         </li>
         <li
           aria-labelledby="21--label "
+          aria-selected={false}
           className="c2 c8"
           data-id="21"
           id="21"


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Addresses the following a11y audit issue: https://github.com/github/accessibility-audits/issues/4484 (GitHub staff only)

This PR fixes an accessibility issue with `ActionList` items not reporting their selection state to screen readers. 

The `aria-selected` (or `aria-checked`) attributes were not being applied to `ActionList.Item` because they were only being read from `ActionListContainerContext`, but `ActionList` instances don't provide that context.

The solution I chose here was to automatically infer the selection attribute type based on the item's role: `menuitemcheckbox` and `menuitemradio` roles get an inferred selection attribute of `aria-checked`, while `option` roles will get `aria-selected`. 

Of course, if a selection attribute is specified through `ActionListContainerContext`, that will be preferred.

Interestingly, selection state was [asserted](https://github.com/primer/react/blob/c2a53a003fb392b97cd33aa5eea0329e4f726874/src/ActionList/ActionList.test.tsx#L95-L96) in one of the component tests, but the `aria-selected` attribute was [manually provided](https://github.com/primer/react/blob/c2a53a003fb392b97cd33aa5eea0329e4f726874/src/ActionList/ActionList.test.tsx#L47) in the test stub. Removing that allows the test to assert the actual selection behavior.

## Demo

This screenshot demonstrates the NVDA screenreader properly announcing the selection state with this change:

> <img width="758" alt="screenshot of NVDA properly announcing selection state" src="https://github.com/primer/react/assets/431533/ccd1719c-4635-4eca-8f14-babdd891d28c">

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
