### PR TITLE
fix(theme): add font stack as fallback to custom property

### DIFF
--- a/.changeset/selfish-guests-stare.md
+++ b/.changeset/selfish-guests-stare.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Update mono font in theme to use font stack as fallback to custom property

--- a/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1212,7 +1212,7 @@ exports[`TextInput renders monospace 1`] = `
   align-items: stretch;
   min-height: 32px;
   overflow: hidden;
-  font-family: var(--fontStack-monospace),SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  font-family: var(--fontStack-monospace,SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace);
 }
 
 .c0 input,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -20,15 +20,14 @@ const fonts = {
     'Apple Color Emoji',
     'Segoe UI Emoji',
   ]),
-  mono: fontStack([
-    'var(--fontStack-monospace)',
+  mono: `var(--fontStack-monospace, ${fontStack([
     'SFMono-Regular',
     'Consolas',
     'Liberation Mono',
     'Menlo',
     'Courier',
     'monospace',
-  ]),
+  ])})`,
 }
 
 const lineHeights = {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update the value for `mono` in our theme. The font stack is now the fallback value of the CSS Custom Property

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `mono` font family value in theme

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Verify code snippets and other instances that use a `mono` value from the theme now render with the correct font family