### PR TITLE
docs: update source urls to point to new location in monorepo

### DIFF
--- a/docs/content/ActionList.mdx
+++ b/docs/content/ActionList.mdx
@@ -2,7 +2,7 @@
 componentId: action_list
 title: ActionList
 status: Beta
-source: https://github.com/primer/react/tree/main/src/ActionList
+source: https://github.com/primer/react/tree/main/packages/react/src/ActionList
 storybook: '/react/storybook?path=/story/components-actionlist'
 description: An ActionList is a list of items that can be activated or selected. ActionList is the base component for many menu-type components, including ActionMenu and SelectPanel.
 ---

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -3,7 +3,7 @@ componentId: action_menu
 title: ActionMenu
 status: Beta
 a11yReviewed: false
-source: https://github.com/primer/react/tree/main/src/ActionMenu.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/ActionMenu.tsx
 storybook: '/react/storybook?path=/story/components-actionmenu'
 description: An ActionMenu is an ActionList-based component for creating a menu of actions that expands through a trigger button.
 ---

--- a/docs/content/AnchoredOverlay.mdx
+++ b/docs/content/AnchoredOverlay.mdx
@@ -2,7 +2,7 @@
 componentId: anchored_overlay
 title: AnchoredOverlay
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/AnchoredOverlay/AnchoredOverlay.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
 storybook: '/react/storybook?path=/story/behaviors-anchoredoverlay--default-portal'
 ---
 

--- a/docs/content/Autocomplete.mdx
+++ b/docs/content/Autocomplete.mdx
@@ -3,7 +3,7 @@ componentId: autocomplete
 title: Autocomplete
 status: Alpha
 description: Used to render a text input that allows a user to quickly filter through a list of options to pick one or more values.
-source: https://github.com/primer/react/tree/main/src/Autocomplete
+source: https://github.com/primer/react/tree/main/packages/react/src/Autocomplete
 storybook: '/react/storybook?path=/story/components-autocomplete'
 ---
 

--- a/docs/content/Avatar.mdx
+++ b/docs/content/Avatar.mdx
@@ -2,7 +2,7 @@
 title: Avatar
 status: Alpha
 componentId: avatar
-source: https://github.com/primer/react/blob/main/src/Avatar
+source: https://github.com/primer/react/tree/main/packages/react/src/Avatar
 ---
 
 import data from '../../packages/react/src/Avatar/Avatar.docs.json'

--- a/docs/content/AvatarPair.mdx
+++ b/docs/content/AvatarPair.mdx
@@ -2,7 +2,7 @@
 componentId: avatar_pair
 title: AvatarPair
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/AvatarPair
+source: https://github.com/primer/react/tree/main/packages/react/src/AvatarPair
 ---
 
 import data from '../../packages/react/src/AvatarPair/AvatarPair.docs.json'

--- a/docs/content/AvatarStack.mdx
+++ b/docs/content/AvatarStack.mdx
@@ -3,7 +3,7 @@ componentId: avatar_stack
 title: AvatarStack
 status: Alpha
 description: Use an avatar stack to display two or more avatars in an inline stack.
-source: https://github.com/primer/react/blob/main/src/AvatarStack
+source: https://github.com/primer/react/tree/main/packages/react/src/AvatarStack
 storybook: '/react/storybook?path=/story/components-avatarstack--default'
 ---
 

--- a/docs/content/Box.mdx
+++ b/docs/content/Box.mdx
@@ -3,7 +3,7 @@ componentId: box
 title: Box
 status: Beta
 description: A low-level utility component that accepts styles to enable custom theme-aware styling
-source: https://github.com/primer/react/blob/main/src/Box.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/Box.tsx
 ---
 
 import data from '../../packages/react/src/Box/Box.docs.json'

--- a/docs/content/BranchName.mdx
+++ b/docs/content/BranchName.mdx
@@ -2,7 +2,7 @@
 componentId: branch_name
 title: BranchName
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/BranchName/BranchName.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/BranchName/BranchName.tsx
 ---
 
 import data from '../../packages/react/src/BranchName/BranchName.docs.json'

--- a/docs/content/Breadcrumbs.mdx
+++ b/docs/content/Breadcrumbs.mdx
@@ -3,7 +3,7 @@ componentId: breadcrumbs
 title: Breadcrumbs
 status: Alpha
 description: Use breadcrumbs to show navigational context on pages that are many levels deep in a site’s hierarchy. Breadcrumbs show and link to parent, grandparent, and sometimes great-grandparent pages.
-source: https://github.com/primer/react/blob/main/src/Breadcrumbs/Breadcrumbs.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/Breadcrumbs/Breadcrumbs.tsx
 ---
 
 import data from '../../packages/react/src/Breadcrumbs/Breadcrumbs.docs.json'

--- a/docs/content/Button.mdx
+++ b/docs/content/Button.mdx
@@ -2,7 +2,7 @@
 componentId: button
 title: Button
 status: Alpha
-source: https://github.com/primer/react/tree/main/src/Button
+source: https://github.com/primer/react/tree/main/packages/react/src/Button
 storybook: '/react/storybook?path=/story/components-button--playground'
 description: Use button for the main actions on a page or form.
 ---

--- a/docs/content/ButtonGroup.mdx
+++ b/docs/content/ButtonGroup.mdx
@@ -2,7 +2,7 @@
 title: ButtonGroup
 componentId: button_group
 status: Alpha
-source: https://github.com/primer/react/tree/main/src/ButtonGroup
+source: https://github.com/primer/react/tree/main/packages/react/src/ButtonGroup
 storybook: '/react/storybook?path=/story/components-buttongroup--default'
 ---
 

--- a/docs/content/Checkbox.mdx
+++ b/docs/content/Checkbox.mdx
@@ -2,7 +2,7 @@
 title: Checkbox
 description: Use checkboxes to toggle between checked and unchecked states in a list or as a standalone form field
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Checkbox
+source: https://github.com/primer/react/tree/main/packages/react/src/Checkbox
 storybook: '/react/storybook?path=/story/components-forms-checkbox'
 componentId: checkbox
 ---

--- a/docs/content/CheckboxGroup.mdx
+++ b/docs/content/CheckboxGroup.mdx
@@ -3,7 +3,7 @@ title: CheckboxGroup
 componentId: checkbox_group
 description: Renders a set of checkboxes to let users make one or more selections from a short list of options
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/CheckboxGroup/CheckboxGroup.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/CheckboxGroup/CheckboxGroup.tsx
 storybook: '/react/storybook/?path=/story/components-forms-checkboxgroup-examples'
 ---
 

--- a/docs/content/CircleBadge.mdx
+++ b/docs/content/CircleBadge.mdx
@@ -2,7 +2,7 @@
 componentId: circle_badge
 title: CircleBadge
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/CircleBadge
+source: https://github.com/primer/react/tree/main/packages/react/src/CircleBadge
 ---
 
 import data from '../../packages/react/src/CircleBadge/CircleBadge.docs.json'

--- a/docs/content/CircleOcticon.mdx
+++ b/docs/content/CircleOcticon.mdx
@@ -2,7 +2,7 @@
 componentId: circle_octicon
 title: CircleOcticon
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/CircleOcticon
+source: https://github.com/primer/react/tree/main/packages/react/src/CircleOcticon
 ---
 
 import data from '../../packages/react/src/CircleOcticon/CircleOcticon.docs.json'

--- a/docs/content/CounterLabel.mdx
+++ b/docs/content/CounterLabel.mdx
@@ -3,7 +3,7 @@ componentId: counter_label
 title: CounterLabel
 description: Use the CounterLabel component to add a count to navigational elements and buttons.
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/CounterLabel/CounterLabel.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/CounterLabel/CounterLabel.tsx
 ---
 
 import data from '../../packages/react/src/CounterLabel/CounterLabel.docs.json'

--- a/docs/content/Details.mdx
+++ b/docs/content/Details.mdx
@@ -2,7 +2,7 @@
 componentId: details
 title: Details
 status: Alpha
-source: https://github.com/primer/react/tree/main/src/Details
+source: https://github.com/primer/react/tree/main/packages/react/src/Details
 storybook: '/react/storybook/?path=/story/components-details--default'
 ---
 

--- a/docs/content/Dialog.mdx
+++ b/docs/content/Dialog.mdx
@@ -1,7 +1,7 @@
 ---
 title: Dialog
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Dialog
+source: https://github.com/primer/react/tree/main/packages/react/src/Dialog
 ---
 
 import data from '../../packages/react/src/Dialog.docs.json'

--- a/docs/content/FilterList.mdx
+++ b/docs/content/FilterList.mdx
@@ -3,7 +3,7 @@ componentId: filter_list
 title: FilterList
 status: Deprecated
 description: The FilterList component is a menu with filter options that filter the main content of the page.
-source: https://github.com/primer/react/blob/main/src/FilterList
+source: https://github.com/primer/react/tree/main/packages/react/src/FilterList
 ---
 
 import data from '../../packages/react/src/deprecated/FilterList/FilterList.docs.json'

--- a/docs/content/FilteredSearch.mdx
+++ b/docs/content/FilteredSearch.mdx
@@ -3,7 +3,7 @@ componentId: filtered_search
 title: FilteredSearch
 status: Deprecated
 description: The FilteredSearch component helps style an ActionMenu and a TextInput side-by-side.
-source: https://github.com/primer/react/blob/main/src/FilteredSearch
+source: https://github.com/primer/react/tree/main/packages/react/src/FilteredSearch
 ---
 
 import data from '../../packages/react/src/deprecated/FilteredSearch/FilteredSearch.docs.json'

--- a/docs/content/Flash.mdx
+++ b/docs/content/Flash.mdx
@@ -2,7 +2,7 @@
 componentId: flash
 title: Flash
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Flash
+source: https://github.com/primer/react/tree/main/packages/react/src/Flash
 ---
 
 import data from '../../packages/react/src/Flash/Flash.docs.json'

--- a/docs/content/FormControl.mdx
+++ b/docs/content/FormControl.mdx
@@ -3,7 +3,7 @@ componentId: form_control
 title: FormControl
 status: Alpha
 description: Renders a labelled input and, optionally, associated validation text and/or hint text.
-source: https://github.com/primer/react/blob/main/src/FormControl/FormControl.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/FormControl/FormControl.tsx
 storybook: '/react/storybook?path=/story/components-forms-autocomplete'
 ---
 

--- a/docs/content/Header.mdx
+++ b/docs/content/Header.mdx
@@ -2,7 +2,7 @@
 title: Header
 description: Use the Header component to create a header that has all of its items aligned vertically with consistent horizontal spacing
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Header
+source: https://github.com/primer/react/tree/main/packages/react/src/Header
 componentId: header
 ---
 

--- a/docs/content/Heading.mdx
+++ b/docs/content/Heading.mdx
@@ -1,7 +1,7 @@
 ---
 title: Heading
 description: Use Heading to structure your content and provide an accessible experience for users of assistive technologies.
-source: https://github.com/primer/react/blob/main/src/Heading
+source: https://github.com/primer/react/tree/main/packages/react/src/Heading
 storybook: '/react/storybook?path=/story/components-heading--default'
 status: Alpha
 componentId: heading

--- a/docs/content/IconButton.mdx
+++ b/docs/content/IconButton.mdx
@@ -2,7 +2,7 @@
 title: IconButton
 componentId: icon_button
 status: Alpha
-source: https://github.com/primer/react/tree/main/src/Button
+source: https://github.com/primer/react/tree/main/packages/react/src/Button
 storybook: '/react/storybook?path=/story/components-iconbutton--playground'
 description: An accessible button component with no text and only icon.
 ---

--- a/docs/content/Label.mdx
+++ b/docs/content/Label.mdx
@@ -2,7 +2,7 @@
 title: Label
 componentId: label
 status: Alpha
-source: https://github.com/primer/react/tree/main/src/Label
+source: https://github.com/primer/react/tree/main/packages/react/src/Label
 storybook: '/react/storybook?path=/story/components-label--label'
 description: Use Label components to add contextual metadata to a design.
 ---

--- a/docs/content/LabelGroup.mdx
+++ b/docs/content/LabelGroup.mdx
@@ -1,7 +1,7 @@
 ---
 title: LabelGroup
 description: Use LabelGroup components to add commonly used margins and other layout constraints to groups of Labels
-source: https://github.com/primer/react/blob/main/src/LabelGroup
+source: https://github.com/primer/react/tree/main/packages/react/src/LabelGroup
 status: Alpha
 componentId: label_group
 ---

--- a/docs/content/Link.mdx
+++ b/docs/content/Link.mdx
@@ -2,7 +2,7 @@
 componentId: link
 title: Link
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Link/Link.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/Link/Link.tsx
 storybook: '/react/storybook/?path=/story/components-link--default'
 ---
 

--- a/docs/content/NavList.mdx
+++ b/docs/content/NavList.mdx
@@ -3,7 +3,7 @@ title: NavList
 status: Alpha
 componentId: nav_list
 description: Use a nav list to render a vertical list of navigation links.
-source: https://github.com/primer/react/tree/main/src/NavList
+source: https://github.com/primer/react/tree/main/packages/react/src/NavList
 storybook: '/react/storybook/?path=/story/components-navlist--simple'
 ---
 

--- a/docs/content/Octicon.mdx
+++ b/docs/content/Octicon.mdx
@@ -2,7 +2,7 @@
 description: Use Octicon to render an Octicon as a component.
 title: Octicon
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Octicon/Octicon.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/Octicon/Octicon.tsx
 componentId: octicon
 ---
 

--- a/docs/content/Overlay.mdx
+++ b/docs/content/Overlay.mdx
@@ -3,7 +3,7 @@ title: Overlay
 description: Use Overlay to provide a flexible floating surface for displaying transient content such as menus, selection options, dialogs, and more.
 componentId: overlay
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Overlay
+source: https://github.com/primer/react/tree/main/packages/react/src/Overlay
 storybook: '/react/storybook?path=/story/private-components-overlay--dropdown-overlay'
 ---
 

--- a/docs/content/PageLayout.mdx
+++ b/docs/content/PageLayout.mdx
@@ -3,7 +3,7 @@ title: PageLayout
 componentId: page_layout
 status: Alpha
 # description: TODO
-source: https://github.com/primer/react/tree/main/src/PageLayout
+source: https://github.com/primer/react/tree/main/packages/react/src/PageLayout
 storybook: '/react/storybook?path=/story/components-pagelayout--default'
 a11yReviewed: true
 ---

--- a/docs/content/Pagehead.md
+++ b/docs/content/Pagehead.md
@@ -2,7 +2,7 @@
 componentId: pagehead
 title: Pagehead
 description: Use Pagehead to provide a clear, separated page title.
-source: https://github.com/primer/react/blob/main/src/Pagehead
+source: https://github.com/primer/react/tree/main/packages/react/src/Pagehead
 status: Alpha
 ---
 

--- a/docs/content/Pagination.md
+++ b/docs/content/Pagination.md
@@ -2,7 +2,7 @@
 title: Pagination
 componentId: pagination
 description: Use Pagination to display a sequence of links that allow navigation to discrete, related pages.
-source: https://github.com/primer/react/blob/main/src/Pagination/Pagination.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/Pagination/Pagination.tsx
 storybook: '/react/storybook?path=/story/components-pagination-features--hide-page-numbers'
 status: Alpha
 ---

--- a/docs/content/PointerBox.mdx
+++ b/docs/content/PointerBox.mdx
@@ -3,7 +3,7 @@ title: PointerBox
 description: A customisable, bordered Box with a caret pointer
 componentId: pointer_box
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/PointerBox
+source: https://github.com/primer/react/tree/main/packages/react/src/PointerBox
 ---
 
 import data from '../../packages/react/src/PointerBox/PointerBox.docs.json'

--- a/docs/content/Popover.md
+++ b/docs/content/Popover.md
@@ -3,7 +3,7 @@ title: Popover
 description: Use Popovers to bring attention to specific user interface elements and suggest an action or to guide users through a new experience
 componentId: popover
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Popover
+source: https://github.com/primer/react/tree/main/packages/react/src/Popover
 ---
 
 import data from '../../packages/react/src/Popover/Popover.docs.json'

--- a/docs/content/Portal.mdx
+++ b/docs/content/Portal.mdx
@@ -2,7 +2,7 @@
 title: Portal
 description: Portals allow you to create a separation between the logical React component hierarchy and the physical DOM.
 componentId: portal
-source: https://github.com/primer/react/blob/main/src/Portal/Portal.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/Portal/Portal.tsx
 status: Alpha
 ---
 

--- a/docs/content/ProgressBar.mdx
+++ b/docs/content/ProgressBar.mdx
@@ -2,7 +2,7 @@
 title: ProgressBar
 componentId: progress_bar
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/ProgressBar
+source: https://github.com/primer/react/tree/main/packages/react/src/ProgressBar
 ---
 
 import data from '../../packages/react/src/ProgressBar/ProgressBar.docs.json'

--- a/docs/content/Radio.mdx
+++ b/docs/content/Radio.mdx
@@ -3,7 +3,7 @@ componentId: radio
 title: Radio
 description: Use radios when a user needs to select one option from a list
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Radio
+source: https://github.com/primer/react/tree/main/packages/react/src/Radio
 storybook: '/react/storybook?path=/story/components-forms-radiogroup'
 ---
 

--- a/docs/content/RadioGroup.mdx
+++ b/docs/content/RadioGroup.mdx
@@ -3,7 +3,7 @@ title: RadioGroup
 componentId: radio_group
 description: Renders a set of radio inputs to let users make a single selection from a short list of options
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/RadioGroup/RadioGroup.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/RadioGroup/RadioGroup.tsx
 storybook: '/react/storybook/?path=/story/components-forms-radiogroup-examples'
 ---
 

--- a/docs/content/RelativeTime.mdx
+++ b/docs/content/RelativeTime.mdx
@@ -2,7 +2,7 @@
 componentId: relative-time
 title: RelativeTime
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/RelativeTime
+source: https://github.com/primer/react/tree/main/packages/react/src/RelativeTime
 ---
 
 import data from '../../packages/react/src/RelativeTime/RelativeTime.docs.json'

--- a/docs/content/SegmentedControl.mdx
+++ b/docs/content/SegmentedControl.mdx
@@ -3,7 +3,7 @@ componentId: segmented_control
 title: SegmentedControl
 description: Use a segmented control to let users select an option from a short list and immediately apply the selection
 status: Alpha
-source: https://github.com/primer/react/tree/main/src/SegmentedControl
+source: https://github.com/primer/react/tree/main/packages/react/src/SegmentedControl
 storybook: '/react/storybook/?path=/story/components-segmentedcontrol'
 ---
 

--- a/docs/content/Select.mdx
+++ b/docs/content/Select.mdx
@@ -4,7 +4,7 @@ title: Select
 description: Use a select input when a user needs to select one option from a long list
 status: Alpha
 a11yReviewed: true
-source: https://github.com/primer/react/blob/main/src/Select.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/Select.tsx
 storybook: '/react/storybook?path=/story/components-forms-select--default'
 ---
 

--- a/docs/content/SelectPanel.mdx
+++ b/docs/content/SelectPanel.mdx
@@ -2,7 +2,7 @@
 componentId: select_panel
 title: SelectPanel
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/SelectPanel
+source: https://github.com/primer/react/tree/main/packages/react/src/SelectPanel
 ---
 
 import data from '../../packages/react/src/SelectPanel/SelectPanel.docs.json'

--- a/docs/content/Spinner.mdx
+++ b/docs/content/Spinner.mdx
@@ -3,7 +3,7 @@ title: Spinner
 status: Alpha
 description: Use spinners to let users know that content is being loaded.
 componentId: spinner
-source: https://github.com/primer/react/blob/main/src/Spinner/Spinner.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/Spinner/Spinner.tsx
 ---
 
 import data from '../../packages/react/src/Spinner/Spinner.docs.json'

--- a/docs/content/SplitPageLayout.mdx
+++ b/docs/content/SplitPageLayout.mdx
@@ -3,7 +3,7 @@ title: SplitPageLayout
 componentId: split_page_layout
 status: Alpha
 description: Provides structure for a split page layout, including independent scrolling for the pane and content regions. Useful for responsive list/detail patterns, when an item in the pane updates the page content on selection.
-source: https://github.com/primer/react/tree/main/src/SplitPageLayout
+source: https://github.com/primer/react/tree/main/packages/react/src/SplitPageLayout
 storybook: '/react/storybook?path=/story/components-splitpagelayout--default'
 a11yReviewed: true
 ---

--- a/docs/content/StateLabel.mdx
+++ b/docs/content/StateLabel.mdx
@@ -3,7 +3,7 @@ componentId: state_label
 title: StateLabel
 status: Alpha
 storybook: '/react/storybook/?path=/story/components-statelabel--default'
-source: https://github.com/primer/react/tree/main/src/StateLabel
+source: https://github.com/primer/react/tree/main/packages/react/src/StateLabel
 ---
 
 import data from '../../packages/react/src/StateLabel/StateLabel.docs.json'

--- a/docs/content/SubNav.mdx
+++ b/docs/content/SubNav.mdx
@@ -2,7 +2,7 @@
 componentId: sub_nav
 title: SubNav
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/SubNav
+source: https://github.com/primer/react/tree/main/packages/react/src/SubNav
 ---
 
 import data from '../../packages/react/src/SubNav/SubNav.docs.json'

--- a/docs/content/TabNav.mdx
+++ b/docs/content/TabNav.mdx
@@ -2,7 +2,7 @@
 componentId: tab_nav
 title: TabNav
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/TabNav
+source: https://github.com/primer/react/tree/main/packages/react/src/TabNav
 ---
 
 import data from '../../packages/react/src/TabNav/TabNav.docs.json'

--- a/docs/content/Text.mdx
+++ b/docs/content/Text.mdx
@@ -3,7 +3,7 @@ componentId: text
 title: Text
 a11yReviewed: true
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Text
+source: https://github.com/primer/react/tree/main/packages/react/src/Text
 ---
 
 import data from '../../packages/react/src/Text/Text.docs.json'

--- a/docs/content/TextInput.mdx
+++ b/docs/content/TextInput.mdx
@@ -2,7 +2,7 @@
 componentId: text_input
 title: TextInput
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/TextInput
+source: https://github.com/primer/react/tree/main/packages/react/src/TextInput
 storybook: '/react/storybook?path=/story/components-forms-textinput--default'
 ---
 

--- a/docs/content/TextInputWithTokens.mdx
+++ b/docs/content/TextInputWithTokens.mdx
@@ -3,7 +3,7 @@ componentId: text_input_with_tokens
 title: TextInputWithTokens
 status: Alpha
 description: Used to show multiple values in one field
-source: https://github.com/primer/react/tree/main/src/TextInputWithTokens
+source: https://github.com/primer/react/tree/main/packages/react/src/TextInputWithTokens
 storybook: '/react/storybook?path=/story/components-forms-textinputwithtokens--default'
 ---
 

--- a/docs/content/Textarea.mdx
+++ b/docs/content/Textarea.mdx
@@ -3,7 +3,7 @@ componentId: textarea
 title: Textarea
 description: Use Textarea for multi-line text input form fields
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Textarea
+source: https://github.com/primer/react/tree/main/packages/react/src/Textarea
 storybook: '/react/storybook?path=/story/components-forms-textarea--textarea-story'
 ---
 

--- a/docs/content/Timeline.mdx
+++ b/docs/content/Timeline.mdx
@@ -2,7 +2,7 @@
 componentId: timeline
 title: Timeline
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Timeline
+source: https://github.com/primer/react/tree/main/packages/react/src/Timeline
 ---
 
 import data from '../../packages/react/src/Timeline/Timeline.docs.json'

--- a/docs/content/ToggleSwitch.mdx
+++ b/docs/content/ToggleSwitch.mdx
@@ -3,7 +3,7 @@ componentId: toggle_switch
 title: ToggleSwitch
 description: Toggles a setting on or off, and immediately saves the change
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/ToggleSwitch
+source: https://github.com/primer/react/tree/main/packages/react/src/ToggleSwitch
 storybook: '/react/storybook?path=/story/components-toggleswitch-examples--default'
 ---
 

--- a/docs/content/Token.mdx
+++ b/docs/content/Token.mdx
@@ -3,7 +3,7 @@ componentId: token
 title: Token
 status: Alpha
 description: A Token represents a piece of data. They are typically used to show a collection of related attributes.
-source: https://github.com/primer/react/tree/main/src/Token
+source: https://github.com/primer/react/tree/main/packages/react/src/Token
 storybook: '/react/storybook?path=/story/components-token--default-token'
 ---
 

--- a/docs/content/Tooltip.mdx
+++ b/docs/content/Tooltip.mdx
@@ -2,7 +2,7 @@
 componentId: tooltip
 title: Tooltip
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Tooltip/Tooltip.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/Tooltip/Tooltip.tsx
 ---
 
 import data from '../../packages/react/src/Tooltip/Tooltip.docs.json'

--- a/docs/content/TreeView.mdx
+++ b/docs/content/TreeView.mdx
@@ -4,7 +4,7 @@ componentId: tree_view
 status: Beta
 description: A hierarchical list of items where nested items can be expanded and collapsed.
 a11yReviewed: true
-source: https://github.com/primer/react/tree/main/src/TreeView
+source: https://github.com/primer/react/tree/main/packages/react/src/TreeView
 storybook: '/react/storybook?path=/story/components-treeview'
 ---
 

--- a/docs/content/Truncate.mdx
+++ b/docs/content/Truncate.mdx
@@ -2,7 +2,7 @@
 componentId: truncate
 title: Truncate
 status: Alpha
-source: https://github.com/primer/react/blob/main/src/Truncate
+source: https://github.com/primer/react/tree/main/packages/react/src/Truncate
 ---
 
 import data from '../../packages/react/src/Truncate/Truncate.docs.json'

--- a/docs/content/UnderlineNav.mdx
+++ b/docs/content/UnderlineNav.mdx
@@ -4,7 +4,7 @@ componentId: underline_nav
 status: Alpha
 a11yReviewed: true
 description: Use an underlined nav to allow tab like navigation with overflow behaviour in your UI.
-source: https://github.com/primer/react/tree/main/src/UnderlineNav
+source: https://github.com/primer/react/tree/main/packages/react/src/UnderlineNav
 storybook: '/react/storybook/?path=/story/components-underlinenav--playground'
 ---
 

--- a/docs/content/deprecated/ActionList.mdx
+++ b/docs/content/deprecated/ActionList.mdx
@@ -1,7 +1,7 @@
 ---
 title: ActionList (legacy)
 status: Deprecated
-source: https://github.com/primer/react/tree/main/src/deprecated/ActionList
+source: https://github.com/primer/react/tree/main/packages/react/src/deprecated/ActionList
 ---
 
 An `ActionList` is a list of items which can be activated or selected. `ActionList` is the base component for many of our menu-type components, including and `ActionMenu`.

--- a/docs/content/deprecated/ActionMenu.mdx
+++ b/docs/content/deprecated/ActionMenu.mdx
@@ -1,7 +1,7 @@
 ---
 title: ActionMenu (legacy)
 status: Deprecated
-source: https://github.com/primer/react/tree/main/src/deprecated/ActionMenu.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/deprecated/ActionMenu.tsx
 ---
 
 An `ActionMenu` is an ActionList-based component for creating a menu of actions that expands through a trigger button.

--- a/docs/content/deprecated/Buttons.mdx
+++ b/docs/content/deprecated/Buttons.mdx
@@ -1,7 +1,7 @@
 ---
 title: Button (legacy)
 status: Deprecated
-source: https://github.com/primer/react/blob/main/src/Button
+source: https://github.com/primer/react/tree/main/packages/react/src/Button
 storybook: '/react/storybook?path=/story/components-button--default-button'
 ---
 

--- a/docs/content/drafts/Hidden.mdx
+++ b/docs/content/drafts/Hidden.mdx
@@ -3,7 +3,7 @@ title: Hidden
 componentId: hidden
 status: Draft
 description: Use Hidden to responsively hide or show content in narrow, regular and wide viewports.
-source: https://github.com/primer/react/blob/main/src/Hidden/index.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/Hidden/index.tsx
 storybook: '/react/storybook/?path=/story/drafts-components-hidden--playground'
 ---
 

--- a/docs/content/drafts/InlineAutocomplete.mdx
+++ b/docs/content/drafts/InlineAutocomplete.mdx
@@ -3,7 +3,7 @@ title: InlineAutocomplete
 componentId: inline_autocomplete
 status: Deprecated
 description: Provides inline auto completion suggestions for an input or textarea.
-source: https://github.com/primer/react/tree/main/src/drafts/InlineAutocomplete
+source: https://github.com/primer/react/tree/main/packages/react/src/drafts/InlineAutocomplete
 storybook: '/react/storybook?path=/story/deprecated-components-inlineautocomplete--default'
 ---
 

--- a/docs/content/drafts/PageHeader.mdx
+++ b/docs/content/drafts/PageHeader.mdx
@@ -3,7 +3,7 @@ title: PageHeader
 componentId: page_header
 status: Draft
 description: PageHeader is used to determine the arrangement of the top-level headings and how elements adopt to different viewports.
-source: https://github.com/primer/react/tree/main/src/PageHeader
+source: https://github.com/primer/react/tree/main/packages/react/src/PageHeader
 storybook: '/react/storybook/?path=/story/drafts-components-pageheader--playground'
 ---
 

--- a/docs/content/drafts/SelectPanel.mdx
+++ b/docs/content/drafts/SelectPanel.mdx
@@ -2,7 +2,7 @@
 componentId: selectpanel_v2
 title: SelectPanel v2
 status: Draft
-source: https://github.com/primer/react/blob/main/src/drafts/SelectPanel2
+source: https://github.com/primer/react/tree/main/packages/react/src/drafts/SelectPanel2
 storybook: '/react/storybook/?path=/story/drafts-components-selectpanel'
 ---
 

--- a/docs/content/drafts/Tooltip.mdx
+++ b/docs/content/drafts/Tooltip.mdx
@@ -2,7 +2,7 @@
 componentId: tooltip_v2
 title: Tooltip v2
 status: Draft
-source: https://github.com/primer/react/blob/main/src/drafts/Tooltip.tsx
+source: https://github.com/primer/react/tree/main/packages/react/src/drafts/Tooltip.tsx
 ---
 
 import data from '../../../packages/react/src/drafts/Tooltip/Tooltip.docs.json'

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -143,7 +143,7 @@ Like React, Primer React emits warnings to the JavaScript console under certain 
 
 ## Testing
 
-Testing your application with Primer React is no different than testing your application with any other React library. Depending on your test environment and the testing libraries you use, you may need polyfills. For example if you are using `jest`, it runs via Node runtime and uses [JSDOM](https://github.com/jsdom/jsdom) as a DOM implementation, so you will need to mock some browser APIs. We have [helpers](https://github.com/primer/react/blob/main/src/utils/test-helpers.tsx) that you can utilize to mock some of these APIs. You can import the helpers in your test setup file like so:
+Testing your application with Primer React is no different than testing your application with any other React library. Depending on your test environment and the testing libraries you use, you may need polyfills. For example if you are using `jest`, it runs via Node runtime and uses [JSDOM](https://github.com/jsdom/jsdom) as a DOM implementation, so you will need to mock some browser APIs. We have [helpers](https://github.com/primer/react/tree/main/packages/react/src/utils/test-helpers.tsx) that you can utilize to mock some of these APIs. You can import the helpers in your test setup file like so:
 
 ```js
 import '@primer/react/lib-esm/utils/test-helpers' // For ESM

--- a/docs/content/primer-theme.md
+++ b/docs/content/primer-theme.md
@@ -4,13 +4,13 @@ title: Primer Theme
 
 import {theme} from '@primer/react'
 
-Primer React components come with built-in access to our Primer theme. The [theme file](https://github.com/primer/react/blob/main/src/theme.ts) contains an object which holds values for common variables such as color, fonts, box shadows, and more. Our theme file pulls many of its color and typography values from [primer-primitives](https://github.com/primer/primer-primitives).
+Primer React components come with built-in access to our Primer theme. The [theme file](https://github.com/primer/react/tree/main/packages/react/src/theme.ts) contains an object which holds values for common variables such as color, fonts, box shadows, and more. Our theme file pulls many of its color and typography values from [primer-primitives](https://github.com/primer/primer-primitives).
 
 Many of our theme keys correspond to system props on our components. For example, if you'd like to set the max width on a `<Box>` set the `maxWidth` prop to `medium`: `<Box maxWidth='medium'>`
 
 In the background, [styled-system](https://github.com/styled-system/styled-system) does the work of finding the `medium` value from `maxWidth` key in the theme file and applying the corresponding CSS.
 
-Learn more about [our full theme](https://github.com/primer/react/blob/main/src/theme.ts).
+Learn more about [our full theme](https://github.com/primer/react/tree/main/packages/react/src/theme.ts).
 
 ### Custom Theming
 

--- a/packages/react/src/PageHeader/PageHeader.examples.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.examples.stories.tsx
@@ -212,8 +212,8 @@ export const FilesPage = () => (
       <PageHeader.TitleArea>
         <Breadcrumbs>
           <Breadcrumbs.Item href="https://github.com/primer/react/tree/main">react</Breadcrumbs.Item>
-          <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/src">src</Breadcrumbs.Item>
-          <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/src/PageHeader">
+          <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src">src</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader">
             PageHeader
           </Breadcrumbs.Item>
           <Breadcrumbs.Item href="https://github.com/primer/react/blob/main/src/PageHeader/PageHeader.tsx">

--- a/packages/react/src/PageHeader/PageHeader.examples.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.examples.stories.tsx
@@ -216,7 +216,7 @@ export const FilesPage = () => (
           <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader">
             PageHeader
           </Breadcrumbs.Item>
-          <Breadcrumbs.Item href="https://github.com/primer/react/blob/main/src/PageHeader/PageHeader.tsx">
+          <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader/PageHeader.tsx">
             PageHeader.tsx
           </Breadcrumbs.Item>
         </Breadcrumbs>

--- a/packages/react/src/PageHeader/PageHeader.features.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.features.stories.tsx
@@ -76,7 +76,7 @@ export const WithComponentAsATitle = () => (
           <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader">
             PageHeader
           </Breadcrumbs.Item>
-          <Breadcrumbs.Item href="https://github.com/primer/react/blob/main/src/PageHeader/PageHeader.tsx">
+          <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader/PageHeader.tsx">
             PageHeader.tsx
           </Breadcrumbs.Item>
         </Breadcrumbs>
@@ -243,7 +243,7 @@ export const WithContextBarAndActionsOfContextArea = () => (
             <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader">
               PageHeader
             </Breadcrumbs.Item>
-            <Breadcrumbs.Item href="https://github.com/primer/react/blob/main/src/PageHeader/PageHeader.tsx">
+            <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader/PageHeader.tsx">
               PageHeader.tsx
             </Breadcrumbs.Item>
           </Breadcrumbs>

--- a/packages/react/src/PageHeader/PageHeader.features.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.features.stories.tsx
@@ -72,8 +72,8 @@ export const WithComponentAsATitle = () => (
       <PageHeader.TitleArea>
         <Breadcrumbs>
           <Breadcrumbs.Item href="https://github.com/primer/react/tree/main">react</Breadcrumbs.Item>
-          <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/src">src</Breadcrumbs.Item>
-          <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/src/PageHeader">
+          <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src">src</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader">
             PageHeader
           </Breadcrumbs.Item>
           <Breadcrumbs.Item href="https://github.com/primer/react/blob/main/src/PageHeader/PageHeader.tsx">
@@ -239,8 +239,8 @@ export const WithContextBarAndActionsOfContextArea = () => (
         <PageHeader.ContextBar>
           <Breadcrumbs>
             <Breadcrumbs.Item href="https://github.com/primer/react/tree/main">react</Breadcrumbs.Item>
-            <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/src">src</Breadcrumbs.Item>
-            <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/src/PageHeader">
+            <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src">src</Breadcrumbs.Item>
+            <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader">
               PageHeader
             </Breadcrumbs.Item>
             <Breadcrumbs.Item href="https://github.com/primer/react/blob/main/src/PageHeader/PageHeader.tsx">

--- a/packages/react/src/PageHeader/PageHeader.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.stories.tsx
@@ -194,8 +194,8 @@ export const Playground: Story = args => (
         <PageHeader.ContextBar hidden={!args.hasContextBar}>
           <Breadcrumbs>
             <Breadcrumbs.Item href="https://github.com/primer/react/tree/main">react</Breadcrumbs.Item>
-            <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/src">src</Breadcrumbs.Item>
-            <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/src/PageHeader">
+            <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src">src</Breadcrumbs.Item>
+            <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader">
               PageHeader
             </Breadcrumbs.Item>
             <Breadcrumbs.Item href="https://github.com/primer/react/blob/main/src/PageHeader/PageHeader.tsx">

--- a/packages/react/src/PageHeader/PageHeader.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.stories.tsx
@@ -198,7 +198,7 @@ export const Playground: Story = args => (
             <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader">
               PageHeader
             </Breadcrumbs.Item>
-            <Breadcrumbs.Item href="https://github.com/primer/react/blob/main/src/PageHeader/PageHeader.tsx">
+            <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader/PageHeader.tsx">
               PageHeader.tsx
             </Breadcrumbs.Item>
           </Breadcrumbs>

--- a/packages/react/src/UnderlineNav/styles.ts
+++ b/packages/react/src/UnderlineNav/styles.ts
@@ -128,7 +128,7 @@ export const getLinkStyles = (theme?: Theme, ariaCurrent?: string | boolean) => 
 })
 
 export const menuItemStyles = {
-  // This is needed to hide the selected check icon on the menu item. https://github.com/primer/react/blob/main/src/ActionList/Selection.tsx#L32
+  // This is needed to hide the selected check icon on the menu item. https://github.com/primer/react/tree/main/packages/react/src/ActionList/Selection.tsx#L32
   '& > span': {
     display: 'none',
   },

--- a/packages/react/src/drafts/Tooltip/Tooltip.examples.stories.tsx
+++ b/packages/react/src/drafts/Tooltip/Tooltip.examples.stories.tsx
@@ -100,7 +100,7 @@ export const FilesPage = () => (
         <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader">
           PageHeader
         </Breadcrumbs.Item>
-        <Breadcrumbs.Item href="https://github.com/primer/react/blob/main/src/PageHeader/PageHeader.tsx">
+        <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader/PageHeader.tsx">
           PageHeader.tsx
         </Breadcrumbs.Item>
       </Breadcrumbs>

--- a/packages/react/src/drafts/Tooltip/Tooltip.examples.stories.tsx
+++ b/packages/react/src/drafts/Tooltip/Tooltip.examples.stories.tsx
@@ -96,8 +96,10 @@ export const FilesPage = () => (
     <PageHeader.TitleArea>
       <Breadcrumbs>
         <Breadcrumbs.Item href="https://github.com/primer/react/tree/main">react</Breadcrumbs.Item>
-        <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/src">src</Breadcrumbs.Item>
-        <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/src/PageHeader">PageHeader</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src">src</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="https://github.com/primer/react/tree/main/packages/react/src/PageHeader">
+          PageHeader
+        </Breadcrumbs.Item>
         <Breadcrumbs.Item href="https://github.com/primer/react/blob/main/src/PageHeader/PageHeader.tsx">
           PageHeader.tsx
         </Breadcrumbs.Item>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/4240

Updates the source url for files to the new monorepo structure

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Source url for mdx component files have been changed

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a docs related change

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- [ ] Verify I didn't miss any links 😓
- [ ] Verify that the new locations are correct