### PR TITLE
Refactor/remove focus visible polyfill

### DIFF
--- a/.changeset/tricky-planets-drum.md
+++ b/.changeset/tricky-planets-drum.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Remove support for focus-visible polyfill

--- a/@types/focus-visible/index.d.ts
+++ b/@types/focus-visible/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'focus-visible'

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "clsx": "^1.2.1",
         "color2k": "^2.0.3",
         "deepmerge": "^4.2.2",
-        "focus-visible": "^5.2.0",
         "fzy.js": "^0.4.1",
         "history": "^5.0.0",
         "lodash.isempty": "^4.4.0",
@@ -8151,19 +8150,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@storybook/addon-highlight": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-7.6.2.tgz",
-      "integrity": "sha512-HjV/DPUaBtH4HWc2zeZE3Oo8qQ7IWscpsYSa2NvflaMSHw3qaskfBLq60QVvodCvxlxaoQe3GfXx+eNg4mvaBw==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/global": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/addon-interactions": {
@@ -22607,11 +22593,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/focus-visible": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
-      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.4",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "clsx": "^1.2.1",
     "color2k": "^2.0.3",
     "deepmerge": "^4.2.2",
-    "focus-visible": "^5.2.0",
     "fzy.js": "^0.4.1",
     "history": "^5.0.0",
     "lodash.isempty": "^4.4.0",

--- a/src/BaseStyles.tsx
+++ b/src/BaseStyles.tsx
@@ -4,26 +4,23 @@ import {COMMON, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from './co
 import {useTheme} from './ThemeProvider'
 import {ComponentProps} from './utils/types'
 
-// load polyfill for :focus-visible
-import 'focus-visible'
-
 const GlobalStyle = createGlobalStyle<{colorScheme?: 'light' | 'dark'}>`
   * { box-sizing: border-box; }
   body { margin: 0; }
   table { border-collapse: collapse; }
   input { color-scheme: ${props => props.colorScheme}; }
 
-  [role="button"]:focus:not(:focus-visible):not(.focus-visible),
-  [role="tabpanel"][tabindex="0"]:focus:not(:focus-visible):not(.focus-visible),
-  button:focus:not(:focus-visible):not(.focus-visible),
-  summary:focus:not(:focus-visible):not(.focus-visible),
-  a:focus:not(:focus-visible):not(.focus-visible) {
+  [role="button"]:focus:not(:focus-visible)
+  [role="tabpanel"][tabindex="0"]:focus:not(:focus-visible)
+  button:focus:not(:focus-visible),
+  summary:focus:not(:focus-visible),
+  a:focus:not(:focus-visible) {
     outline: none;
     box-shadow: none;
   }
 
-  [tabindex="0"]:focus:not(:focus-visible):not(.focus-visible),
-  details-dialog:focus:not(:focus-visible):not(.focus-visible) {
+  [tabindex="0"]:focus:not(:focus-visible),
+  details-dialog:focus:not(:focus-visible) {
     outline: none;
   }
 `

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -87,8 +87,7 @@ const UlBox = styled.ul<SxProp>`
   .PRIVATE_TreeView-item {
     outline: none;
 
-    &:focus-visible > div,
-    &.focus-visible > div {
+    &:focus-visible > div {
       box-shadow: inset 0 0 0 2px ${get(`colors.accent.fg`)};
       @media (forced-colors: active) {
         outline: 2px solid HighlightText;


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

In our maintainer sync today, it came up that we no longer need to polyfill `focus-visible` based on GitHub's browser support range. This PR removes this polyfill and any references to the explicit `.focus-visible` class

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Instances of `.focus-visible` to just `:focus-visible`

#### Removed

<!-- List of things removed in this PR -->

- The `focus-visible` polyfill

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release

I selected a minor release here but could also see this considered a breaking change since we don't explicitly call out our browser compatability (unless we indicate that it should match GitHub's?)

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- This PR changes some BaseStyles so we should confirm that none of these impact major functionality
- In most cases, this PR removes CSS selectors which had a fallback already with `:focus-visible`. We should make sure no remaining `.focus-visible` selectors remain or are in use