### PR TITLE
feat: remove dedicated type entrypoints

### DIFF
--- a/.changeset/lovely-tools-share.md
+++ b/.changeset/lovely-tools-share.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Replace subfolders used for TypeScript types with "types" field in "exports"

--- a/packages/react/deprecated/package.json
+++ b/packages/react/deprecated/package.json
@@ -1,9 +1,0 @@
-{
-    "_comment1": "this is required only for typescript. once this is fixed https://github.com/microsoft/TypeScript/issues/33079 we can remove this hack",
-    "name": "@primer/react/deprecated",
-    "types": "../lib-esm/deprecated/index.d.ts",
-    "main": "../lib-esm/deprecated/index.js",
-    "type": "module",
-    "sideEffects": false
-  }
-  

--- a/packages/react/drafts/package.json
+++ b/packages/react/drafts/package.json
@@ -1,9 +1,0 @@
-{
-    "_comment1": "this is required only for typescript. once this is fixed https://github.com/microsoft/TypeScript/issues/33079 we can remove this hack",
-    "name": "@primer/react/drafts",
-    "types": "../lib-esm/drafts/index.d.ts",
-    "main": "../lib-esm/drafts/index.js",
-    "type": "module",
-    "sideEffects": false
-  }
-  

--- a/packages/react/experimental/package.json
+++ b/packages/react/experimental/package.json
@@ -1,8 +1,0 @@
-{
-  "_comment1": "this is required only for typescript. once this is fixed https://github.com/microsoft/TypeScript/issues/33079 we can remove this hack",
-  "name": "@primer/react/experimental",
-  "types": "../lib-esm/experimental/index.d.ts",
-  "main": "../lib-esm/experimental/index.js",
-  "type": "module",
-  "sideEffects": false
-}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,22 +6,48 @@
   "module": "lib-esm/index.js",
   "exports": {
     ".": {
+      "types": {
+        "import": "./lib-esm/index.d.ts",
+        "require": "./lib/index.d.ts"
+      },
       "import": "./lib-esm/index.js",
       "require": "./lib/index.js"
     },
     "./experimental": {
+      "types": {
+        "import": "./lib-esm/experimental/index.d.ts",
+        "require": "./lib/experimental/index.d.ts"
+      },
       "import": "./lib-esm/experimental/index.js",
       "require": "./lib/experimental/index.js"
     },
     "./drafts": {
+      "types": {
+        "import": "./lib-esm/drafts/index.d.ts",
+        "require": "./lib/drafts/index.d.ts"
+      },
       "import": "./lib-esm/drafts/index.js",
       "require": "./lib/drafts/index.js"
     },
     "./deprecated": {
+      "types": {
+        "import": "./lib-esm/deprecated/index.d.ts",
+        "require": "./lib/deprecated/index.d.ts"
+      },
       "import": "./lib-esm/deprecated/index.js",
       "require": "./lib/deprecated/index.js"
     },
     "./lib-esm/*": {
+      "types": {
+        "import": [
+          "./lib-esm/*.d.ts",
+          "./lib-esm/*/index.d.ts"
+        ],
+        "require": [
+          "./lib/*.d.ts",
+          "./lib/*/index.d.ts"
+        ]
+      },
       "import": [
         "./lib-esm/*.js",
         "./lib-esm/*/index.js"


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Remembered this when reviewing #4225 that we have dedicated subfolders for TypeScript types to resolve correctly and that the `package.json` files in these folders have a link to an issue.

It appears that this issue is closed and so I wanted to test it out to see if it worked as intended. If so, we can remove these folders in preference of the types in `exports`

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add `types` to conditional exports in `package.json`

#### Removed

<!-- List of things removed in this PR -->

- Remove `drafts`, `experimental`, and `deprecated` stub folders

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release

### Testing & Reviewing

- [ ] Verify that these folders are no longer needed in case I missed anything 😅 
- [ ] Double check that CI passes
- [ ] For testing upstream, I opened up a PR and they seem to be okay and are failing due to unrelated changes