### PR TITLE
Update Link `inline` prop description

### DIFF
--- a/.changeset/nice-seals-decide.md
+++ b/.changeset/nice-seals-decide.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Deprecate the `underline` property of the Link component in favor of the new `inline` property to better handle link visibility and accessibility when adjacent to text.

--- a/src/Link/Link.docs.json
+++ b/src/Link/Link.docs.json
@@ -15,25 +15,26 @@
       "name": "muted",
       "type": "boolean",
       "defaultValue": "false",
-      "description": "Uses a less prominent shade for Link color, and the default link shade on hover"
+      "description": "Uses a less prominent shade for Link color, and the default link shade on hover."
     },
     {
       "name": "inline",
       "type": "boolean",
       "defaultValue": "false",
-      "description": "Tag link inside a text block"
+      "description": "Set to true for links adjacent to text, underlining them for clear visibility and improved accessibility."
     },
     {
       "name": "underline",
       "type": "boolean",
       "defaultValue": "false",
-      "description": "Adds underline to the Link"
+      "description": "Adds underline to the Link",
+      "deprecated": true
     },
     {
       "name": "hoverColor",
       "type": "string",
       "defaultValue": "",
-      "description": "Color used when hovering over link"
+      "description": "Color used when hovering over the link."
     },
     {
       "name": "ref",


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

https://github.com/github/primer/issues/2099

Updates the Link `inline` property description and set the `underline` property to "deprecated".