### PR TITLE
ci(deploy): update deploy preview workflows to use latest artifact actions

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: docs
       - name: Build docs preview
         run: npm run build:docs:preview
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           name: github-pages
           path: docs/public
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4
         with:
           preview: true
 

--- a/.github/workflows/deploy_preview_forks.yml
+++ b/.github/workflows/deploy_preview_forks.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: docs
       - name: Build docs preview
         run: npm run build:docs:preview
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           name: github-pages
           path: docs/public
@@ -46,6 +46,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4
         with:
           preview: true


### PR DESCRIPTION


<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

The group of artifact actions were updated last month and I believe they need to be bumped together in order for each of them to work. This PR updates our deploy preview workflows to use the latest versions of `actions/upload-pages-artifact` and `actions/deploy-pages` so that they work in unison instead of updating them separately.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `deploy_preview.yml` and `deploy_preview_forks.yml` to use the latest versions of `actions/upload-pages-artifact` and `actions/deploy-pages`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->


- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

Deploy previews should work in this PR, otherwise something is wrong 😅 