### PR TITLE
test: remove expect.extend calls to toHaveNoViolations

### DIFF
--- a/src/CounterLabel/CounterLabel.test.tsx
+++ b/src/CounterLabel/CounterLabel.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {CounterLabel} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('CounterLabel', () => {
   behavesAsComponent({Component: CounterLabel, options: {skipAs: true, skipSx: true}})

--- a/src/Heading/__tests__/Heading.test.tsx
+++ b/src/Heading/__tests__/Heading.test.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 import {Heading} from '../..'
 import {render, behavesAsComponent, checkExports} from '../../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import ThemeProvider from '../../ThemeProvider'
-expect.extend(toHaveNoViolations)
 
 const theme = {
   breakpoints: ['400px', '640px', '960px', '1280px'],

--- a/src/SelectPanel/SelectPanel.test.tsx
+++ b/src/SelectPanel/SelectPanel.test.tsx
@@ -1,13 +1,11 @@
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import React from 'react'
 import theme from '../theme'
 import {SelectPanel} from '../SelectPanel'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {BaseStyles, SSRProvider, ThemeProvider} from '..'
 import {ItemInput} from '../deprecated/ActionList/List'
-
-expect.extend(toHaveNoViolations)
 
 const items = [{text: 'Foo'}, {text: 'Bar'}, {text: 'Baz'}, {text: 'Bon'}] as ItemInput[]
 

--- a/src/Text/Text.test.tsx
+++ b/src/Text/Text.test.tsx
@@ -3,9 +3,7 @@ import {Text} from '..'
 import theme from '../theme'
 import {px, render, renderStyles, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('Text', () => {
   behavesAsComponent({Component: Text})

--- a/src/Tooltip/Tooltip.test.tsx
+++ b/src/Tooltip/Tooltip.test.tsx
@@ -2,11 +2,9 @@ import React from 'react'
 import Tooltip, {TooltipProps} from './Tooltip'
 import {render, renderClasses, rendersClass, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 
 /* Tooltip v1 */
-
-expect.extend(toHaveNoViolations)
 
 describe('Tooltip', () => {
   behavesAsComponent({Component: Tooltip})

--- a/src/Truncate/Truncate.test.tsx
+++ b/src/Truncate/Truncate.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {Truncate} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('Truncate', () => {
   behavesAsComponent({

--- a/src/__tests__/ActionMenu.test.tsx
+++ b/src/__tests__/ActionMenu.test.tsx
@@ -1,6 +1,6 @@
 import {render as HTMLRender, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import React from 'react'
 import theme from '../theme'
 import {ActionMenu, ActionList, BaseStyles, ThemeProvider, SSRProvider, Tooltip, Button} from '..'
@@ -8,7 +8,6 @@ import {Tooltip as TooltipV2} from '../drafts/Tooltip/Tooltip'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {SingleSelect} from '../ActionMenu/ActionMenu.features.stories'
 import {MixedSelection} from '../ActionMenu/ActionMenu.examples.stories'
-expect.extend(toHaveNoViolations)
 
 function Example(): JSX.Element {
   return (

--- a/src/__tests__/AnchoredOverlay.test.tsx
+++ b/src/__tests__/AnchoredOverlay.test.tsx
@@ -2,13 +2,12 @@ import React, {useCallback, useState} from 'react'
 import {AnchoredOverlay} from '../AnchoredOverlay'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender, fireEvent} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import {SSRProvider} from '../index'
 import {Button} from '../deprecated'
 import theme from '../theme'
 import BaseStyles from '../BaseStyles'
 import {ThemeProvider} from '../ThemeProvider'
-expect.extend(toHaveNoViolations)
 
 type TestComponentSettings = {
   initiallyOpen?: boolean

--- a/src/__tests__/Avatar.test.tsx
+++ b/src/__tests__/Avatar.test.tsx
@@ -3,9 +3,7 @@ import {Avatar} from '..'
 import theme from '../theme'
 import {px, render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('Avatar', () => {
   behavesAsComponent({Component: Avatar})

--- a/src/__tests__/AvatarStack.test.tsx
+++ b/src/__tests__/AvatarStack.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {AvatarStack} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 const avatarComp = (
   <AvatarStack>

--- a/src/__tests__/Box.test.tsx
+++ b/src/__tests__/Box.test.tsx
@@ -1,10 +1,9 @@
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import React from 'react'
 import {Box} from '..'
 import theme from '../theme'
 import {behavesAsComponent, checkExports, render} from '../utils/testing'
-expect.extend(toHaveNoViolations)
 
 describe('Box', () => {
   behavesAsComponent({Component: Box})

--- a/src/__tests__/Caret.test.tsx
+++ b/src/__tests__/Caret.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import Caret, {CaretProps} from '../Caret'
 import {render, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('Caret', () => {
   it('renders <svg>', () => {

--- a/src/__tests__/Checkbox.test.tsx
+++ b/src/__tests__/Checkbox.test.tsx
@@ -2,10 +2,7 @@ import React from 'react'
 import {Checkbox} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {render} from '@testing-library/react'
-import {toHaveNoViolations} from 'jest-axe'
 import userEvent from '@testing-library/user-event'
-
-expect.extend(toHaveNoViolations)
 
 describe('Checkbox', () => {
   beforeEach(() => {

--- a/src/__tests__/CircleOcticon.test.tsx
+++ b/src/__tests__/CircleOcticon.test.tsx
@@ -4,9 +4,7 @@ import theme from '../theme'
 import {CircleOcticon} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('CircleOcticon', () => {
   behavesAsComponent({

--- a/src/__tests__/Dialog.test.tsx
+++ b/src/__tests__/Dialog.test.tsx
@@ -2,9 +2,8 @@ import React, {useState, useRef} from 'react'
 import {Dialog, Box, Text} from '..'
 import {Button} from '../deprecated'
 import {render as HTMLRender, fireEvent} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import {behavesAsComponent, checkExports} from '../utils/testing'
-expect.extend(toHaveNoViolations)
 
 /* Dialog Version 2 */
 

--- a/src/__tests__/FormControl.test.tsx
+++ b/src/__tests__/FormControl.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {render} from '@testing-library/react'
 import {renderHook} from '@testing-library/react-hooks'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import {
   Autocomplete,
   Checkbox,
@@ -14,7 +14,6 @@ import {
   useFormControlForwardedProps,
 } from '..'
 import {MarkGithubIcon} from '@primer/octicons-react'
-expect.extend(toHaveNoViolations)
 
 const LABEL_TEXT = 'Form control'
 const CAPTION_TEXT = 'Hint text'

--- a/src/__tests__/Header.test.tsx
+++ b/src/__tests__/Header.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {Header} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('Header', () => {
   behavesAsComponent({Component: Header})

--- a/src/__tests__/Label.test.tsx
+++ b/src/__tests__/Label.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import {render} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import Label, {variants, LabelColorOptions} from '../Label'
 import {renderStyles} from '../utils/testing'
-expect.extend(toHaveNoViolations)
 
 describe('Label', () => {
   it('renders text node child', () => {

--- a/src/__tests__/LabelGroup.test.tsx
+++ b/src/__tests__/LabelGroup.test.tsx
@@ -1,12 +1,10 @@
 import React from 'react'
 import {render as HTMLRender, waitFor} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import {LabelGroup, Label, ThemeProvider, BaseStyles} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import theme from '../theme'
 import userEvent from '@testing-library/user-event'
-
-expect.extend(toHaveNoViolations)
 
 const ThemeAndStyleContainer: React.FC<React.PropsWithChildren> = ({children}) => (
   <ThemeProvider theme={theme}>

--- a/src/__tests__/Octicon.test.tsx
+++ b/src/__tests__/Octicon.test.tsx
@@ -3,9 +3,7 @@ import {XIcon} from '@primer/octicons-react'
 import {Octicon} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('Octicon', () => {
   behavesAsComponent({

--- a/src/__tests__/Pagehead.test.tsx
+++ b/src/__tests__/Pagehead.test.tsx
@@ -3,9 +3,7 @@ import {Pagehead} from '..'
 import theme from '../theme'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('Pagehead', () => {
   behavesAsComponent({Component: Pagehead})

--- a/src/__tests__/Pagination/Pagination.test.tsx
+++ b/src/__tests__/Pagination/Pagination.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import Pagination from '../../Pagination'
 import {behavesAsComponent} from '../../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 const reqProps = {pageCount: 10, currentPage: 1}
 const comp = <Pagination {...reqProps} />

--- a/src/__tests__/PointerBox.test.tsx
+++ b/src/__tests__/PointerBox.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {PointerBox} from '..'
 import {render, behavesAsComponent, checkExports, renderStyles} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('PointerBox', () => {
   behavesAsComponent({Component: PointerBox})

--- a/src/__tests__/Popover.test.tsx
+++ b/src/__tests__/Popover.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import Popover, {PopoverProps} from '../Popover'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 const comp = (
   <Popover caret="top" open>

--- a/src/__tests__/ProgressBar.test.tsx
+++ b/src/__tests__/ProgressBar.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {ProgressBar} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('ProgressBar', () => {
   behavesAsComponent({Component: ProgressBar})

--- a/src/__tests__/Radio.test.tsx
+++ b/src/__tests__/Radio.test.tsx
@@ -2,9 +2,6 @@ import React from 'react'
 import {Radio} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {render, fireEvent} from '@testing-library/react'
-import {toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
 
 describe('Radio', () => {
   const defaultProps = {

--- a/src/__tests__/RelativeTime.test.tsx
+++ b/src/__tests__/RelativeTime.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import {RelativeTime} from '..'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
-expect.extend(toHaveNoViolations)
 
 describe('RelativeTime', () => {
   behavesAsComponent({Component: RelativeTime})

--- a/src/__tests__/Select.test.tsx
+++ b/src/__tests__/Select.test.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import {Select} from '..'
 import {render} from '@testing-library/react'
-import {toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
 
 describe('Select', () => {
   it('renders a select input', () => {

--- a/src/__tests__/Spinner.test.tsx
+++ b/src/__tests__/Spinner.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {Spinner, SpinnerProps} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('Spinner', () => {
   behavesAsComponent({

--- a/src/__tests__/SubNavLink.test.tsx
+++ b/src/__tests__/SubNavLink.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {SubNav} from '..'
 import {render, behavesAsComponent} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('SubNav.Link', () => {
   behavesAsComponent({Component: SubNav.Link})

--- a/src/__tests__/Textarea.test.tsx
+++ b/src/__tests__/Textarea.test.tsx
@@ -2,11 +2,8 @@ import React from 'react'
 import {Textarea} from '..'
 import {behavesAsComponent, checkExports, renderStyles} from '../utils/testing'
 import {render} from '@testing-library/react'
-import {toHaveNoViolations} from 'jest-axe'
 import userEvent from '@testing-library/user-event'
 import {DEFAULT_TEXTAREA_ROWS, DEFAULT_TEXTAREA_COLS, DEFAULT_TEXTAREA_RESIZE} from '../Textarea'
-
-expect.extend(toHaveNoViolations)
 
 describe('Textarea', () => {
   beforeEach(() => {

--- a/src/__tests__/deprecated/ActionList.test.tsx
+++ b/src/__tests__/deprecated/ActionList.test.tsx
@@ -1,11 +1,10 @@
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import React from 'react'
 import theme from '../../theme'
 import {ActionList} from '../../deprecated/ActionList'
 import {behavesAsComponent, checkExports} from '../../utils/testing'
 import {BaseStyles, ThemeProvider} from '../..'
-expect.extend(toHaveNoViolations)
 
 function SimpleActionList(): JSX.Element {
   return (

--- a/src/__tests__/deprecated/ActionMenu.test.tsx
+++ b/src/__tests__/deprecated/ActionMenu.test.tsx
@@ -1,12 +1,11 @@
 import {render as HTMLRender, fireEvent} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
+import {axe} from 'jest-axe'
 import React from 'react'
 import theme from '../../theme'
 import {ActionMenu} from '../../deprecated'
 import {behavesAsComponent, checkExports} from '../../utils/testing'
 import {BaseStyles, SSRProvider, ThemeProvider} from '../..'
 import {ItemProps} from '../../deprecated/ActionList/Item'
-expect.extend(toHaveNoViolations)
 
 const items = [
   {text: 'New file'},

--- a/src/__tests__/deprecated/Button.test.tsx
+++ b/src/__tests__/deprecated/Button.test.tsx
@@ -11,9 +11,7 @@ import {
 import {ButtonGroup} from '../..'
 import {render, behavesAsComponent, checkExports} from '../../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 function noop() {}
 

--- a/src/__tests__/deprecated/FilterList.test.tsx
+++ b/src/__tests__/deprecated/FilterList.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {FilterList} from '../../deprecated'
 import {render, behavesAsComponent, checkExports} from '../../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('FilterList', () => {
   behavesAsComponent({Component: FilterList})

--- a/src/__tests__/deprecated/FilterListItem.test.tsx
+++ b/src/__tests__/deprecated/FilterListItem.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {FilterList} from '../../deprecated'
 import {render, behavesAsComponent} from '../../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('FilterList.Item', () => {
   behavesAsComponent({Component: FilterList.Item})

--- a/src/__tests__/deprecated/FilteredSearch.test.tsx
+++ b/src/__tests__/deprecated/FilteredSearch.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {FilteredSearch} from '../../deprecated'
 import {render, behavesAsComponent, checkExports} from '../../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('FilteredSearch', () => {
   behavesAsComponent({Component: FilteredSearch})

--- a/src/deprecated/UnderlineNav/UnderlineNavLink.test.tsx
+++ b/src/deprecated/UnderlineNav/UnderlineNavLink.test.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import {UnderlineNav} from '../../deprecated'
 import {render} from '../../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
-import {axe, toHaveNoViolations} from 'jest-axe'
-
-expect.extend(toHaveNoViolations)
+import {axe} from 'jest-axe'
 
 describe('UnderlineNav.Link', () => {
   it('renders an <a> by default', () => {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This is a small refactor to remove calls to `expect.extend(toHaveNoViolations)` in individual test suites since we have a setup call that includes this by default.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Remove calls to `expect.extend(toHaveNoViolations)` in individual test suites

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to tests
