### PR TITLE
ci(release-conductor): update release conductor workflow to use gh cli

### DIFF
--- a/.github/workflows/assign_release_conductor.yml
+++ b/.github/workflows/assign_release_conductor.yml
@@ -13,6 +13,8 @@ jobs:
   assign-release-conductor:
     if: ${{ github.head_ref == 'changeset-release/main' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/assign_release_conductor.yml
+++ b/.github/workflows/assign_release_conductor.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   assign-release-conductor:
-    if: github.head_ref == 'changeset-release/main'
+    if: ${{ github.head_ref == 'changeset-release/main' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/assign_release_conductor.yml
+++ b/.github/workflows/assign_release_conductor.yml
@@ -25,78 +25,19 @@ jobs:
           schedule-id: 'P3IIVC4'
           token: ${{ secrets.PAGERDUTY_API_KEY_SID }}
       - run: echo ${{ steps.pagerduty.outputs.user }} is release conductor
-      - name: Add user as assignee and reviewer
-        uses: actions/github-script@v7
+      - name: Remove previous conductor
         env:
-          PR_NUMBER: ${{ github.event.inputs.pull-request || github.event.pull_request.number }}
-          RELEASE_CONDUCTOR: ${{ steps.pagerduty.outputs.user }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.inputs.pull-request || github.event.pull_request.number }}
           PREV_RELEASE_CONDUCTOR: ${{ steps.pagerduty.outputs.previous-schedule-user }}
-        with:
-          script: |
-            const { PR_NUMBER, RELEASE_CONDUCTOR, PREV_RELEASE_CONDUCTOR } = process.env;
-
-            const { data: pull } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: PR_NUMBER,
-            });
-
-            // If the previous release conductor was added as an assignee, remove them
-            const hasPreviousAssignee = pull.assignees.find((assignee) => {
-              return assignee.login === PREV_RELEASE_CONDUCTOR;
-            });
-
-            if (hasPreviousAssignee) {
-              await github.rest.issues.removeAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: PR_NUMBER,
-                assignees: [PREV_RELEASE_CONDUCTOR],
-              });
-            }
-
-            // If the previous release conductor was added as a reviewer, remove them
-            const { data: requestedReviewers } = await github.rest.pulls.listRequestedReviewers({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: PR_NUMBER,
-            });
-            const hasPreviousReviewer = requestedReviewers.users.find((user) => {
-              return user.login === PREV_RELEASE_CONDUCTOR;
-            });
-
-            if (hasPreviousReviewer) {
-              await github.rest.pulls.removeRequestedReviewers({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: PR_NUMBER,
-                reviewers: [PREV_RELEASE_CONDUCTOR],
-              });
-            }
-
-            // Add the current release conductor as an assignee if they are not currently assigned
-            const hasAssignee = pull.assignees.find((assignee) => {
-              return assignee.login === RELEASE_CONDUCTOR;
-            });
-            if (!hasAssignee) {
-              await github.rest.issues.addAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: PR_NUMBER,
-                assignees: [RELEASE_CONDUCTOR]
-              })
-            }
-
-            // Request the current release conductor as a reviewer if they are not currently requested
-            const hasReviewer = requestedReviewers.users.find((user) => {
-              return user.login === RELEASE_CONDUCTOR;
-            });
-
-            if (!hasReviewer) {
-              await github.rest.pulls.requestReviewers({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: PR_NUMBER,
-                reviewers: [RELEASE_CONDUCTOR]
-              })
-            }
+        run: |
+          gh pr edit $PR --remove-assignee $PREV_RELEASE_CONDUCTOR
+          gh pr edit $PR --remove-reviewer $PREV_RELEASE_CONDUCTOR
+      - name: Add current conductor as assignee and reviewer
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.inputs.pull-request || github.event.pull_request.number }}
+          RELEASE_CONDUCTOR: ${{ steps.pagerduty.outputs.user }}
+        run: |
+          gh pr edit $PR --add-assignee $RELEASE_CONDUCTOR
+          gh pr edit $PR --add-reviewer $RELEASE_CONDUCTOR

--- a/.github/workflows/assign_release_conductor.yml
+++ b/.github/workflows/assign_release_conductor.yml
@@ -33,13 +33,39 @@ jobs:
           PR: ${{ github.event.inputs.pull-request || github.event.pull_request.number }}
           PREV_RELEASE_CONDUCTOR: ${{ steps.pagerduty.outputs.previous-schedule-user }}
         run: |
-          gh pr edit $PR --remove-assignee $PREV_RELEASE_CONDUCTOR
-          gh pr edit $PR --remove-reviewer $PREV_RELEASE_CONDUCTOR
+          # Remove as assignee
+          gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/issues/$PR/assignees" \
+            -f "assignees[]=$PREV_RELEASE_CONDUCTOR"
+
+          # Remove as requested reviewer
+          gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/pulls/$PR/requested_reviewers" \
+            -f "reviewers[]=$PREV_RELEASE_CONDUCTOR"
       - name: Add current conductor as assignee and reviewer
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.inputs.pull-request || github.event.pull_request.number }}
           RELEASE_CONDUCTOR: ${{ steps.pagerduty.outputs.user }}
         run: |
-          gh pr edit $PR --add-assignee $RELEASE_CONDUCTOR
-          gh pr edit $PR --add-reviewer $RELEASE_CONDUCTOR
+          # Add as assignee
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/issues/$PR/assignees" \
+            -f "assignees[]=$RELEASE_CONDUCTOR"
+
+          # Add as requested reviewer
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/pulls/$PR/requested_reviewers" \
+            -f "reviewers[]=$RELEASE_CONDUCTOR"


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This cleans up our workflow for adding the release conductor to a PR by removing the custom script and using the `gh` cli directly to edit the PR.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `assign_release_conductor.yml` to use the `gh` cli directly instead of a custom script

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to a GitHub Actions workflow

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

Thankfully we can test this with workflow_dispatch now so will try it out on the latest Release tracking PR 🎉 