### PR TITLE
Fixed TextInput.Action tooltip is clipped #4091

### DIFF
--- a/src/internal/components/TextInputWrapper.tsx
+++ b/src/internal/components/TextInputWrapper.tsx
@@ -103,7 +103,6 @@ export const TextInputBaseWrapper = styled.span<StyledBaseWrapperProps>`
   display: inline-flex;
   align-items: stretch;
   min-height: 32px;
-  overflow: hidden;
 
   input,
   textarea {


### PR DESCRIPTION
Closes #4091

![image](https://github.com/primer/react/assets/137499840/1fdad245-d941-4f80-b2e3-ec6fa9d96586)
