### PR TITLE
Render SubNav items as list of links

### DIFF
--- a/.changeset/silly-humans-fly.md
+++ b/.changeset/silly-humans-fly.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Render links in `SubNav` inside a `<ul>` element and links as `<li>` elements

--- a/src/SubNav/SubNav.tsx
+++ b/src/SubNav/SubNav.tsx
@@ -52,7 +52,7 @@ function SubNav({actions, className, children, label, ...rest}: SubNavProps) {
 
 export type SubNavLinksProps = SxProp
 
-const SubNavLinks = styled.div<SubNavLinksProps>`
+const SubNavLinks = styled.ul<SubNavLinksProps>`
   display: flex;
   ${sx};
 `
@@ -63,7 +63,7 @@ type StyledSubNavLinkProps = {
 } & SxProp
 
 const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
-  className: clsx(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className),
+  className: clsx(ITEM_CLASS, props.selected && SELECTED_CLASS, props.className, 'SubNav-link'),
 }))<StyledSubNavLinkProps>`
   padding-left: ${get('space.3')};
   padding-right: ${get('space.3')};
@@ -80,17 +80,6 @@ const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
   display: flex;
   align-items: center;
 
-  &:first-of-type {
-    border-top-left-radius: ${get('radii.2')};
-    border-bottom-left-radius: ${get('radii.2')};
-    border-left: 1px solid ${get('colors.border.default')};
-  }
-
-  &:last-of-type {
-    border-top-right-radius: ${get('radii.2')};
-    border-bottom-right-radius: ${get('radii.2')};
-  }
-
   &:hover,
   &:focus {
     text-decoration: none;
@@ -102,7 +91,26 @@ const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
     }
   }
 
-  &.selected {
+  ${sx};
+`
+
+const SubNavListItem = styled.li`
+  display: flex;
+  align-items: center;
+  list-style: none;
+
+  &:first-of-type .SubNav-link {
+    border-top-left-radius: ${get('radii.2')};
+    border-bottom-left-radius: ${get('radii.2')};
+    border-left: 1px solid ${get('colors.border.default')};
+  }
+
+  &:last-of-type .SubNav-link {
+    border-top-right-radius: ${get('radii.2')};
+    border-bottom-right-radius: ${get('radii.2')};
+  }
+
+  .SubNav-link.selected {
     color: ${get('colors.fg.onEmphasis')};
     background-color: ${get('colors.accent.emphasis')};
     border-color: ${get('colors.accent.emphasis')};
@@ -110,13 +118,18 @@ const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
       color: ${get('colors.fg.onEmphasis')};
     }
   }
-
-  ${sx};
 `
 
-SubNavLink.displayName = 'SubNav.Link'
+function SubNavLinkListItem(props: ComponentProps<typeof SubNavLink>) {
+  return (
+    <SubNavListItem className="SubNav-item">
+      <SubNavLink {...props} />
+    </SubNavListItem>
+  )
+}
+SubNavLinkListItem.displayName = 'SubNav.Link'
 
 SubNavLinks.displayName = 'SubNav.Links'
 
 export type SubNavLinkProps = ComponentProps<typeof SubNavLink>
-export default Object.assign(SubNav, {Link: SubNavLink, Links: SubNavLinks})
+export default Object.assign(SubNav, {Link: SubNavLinkListItem, Links: SubNavLinks})

--- a/src/SubNav/SubNav.tsx
+++ b/src/SubNav/SubNav.tsx
@@ -54,6 +54,7 @@ export type SubNavLinksProps = SxProp
 
 const SubNavLinks = styled.ul<SubNavLinksProps>`
   display: flex;
+  list-style: none;
   margin: 0;
   padding: 0;
   ${sx};
@@ -99,7 +100,6 @@ const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
 const SubNavListItem = styled.li`
   display: flex;
   align-items: center;
-  list-style: none;
 
   &:first-of-type .SubNav-link {
     border-top-left-radius: ${get('radii.2')};

--- a/src/SubNav/SubNav.tsx
+++ b/src/SubNav/SubNav.tsx
@@ -54,6 +54,8 @@ export type SubNavLinksProps = SxProp
 
 const SubNavLinks = styled.ul<SubNavLinksProps>`
   display: flex;
+  margin: 0;
+  padding: 0;
   ${sx};
 `
 

--- a/src/__tests__/SubNavLink.test.tsx
+++ b/src/__tests__/SubNavLink.test.tsx
@@ -7,14 +7,24 @@ import {axe, toHaveNoViolations} from 'jest-axe'
 expect.extend(toHaveNoViolations)
 
 describe('SubNav.Link', () => {
-  behavesAsComponent({Component: SubNav.Link})
+  // This component does respect the `as` prop, but it affects the link inside, rather than the wrapping element,
+  // which causes the test to fail.
+  behavesAsComponent({Component: SubNav.Link, options: {skipAs: true}})
 
-  it('renders an <a> by default', () => {
-    expect(render(<SubNav.Link />).type).toEqual('a')
+  it('renders an <li> + <a> by default', () => {
+    const result = render(<SubNav.Link />)
+    expect(result.type).toEqual('li')
+    const firstChild = result.children![0]!
+    if (typeof firstChild !== 'object') throw new Error(`unexpected child type: ${typeof firstChild}`)
+    expect(firstChild.type).toEqual('a')
   })
 
   it('should have no axe violations', async () => {
-    const {container} = HTMLRender(<SubNav.Link />)
+    const {container} = HTMLRender(
+      <SubNav.Links>
+        <SubNav.Link />
+      </SubNav.Links>,
+    )
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })

--- a/src/__tests__/__snapshots__/SubNavLink.test.tsx.snap
+++ b/src/__tests__/__snapshots__/SubNavLink.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SubNav.Link renders consistently 1`] = `
-.c0 {
+.c1 {
   padding-left: 16px;
   padding-right: 16px;
   font-weight: 500;
@@ -25,19 +25,8 @@ exports[`SubNav.Link renders consistently 1`] = `
   align-items: center;
 }
 
-.c0:first-of-type {
-  border-top-left-radius: 6px;
-  border-bottom-left-radius: 6px;
-  border-left: 1px solid #d0d7de;
-}
-
-.c0:last-of-type {
-  border-top-right-radius: 6px;
-  border-bottom-right-radius: 6px;
-}
-
-.c0:hover,
-.c0:focus {
+.c1:hover,
+.c1:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #f6f8fa;
@@ -45,28 +34,54 @@ exports[`SubNav.Link renders consistently 1`] = `
   transition: background-color 0.2s ease;
 }
 
-.c0:hover .SubNav-octicon,
-.c0:focus .SubNav-octicon {
+.c1:hover .SubNav-octicon,
+.c1:focus .SubNav-octicon {
   color: #656d76;
 }
 
-.c0.selected {
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0:first-of-type .SubNav-link {
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+  border-left: 1px solid #d0d7de;
+}
+
+.c0:last-of-type .SubNav-link {
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
+.c0 .SubNav-link.selected {
   color: #ffffff;
   background-color: #0969da;
   border-color: #0969da;
 }
 
-.c0.selected .SubNav-octicon {
+.c0 .SubNav-link.selected .SubNav-octicon {
   color: #ffffff;
 }
 
-<a
+<li
   className="c0 SubNav-item"
-/>
+>
+  <a
+    className="c1 SubNav-item SubNav-link"
+  />
+</li>
 `;
 
 exports[`SubNav.Link respects the "selected" prop 1`] = `
-.c0 {
+.c1 {
   padding-left: 16px;
   padding-right: 16px;
   font-weight: 500;
@@ -90,19 +105,8 @@ exports[`SubNav.Link respects the "selected" prop 1`] = `
   align-items: center;
 }
 
-.c0:first-of-type {
-  border-top-left-radius: 6px;
-  border-bottom-left-radius: 6px;
-  border-left: 1px solid #d0d7de;
-}
-
-.c0:last-of-type {
-  border-top-right-radius: 6px;
-  border-bottom-right-radius: 6px;
-}
-
-.c0:hover,
-.c0:focus {
+.c1:hover,
+.c1:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #f6f8fa;
@@ -110,23 +114,49 @@ exports[`SubNav.Link respects the "selected" prop 1`] = `
   transition: background-color 0.2s ease;
 }
 
-.c0:hover .SubNav-octicon,
-.c0:focus .SubNav-octicon {
+.c1:hover .SubNav-octicon,
+.c1:focus .SubNav-octicon {
   color: #656d76;
 }
 
-.c0.selected {
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0:first-of-type .SubNav-link {
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+  border-left: 1px solid #d0d7de;
+}
+
+.c0:last-of-type .SubNav-link {
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
+.c0 .SubNav-link.selected {
   color: #ffffff;
   background-color: #0969da;
   border-color: #0969da;
 }
 
-.c0.selected .SubNav-octicon {
+.c0 .SubNav-link.selected .SubNav-octicon {
   color: #ffffff;
 }
 
-<a
-  className="c0 SubNav-item selected"
-  selected={true}
-/>
+<li
+  className="c0 SubNav-item"
+>
+  <a
+    className="c1 SubNav-item selected SubNav-link"
+    selected={true}
+  />
+</li>
 `;


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Related to https://github.com/github/accessibility-audits/issues/6857 (link for Hubbers)

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Currently, the SubNav renders as an unstructured list links. This PR updates the `SubNav.Links` component to render as an unordered list, and the `SubNav.Link` component to render as a list item with a link inside of it. This assists assistive technologies like screen readers to semantically understand this content as a list and know how many items are contained within it.

Markup before:
```html
<nav class="SubNav__SubNavBase-sc-1t692wx-0 dDXmIw SubNav" aria-label="Main">
  <div class="SubNav-body">
    <div class="SubNav__SubNavLinks-sc-1t692wx-1 bTBMwI">
      <a href="#home" class="SubNav__SubNavLink-sc-1t692wx-2 fUwOAn SubNav-item selected">Home</a>
      <a href="#documentation" class="SubNav__SubNavLink-sc-1t692wx-2 fUwOAn SubNav-item">Documentation</a>
      <a href="#support" class="SubNav__SubNavLink-sc-1t692wx-2 fUwOAn SubNav-item">Support</a>
    </div>
  </div>
</nav>

```

Markup after:
```html
<nav class="SubNav__SubNavBase-sc-1t692wx-0 jxszgM SubNav" aria-label="Main">
  <div class="SubNav-body">
    <ul class="SubNav__SubNavLinks-sc-1t692wx-1 eAhMXB">
      <li class="SubNav__SubNavListItem-sc-1t692wx-3 hGWZcs SubNav-item">
        <a href="#home" class="SubNav__SubNavLink-sc-1t692wx-2 jKjUgd SubNav-item selected SubNav-link">Home</a>
      </li>
      <li class="SubNav__SubNavListItem-sc-1t692wx-3 hGWZcs SubNav-item">
        <a href="#documentation" class="SubNav__SubNavLink-sc-1t692wx-2 jKjUgd SubNav-item SubNav-link">Documentation</a>
      </li>
      <li class="SubNav__SubNavListItem-sc-1t692wx-3 hGWZcs SubNav-item">
        <a href="#support" class="SubNav__SubNavLink-sc-1t692wx-2 jKjUgd SubNav-item SubNav-link">Support</a>
      </li>
    </ul>
  </div>
</nav>

```

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->

- `SubNav.Links` now renders as a `<ul>` tag
- `SubNav.Link` now renders as an `<a>` tag inside of a `<li>` tag

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
