### PR TITLE
ci: update deploy_preview_forks workflows

### DIFF
--- a/.github/workflows/deploy_preview_forks.yml
+++ b/.github/workflows/deploy_preview_forks.yml
@@ -21,9 +21,6 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
-      - name: Install docs dependencies
-        run: npm ci --legacy-peer-deps
-        working-directory: docs
       - name: Build docs preview
         run: npm run build:docs:preview
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Noticed this after the merge recently, this PR updates our workflow for deploying a preview from forks to only run `npm ci` at the top level and no longer install from the docs workspace specifically

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `deploy_preview_forks.yml` workflow to only install dependencies once

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to our CI processes

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Not sure how to specifically test this without using a PR from a fork. Thankfully we have some PRs opened now from forks that we can use to test this once merged