### PR TITLE
SelectPanel2: Fix height for fit-content in Safari

### DIFF
--- a/.changeset/selectpanel-fix-height.md
+++ b/.changeset/selectpanel-fix-height.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+experimental/SelectPanel: Fix height for `fit-content`

--- a/.changeset/selectpanel-fix-height.md
+++ b/.changeset/selectpanel-fix-height.md
@@ -2,4 +2,4 @@
 '@primer/react': patch
 ---
 
-experimental/SelectPanel: Fix height for `fit-content`
+experimental/SelectPanel: Fix height for `fit-content` in Safari

--- a/.changeset/warm-actors-jam.md
+++ b/.changeset/warm-actors-jam.md
@@ -1,5 +1,0 @@
----
-'@primer/react': patch
----
-
-Adjusts `height` styling of `SelectPanel` form to be 100% height of the container.

--- a/src/Overlay/Overlay.tsx
+++ b/src/Overlay/Overlay.tsx
@@ -29,6 +29,7 @@ const heightMap = {
   xlarge: '600px',
   auto: 'auto',
   initial: 'auto', // Passing 'initial' initially applies 'auto'
+  'fit-content': 'fit-content',
 }
 
 const widthMap = {

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -80,7 +80,7 @@ const Panel: React.FC<SelectPanelProps> = ({
   onSubmit: propsOnSubmit,
 
   width = 'medium',
-  height = 'large',
+  height = 'fit-content',
   ...props
 }) => {
   const [internalOpen, setInternalOpen] = React.useState(defaultOpen)
@@ -246,8 +246,6 @@ const Panel: React.FC<SelectPanelProps> = ({
             sx={{
               display: 'flex',
               flexDirection: 'column',
-              height: 'initial',
-              minHeight: '100%',
             }}
           >
             {slots.header ?? /* render default header as fallback */ <SelectPanelHeader />}

--- a/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -80,7 +80,7 @@ const Panel: React.FC<SelectPanelProps> = ({
   onSubmit: propsOnSubmit,
 
   width = 'medium',
-  height = 'fit-content',
+  height = 'large',
   ...props
 }) => {
   const [internalOpen, setInternalOpen] = React.useState(defaultOpen)
@@ -196,7 +196,7 @@ const Panel: React.FC<SelectPanelProps> = ({
   return (
     <>
       {Anchor}
-      {/* @ts-ignore TODO: StyledOverlay does not like height:fit-content */}
+
       <StyledOverlay
         as="dialog"
         ref={dialogRef}
@@ -208,6 +208,7 @@ const Panel: React.FC<SelectPanelProps> = ({
           // reset dialog default styles
           border: 'none',
           padding: 0,
+          '&[open]': {display: 'flex'}, // to fit children
 
           ...(variant === 'anchored' ? {margin: 0, top: position?.top, left: position?.left} : {}),
           '::backdrop': {backgroundColor: variant === 'anchored' ? 'transparent' : 'primer.canvas.backdrop'},
@@ -243,10 +244,7 @@ const Panel: React.FC<SelectPanelProps> = ({
             as="form"
             method="dialog"
             onSubmit={onInternalSubmit}
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-            }}
+            sx={{display: 'flex', flexDirection: 'column', width: '100%'}}
           >
             {slots.header ?? /* render default header as fallback */ <SelectPanelHeader />}
 

--- a/src/drafts/SelectPanel2/stories/SelectPanel.examples.stories.tsx
+++ b/src/drafts/SelectPanel2/stories/SelectPanel.examples.stories.tsx
@@ -582,12 +582,19 @@ export const WithFilterButtons = () => {
 }
 
 export const ShortSelectPanel = () => {
-  const [channels, setChannels] = React.useState({GitHub: true, Email: false})
+  const [channels, setChannels] = React.useState({GitHub: false, Email: false})
+  const [onlyFailures, setOnlyFailures] = React.useState(false)
 
   const onSubmit = () => {
     // eslint-disable-next-line no-console
     console.log('form submitted')
   }
+
+  const toggleChannel = (channel: keyof typeof channels) => {
+    setChannels({...channels, [channel]: !channels[channel]})
+  }
+
+  const channelsEnabled = channels.GitHub || channels.Email
 
   return (
     <>
@@ -601,21 +608,30 @@ export const ShortSelectPanel = () => {
           {Object.keys(channels)
             .filter(channel => channels[channel as keyof typeof channels])
             .join(', ') || 'Never'}
+          {onlyFailures && channelsEnabled && ' (Failed workflows only)'}
         </SelectPanel.Button>
 
         <ActionList>
-          <ActionList.Item
-            selected={channels.GitHub}
-            onSelect={() => setChannels({...channels, GitHub: !channels.GitHub})}
-          >
+          <ActionList.Item selected={channels.GitHub} onSelect={() => toggleChannel('GitHub')}>
             On GitHub
           </ActionList.Item>
-          <ActionList.Item
-            selected={channels.Email}
-            onSelect={() => setChannels({...channels, Email: !channels.Email})}
-          >
+          <ActionList.Item selected={channels.Email} onSelect={() => toggleChannel('Email')}>
             Email
           </ActionList.Item>
+          <Box
+            role="none"
+            sx={{
+              transition: 'max-height 100ms ease-out, opacity 100ms ease-out',
+              opacity: channelsEnabled ? 1 : 0,
+              maxHeight: channelsEnabled ? '100px' : 0,
+              overflow: channelsEnabled ? 'visible' : 'hidden',
+            }}
+          >
+            <ActionList.Divider />
+            <ActionList.Item selected={onlyFailures} onSelect={() => setOnlyFailures(!onlyFailures)}>
+              Only notify for failed workflows
+            </ActionList.Item>
+          </Box>
         </ActionList>
         <SelectPanel.Footer />
       </SelectPanel>

--- a/src/drafts/SelectPanel2/stories/SelectPanel.examples.stories.tsx
+++ b/src/drafts/SelectPanel2/stories/SelectPanel.examples.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {SelectPanel} from '../SelectPanel'
-import {ActionList, ActionMenu, Avatar, Box, Button} from '../../../index'
+import {ActionList, ActionMenu, Avatar, Box, Button, Text} from '../../../index'
 import {ArrowRightIcon, EyeIcon, GitBranchIcon, TriangleDownIcon, GearIcon} from '@primer/octicons-react'
 import data from './mock-data'
 
@@ -581,54 +581,41 @@ export const WithFilterButtons = () => {
   )
 }
 
-export const CustomHeight = () => {
-  const initialSelectedLabels = data.issue.labelIds // mock initial state: has selected labels
-  const [selectedLabelIds, setSelectedLabelIds] = React.useState<string[]>(initialSelectedLabels)
-
-  /* Selection */
-  const onLabelSelect = (labelId: string) => {
-    if (!selectedLabelIds.includes(labelId)) setSelectedLabelIds([...selectedLabelIds, labelId])
-    else setSelectedLabelIds(selectedLabelIds.filter(id => id !== labelId))
-  }
+export const ShortSelectPanel = () => {
+  const [channels, setChannels] = React.useState({GitHub: true, Email: false})
 
   const onSubmit = () => {
-    data.issue.labelIds = selectedLabelIds // pretending to persist changes
-
     // eslint-disable-next-line no-console
     console.log('form submitted')
   }
 
-  const sortingFn = (itemA: {id: string}, itemB: {id: string}) => {
-    const initialSelectedIds = data.issue.labelIds
-    if (initialSelectedIds.includes(itemA.id) && initialSelectedIds.includes(itemB.id)) return 1
-    else if (initialSelectedIds.includes(itemA.id)) return -1
-    else if (initialSelectedIds.includes(itemB.id)) return 1
-    else return 1
-  }
-
-  const itemsToShow = data.labels.sort(sortingFn)
-
   return (
     <>
-      <h1>Custom height SelectPanel</h1>
+      <h1>Short SelectPanel</h1>
       <p>
-        Uses <code>height: fit-content</code> to display the full height of the dialog
+        Use <code>height=fit-content</code> to match height of contents
       </p>
-      <SelectPanel title="Select labels" onSubmit={onSubmit} height="fit-content">
-        <SelectPanel.Button>Assign label</SelectPanel.Button>
+      <SelectPanel title="Select notification channels" height="fit-content" onSubmit={onSubmit}>
+        <SelectPanel.Button>
+          <Text sx={{color: 'fg.muted'}}>Notify me:</Text>{' '}
+          {Object.keys(channels)
+            .filter(channel => channels[channel as keyof typeof channels])
+            .join(', ') || 'Never'}
+        </SelectPanel.Button>
 
         <ActionList>
-          {itemsToShow.slice(0, 10).map(label => (
-            <ActionList.Item
-              key={label.id}
-              onSelect={() => onLabelSelect(label.id)}
-              selected={selectedLabelIds.includes(label.id)}
-            >
-              <ActionList.LeadingVisual>{getCircle(label.color)}</ActionList.LeadingVisual>
-              {label.name}
-              <ActionList.Description variant="block">{label.description}</ActionList.Description>
-            </ActionList.Item>
-          ))}
+          <ActionList.Item
+            selected={channels.GitHub}
+            onSelect={() => setChannels({...channels, GitHub: !channels.GitHub})}
+          >
+            On GitHub
+          </ActionList.Item>
+          <ActionList.Item
+            selected={channels.Email}
+            onSelect={() => setChannels({...channels, Email: !channels.Email})}
+          >
+            Email
+          </ActionList.Item>
         </ActionList>
         <SelectPanel.Footer />
       </SelectPanel>


### PR DESCRIPTION
✅ Tested storybook and dotcom in Arc/Chrome, Safari and Firefox

By default, SelectPanel has "large" height (432px) and maintains that when search results need less space:

| Header | Header |
|--------|--------|
| <img width="372" alt="SelectPanel showing all items in a scrollable list" src="https://github.com/primer/react/assets/1863771/8cde51c7-00ba-429a-b4f9-dc8251a35862"> | <img width="392" alt="SelectPanel showing only 2 items, still has the same height" src="https://github.com/primer/react/assets/1863771/331d3506-f624-4b95-9937-6f88ec350f8d"> |


However, for really short panels, you would want it to adjust to the contents, `<SelectPanel height="fit-content">` does the job for that:

https://github.com/primer/react/assets/1863771/dbc59014-d9e4-49ed-9a63-47cde89acc6c

(height transition is part of story, not select panel)