### PR TITLE
IssueLabelToken with variants

### DIFF
--- a/.changeset/moody-goats-destroy.md
+++ b/.changeset/moody-goats-destroy.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Adding a new IssueLabelToken component that uses variants for colors

--- a/package-lock.json
+++ b/package-lock.json
@@ -36216,6 +36216,11 @@
       "version": "2.8.9",
       "license": "ISC"
     },
+    "node_modules/hsluv": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-1.0.1.tgz",
+      "integrity": "sha512-zCaFTiDqBLQjCCFBu0qg7z9ASYPd+Bxx2GDCVZJsnehjK80S+jByqhuFz0pCd2Aw3FSKr18AWbRlwnKR0YdizQ=="
+    },
     "node_modules/html-dom-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.2.0.tgz",
@@ -62097,6 +62102,7 @@
         "focus-visible": "^5.2.0",
         "fzy.js": "^0.4.1",
         "history": "^5.0.0",
+        "hsluv": "1.0.1",
         "lodash.isempty": "^4.4.0",
         "lodash.isobject": "^3.0.2",
         "react-intersection-observer": "^9.4.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -114,7 +114,8 @@
     "react-intersection-observer": "^9.4.3",
     "react-is": "^18.2.0",
     "react-markdown": "8.0.7",
-    "styled-system": "^5.1.5"
+    "styled-system": "^5.1.5",
+    "hsluv": "1.0.1"
   },
   "devDependencies": {
     "@actions/core": "1.10.1",

--- a/packages/react/src/Token/IssueLabelToken.features.stories.tsx
+++ b/packages/react/src/Token/IssueLabelToken.features.stories.tsx
@@ -1,0 +1,113 @@
+import React from 'react'
+import IssueLabelToken from './IssueLabelToken'
+import Box from '../Box'
+import {action} from '@storybook/addon-actions'
+import type {StoryObj} from '@storybook/react'
+import type {hexString} from '../utils/isHex'
+
+export default {
+  title: 'Components/IssueLabelToken',
+  component: IssueLabelToken,
+}
+const variants = [
+  'pink',
+  'plum',
+  'purple',
+  'indigo',
+  'blue',
+  'cyan',
+  'teal',
+  'pine',
+  'green',
+  'lime',
+  'olive',
+  'lemon',
+  'yellow',
+  'orange',
+  'amber',
+  'red',
+  'coral',
+  'gray',
+  'brown',
+  'auburn',
+] as const
+
+type Variants = typeof variants
+type Variant = Variants[number]
+
+export const Interactive: StoryObj = ({variant}: {variant: Variant}) => {
+  return (
+    <Box
+      sx={{
+        alignItems: 'start',
+        gap: 2,
+        display: 'flex',
+        flexWrap: 'wrap',
+        overflow: 'hidden',
+        padding: 2,
+      }}
+    >
+      <IssueLabelToken
+        href="/?path=/story/drafts-components-issuelabeltoken-interactive--interactive"
+        variant={variant}
+        text="Link"
+      />
+      <IssueLabelToken onClick={action('clicked')} variant={variant} text="Button" />
+      <IssueLabelToken tabIndex={0} onFocus={action('focused')} variant={variant} text="Focusable Span" />
+      <IssueLabelToken
+        text="Removable Button"
+        variant={variant}
+        onRemove={action('remove clicked')}
+        onClick={action('button clicked')}
+      />
+    </Box>
+  )
+}
+
+Interactive.args = {
+  variant: variants[0],
+}
+Interactive.argTypes = {
+  variant: {
+    control: {
+      type: 'select',
+    },
+    options: [...variants, undefined],
+  },
+}
+
+export const Hex: StoryObj = ({
+  hex,
+  text,
+  interactive,
+  ...args
+}: {
+  hex: hexString
+  interactive: boolean
+  text: string
+}) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 2,
+        overflow: 'hidden',
+        padding: 2,
+      }}
+    >
+      <IssueLabelToken {...args} text={text} fillColor={hex} onClick={interactive ? () => {} : undefined} />
+    </Box>
+  )
+}
+Hex.args = {
+  hex: '#59B200',
+  text: 'New Token',
+  variant: undefined,
+  interactive: true,
+}
+Hex.argTypes = {
+  hex: {control: {type: 'color'}},
+  variant: {control: {disable: true}},
+  interactive: {control: {type: 'boolean'}},
+}

--- a/packages/react/src/Token/IssueLabelToken.stories.tsx
+++ b/packages/react/src/Token/IssueLabelToken.stories.tsx
@@ -1,0 +1,252 @@
+import React, {useEffect, useState} from 'react'
+import IssueLabelToken from './IssueLabelToken'
+import Box from '../Box'
+import {action} from '@storybook/addon-actions'
+import type {ReactNode} from 'react'
+import type {StoryObj} from '@storybook/react'
+import type {hexString} from '../utils/isHex'
+
+const variants = [
+  'pink',
+  'plum',
+  'purple',
+  'indigo',
+  'blue',
+  'cyan',
+  'teal',
+  'pine',
+  'green',
+  'lime',
+  'olive',
+  'lemon',
+  'yellow',
+  'orange',
+  'amber',
+  'red',
+  'coral',
+  'gray',
+  'brown',
+  'auburn',
+] as const
+
+type Variants = typeof variants
+type Variant = Variants[number]
+
+export default {
+  title: 'Components/IssueLabelToken',
+  component: IssueLabelToken,
+  args: {
+    text: 'Token',
+    variant: 'blue',
+  },
+  argTypes: {
+    variant: {
+      control: {
+        type: 'select',
+      },
+      options: [...variants, undefined],
+    },
+  },
+}
+
+export const Default: StoryObj = ({variant, text, ...args}: {variant: Variant; text: string}) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 2,
+        overflow: 'hidden',
+        padding: 2,
+      }}
+    >
+      <IssueLabelToken {...args} text={text} variant={variant} />
+    </Box>
+  )
+}
+Default.args = {
+  variant: variants[0],
+  text: 'Issue Label',
+}
+
+const getRandomLabels = (amount: number, asVariant = true, args: {interactive?: boolean}): React.ReactNode[] => {
+  const labels: {
+    variant: Variant
+    hex: hexString
+    text: string
+    interactive?: boolean
+  }[] = [
+    {
+      variant: 'red',
+      hex: '#ff1212',
+      text: '🐛 bug',
+    },
+    {
+      variant: 'coral',
+      hex: '#ff8b31',
+      text: 'deep dive 🐙',
+    },
+    {
+      variant: 'orange',
+      hex: '#5a5939',
+      text: 'figma',
+    },
+    {
+      variant: 'amber',
+      hex: '#ffa411',
+      text: '🔥 hot',
+    },
+    {
+      variant: 'yellow',
+      hex: '#ff8600',
+      text: 'question',
+    },
+    {
+      variant: 'brown',
+      hex: '#fff100',
+      text: 'boring',
+    },
+    {
+      variant: 'auburn',
+      hex: '#c0fa00',
+      text: 'sustainable',
+    },
+    {
+      variant: 'blue',
+      hex: '#00faf6',
+      text: 'new',
+    },
+    {
+      variant: 'purple',
+      hex: '#003ba8',
+      text: 'info needed',
+    },
+    {
+      variant: 'gray',
+      hex: '#000000',
+      text: 'wontfix',
+    },
+    {
+      variant: 'olive',
+      hex: '#699909',
+      text: '🫒 lunch',
+    },
+    {
+      variant: 'cyan',
+      hex: '#00fac2',
+      text: '📥 Inbox',
+    },
+    {
+      variant: 'pine',
+      hex: '#518c5c',
+      text: 'documentation',
+    },
+    {
+      variant: 'teal',
+      hex: '#37ff00',
+      text: '✅ Done',
+    },
+    {
+      variant: 'green',
+      hex: '#aaf88a',
+      text: 'enhancement',
+    },
+    {
+      variant: 'lemon',
+      hex: '#fff100',
+      text: 'squeeze 🍋',
+    },
+    {
+      variant: 'lime',
+      hex: '#26ff00',
+      text: 'lame 🍈',
+    },
+    {
+      variant: 'pink',
+      hex: '#fa00ce',
+      text: 'unicorn',
+    },
+    {
+      variant: 'plum',
+      hex: '#2f00ff',
+      text: 'beautify',
+    },
+    {
+      variant: 'indigo',
+      hex: '#c100ff',
+      text: 'mysterious',
+    },
+  ]
+
+  let substract = 0
+  const result: ReactNode[] = []
+  for (let i = 0; amount > i; i++) {
+    if (i - substract > labels.length - 1) {
+      substract += labels.length
+    }
+    const {variant, hex, text} = labels[i - substract]
+    result.push(
+      (
+        <IssueLabelToken
+          key={i}
+          variant={asVariant ? variant : undefined}
+          fillColor={!asVariant ? hex : undefined}
+          text={text}
+          onClick={args.interactive ? () => action('label clicked') : undefined}
+        />
+      ) as ReactNode,
+    )
+  }
+  return result
+}
+
+export const Playground: StoryObj = ({
+  variant,
+  numberOfTokens,
+  text,
+  interactive,
+  ...args
+}: {
+  variant: Variant
+  numberOfTokens: number
+  text: string
+  interactive: boolean
+}) => {
+  const [tokens, setTokens] = useState<React.ReactNode[] | null>(null)
+
+  useEffect(() => {
+    setTokens(getRandomLabels(numberOfTokens - 1, true, {interactive}))
+  }, [numberOfTokens, interactive])
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 2,
+        overflow: 'hidden',
+        padding: 2,
+      }}
+    >
+      <IssueLabelToken {...args} text={text} variant={variant} onClick={interactive ? () => {} : undefined} />
+      {tokens}
+    </Box>
+  )
+}
+Playground.args = {
+  variant: variants[0],
+  text: 'New Token',
+  numberOfTokens: 3,
+  interactive: false,
+}
+
+Playground.argTypes = {
+  variant: {
+    control: {
+      type: 'select',
+    },
+    options: [...variants, undefined],
+  },
+  numberOfTokens: {control: {type: 'range', min: 1, max: 30, step: 1}},
+  interactive: {control: {type: 'boolean'}},
+}

--- a/packages/react/src/Token/IssueLabelToken.tsx
+++ b/packages/react/src/Token/IssueLabelToken.tsx
@@ -1,169 +1,195 @@
+import React, {forwardRef} from 'react'
 import type {MouseEventHandler} from 'react'
-import React, {forwardRef, useMemo} from 'react'
-import type {CSSObject} from '@styled-system/css'
+import TokenBase, {isTokenInteractive} from './TokenBase'
 import type {TokenBaseProps} from './TokenBase'
-import TokenBase, {defaultTokenSize, isTokenInteractive} from './TokenBase'
-import RemoveTokenButton from './_RemoveTokenButton'
-import {parseToHsla, parseToRgba} from 'color2k'
+import {toHex} from 'color2k'
+import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
+import {getColorsFromHex} from './getColorsFromHex'
 import {useTheme} from '../ThemeProvider'
 import TokenTextContainer from './_TokenTextContainer'
-import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
+import RemoveTokenButton from './_RemoveTokenButton'
+import styled from 'styled-components'
+import type {hexString} from '../utils/isHex'
 
-export interface IssueLabelTokenProps extends TokenBaseProps {
-  /**
-   * The color that corresponds to the label
-   */
+export type Variant =
+  | 'pink'
+  | 'plum'
+  | 'purple'
+  | 'indigo'
+  | 'blue'
+  | 'cyan'
+  | 'teal'
+  | 'pine'
+  | 'green'
+  | 'lime'
+  | 'olive'
+  | 'lemon'
+  | 'yellow'
+  | 'orange'
+  | 'red'
+  | 'coral'
+  | 'gray'
+  | 'brown'
+  | 'auburn'
+
+export interface IssueLabelTokenProps extends Omit<TokenBaseProps, 'size'> {
+  // this seems not to work to exlude as property from TokenBaseProps
+  variant?: Variant
   fillColor?: string
 }
 
-const tokenBorderWidthPx = 1
-
-const lightModeStyles = {
-  '--lightness-threshold': '0.453',
-  '--border-threshold': '0.96',
-  '--border-alpha': 'max(0, min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100), 1))',
-  background: 'rgb(var(--label-r), var(--label-g), var(--label-b))',
-  color: 'hsl(0, 0%, calc(var(--lightness-switch) * 100%))',
-  borderWidth: tokenBorderWidthPx,
-  borderStyle: 'solid',
-  borderColor: 'hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) - 25) * 1%),var(--border-alpha))',
+export type variantColor = {
+  backgroundColor: string
+  textColor: string
+  textColorHover: string
+  textColorActive: string
+  backgroundColorHover: string
+  backgroundColorActive: string
 }
 
-const darkModeStyles = {
-  '--lightness-threshold': '0.6',
-  '--background-alpha': '0.18',
-  '--border-alpha': '0.3',
-  '--lighten-by': 'calc(((var(--lightness-threshold) - var(--perceived-lightness)) * 100) * var(--lightness-switch))',
-  borderWidth: tokenBorderWidthPx,
-  borderStyle: 'solid',
-  background: 'rgba(var(--label-r), var(--label-g), var(--label-b), var(--background-alpha))',
-  color: 'hsl(var(--label-h), calc(var(--label-s) * 1%), calc((var(--label-l) + var(--lighten-by)) * 1%))',
-  borderColor:
-    'hsla(var(--label-h), calc(var(--label-s) * 1%),calc((var(--label-l) + var(--lighten-by)) * 1%),var(--border-alpha))',
+const variantColors = (variant: Variant): variantColor => ({
+  backgroundColor: `var(--label-${variant}-bgColor-rest)`,
+  backgroundColorHover: `var(--label-${variant}-bgColor-hover)`,
+  backgroundColorActive: `var(--label-${variant}-bgColor-active)`,
+  textColor: `var(--label-${variant}-fgColor-rest)`,
+  textColorHover: `var(--label-${variant}-fgColor-hover)`,
+  textColorActive: `var(--label-${variant}-fgColor-active)`,
+})
+
+const getLabelColors = (
+  variant?: Variant,
+  fillColor?: string,
+  resolvedColorScheme = 'light',
+  bgColor = '#ffffff',
+): variantColor => {
+  // valid variant
+  if (variant) {
+    return variantColors(variant)
+  }
+  // valid hex string
+  fillColor = fillColor !== undefined ? toHex(fillColor) : undefined
+  if (fillColor) {
+    return getColorsFromHex(fillColor as hexString, resolvedColorScheme, bgColor) // TODO: remove false prop if no selection nessesary for tokens
+  }
+  // if invalid variant and invalid hex string, return default
+  return variantColors('gray')
+}
+
+const StyledIssueLabelToken: typeof TokenBase = styled(TokenBase).withConfig({
+  shouldForwardProp(prop, validator) {
+    if (prop === 'onRemove') {
+      return true
+    }
+    return validator(prop)
+  },
+})`
+  background-color: var(--label-bgColor-rest);
+  color: var(--label-fgColor);
+  padding-right: ${props => (!props.onRemove ? undefined : 0)};
+  position: relative;
+  border: none;
+  &[data-interactive='true'] {
+    &:hover {
+      background-color: var(--label-bgColor-hover);
+      color: var(--label-fgColor-hover);
+    }
+    &:active {
+      background-color: var(--label-bgColor-active);
+      color: var(--label-fgColor-active);
+    }
+  }
+`
+
+const getElementType = (
+  href?: string,
+  onClick?: React.MouseEventHandler<HTMLSpanElement | HTMLLinkElement | HTMLButtonElement>,
+): 'a' | 'button' | 'span' => {
+  if (href) return 'a'
+  if (onClick) return 'button'
+  return 'span'
 }
 
 const IssueLabelToken = forwardRef((props, forwardedRef) => {
   const {
-    as,
-    fillColor = '#999',
+    variant,
+    fillColor,
     onRemove,
     id,
-    isSelected,
     text,
-    size = defaultTokenSize,
-    hideRemoveButton,
-    href,
+    href, // or could we just do it depending on href or onClick?
     onClick,
     ...rest
   } = props
+
+  const {resolvedColorScheme, theme} = useTheme()
+  const bgColor =
+    getComputedStyle(document.documentElement).getPropertyValue(theme?.colors.canvas.default) ||
+    resolvedColorScheme?.startsWith('light')
+      ? '#ffffff'
+      : '#000000'
+
+  const {backgroundColor, textColor, textColorHover, textColorActive, backgroundColorHover, backgroundColorActive} =
+    getLabelColors(variant, fillColor, resolvedColorScheme, bgColor)
+
   const interactiveTokenProps = {
-    as,
+    as: getElementType(href, onClick),
     href,
     onClick,
   }
-  const {resolvedColorScheme} = useTheme()
-  const hasMultipleActionTargets = isTokenInteractive(props) && Boolean(onRemove) && !hideRemoveButton
+
+  const hasMultipleActionTargets = isTokenInteractive(props) && Boolean(onRemove)
+
+  const hasHoverAndActiveStyles = (
+    as: 'a' | 'button' | 'span',
+    onClick?: React.MouseEventHandler<HTMLSpanElement | HTMLLinkElement | HTMLButtonElement>,
+  ) => Boolean(onClick || ['a', 'button'].includes(as))
+
   const onRemoveClick: MouseEventHandler = e => {
     e.stopPropagation()
     onRemove && onRemove()
   }
-  const labelStyles: CSSObject = useMemo(() => {
-    const [r, g, b] = parseToRgba(fillColor)
-    const [h, s, l] = parseToHsla(fillColor)
-    const isLightScheme = !resolvedColorScheme?.startsWith('dark') // fall back to light colors for unknown schemes
-
-    // label hack taken from https://github.com/github/github/blob/master/app/assets/stylesheets/hacks/hx_primer-labels.scss#L43-L108
-    // this logic should eventually live in primer/components. Also worthy of note is that the dotcom hack code will be moving to primer/css soon.
-    return {
-      '--label-r': String(r),
-      '--label-g': String(g),
-      '--label-b': String(b),
-      '--label-h': String(Math.round(h)),
-      '--label-s': String(Math.round(s * 100)),
-      '--label-l': String(Math.round(l * 100)),
-      '--perceived-lightness':
-        'calc(((var(--label-r) * 0.2126) + (var(--label-g) * 0.7152) + (var(--label-b) * 0.0722)) / 255)',
-      '--lightness-switch': 'max(0, min(calc((var(--perceived-lightness) - var(--lightness-threshold)) * -1000), 1))',
-      paddingRight: hideRemoveButton || !onRemove ? undefined : 0,
-      position: 'relative',
-      ...(isLightScheme ? lightModeStyles : darkModeStyles),
-      ...(isSelected
-        ? {
-            background: isLightScheme
-              ? 'hsl(var(--label-h), calc(var(--label-s) * 1%), calc((var(--label-l) - 5) * 1%))'
-              : darkModeStyles.background,
-            ':focus': {
-              outline: 'none',
-            },
-            ':after': {
-              content: '""',
-              position: 'absolute',
-              zIndex: 1,
-              top: `-${tokenBorderWidthPx * 2}px`,
-              right: `-${tokenBorderWidthPx * 2}px`,
-              bottom: `-${tokenBorderWidthPx * 2}px`,
-              left: `-${tokenBorderWidthPx * 2}px`,
-              display: 'block',
-              pointerEvents: 'none',
-              boxShadow: `0 0 0 ${tokenBorderWidthPx * 2}px ${
-                isLightScheme
-                  ? 'rgb(var(--label-r), var(--label-g), var(--label-b))'
-                  : 'hsl(var(--label-h), calc(var(--label-s) * 1%), calc((var(--label-l) + var(--lighten-by)) * 1%))'
-              }`,
-              borderRadius: '999px',
-            },
-          }
-        : {}),
-      ...(isTokenInteractive(props)
-        ? {
-            '&:hover': {
-              ...(isLightScheme
-                ? {
-                    backgroundImage:
-                      'linear-gradient(rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.15)), linear-gradient(rgb(var(--label-r),var(--label-g),var(--label-b)), rgb(var(--label-r),var(--label-g),var(--label-b)))',
-                  }
-                : {
-                    background:
-                      'hsla(var(--label-h), calc(var(--label-s) * 1%), calc(calc(var(--label-l) + 10) * 1%), 0.3);',
-                  }),
-              boxShadow: 'shadow.medium',
-            },
-          }
-        : {}),
-    }
-  }, [fillColor, resolvedColorScheme, hideRemoveButton, onRemove, isSelected, props])
 
   return (
-    <TokenBase
+    <StyledIssueLabelToken
+      data-interactive={hasHoverAndActiveStyles(getElementType(href, onClick), props.onClick)}
       onRemove={onRemove}
       id={id?.toString()}
-      isSelected={isSelected}
       text={text}
-      size={size}
-      sx={labelStyles}
-      {...(!hasMultipleActionTargets ? interactiveTokenProps : {})}
-      {...rest}
+      style={
+        {
+          '--label-bgColor-rest': backgroundColor,
+          '--label-fgColor': textColor,
+          '--label-fgColor-hover': textColorHover,
+          '--label-fgColor-active': textColorActive,
+          '--label-bgColor-hover': backgroundColorHover,
+          '--label-bgColor-active': backgroundColorActive,
+        } as React.CSSProperties
+      }
+      {...(!hasMultipleActionTargets
+        ? {
+            forwardedAs: getElementType(href, onClick),
+            href,
+            onClick,
+          }
+        : {forwardedAs: 'span'})}
+      // add size in case it is added from the outside
+      {...{...rest, size: 'medium'}}
       ref={forwardedRef}
     >
-      <TokenTextContainer {...(hasMultipleActionTargets ? interactiveTokenProps : {})}>{text}</TokenTextContainer>
-      {!hideRemoveButton && onRemove ? (
+      <TokenTextContainer {...(hasMultipleActionTargets ? {...interactiveTokenProps} : {})}>{text}</TokenTextContainer>
+      {onRemove ? (
         <RemoveTokenButton
-          borderOffset={tokenBorderWidthPx}
           onClick={onRemoveClick}
-          size={size}
+          size="medium"
           aria-hidden={hasMultipleActionTargets ? 'true' : 'false'}
-          isParentInteractive={isTokenInteractive(props)}
-          sx={
-            hasMultipleActionTargets
-              ? {
-                  position: 'relative',
-                  zIndex: '1',
-                }
-              : {}
-          }
+          isParentInteractive={isTokenInteractive({...props, as: interactiveTokenProps.as})}
+          sx={{
+            position: 'relative',
+            zIndex: '1',
+          }}
         />
       ) : null}
-    </TokenBase>
+    </StyledIssueLabelToken>
   )
 }) as PolymorphicForwardRefComponent<'span' | 'a' | 'button', IssueLabelTokenProps>
 

--- a/packages/react/src/Token/__tests__/Token.test.tsx
+++ b/packages/react/src/Token/__tests__/Token.test.tsx
@@ -27,22 +27,6 @@ const testTokenComponent = (Component: React.ComponentType<React.PropsWithChildr
     expect(render(<Component text="token" onRemove={onRemoveMock} />)).toMatchSnapshot()
   })
 
-  it('renders button inside the token when the token also has a remove button', () => {
-    const onRemoveMock = jest.fn()
-    const {getByText} = HTMLRender(<Component as="button" text="token" onRemove={onRemoveMock} />)
-
-    expect(render(<Component as="button" text="token" onRemove={onRemoveMock} />).type).not.toEqual('button')
-    expect(getByText('token').tagName.toLowerCase()).toEqual('button')
-  })
-
-  it('renders anchor inside the token when the token also has a remove button', () => {
-    const onRemoveMock = jest.fn()
-    const {getByText} = HTMLRender(<Component as="a" text="token" onRemove={onRemoveMock} />)
-
-    expect(render(<Component as="a" text="token" onRemove={onRemoveMock} />).type).not.toEqual('a')
-    expect(getByText('token').tagName.toLowerCase()).toEqual('a')
-  })
-
   it('renders isSelected', () => {
     expect(render(<Component text="token" isSelected />)).toMatchSnapshot()
   })
@@ -93,6 +77,22 @@ describe('Token components', () => {
         render(<Token text="token" leadingVisual={() => <div style={{backgroundColor: 'blue'}} />} />),
       ).toMatchSnapshot()
     })
+
+    it('renders button inside the token when the token also has a remove button', () => {
+      const onRemoveMock = jest.fn()
+      const {getByText} = HTMLRender(<Token as="button" text="token" onRemove={onRemoveMock} />)
+
+      expect(render(<Token as="button" text="token" onRemove={onRemoveMock} />).type).not.toEqual('button')
+      expect(getByText('token').tagName.toLowerCase()).toEqual('button')
+    })
+
+    it('renders anchor inside the token when the token also has a remove button', () => {
+      const onRemoveMock = jest.fn()
+      const {getByText} = HTMLRender(<Token as="a" text="token" onRemove={onRemoveMock} />)
+
+      expect(render(<Token as="a" text="token" onRemove={onRemoveMock} />).type).not.toEqual('a')
+      expect(getByText('token').tagName.toLowerCase()).toEqual('a')
+    })
   })
 
   describe('IssueLabelToken', () => {
@@ -113,8 +113,28 @@ describe('Token components', () => {
     const AvatarTokenWithDefaultAvatar = ({
       avatarSrc = 'https://avatars.githubusercontent.com/mperrotti',
       ...rest
-    }: Omit<AvatarTokenProps, 'ref'>) => <AvatarToken avatarSrc={avatarSrc} {...rest} />
+    }: Omit<AvatarTokenProps, 'ref' | 'avatarSrc'> & {avatarSrc?: string}) => (
+      <AvatarToken avatarSrc={avatarSrc} {...rest} />
+    )
 
     testTokenComponent(AvatarTokenWithDefaultAvatar)
+
+    it('renders button inside the token when the token also has a remove button', () => {
+      const onRemoveMock = jest.fn()
+      const {getByText} = HTMLRender(<AvatarTokenWithDefaultAvatar as="button" text="token" onRemove={onRemoveMock} />)
+
+      expect(
+        render(<AvatarTokenWithDefaultAvatar as="button" text="token" onRemove={onRemoveMock} />).type,
+      ).not.toEqual('button')
+      expect(getByText('token').tagName.toLowerCase()).toEqual('button')
+    })
+
+    it('renders anchor inside the token when the token also has a remove button', () => {
+      const onRemoveMock = jest.fn()
+      const {getByText} = HTMLRender(<AvatarTokenWithDefaultAvatar as="a" text="token" onRemove={onRemoveMock} />)
+
+      expect(render(<AvatarTokenWithDefaultAvatar as="a" text="token" onRemove={onRemoveMock} />).type).not.toEqual('a')
+      expect(getByText('token').tagName.toLowerCase()).toEqual('a')
+    })
   })
 })

--- a/packages/react/src/Token/__tests__/__snapshots__/Token.test.tsx.snap
+++ b/packages/react/src/Token/__tests__/__snapshots__/Token.test.tsx.snap
@@ -1274,31 +1274,13 @@ exports[`Token components IssueLabelToken renders all sizes 1`] = `
   position: relative;
   white-space: nowrap;
   font-size: 12px;
-  height: 16px;
-  line-height: 16px;
-  padding-left: 4px;
-  padding-right: 4px;
-  --label-r: 153;
-  --label-g: 153;
-  --label-b: 153;
-  --label-h: 0;
-  --label-s: 0;
-  --label-l: 60;
-  --perceived-lightness: calc(((var(--label-r) * 0.2126) + (var(--label-g) * 0.7152) + (var(--label-b) * 0.0722)) / 255);
-  --lightness-switch: max(0,min(calc((var(--perceived-lightness) - var(--lightness-threshold)) * -1000),1));
-  padding-right: 0;
-  position: relative;
-  --lightness-threshold: 0.453;
-  --border-threshold: 0.96;
-  --border-alpha: max(0,min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100),1));
-  background: rgb(var(--label-r),var(--label-g),var(--label-b));
-  color: hsl(0,0%,calc(var(--lightness-switch) * 100%));
-  border-width: 1px;
-  border-style: solid;
-  border-color: hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) - 25) * 1%),var(--border-alpha));
+  height: 20px;
+  line-height: 20px;
+  padding-left: 8px;
+  padding-right: 8px;
 }
 
-.c2 {
+.c3 {
   background-color: transparent;
   font-family: inherit;
   color: currentColor;
@@ -1325,29 +1307,31 @@ exports[`Token components IssueLabelToken renders all sizes 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0;
-  -webkit-transform: translate(1px,-1px);
-  -ms-transform: translate(1px,-1px);
-  transform: translate(1px,-1px);
+  -webkit-transform: translate(undefinedpx,-undefinedpx);
+  -ms-transform: translate(undefinedpx,-undefinedpx);
+  transform: translate(undefinedpx,-undefinedpx);
   -webkit-align-self: baseline;
   -ms-flex-item-align: baseline;
   align-self: baseline;
   border: 0;
   border-radius: 999px;
   margin-left: 4px;
-  height: 16px;
-  width: 16px;
+  height: 20px;
+  width: 20px;
+  position: relative;
+  z-index: 1;
 }
 
-.c2:hover,
-.c2:focus {
+.c3:hover,
+.c3:focus {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted,rgba(175,184,193,0.2)));
 }
 
-.c2:active {
+.c3:active {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-subtle,rgba(234,238,242,0.5)));
 }
 
-.c1 {
+.c2 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -1372,11 +1356,11 @@ exports[`Token components IssueLabelToken renders all sizes 1`] = `
   text-decoration: none;
 }
 
-.c1:is(a,button,[tabIndex='0']) {
+.c2:is(a,button,[tabIndex='0']) {
   cursor: pointer;
 }
 
-.c1:is(a,button,[tabIndex='0']):after {
+.c2:is(a,button,[tabIndex='0']):after {
   content: '';
   position: absolute;
   left: 0;
@@ -1385,29 +1369,58 @@ exports[`Token components IssueLabelToken renders all sizes 1`] = `
   bottom: 0;
 }
 
+.c1 {
+  background-color: var(--label-bgColor-rest);
+  color: var(--label-fgColor);
+  padding-right: 0;
+  position: relative;
+  border: none;
+}
+
+.c1[data-interactive='true']:hover {
+  background-color: var(--label-bgColor-hover);
+  color: var(--label-fgColor-hover);
+}
+
+.c1[data-interactive='true']:active {
+  background-color: var(--label-bgColor-active);
+  color: var(--label-fgColor-active);
+}
+
 <span
-  className="c0"
+  className="c0 c1"
+  data-interactive={false}
   onKeyDown={[Function]}
-  size="small"
+  size="medium"
+  style={
+    {
+      "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+      "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+      "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+      "--label-fgColor": "var(--label-gray-fgColor-rest)",
+      "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+      "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+    }
+  }
 >
   <span
-    className="c1"
+    className="c2"
   >
     token
   </span>
   <button
     aria-hidden="false"
     aria-label="Remove token"
-    className="c2"
+    className="c3"
     onClick={[Function]}
-    size="small"
+    size="medium"
   >
     <svg
       aria-hidden="true"
       className="octicon octicon-x"
       fill="currentColor"
       focusable="false"
-      height={12}
+      height={15}
       style={
         {
           "display": "inline-block",
@@ -1417,7 +1430,7 @@ exports[`Token components IssueLabelToken renders all sizes 1`] = `
         }
       }
       viewBox="0 0 12 12"
-      width={12}
+      width={15}
     >
       <path
         d="M2.22 2.22a.749.749 0 0 1 1.06 0L6 4.939 8.72 2.22a.749.749 0 1 1 1.06 1.06L7.061 6 9.78 8.72a.749.749 0 1 1-1.06 1.06L6 7.061 3.28 9.78a.749.749 0 1 1-1.06-1.06L4.939 6 2.22 3.28a.749.749 0 0 1 0-1.06Z"
@@ -1450,27 +1463,9 @@ exports[`Token components IssueLabelToken renders all sizes 2`] = `
   line-height: 20px;
   padding-left: 8px;
   padding-right: 8px;
-  --label-r: 153;
-  --label-g: 153;
-  --label-b: 153;
-  --label-h: 0;
-  --label-s: 0;
-  --label-l: 60;
-  --perceived-lightness: calc(((var(--label-r) * 0.2126) + (var(--label-g) * 0.7152) + (var(--label-b) * 0.0722)) / 255);
-  --lightness-switch: max(0,min(calc((var(--perceived-lightness) - var(--lightness-threshold)) * -1000),1));
-  padding-right: 0;
-  position: relative;
-  --lightness-threshold: 0.453;
-  --border-threshold: 0.96;
-  --border-alpha: max(0,min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100),1));
-  background: rgb(var(--label-r),var(--label-g),var(--label-b));
-  color: hsl(0,0%,calc(var(--lightness-switch) * 100%));
-  border-width: 1px;
-  border-style: solid;
-  border-color: hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) - 25) * 1%),var(--border-alpha));
 }
 
-.c2 {
+.c3 {
   background-color: transparent;
   font-family: inherit;
   color: currentColor;
@@ -1497,9 +1492,9 @@ exports[`Token components IssueLabelToken renders all sizes 2`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0;
-  -webkit-transform: translate(1px,-1px);
-  -ms-transform: translate(1px,-1px);
-  transform: translate(1px,-1px);
+  -webkit-transform: translate(undefinedpx,-undefinedpx);
+  -ms-transform: translate(undefinedpx,-undefinedpx);
+  transform: translate(undefinedpx,-undefinedpx);
   -webkit-align-self: baseline;
   -ms-flex-item-align: baseline;
   align-self: baseline;
@@ -1508,18 +1503,20 @@ exports[`Token components IssueLabelToken renders all sizes 2`] = `
   margin-left: 4px;
   height: 20px;
   width: 20px;
+  position: relative;
+  z-index: 1;
 }
 
-.c2:hover,
-.c2:focus {
+.c3:hover,
+.c3:focus {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted,rgba(175,184,193,0.2)));
 }
 
-.c2:active {
+.c3:active {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-subtle,rgba(234,238,242,0.5)));
 }
 
-.c1 {
+.c2 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -1544,11 +1541,11 @@ exports[`Token components IssueLabelToken renders all sizes 2`] = `
   text-decoration: none;
 }
 
-.c1:is(a,button,[tabIndex='0']) {
+.c2:is(a,button,[tabIndex='0']) {
   cursor: pointer;
 }
 
-.c1:is(a,button,[tabIndex='0']):after {
+.c2:is(a,button,[tabIndex='0']):after {
   content: '';
   position: absolute;
   left: 0;
@@ -1557,20 +1554,49 @@ exports[`Token components IssueLabelToken renders all sizes 2`] = `
   bottom: 0;
 }
 
+.c1 {
+  background-color: var(--label-bgColor-rest);
+  color: var(--label-fgColor);
+  padding-right: 0;
+  position: relative;
+  border: none;
+}
+
+.c1[data-interactive='true']:hover {
+  background-color: var(--label-bgColor-hover);
+  color: var(--label-fgColor-hover);
+}
+
+.c1[data-interactive='true']:active {
+  background-color: var(--label-bgColor-active);
+  color: var(--label-fgColor-active);
+}
+
 <span
-  className="c0"
+  className="c0 c1"
+  data-interactive={false}
   onKeyDown={[Function]}
   size="medium"
+  style={
+    {
+      "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+      "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+      "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+      "--label-fgColor": "var(--label-gray-fgColor-rest)",
+      "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+      "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+    }
+  }
 >
   <span
-    className="c1"
+    className="c2"
   >
     token
   </span>
   <button
     aria-hidden="false"
     aria-label="Remove token"
-    className="c2"
+    className="c3"
     onClick={[Function]}
     size="medium"
   >
@@ -1618,31 +1644,13 @@ exports[`Token components IssueLabelToken renders all sizes 3`] = `
   position: relative;
   white-space: nowrap;
   font-size: 12px;
-  height: 24px;
-  line-height: 24px;
+  height: 20px;
+  line-height: 20px;
   padding-left: 8px;
   padding-right: 8px;
-  --label-r: 153;
-  --label-g: 153;
-  --label-b: 153;
-  --label-h: 0;
-  --label-s: 0;
-  --label-l: 60;
-  --perceived-lightness: calc(((var(--label-r) * 0.2126) + (var(--label-g) * 0.7152) + (var(--label-b) * 0.0722)) / 255);
-  --lightness-switch: max(0,min(calc((var(--perceived-lightness) - var(--lightness-threshold)) * -1000),1));
-  padding-right: 0;
-  position: relative;
-  --lightness-threshold: 0.453;
-  --border-threshold: 0.96;
-  --border-alpha: max(0,min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100),1));
-  background: rgb(var(--label-r),var(--label-g),var(--label-b));
-  color: hsl(0,0%,calc(var(--lightness-switch) * 100%));
-  border-width: 1px;
-  border-style: solid;
-  border-color: hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) - 25) * 1%),var(--border-alpha));
 }
 
-.c2 {
+.c3 {
   background-color: transparent;
   font-family: inherit;
   color: currentColor;
@@ -1669,29 +1677,31 @@ exports[`Token components IssueLabelToken renders all sizes 3`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0;
-  -webkit-transform: translate(1px,-1px);
-  -ms-transform: translate(1px,-1px);
-  transform: translate(1px,-1px);
+  -webkit-transform: translate(undefinedpx,-undefinedpx);
+  -ms-transform: translate(undefinedpx,-undefinedpx);
+  transform: translate(undefinedpx,-undefinedpx);
   -webkit-align-self: baseline;
   -ms-flex-item-align: baseline;
   align-self: baseline;
   border: 0;
   border-radius: 999px;
-  margin-left: 8px;
-  height: 24px;
-  width: 24px;
+  margin-left: 4px;
+  height: 20px;
+  width: 20px;
+  position: relative;
+  z-index: 1;
 }
 
-.c2:hover,
-.c2:focus {
+.c3:hover,
+.c3:focus {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted,rgba(175,184,193,0.2)));
 }
 
-.c2:active {
+.c3:active {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-subtle,rgba(234,238,242,0.5)));
 }
 
-.c1 {
+.c2 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -1716,11 +1726,11 @@ exports[`Token components IssueLabelToken renders all sizes 3`] = `
   text-decoration: none;
 }
 
-.c1:is(a,button,[tabIndex='0']) {
+.c2:is(a,button,[tabIndex='0']) {
   cursor: pointer;
 }
 
-.c1:is(a,button,[tabIndex='0']):after {
+.c2:is(a,button,[tabIndex='0']):after {
   content: '';
   position: absolute;
   left: 0;
@@ -1729,29 +1739,58 @@ exports[`Token components IssueLabelToken renders all sizes 3`] = `
   bottom: 0;
 }
 
+.c1 {
+  background-color: var(--label-bgColor-rest);
+  color: var(--label-fgColor);
+  padding-right: 0;
+  position: relative;
+  border: none;
+}
+
+.c1[data-interactive='true']:hover {
+  background-color: var(--label-bgColor-hover);
+  color: var(--label-fgColor-hover);
+}
+
+.c1[data-interactive='true']:active {
+  background-color: var(--label-bgColor-active);
+  color: var(--label-fgColor-active);
+}
+
 <span
-  className="c0"
+  className="c0 c1"
+  data-interactive={false}
   onKeyDown={[Function]}
-  size="large"
+  size="medium"
+  style={
+    {
+      "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+      "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+      "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+      "--label-fgColor": "var(--label-gray-fgColor-rest)",
+      "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+      "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+    }
+  }
 >
   <span
-    className="c1"
+    className="c2"
   >
     token
   </span>
   <button
     aria-hidden="false"
     aria-label="Remove token"
-    className="c2"
+    className="c3"
     onClick={[Function]}
-    size="large"
+    size="medium"
   >
     <svg
       aria-hidden="true"
       className="octicon octicon-x"
       fill="currentColor"
       focusable="false"
-      height={18}
+      height={15}
       style={
         {
           "display": "inline-block",
@@ -1760,11 +1799,11 @@ exports[`Token components IssueLabelToken renders all sizes 3`] = `
           "verticalAlign": "text-bottom",
         }
       }
-      viewBox="0 0 16 16"
-      width={18}
+      viewBox="0 0 12 12"
+      width={15}
     >
       <path
-        d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"
+        d="M2.22 2.22a.749.749 0 0 1 1.06 0L6 4.939 8.72 2.22a.749.749 0 1 1 1.06 1.06L7.061 6 9.78 8.72a.749.749 0 1 1-1.06 1.06L6 7.061 3.28 9.78a.749.749 0 1 1-1.06-1.06L4.939 6 2.22 3.28a.749.749 0 0 1 0-1.06Z"
       />
     </svg>
   </button>
@@ -1789,34 +1828,14 @@ exports[`Token components IssueLabelToken renders all sizes 4`] = `
   text-decoration: none;
   position: relative;
   white-space: nowrap;
-  font-size: 14px;
-  height: 32px;
-  line-height: 32px;
-  padding-left: 16px;
-  padding-right: 16px;
-  padding-top: 0;
-  padding-bottom: 0;
-  --label-r: 153;
-  --label-g: 153;
-  --label-b: 153;
-  --label-h: 0;
-  --label-s: 0;
-  --label-l: 60;
-  --perceived-lightness: calc(((var(--label-r) * 0.2126) + (var(--label-g) * 0.7152) + (var(--label-b) * 0.0722)) / 255);
-  --lightness-switch: max(0,min(calc((var(--perceived-lightness) - var(--lightness-threshold)) * -1000),1));
-  padding-right: 0;
-  position: relative;
-  --lightness-threshold: 0.453;
-  --border-threshold: 0.96;
-  --border-alpha: max(0,min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100),1));
-  background: rgb(var(--label-r),var(--label-g),var(--label-b));
-  color: hsl(0,0%,calc(var(--lightness-switch) * 100%));
-  border-width: 1px;
-  border-style: solid;
-  border-color: hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) - 25) * 1%),var(--border-alpha));
+  font-size: 12px;
+  height: 20px;
+  line-height: 20px;
+  padding-left: 8px;
+  padding-right: 8px;
 }
 
-.c2 {
+.c3 {
   background-color: transparent;
   font-family: inherit;
   color: currentColor;
@@ -1843,29 +1862,31 @@ exports[`Token components IssueLabelToken renders all sizes 4`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0;
-  -webkit-transform: translate(1px,-1px);
-  -ms-transform: translate(1px,-1px);
-  transform: translate(1px,-1px);
+  -webkit-transform: translate(undefinedpx,-undefinedpx);
+  -ms-transform: translate(undefinedpx,-undefinedpx);
+  transform: translate(undefinedpx,-undefinedpx);
   -webkit-align-self: baseline;
   -ms-flex-item-align: baseline;
   align-self: baseline;
   border: 0;
   border-radius: 999px;
-  margin-left: 8px;
-  height: 32px;
-  width: 32px;
+  margin-left: 4px;
+  height: 20px;
+  width: 20px;
+  position: relative;
+  z-index: 1;
 }
 
-.c2:hover,
-.c2:focus {
+.c3:hover,
+.c3:focus {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted,rgba(175,184,193,0.2)));
 }
 
-.c2:active {
+.c3:active {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-subtle,rgba(234,238,242,0.5)));
 }
 
-.c1 {
+.c2 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -1890,11 +1911,11 @@ exports[`Token components IssueLabelToken renders all sizes 4`] = `
   text-decoration: none;
 }
 
-.c1:is(a,button,[tabIndex='0']) {
+.c2:is(a,button,[tabIndex='0']) {
   cursor: pointer;
 }
 
-.c1:is(a,button,[tabIndex='0']):after {
+.c2:is(a,button,[tabIndex='0']):after {
   content: '';
   position: absolute;
   left: 0;
@@ -1903,29 +1924,58 @@ exports[`Token components IssueLabelToken renders all sizes 4`] = `
   bottom: 0;
 }
 
+.c1 {
+  background-color: var(--label-bgColor-rest);
+  color: var(--label-fgColor);
+  padding-right: 0;
+  position: relative;
+  border: none;
+}
+
+.c1[data-interactive='true']:hover {
+  background-color: var(--label-bgColor-hover);
+  color: var(--label-fgColor-hover);
+}
+
+.c1[data-interactive='true']:active {
+  background-color: var(--label-bgColor-active);
+  color: var(--label-fgColor-active);
+}
+
 <span
-  className="c0"
+  className="c0 c1"
+  data-interactive={false}
   onKeyDown={[Function]}
-  size="xlarge"
+  size="medium"
+  style={
+    {
+      "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+      "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+      "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+      "--label-fgColor": "var(--label-gray-fgColor-rest)",
+      "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+      "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+    }
+  }
 >
   <span
-    className="c1"
+    className="c2"
   >
     token
   </span>
   <button
     aria-hidden="false"
     aria-label="Remove token"
-    className="c2"
+    className="c3"
     onClick={[Function]}
-    size="xlarge"
+    size="medium"
   >
     <svg
       aria-hidden="true"
       className="octicon octicon-x"
       fill="currentColor"
       focusable="false"
-      height={24}
+      height={15}
       style={
         {
           "display": "inline-block",
@@ -1934,11 +1984,11 @@ exports[`Token components IssueLabelToken renders all sizes 4`] = `
           "verticalAlign": "text-bottom",
         }
       }
-      viewBox="0 0 24 24"
-      width={24}
+      viewBox="0 0 12 12"
+      width={15}
     >
       <path
-        d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+        d="M2.22 2.22a.749.749 0 0 1 1.06 0L6 4.939 8.72 2.22a.749.749 0 1 1 1.06 1.06L7.061 6 9.78 8.72a.749.749 0 1 1-1.06 1.06L6 7.061 3.28 9.78a.749.749 0 1 1-1.06-1.06L4.939 6 2.22 3.28a.749.749 0 0 1 0-1.06Z"
       />
     </svg>
   </button>
@@ -1968,27 +2018,9 @@ exports[`Token components IssueLabelToken renders custom fill color 1`] = `
   line-height: 20px;
   padding-left: 8px;
   padding-right: 8px;
-  --label-r: 3;
-  --label-g: 102;
-  --label-b: 214;
-  --label-h: 212;
-  --label-s: 97;
-  --label-l: 43;
-  --perceived-lightness: calc(((var(--label-r) * 0.2126) + (var(--label-g) * 0.7152) + (var(--label-b) * 0.0722)) / 255);
-  --lightness-switch: max(0,min(calc((var(--perceived-lightness) - var(--lightness-threshold)) * -1000),1));
-  padding-right: 0;
-  position: relative;
-  --lightness-threshold: 0.453;
-  --border-threshold: 0.96;
-  --border-alpha: max(0,min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100),1));
-  background: rgb(var(--label-r),var(--label-g),var(--label-b));
-  color: hsl(0,0%,calc(var(--lightness-switch) * 100%));
-  border-width: 1px;
-  border-style: solid;
-  border-color: hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) - 25) * 1%),var(--border-alpha));
 }
 
-.c2 {
+.c3 {
   background-color: transparent;
   font-family: inherit;
   color: currentColor;
@@ -2015,9 +2047,9 @@ exports[`Token components IssueLabelToken renders custom fill color 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0;
-  -webkit-transform: translate(1px,-1px);
-  -ms-transform: translate(1px,-1px);
-  transform: translate(1px,-1px);
+  -webkit-transform: translate(undefinedpx,-undefinedpx);
+  -ms-transform: translate(undefinedpx,-undefinedpx);
+  transform: translate(undefinedpx,-undefinedpx);
   -webkit-align-self: baseline;
   -ms-flex-item-align: baseline;
   align-self: baseline;
@@ -2026,18 +2058,20 @@ exports[`Token components IssueLabelToken renders custom fill color 1`] = `
   margin-left: 4px;
   height: 20px;
   width: 20px;
+  position: relative;
+  z-index: 1;
 }
 
-.c2:hover,
-.c2:focus {
+.c3:hover,
+.c3:focus {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted,rgba(175,184,193,0.2)));
 }
 
-.c2:active {
+.c3:active {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-subtle,rgba(234,238,242,0.5)));
 }
 
-.c1 {
+.c2 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -2062,11 +2096,11 @@ exports[`Token components IssueLabelToken renders custom fill color 1`] = `
   text-decoration: none;
 }
 
-.c1:is(a,button,[tabIndex='0']) {
+.c2:is(a,button,[tabIndex='0']) {
   cursor: pointer;
 }
 
-.c1:is(a,button,[tabIndex='0']):after {
+.c2:is(a,button,[tabIndex='0']):after {
   content: '';
   position: absolute;
   left: 0;
@@ -2075,20 +2109,49 @@ exports[`Token components IssueLabelToken renders custom fill color 1`] = `
   bottom: 0;
 }
 
+.c1 {
+  background-color: var(--label-bgColor-rest);
+  color: var(--label-fgColor);
+  padding-right: 0;
+  position: relative;
+  border: none;
+}
+
+.c1[data-interactive='true']:hover {
+  background-color: var(--label-bgColor-hover);
+  color: var(--label-fgColor-hover);
+}
+
+.c1[data-interactive='true']:active {
+  background-color: var(--label-bgColor-active);
+  color: var(--label-fgColor-active);
+}
+
 <span
-  className="c0"
+  className="c0 c1"
+  data-interactive={false}
   onKeyDown={[Function]}
   size="medium"
+  style={
+    {
+      "--label-bgColor-active": undefined,
+      "--label-bgColor-hover": "#d4dcf8",
+      "--label-bgColor-rest": "#e1e7ff",
+      "--label-fgColor": "#3765bc",
+      "--label-fgColor-active": undefined,
+      "--label-fgColor-hover": undefined,
+    }
+  }
 >
   <span
-    className="c1"
+    className="c2"
   >
     token
   </span>
   <button
     aria-hidden="false"
     aria-label="Remove token"
-    className="c2"
+    className="c3"
     onClick={[Function]}
     size="medium"
   >
@@ -2140,27 +2203,9 @@ exports[`Token components IssueLabelToken renders default fill color 1`] = `
   line-height: 20px;
   padding-left: 8px;
   padding-right: 8px;
-  --label-r: 153;
-  --label-g: 153;
-  --label-b: 153;
-  --label-h: 0;
-  --label-s: 0;
-  --label-l: 60;
-  --perceived-lightness: calc(((var(--label-r) * 0.2126) + (var(--label-g) * 0.7152) + (var(--label-b) * 0.0722)) / 255);
-  --lightness-switch: max(0,min(calc((var(--perceived-lightness) - var(--lightness-threshold)) * -1000),1));
-  padding-right: 0;
-  position: relative;
-  --lightness-threshold: 0.453;
-  --border-threshold: 0.96;
-  --border-alpha: max(0,min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100),1));
-  background: rgb(var(--label-r),var(--label-g),var(--label-b));
-  color: hsl(0,0%,calc(var(--lightness-switch) * 100%));
-  border-width: 1px;
-  border-style: solid;
-  border-color: hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) - 25) * 1%),var(--border-alpha));
 }
 
-.c2 {
+.c3 {
   background-color: transparent;
   font-family: inherit;
   color: currentColor;
@@ -2187,9 +2232,9 @@ exports[`Token components IssueLabelToken renders default fill color 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0;
-  -webkit-transform: translate(1px,-1px);
-  -ms-transform: translate(1px,-1px);
-  transform: translate(1px,-1px);
+  -webkit-transform: translate(undefinedpx,-undefinedpx);
+  -ms-transform: translate(undefinedpx,-undefinedpx);
+  transform: translate(undefinedpx,-undefinedpx);
   -webkit-align-self: baseline;
   -ms-flex-item-align: baseline;
   align-self: baseline;
@@ -2198,18 +2243,20 @@ exports[`Token components IssueLabelToken renders default fill color 1`] = `
   margin-left: 4px;
   height: 20px;
   width: 20px;
+  position: relative;
+  z-index: 1;
 }
 
-.c2:hover,
-.c2:focus {
+.c3:hover,
+.c3:focus {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted,rgba(175,184,193,0.2)));
 }
 
-.c2:active {
+.c3:active {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-subtle,rgba(234,238,242,0.5)));
 }
 
-.c1 {
+.c2 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -2234,11 +2281,11 @@ exports[`Token components IssueLabelToken renders default fill color 1`] = `
   text-decoration: none;
 }
 
-.c1:is(a,button,[tabIndex='0']) {
+.c2:is(a,button,[tabIndex='0']) {
   cursor: pointer;
 }
 
-.c1:is(a,button,[tabIndex='0']):after {
+.c2:is(a,button,[tabIndex='0']):after {
   content: '';
   position: absolute;
   left: 0;
@@ -2247,20 +2294,49 @@ exports[`Token components IssueLabelToken renders default fill color 1`] = `
   bottom: 0;
 }
 
+.c1 {
+  background-color: var(--label-bgColor-rest);
+  color: var(--label-fgColor);
+  padding-right: 0;
+  position: relative;
+  border: none;
+}
+
+.c1[data-interactive='true']:hover {
+  background-color: var(--label-bgColor-hover);
+  color: var(--label-fgColor-hover);
+}
+
+.c1[data-interactive='true']:active {
+  background-color: var(--label-bgColor-active);
+  color: var(--label-fgColor-active);
+}
+
 <span
-  className="c0"
+  className="c0 c1"
+  data-interactive={false}
   onKeyDown={[Function]}
   size="medium"
+  style={
+    {
+      "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+      "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+      "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+      "--label-fgColor": "var(--label-gray-fgColor-rest)",
+      "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+      "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+    }
+  }
 >
   <span
-    className="c1"
+    className="c2"
   >
     token
   </span>
   <button
     aria-hidden="false"
     aria-label="Remove token"
-    className="c2"
+    className="c3"
     onClick={[Function]}
     size="medium"
   >
@@ -2312,44 +2388,9 @@ exports[`Token components IssueLabelToken renders isSelected 1`] = `
   line-height: 20px;
   padding-left: 8px;
   padding-right: 8px;
-  --label-r: 153;
-  --label-g: 153;
-  --label-b: 153;
-  --label-h: 0;
-  --label-s: 0;
-  --label-l: 60;
-  --perceived-lightness: calc(((var(--label-r) * 0.2126) + (var(--label-g) * 0.7152) + (var(--label-b) * 0.0722)) / 255);
-  --lightness-switch: max(0,min(calc((var(--perceived-lightness) - var(--lightness-threshold)) * -1000),1));
-  position: relative;
-  --lightness-threshold: 0.453;
-  --border-threshold: 0.96;
-  --border-alpha: max(0,min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100),1));
-  background: hsl(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) - 5) * 1%));
-  color: hsl(0,0%,calc(var(--lightness-switch) * 100%));
-  border-width: 1px;
-  border-style: solid;
-  border-color: hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) - 25) * 1%),var(--border-alpha));
 }
 
-.c0:focus {
-  outline: none;
-}
-
-.c0:after {
-  content: "";
-  position: absolute;
-  z-index: 1;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  display: block;
-  pointer-events: none;
-  box-shadow: 0 0 0 2px rgb(var(--label-r),var(--label-g),var(--label-b));
-  border-radius: 999px;
-}
-
-.c1 {
+.c2 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -2374,11 +2415,11 @@ exports[`Token components IssueLabelToken renders isSelected 1`] = `
   text-decoration: none;
 }
 
-.c1:is(a,button,[tabIndex='0']) {
+.c2:is(a,button,[tabIndex='0']) {
   cursor: pointer;
 }
 
-.c1:is(a,button,[tabIndex='0']):after {
+.c2:is(a,button,[tabIndex='0']):after {
   content: '';
   position: absolute;
   left: 0;
@@ -2387,13 +2428,41 @@ exports[`Token components IssueLabelToken renders isSelected 1`] = `
   bottom: 0;
 }
 
+.c1 {
+  background-color: var(--label-bgColor-rest);
+  color: var(--label-fgColor);
+  position: relative;
+  border: none;
+}
+
+.c1[data-interactive='true']:hover {
+  background-color: var(--label-bgColor-hover);
+  color: var(--label-fgColor-hover);
+}
+
+.c1[data-interactive='true']:active {
+  background-color: var(--label-bgColor-active);
+  color: var(--label-fgColor-active);
+}
+
 <span
-  className="c0"
+  className="c0 c1"
+  data-interactive={false}
   onKeyDown={[Function]}
   size="medium"
+  style={
+    {
+      "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+      "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+      "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+      "--label-fgColor": "var(--label-gray-fgColor-rest)",
+      "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+      "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+    }
+  }
 >
   <span
-    className="c1"
+    className="c2"
   >
     token
   </span>
@@ -2423,27 +2492,9 @@ exports[`Token components IssueLabelToken renders with a remove button 1`] = `
   line-height: 20px;
   padding-left: 8px;
   padding-right: 8px;
-  --label-r: 153;
-  --label-g: 153;
-  --label-b: 153;
-  --label-h: 0;
-  --label-s: 0;
-  --label-l: 60;
-  --perceived-lightness: calc(((var(--label-r) * 0.2126) + (var(--label-g) * 0.7152) + (var(--label-b) * 0.0722)) / 255);
-  --lightness-switch: max(0,min(calc((var(--perceived-lightness) - var(--lightness-threshold)) * -1000),1));
-  padding-right: 0;
-  position: relative;
-  --lightness-threshold: 0.453;
-  --border-threshold: 0.96;
-  --border-alpha: max(0,min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100),1));
-  background: rgb(var(--label-r),var(--label-g),var(--label-b));
-  color: hsl(0,0%,calc(var(--lightness-switch) * 100%));
-  border-width: 1px;
-  border-style: solid;
-  border-color: hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) - 25) * 1%),var(--border-alpha));
 }
 
-.c2 {
+.c3 {
   background-color: transparent;
   font-family: inherit;
   color: currentColor;
@@ -2470,9 +2521,9 @@ exports[`Token components IssueLabelToken renders with a remove button 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0;
-  -webkit-transform: translate(1px,-1px);
-  -ms-transform: translate(1px,-1px);
-  transform: translate(1px,-1px);
+  -webkit-transform: translate(undefinedpx,-undefinedpx);
+  -ms-transform: translate(undefinedpx,-undefinedpx);
+  transform: translate(undefinedpx,-undefinedpx);
   -webkit-align-self: baseline;
   -ms-flex-item-align: baseline;
   align-self: baseline;
@@ -2481,18 +2532,20 @@ exports[`Token components IssueLabelToken renders with a remove button 1`] = `
   margin-left: 4px;
   height: 20px;
   width: 20px;
+  position: relative;
+  z-index: 1;
 }
 
-.c2:hover,
-.c2:focus {
+.c3:hover,
+.c3:focus {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted,rgba(175,184,193,0.2)));
 }
 
-.c2:active {
+.c3:active {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-subtle,rgba(234,238,242,0.5)));
 }
 
-.c1 {
+.c2 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -2517,11 +2570,11 @@ exports[`Token components IssueLabelToken renders with a remove button 1`] = `
   text-decoration: none;
 }
 
-.c1:is(a,button,[tabIndex='0']) {
+.c2:is(a,button,[tabIndex='0']) {
   cursor: pointer;
 }
 
-.c1:is(a,button,[tabIndex='0']):after {
+.c2:is(a,button,[tabIndex='0']):after {
   content: '';
   position: absolute;
   left: 0;
@@ -2530,20 +2583,49 @@ exports[`Token components IssueLabelToken renders with a remove button 1`] = `
   bottom: 0;
 }
 
+.c1 {
+  background-color: var(--label-bgColor-rest);
+  color: var(--label-fgColor);
+  padding-right: 0;
+  position: relative;
+  border: none;
+}
+
+.c1[data-interactive='true']:hover {
+  background-color: var(--label-bgColor-hover);
+  color: var(--label-fgColor-hover);
+}
+
+.c1[data-interactive='true']:active {
+  background-color: var(--label-bgColor-active);
+  color: var(--label-fgColor-active);
+}
+
 <span
-  className="c0"
+  className="c0 c1"
+  data-interactive={false}
   onKeyDown={[Function]}
   size="medium"
+  style={
+    {
+      "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+      "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+      "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+      "--label-fgColor": "var(--label-gray-fgColor-rest)",
+      "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+      "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+    }
+  }
 >
   <span
-    className="c1"
+    className="c2"
   >
     token
   </span>
   <button
     aria-hidden="false"
     aria-label="Remove token"
-    className="c2"
+    className="c3"
     onClick={[Function]}
     size="medium"
   >

--- a/packages/react/src/Token/getColorsFromHex.ts
+++ b/packages/react/src/Token/getColorsFromHex.ts
@@ -1,0 +1,131 @@
+import {getContrast} from 'color2k'
+import {Hsluv} from 'hsluv'
+import type {hexString} from '../utils/isHex'
+import type {variantColor} from '../Token/IssueLabelToken'
+
+/**
+ * transforms a hex color provided by the user into a color object with background and text colors
+ * @param colorHex — the hex color provided by the user
+ * @param colorScheme — the color scheme the user has currently set
+ * @param isSelected
+ * @param bgColor — the background color from the selected theme, needed to calc the contrast for the colors
+ * @returns
+ */
+export const getColorsFromHex = (colorHex: hexString, colorScheme = 'light', bgColor: string): variantColor => {
+  // start values for light mode
+  let bgLightness = 96
+  let lightnessIncrement = -1
+  let ratio = 4.5
+  // start values for dark mode
+  if (colorScheme.startsWith('dark')) {
+    bgLightness = 16
+    lightnessIncrement = 1
+    ratio = 5.5
+  }
+
+  // get hue and saturation value from hex color
+  // eslint-disable-next-line prefer-const
+  let {h, s} = hexToHsluv(colorHex)
+
+  // avoid intense bright colors
+  if (h >= 58 && h <= 198 && s > 70) {
+    s = 70
+  }
+  /**
+   * creating a background color from the provided hex color
+   */
+  const {colorHex: backgroundColor, lightness: currentBgLightness} = getColorWithContrast(
+    hsluvToHex({h, s, l: bgLightness}),
+    bgColor,
+    1.2,
+    lightnessIncrement as 1 | -1,
+  )
+
+  // avoid intense bright colors
+  if (h >= 58 && h <= 316 && s > 80) {
+    s = 80
+  }
+  /**
+   * creating a text color from with a contrast ratio of at least 4.5 to the generated background color
+   */
+  const {colorHex: textColor} = getColorWithContrast(
+    hsluvToHex({h, s, l: 50}),
+    backgroundColor,
+    ratio,
+    lightnessIncrement as 1 | -1,
+  )
+
+  return {
+    backgroundColor,
+    textColor,
+    backgroundColorHover: hsluvToHex({h, s, l: currentBgLightness + 4 * lightnessIncrement}),
+    backgroundColorPressed: hsluvToHex({h, s, l: currentBgLightness + 8 * lightnessIncrement}),
+  }
+}
+/**
+ * Changes the lightness of a hex color until the contrast ratio is reached and returns the new hex color
+ * @param colorHex — initial hex color
+ * @param bgHex — color to check the contrast against
+ * @param contrastRatio — the contrast ratio to reach
+ * @param increment — the direction to change the lightness depending on the color scheme
+ * @returns the new hex color
+ */
+const getColorWithContrast = (
+  colorHex: hexString,
+  bgHex: string,
+  contrastRatio: number,
+  increment: 1 | -1,
+): {colorHex: hexString; lightness: number} => {
+  // deconstruct color
+  const hsluv = hexToHsluv(colorHex)
+  let {l: lightness} = hsluv
+  const {h, s} = hsluv
+  // change lightness until contrast is reached
+  while (getContrast(colorHex, bgHex) < contrastRatio && lightness > 0 && lightness < 100) {
+    lightness += increment
+    colorHex = hsluvToHex({h, s, l: lightness})
+  }
+  // return hex color and ligthness
+  return {colorHex, lightness}
+}
+
+/**
+ * Takes a hex value and returns the hue, saturation and lightness for HSLuv as an object
+ * @param hex user provided hex string
+ * @returns an object with the hue, saturation and lightness values
+ */
+const hexToHsluv = (
+  hex: hexString,
+): {
+  h: number
+  s: number
+  l: number
+} => {
+  // convert hex to hsluv
+  const color = new Hsluv()
+  color.hex = hex
+  color.hexToHsluv()
+  // extract h, s and l values
+  const {hsluv_h: h, hsluv_s: s, hsluv_l: l} = color
+  // return h, s, l as an object
+  return {h, s, l}
+}
+/**
+ * Takes an object with hue, saturation and lightness values and returns a hex string
+ * @param hex user provided hex string
+ * @returns an object with the hue, saturation and lightness values
+ */
+const hsluvToHex = ({h, s, l}: {h: number; s: number; l: number}): hexString => {
+  // create a new HSLuv color object and assign values
+  const color = new Hsluv()
+  // eslint-disable-next-line camelcase
+  color.hsluv_h = h
+  // eslint-disable-next-line camelcase
+  color.hsluv_s = s
+  // eslint-disable-next-line camelcase
+  color.hsluv_l = l
+  // convert hsluv to hex
+  color.hsluvToHex()
+  // return hex string
+  return color.hex as hexString
+}

--- a/packages/react/src/__tests__/__snapshots__/TextInputWithTokens.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/TextInputWithTokens.test.tsx.snap
@@ -17269,39 +17269,14 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
   text-decoration: none;
   position: relative;
   white-space: nowrap;
-  font-size: 14px;
-  height: 32px;
-  line-height: 32px;
-  padding-left: 16px;
-  padding-right: 16px;
-  padding-top: 0;
-  padding-bottom: 0;
-  --label-r: 153;
-  --label-g: 153;
-  --label-b: 153;
-  --label-h: 0;
-  --label-s: 0;
-  --label-l: 60;
-  --perceived-lightness: calc(((var(--label-r) * 0.2126) + (var(--label-g) * 0.7152) + (var(--label-b) * 0.0722)) / 255);
-  --lightness-switch: max(0,min(calc((var(--perceived-lightness) - var(--lightness-threshold)) * -1000),1));
-  padding-right: 0;
-  position: relative;
-  --lightness-threshold: 0.453;
-  --border-threshold: 0.96;
-  --border-alpha: max(0,min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100),1));
-  background: rgb(var(--label-r),var(--label-g),var(--label-b));
-  color: hsl(0,0%,calc(var(--lightness-switch) * 100%));
-  border-width: 1px;
-  border-style: solid;
-  border-color: hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) - 25) * 1%),var(--border-alpha));
+  font-size: 12px;
+  height: 20px;
+  line-height: 20px;
+  padding-left: 8px;
+  padding-right: 8px;
 }
 
-.c5:hover {
-  background-image: linear-gradient(rgba(0,0,0,0.15),rgba(0,0,0,0.15)),linear-gradient(rgb(var(--label-r),var(--label-g),var(--label-b)),rgb(var(--label-r),var(--label-g),var(--label-b)));
-  box-shadow: var(--shadow-resting-medium,var(--color-shadow-medium,0 3px 6px rgba(140,149,159,0.15)));
-}
-
-.c7 {
+.c8 {
   background-color: transparent;
   font-family: inherit;
   color: currentColor;
@@ -17328,31 +17303,31 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0;
-  -webkit-transform: translate(1px,-1px);
-  -ms-transform: translate(1px,-1px);
-  transform: translate(1px,-1px);
+  -webkit-transform: translate(undefinedpx,-undefinedpx);
+  -ms-transform: translate(undefinedpx,-undefinedpx);
+  transform: translate(undefinedpx,-undefinedpx);
   -webkit-align-self: baseline;
   -ms-flex-item-align: baseline;
   align-self: baseline;
   border: 0;
   border-radius: 999px;
-  margin-left: 8px;
-  height: 32px;
-  width: 32px;
+  margin-left: 4px;
+  height: 20px;
+  width: 20px;
   position: relative;
   z-index: 1;
 }
 
-.c7:hover,
-.c7:focus {
+.c8:hover,
+.c8:focus {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted,rgba(175,184,193,0.2)));
 }
 
-.c7:active {
+.c8:active {
   background-color: var(--bgColor-neutral-muted,var(--color-neutral-subtle,rgba(234,238,242,0.5)));
 }
 
-.c6 {
+.c7 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -17377,17 +17352,35 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
   text-decoration: none;
 }
 
-.c6:is(a,button,[tabIndex='0']) {
+.c7:is(a,button,[tabIndex='0']) {
   cursor: pointer;
 }
 
-.c6:is(a,button,[tabIndex='0']):after {
+.c7:is(a,button,[tabIndex='0']):after {
   content: '';
   position: absolute;
   left: 0;
   top: 0;
   right: 0;
   bottom: 0;
+}
+
+.c6 {
+  background-color: var(--label-bgColor-rest);
+  color: var(--label-fgColor);
+  padding-right: 0;
+  position: relative;
+  border: none;
+}
+
+.c6[data-interactive='true']:hover {
+  background-color: var(--label-bgColor-hover);
+  color: var(--label-fgColor-hover);
+}
+
+.c6[data-interactive='true']:active {
+  background-color: var(--label-bgColor-active);
+  color: var(--label-fgColor-active);
 }
 
 @media (min-width:768px) {
@@ -17418,25 +17411,36 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
       />
     </div>
     <span
-      className="c5"
+      className="c5 c6"
+      data-interactive={true}
       onBlur={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      size="xlarge"
+      size="medium"
+      style={
+        {
+          "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+          "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+          "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+          "--label-fgColor": "var(--label-gray-fgColor-rest)",
+          "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+          "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+        }
+      }
       tabIndex={0}
     >
-      <span
-        className="c6"
+      <button
+        className="c7"
         onClick={[Function]}
       >
         zero
-      </span>
+      </button>
       <span
         aria-hidden="true"
-        className="c7"
+        className="c8"
         onClick={[Function]}
-        size="xlarge"
+        size="medium"
         tabIndex={-1}
       >
         <svg
@@ -17444,7 +17448,7 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
           className="octicon octicon-x"
           fill="currentColor"
           focusable="false"
-          height={24}
+          height={15}
           style={
             {
               "display": "inline-block",
@@ -17453,35 +17457,46 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
               "verticalAlign": "text-bottom",
             }
           }
-          viewBox="0 0 24 24"
-          width={24}
+          viewBox="0 0 12 12"
+          width={15}
         >
           <path
-            d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+            d="M2.22 2.22a.749.749 0 0 1 1.06 0L6 4.939 8.72 2.22a.749.749 0 1 1 1.06 1.06L7.061 6 9.78 8.72a.749.749 0 1 1-1.06 1.06L6 7.061 3.28 9.78a.749.749 0 1 1-1.06-1.06L4.939 6 2.22 3.28a.749.749 0 0 1 0-1.06Z"
           />
         </svg>
       </span>
     </span>
     <span
-      className="c5"
+      className="c5 c6"
+      data-interactive={true}
       onBlur={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      size="xlarge"
+      size="medium"
+      style={
+        {
+          "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+          "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+          "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+          "--label-fgColor": "var(--label-gray-fgColor-rest)",
+          "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+          "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+        }
+      }
       tabIndex={0}
     >
-      <span
-        className="c6"
+      <button
+        className="c7"
         onClick={[Function]}
       >
         one
-      </span>
+      </button>
       <span
         aria-hidden="true"
-        className="c7"
+        className="c8"
         onClick={[Function]}
-        size="xlarge"
+        size="medium"
         tabIndex={-1}
       >
         <svg
@@ -17489,7 +17504,7 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
           className="octicon octicon-x"
           fill="currentColor"
           focusable="false"
-          height={24}
+          height={15}
           style={
             {
               "display": "inline-block",
@@ -17498,35 +17513,46 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
               "verticalAlign": "text-bottom",
             }
           }
-          viewBox="0 0 24 24"
-          width={24}
+          viewBox="0 0 12 12"
+          width={15}
         >
           <path
-            d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+            d="M2.22 2.22a.749.749 0 0 1 1.06 0L6 4.939 8.72 2.22a.749.749 0 1 1 1.06 1.06L7.061 6 9.78 8.72a.749.749 0 1 1-1.06 1.06L6 7.061 3.28 9.78a.749.749 0 1 1-1.06-1.06L4.939 6 2.22 3.28a.749.749 0 0 1 0-1.06Z"
           />
         </svg>
       </span>
     </span>
     <span
-      className="c5"
+      className="c5 c6"
+      data-interactive={true}
       onBlur={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      size="xlarge"
+      size="medium"
+      style={
+        {
+          "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+          "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+          "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+          "--label-fgColor": "var(--label-gray-fgColor-rest)",
+          "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+          "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+        }
+      }
       tabIndex={0}
     >
-      <span
-        className="c6"
+      <button
+        className="c7"
         onClick={[Function]}
       >
         two
-      </span>
+      </button>
       <span
         aria-hidden="true"
-        className="c7"
+        className="c8"
         onClick={[Function]}
-        size="xlarge"
+        size="medium"
         tabIndex={-1}
       >
         <svg
@@ -17534,7 +17560,7 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
           className="octicon octicon-x"
           fill="currentColor"
           focusable="false"
-          height={24}
+          height={15}
           style={
             {
               "display": "inline-block",
@@ -17543,35 +17569,46 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
               "verticalAlign": "text-bottom",
             }
           }
-          viewBox="0 0 24 24"
-          width={24}
+          viewBox="0 0 12 12"
+          width={15}
         >
           <path
-            d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+            d="M2.22 2.22a.749.749 0 0 1 1.06 0L6 4.939 8.72 2.22a.749.749 0 1 1 1.06 1.06L7.061 6 9.78 8.72a.749.749 0 1 1-1.06 1.06L6 7.061 3.28 9.78a.749.749 0 1 1-1.06-1.06L4.939 6 2.22 3.28a.749.749 0 0 1 0-1.06Z"
           />
         </svg>
       </span>
     </span>
     <span
-      className="c5"
+      className="c5 c6"
+      data-interactive={true}
       onBlur={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      size="xlarge"
+      size="medium"
+      style={
+        {
+          "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+          "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+          "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+          "--label-fgColor": "var(--label-gray-fgColor-rest)",
+          "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+          "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+        }
+      }
       tabIndex={0}
     >
-      <span
-        className="c6"
+      <button
+        className="c7"
         onClick={[Function]}
       >
         three
-      </span>
+      </button>
       <span
         aria-hidden="true"
-        className="c7"
+        className="c8"
         onClick={[Function]}
-        size="xlarge"
+        size="medium"
         tabIndex={-1}
       >
         <svg
@@ -17579,7 +17616,7 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
           className="octicon octicon-x"
           fill="currentColor"
           focusable="false"
-          height={24}
+          height={15}
           style={
             {
               "display": "inline-block",
@@ -17588,35 +17625,46 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
               "verticalAlign": "text-bottom",
             }
           }
-          viewBox="0 0 24 24"
-          width={24}
+          viewBox="0 0 12 12"
+          width={15}
         >
           <path
-            d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+            d="M2.22 2.22a.749.749 0 0 1 1.06 0L6 4.939 8.72 2.22a.749.749 0 1 1 1.06 1.06L7.061 6 9.78 8.72a.749.749 0 1 1-1.06 1.06L6 7.061 3.28 9.78a.749.749 0 1 1-1.06-1.06L4.939 6 2.22 3.28a.749.749 0 0 1 0-1.06Z"
           />
         </svg>
       </span>
     </span>
     <span
-      className="c5"
+      className="c5 c6"
+      data-interactive={true}
       onBlur={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      size="xlarge"
+      size="medium"
+      style={
+        {
+          "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+          "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+          "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+          "--label-fgColor": "var(--label-gray-fgColor-rest)",
+          "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+          "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+        }
+      }
       tabIndex={0}
     >
-      <span
-        className="c6"
+      <button
+        className="c7"
         onClick={[Function]}
       >
         four
-      </span>
+      </button>
       <span
         aria-hidden="true"
-        className="c7"
+        className="c8"
         onClick={[Function]}
-        size="xlarge"
+        size="medium"
         tabIndex={-1}
       >
         <svg
@@ -17624,7 +17672,7 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
           className="octicon octicon-x"
           fill="currentColor"
           focusable="false"
-          height={24}
+          height={15}
           style={
             {
               "display": "inline-block",
@@ -17633,35 +17681,46 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
               "verticalAlign": "text-bottom",
             }
           }
-          viewBox="0 0 24 24"
-          width={24}
+          viewBox="0 0 12 12"
+          width={15}
         >
           <path
-            d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+            d="M2.22 2.22a.749.749 0 0 1 1.06 0L6 4.939 8.72 2.22a.749.749 0 1 1 1.06 1.06L7.061 6 9.78 8.72a.749.749 0 1 1-1.06 1.06L6 7.061 3.28 9.78a.749.749 0 1 1-1.06-1.06L4.939 6 2.22 3.28a.749.749 0 0 1 0-1.06Z"
           />
         </svg>
       </span>
     </span>
     <span
-      className="c5"
+      className="c5 c6"
+      data-interactive={true}
       onBlur={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      size="xlarge"
+      size="medium"
+      style={
+        {
+          "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+          "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+          "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+          "--label-fgColor": "var(--label-gray-fgColor-rest)",
+          "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+          "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+        }
+      }
       tabIndex={0}
     >
-      <span
-        className="c6"
+      <button
+        className="c7"
         onClick={[Function]}
       >
         five
-      </span>
+      </button>
       <span
         aria-hidden="true"
-        className="c7"
+        className="c8"
         onClick={[Function]}
-        size="xlarge"
+        size="medium"
         tabIndex={-1}
       >
         <svg
@@ -17669,7 +17728,7 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
           className="octicon octicon-x"
           fill="currentColor"
           focusable="false"
-          height={24}
+          height={15}
           style={
             {
               "display": "inline-block",
@@ -17678,35 +17737,46 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
               "verticalAlign": "text-bottom",
             }
           }
-          viewBox="0 0 24 24"
-          width={24}
+          viewBox="0 0 12 12"
+          width={15}
         >
           <path
-            d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+            d="M2.22 2.22a.749.749 0 0 1 1.06 0L6 4.939 8.72 2.22a.749.749 0 1 1 1.06 1.06L7.061 6 9.78 8.72a.749.749 0 1 1-1.06 1.06L6 7.061 3.28 9.78a.749.749 0 1 1-1.06-1.06L4.939 6 2.22 3.28a.749.749 0 0 1 0-1.06Z"
           />
         </svg>
       </span>
     </span>
     <span
-      className="c5"
+      className="c5 c6"
+      data-interactive={true}
       onBlur={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      size="xlarge"
+      size="medium"
+      style={
+        {
+          "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+          "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+          "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+          "--label-fgColor": "var(--label-gray-fgColor-rest)",
+          "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+          "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+        }
+      }
       tabIndex={0}
     >
-      <span
-        className="c6"
+      <button
+        className="c7"
         onClick={[Function]}
       >
         six
-      </span>
+      </button>
       <span
         aria-hidden="true"
-        className="c7"
+        className="c8"
         onClick={[Function]}
-        size="xlarge"
+        size="medium"
         tabIndex={-1}
       >
         <svg
@@ -17714,7 +17784,7 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
           className="octicon octicon-x"
           fill="currentColor"
           focusable="false"
-          height={24}
+          height={15}
           style={
             {
               "display": "inline-block",
@@ -17723,35 +17793,46 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
               "verticalAlign": "text-bottom",
             }
           }
-          viewBox="0 0 24 24"
-          width={24}
+          viewBox="0 0 12 12"
+          width={15}
         >
           <path
-            d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+            d="M2.22 2.22a.749.749 0 0 1 1.06 0L6 4.939 8.72 2.22a.749.749 0 1 1 1.06 1.06L7.061 6 9.78 8.72a.749.749 0 1 1-1.06 1.06L6 7.061 3.28 9.78a.749.749 0 1 1-1.06-1.06L4.939 6 2.22 3.28a.749.749 0 0 1 0-1.06Z"
           />
         </svg>
       </span>
     </span>
     <span
-      className="c5"
+      className="c5 c6"
+      data-interactive={true}
       onBlur={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      size="xlarge"
+      size="medium"
+      style={
+        {
+          "--label-bgColor-active": "var(--label-gray-bgColor-active)",
+          "--label-bgColor-hover": "var(--label-gray-bgColor-hover)",
+          "--label-bgColor-rest": "var(--label-gray-bgColor-rest)",
+          "--label-fgColor": "var(--label-gray-fgColor-rest)",
+          "--label-fgColor-active": "var(--label-gray-fgColor-active)",
+          "--label-fgColor-hover": "var(--label-gray-fgColor-hover)",
+        }
+      }
       tabIndex={0}
     >
-      <span
-        className="c6"
+      <button
+        className="c7"
         onClick={[Function]}
       >
         seven
-      </span>
+      </button>
       <span
         aria-hidden="true"
-        className="c7"
+        className="c8"
         onClick={[Function]}
-        size="xlarge"
+        size="medium"
         tabIndex={-1}
       >
         <svg
@@ -17759,7 +17840,7 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
           className="octicon octicon-x"
           fill="currentColor"
           focusable="false"
-          height={24}
+          height={15}
           style={
             {
               "display": "inline-block",
@@ -17768,11 +17849,11 @@ exports[`TextInputWithTokens renders with tokens using a custom token component 
               "verticalAlign": "text-bottom",
             }
           }
-          viewBox="0 0 24 24"
-          width={24}
+          viewBox="0 0 12 12"
+          width={15}
         >
           <path
-            d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+            d="M2.22 2.22a.749.749 0 0 1 1.06 0L6 4.939 8.72 2.22a.749.749 0 1 1 1.06 1.06L7.061 6 9.78 8.72a.749.749 0 1 1-1.06 1.06L6 7.061 3.28 9.78a.749.749 0 1 1-1.06-1.06L4.939 6 2.22 3.28a.749.749 0 0 1 0-1.06Z"
           />
         </svg>
       </span>

--- a/packages/react/src/utils/__tests__/isHex.test.ts
+++ b/packages/react/src/utils/__tests__/isHex.test.ts
@@ -1,0 +1,26 @@
+import {isHex} from '../isHex'
+
+describe('utils: isHex', () => {
+  it('should return true for valid hex3, hex4, hex6 and hex8 strings', () => {
+    expect(isHex('#fff')).toBe(true)
+    expect(isHex('#123a')).toBe(true)
+    expect(isHex('#ffffff')).toBe(true)
+    expect(isHex('#ffffffaa')).toBe(true)
+  })
+  it('should return false for invalid hex strings', () => {
+    expect(isHex('#ff')).toBe(false)
+    expect(isHex('#ff345')).toBe(false)
+    expect(isHex('#ff345ff')).toBe(false)
+  })
+  it('should return true for valid strings', () => {
+    expect(isHex('fff')).toBe(true)
+    expect(isHex('ff34')).toBe(true)
+    expect(isHex('ff345f')).toBe(true)
+    expect(isHex('ff345faa')).toBe(true)
+  })
+  it('should return false for invalid strings', () => {
+    expect(isHex('ff')).toBe(false)
+    expect(isHex('ff345')).toBe(false)
+    expect(isHex('ff345ff')).toBe(false)
+  })
+})

--- a/packages/react/src/utils/isHex.ts
+++ b/packages/react/src/utils/isHex.ts
@@ -1,0 +1,3 @@
+const hexRegEx = /^#?(?:(?:[\da-f]{3}){1,2}|(?:[\da-f]{4}){1,2})$/i
+export type hexString = `#${string}`
+export const isHex = (hex: string | hexString): hex is hexString => hexRegEx.test(hex)


### PR DESCRIPTION
This PR updates the `IssueLabelToken` component to use `variants` for color instead of hex colors.
Hex colors are still supported to provide backwards compatibility.

I added a new `IssueLabelToken` component to the draft folder.


### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
