### PR TITLE
SelectPanel2: Add SelectPanel.SecondaryAction

### DIFF
--- a/.changeset/sharp-seahorses-guess.md
+++ b/.changeset/sharp-seahorses-guess.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+experimental/SelectPanel: Add SelectPanel.SecondaryAction

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -15,12 +15,17 @@ import {
   Text,
   ActionListProps,
   Octicon,
+  Link,
+  LinkProps,
+  Checkbox,
 } from '../../index'
 import {ActionListContainerContext} from '../../ActionList/ActionListContainerContext'
 import {useSlots} from '../../hooks/useSlots'
 import {useProvidedRefOrCreate, useId, useAnchoredPosition} from '../../hooks'
 import {useFocusZone} from '../../hooks/useFocusZone'
 import {StyledOverlay, OverlayProps} from '../../Overlay/Overlay'
+import InputLabel from '../../internal/components/InputLabel'
+import {invariant} from '../../utils/invariant'
 
 const SelectPanelContext = React.createContext<{
   title: string
@@ -405,7 +410,9 @@ const SelectPanelFooter = ({...props}) => {
       sx={{
         display: 'flex',
         justifyContent: 'space-between',
-        padding: 3,
+        alignItems: 'center',
+        padding: hidePrimaryActions ? 2 : 3,
+        minHeight: '44px',
         borderTop: '1px solid',
         borderColor: 'border.default',
       }}
@@ -426,13 +433,38 @@ const SelectPanelFooter = ({...props}) => {
   )
 }
 
-// TODO: is this the right way to add button props?
 const SelectPanelSecondaryButton: React.FC<ButtonProps> = props => {
   return <Button type="button" size="small" block {...props} />
 }
-// SelectPanel.SecondaryLink = props => {
-//   return <a {...props}>{props.children}</a>
-// }
+
+const SelectPanelSecondaryLink: React.FC<LinkProps> = props => {
+  return (
+    // @ts-ignore TODO: is as prop is not recognised by button?
+    <Button as={Link} size="small" variant="invisible" block {...props} sx={{fontSize: 0}}>
+      {props.children}
+    </Button>
+  )
+}
+
+const SelectPanelSecondaryCheckbox: React.FC<{children: string; id?: string}> = props => {
+  const id = useId(props.id)
+  const {selectionVariant} = React.useContext(SelectPanelContext)
+
+  // Checkbox should not be used with instant selection
+  invariant(
+    selectionVariant !== 'instant',
+    'Sorry! Secondary action with checkbox is not allowed with selectionVariant="instant"',
+  )
+
+  return (
+    <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
+      <Checkbox id={id} sx={{marginTop: 0}} />
+      <InputLabel htmlFor={id} sx={{fontSize: 0}}>
+        {props.children}
+      </InputLabel>
+    </Box>
+  )
+}
 
 const SelectPanelLoading: React.FC<{children: string}> = ({children = 'Fetching items...'}) => {
   return (
@@ -536,7 +568,9 @@ export const SelectPanel = Object.assign(Panel, {
   Header: SelectPanelHeader,
   SearchInput: SelectPanelSearchInput,
   Footer: SelectPanelFooter,
-  SecondaryButton: SelectPanelSecondaryButton,
   Loading: SelectPanelLoading,
   Message: SelectPanelMessage,
+  SecondaryButton: SelectPanelSecondaryButton,
+  SecondaryLink: SelectPanelSecondaryLink,
+  SecondaryCheckbox: SelectPanelSecondaryCheckbox,
 })

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -395,7 +395,7 @@ const SelectPanelSearchInput: React.FC<TextInputProps> = ({onChange: propsOnChan
   )
 }
 
-const FooterContext = React.createContext(false)
+const FooterContext = React.createContext<boolean>(false)
 const SelectPanelFooter = ({...props}) => {
   const {onCancel, selectionVariant} = React.useContext(SelectPanelContext)
 

--- a/src/drafts/SelectPanel2/stories/SelectPanel.default.stories.tsx
+++ b/src/drafts/SelectPanel2/stories/SelectPanel.default.stories.tsx
@@ -103,7 +103,7 @@ export const Default = () => {
         )}
 
         <SelectPanel.Footer>
-          <SelectPanel.SecondaryButton>Edit labels</SelectPanel.SecondaryButton>
+          <SelectPanel.SecondaryAction variant="button">Edit labels</SelectPanel.SecondaryAction>
         </SelectPanel.Footer>
       </SelectPanel>
     </>

--- a/src/drafts/SelectPanel2/stories/SelectPanel.examples.stories.tsx
+++ b/src/drafts/SelectPanel2/stories/SelectPanel.examples.stories.tsx
@@ -205,7 +205,9 @@ export const AsyncWithSuspendedList = () => {
         <React.Suspense fallback={<SelectPanel.Loading>Fetching labels...</SelectPanel.Loading>}>
           <SuspendedActionList query={query} />
           <SelectPanel.Footer>
-            <SelectPanel.SecondaryButton>Edit labels</SelectPanel.SecondaryButton>
+            <SelectPanel.SecondaryAction variant="link" href="/settings">
+              Edit labels
+            </SelectPanel.SecondaryAction>
           </SelectPanel.Footer>
         </React.Suspense>
       </SelectPanel>
@@ -589,7 +591,9 @@ export const WithFilterButtons = () => {
         )}
 
         <SelectPanel.Footer>
-          <SelectPanel.SecondaryLink href={`/${selectedFilter}`}>View all {selectedFilter}</SelectPanel.SecondaryLink>
+          <SelectPanel.SecondaryAction variant="link" href={`/${selectedFilter}`}>
+            View all {selectedFilter}
+          </SelectPanel.SecondaryAction>
         </SelectPanel.Footer>
       </SelectPanel>
     </>

--- a/src/drafts/SelectPanel2/stories/SelectPanel.examples.stories.tsx
+++ b/src/drafts/SelectPanel2/stories/SelectPanel.examples.stories.tsx
@@ -574,7 +574,7 @@ export const WithFilterButtons = () => {
             Try a different search term
           </SelectPanel.Message>
         ) : (
-          <ActionList selectionVariant="single">
+          <ActionList>
             {itemsToShow.map(item => (
               <ActionList.Item
                 key={item.id}
@@ -589,10 +589,7 @@ export const WithFilterButtons = () => {
         )}
 
         <SelectPanel.Footer>
-          {/* @ts-ignore TODO as prop is not identified by button? */}
-          <SelectPanel.SecondaryButton as="a" href={`/${selectedFilter}`}>
-            View all {selectedFilter}
-          </SelectPanel.SecondaryButton>
+          <SelectPanel.SecondaryLink href={`/${selectedFilter}`}>View all {selectedFilter}</SelectPanel.SecondaryLink>
         </SelectPanel.Footer>
       </SelectPanel>
     </>

--- a/src/drafts/SelectPanel2/stories/SelectPanel.features.stories.tsx
+++ b/src/drafts/SelectPanel2/stories/SelectPanel.features.stories.tsx
@@ -38,7 +38,7 @@ export const InstantSelectionVariant = () => {
           ))}
         </ActionList>
         <SelectPanel.Footer>
-          <SelectPanel.SecondaryButton>Edit tags</SelectPanel.SecondaryButton>
+          <SelectPanel.SecondaryAction variant="button">Edit tags</SelectPanel.SecondaryAction>
         </SelectPanel.Footer>
       </SelectPanel>
     </>

--- a/src/drafts/SelectPanel2/stories/SelectPanel.playground.stories.tsx
+++ b/src/drafts/SelectPanel2/stories/SelectPanel.playground.stories.tsx
@@ -11,10 +11,16 @@ export default {
   args: {
     title: 'Select labels',
     selectionVariant: 'multiple',
+    secondaryActionVariant: 'button',
   },
   argTypes: {
-    secondaryButtonText: {
-      name: 'Secondary button text',
+    secondaryActionVariant: {
+      name: 'Secondary action variant',
+      type: 'enum',
+      options: ['button', 'link', 'checkbox'],
+    },
+    secondaryActionText: {
+      name: 'Secondary action text',
       type: 'string',
     },
   },
@@ -125,8 +131,10 @@ export const Playground: StoryFn = args => {
         )}
 
         <SelectPanel.Footer>
-          {args.secondaryButtonText ? (
-            <SelectPanel.SecondaryButton>{args.secondaryButtonText}</SelectPanel.SecondaryButton>
+          {args.secondaryActionText ? (
+            <SelectPanel.SecondaryAction variant={args.secondaryActionVariant}>
+              {args.secondaryActionText}
+            </SelectPanel.SecondaryAction>
           ) : null}
         </SelectPanel.Footer>
       </SelectPanel>


### PR DESCRIPTION
- Closes https://github.com/github/primer/issues/2379


```tsx
<SelectPanel.Footer>
  <SelectPanel.SecondaryAction variant="button">Edit labels</SelectPanel.SecondaryAction>
</SelectPanel.Footer>
```
<img width="347" alt="Secondary action button" src="https://github.com/primer/react/assets/1863771/4865db75-0deb-4600-8721-a03b99af77ce">

```tsx
<SelectPanel.Footer>
  <SelectPanel.SecondaryAction variant="link">Edit labels</SelectPanel.SecondaryAction>
</SelectPanel.Footer>
```
<img width="348" alt="Secondary action link" src="https://github.com/primer/react/assets/1863771/d60d523d-8506-4b23-ace1-f329311f1f1e">

```tsx
<SelectPanel.Footer>
  <SelectPanel.SecondaryAction variant="checkbox">Set as default</SelectPanel.SecondaryAction>
</SelectPanel.Footer>
```
<img width="351" alt="Secondary action checkbox" src="https://github.com/primer/react/assets/1863771/2d1e024f-c949-427e-920c-2f38442e7299">


