### PR TITLE
Bugfix: Honor `sx` on draft `Dialog.Header`

### DIFF
--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -342,6 +342,7 @@ const Header = styled.div<SxProp>`
   padding: ${get('space.2')};
   z-index: 1;
   flex-shrink: 0;
+  ${sx};
 `
 
 const Title = styled.h1<SxProp>`


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->



<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

`sx` was supported but it wasn't applied on top of standard `Header` styles.
```tsx
<Dialog.Header sx={{borderBottomWidth: 0}}>
```
This does nothing because `sx` is listed on the props but it's ignored on the component. It's the only component missing it (see `Title`, `Subtitle`, `Body`, and `Footer`).

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

No API changes.

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

When using `renderHeader`, we couldn't use `Dialog.Header` to change the style, so we had to use a `Box` and copy & change the styles from the `Dialog.Header` definition.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
