### PR TITLE
SelectPanel2: Submit panel when an item is selected with Enter

### DIFF
--- a/.changeset/polite-rockets-yawn.md
+++ b/.changeset/polite-rockets-yawn.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+SelectPanel2: Submit panel when an item is selected with `Enter` key

--- a/packages/react/src/ActionList/Item.tsx
+++ b/packages/react/src/ActionList/Item.tsx
@@ -88,7 +88,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       ) => {
         if (typeof onSelectUser === 'function') onSelectUser(event)
         if (event.defaultPrevented) return
-        if (typeof afterSelect === 'function') afterSelect()
+        if (typeof afterSelect === 'function') afterSelect(event)
       },
       [onSelectUser],
     )

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -142,8 +142,12 @@ const Panel: React.FC<SelectPanelProps> = ({
     if (typeof propsOnClearSelection === 'function') propsOnClearSelection()
   }
 
-  const internalAfterSelect = () => {
+  const internalAfterSelect = (event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => {
     if (selectionVariant === 'instant') onInternalSubmit()
+
+    if (event.type === 'keypress') {
+      if ((event as React.KeyboardEvent<HTMLLIElement>).key === 'Enter') onInternalSubmit()
+    }
   }
 
   /* Search/Filter */


### PR DESCRIPTION
- [x] Pressing Space selects and deselects the focused item
- [x] Pressing Enter selects and deselects the focused item **AND submits and closes panel**

https://github.com/primer/react/assets/1863771/276af72b-07d5-4460-87e9-cd2a41a31d9d


Known bug: Pressing Enter in the search input also submits the panel which it should not, will update that after https://github.com/primer/react/pull/4199 is merged