### PR TITLE
docs: update StyledOcticon references in docs

### DIFF
--- a/docs/content/drafts/Tooltip.mdx
+++ b/docs/content/drafts/Tooltip.mdx
@@ -36,7 +36,7 @@ Tooltip can be used to label interactive controls that has no visible text label
 ```jsx live
 <Tooltip text="Contribution Documentation for 'Primer React'" type="label">
   <Link href="https://github.com/primer/react/contributor-docs/CONTRIBUTING.md" sx={{ml: 1, color: 'fg.muted'}}>
-    <StyledOcticon icon={BookIcon} sx={{color: 'fg.muted'}} />
+    <Octicon icon={BookIcon} sx={{color: 'fg.muted'}} />
   </Link>
 </Tooltip>
 ```

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -90,6 +90,8 @@
       url: /Link
     - title: NavList
       url: /NavList
+    - title: Octicon
+      url: /Octicon
     - title: Overlay
       url: /Overlay
     - title: Pagehead
@@ -124,8 +126,6 @@
       url: /SplitPageLayout
     - title: StateLabel
       url: /StateLabel
-    - title: Octicon
-      url: /Octicon
     - title: SubNav
       url: /SubNav
     - title: ToggleSwitch


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/4137

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Change `StyledOcticon` to `Octicon` in `Tooltip.mdx`
- Update side nav in docs to be alphabetical

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Verify in the deploy preview that the side nav has been updated
- Verify in the deploy preview that the Tooltip example renders as expected