### PR TITLE
docs: update versioning guide with prop spread

### DIFF
--- a/contributor-docs/versioning.md
+++ b/contributor-docs/versioning.md
@@ -5,14 +5,15 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-* [Overview](#overview)
-* [Changes](#changes)
-* [Reference](#reference)
-  * [The type of a prop is broadened](#the-type-of-a-prop-is-broadened)
-  * [The type of a prop is narrowed](#the-type-of-a-prop-is-narrowed)
-  * [The `display` property used for the container of `children` is changed](#the-display-property-used-for-the-container-of-children-is-changed)
-  * [A component includes a landmark role](#a-component-includes-a-landmark-role)
-  * [A component no longer includes a landmark role](#a-component-no-longer-includes-a-landmark-role)
+- [Overview](#overview)
+- [Changes](#changes)
+- [Reference](#reference)
+  - [The type of a prop is broadened](#the-type-of-a-prop-is-broadened)
+  - [The type of a prop is narrowed](#the-type-of-a-prop-is-narrowed)
+  - [The `display` property used for the container of `children` is changed](#the-display-property-used-for-the-container-of-children-is-changed)
+  - [A component includes a landmark role](#a-component-includes-a-landmark-role)
+  - [A component no longer includes a landmark role](#a-component-no-longer-includes-a-landmark-role)
+  - [The element onto which props are spread is changed](#the-element-onto-which-props-are-spread-is-changed)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- prettier-ignore-end -->
@@ -52,6 +53,7 @@ For a full list of releases, visit our [releases](https://github.com/primer/reac
 |               | [The type of a prop is narrowed](#the-type-of-a-prop-is-narrowed)                                                                             | `major`             |
 |               | A prop is deprecated                                                                                                                          | `minor`             |
 |               | A prop is removed                                                                                                                             | `major`             |
+|               | [The element onto which props are spread is changed](#the-element-onto-which-props-are-spread-is-changed)                                     | potentially `major` |
 | Package       | A dependency is added                                                                                                                         | `minor`             |
 |               | A dependency is removed and it does not affect the public API of the package                                                                  | `minor`             |
 |               | A dependency is removed and it does affect the public API of the package                                                                      | `major`             |
@@ -163,3 +165,78 @@ of products and should be treated carefully. In certain situations, it may
 be possible to remove a landmark role that is superfluous in a `minor` release.
 However, most cases should treat this as a breaking change and should draft a
 migration plan accordingly for product teams.
+
+### The element onto which props are spread is changed
+
+semver bump: potentially **major**
+
+This situation has a couple of scenarios where it may be considered a breaking change:
+
+- When the changes to the public types for `props` do not overlap due to the change in element
+- When the values provided as `props` may contribute to layout
+
+These scenarios can occur when either adding a new container element or when
+moving `props` that are spread from a container to an element contained within
+the container.
+
+<details>
+<summary>When the changes to the public types for `props` do not overlap due to the change in element</summary>
+
+```tsx
+/* Before */
+
+type Props = React.ComponentPropsWithoutRef<'input'>
+
+function Component(props: Props) {
+  return <input {...props} />
+}
+
+/* After */
+
+// This type does not fully overlap with the previous type and is a breaking
+// change
+type Props = React.ComponentPropsWithoutRef<'div'>
+
+function Component(props: Props) {
+  return (
+    <div {...props}>
+      <input />
+    </div>
+  )
+}
+```
+
+</details>
+
+<details>
+<summary>When the values provided as `props` may contribute to layout</summary>
+
+```tsx
+/* Before */
+
+type Props = {
+  /* ... */
+}
+
+function Component(props) {
+  return <svg {...props} />
+}
+
+/* After */
+
+type Props = {
+  /* ... */
+}
+
+// When adding the new container element, values that may have influenced layout
+// will no longer apply as the `<svg>` element is within the container element.
+function Component(props) {
+  return (
+    <div>
+      <svg {...props} />
+    </div>
+  )
+}
+```
+
+</details>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Add a section to our versioning docs to handle a scenario for changing the element onto which props are spread.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add a section to our versioning docs to handle a scenario for changing the element onto which props are spread.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

Would love feedback around having this case in our versioning guide 👀 

- Is this a situation worth documenting in our versioning guide?
- Does this feel like an appropriate version bump for this situation?
- Do the examples clearly convey why the version bump is what it is?
- Are there any scenarios that are missing that should be added?