### PR TITLE
ci: update release, release_candidate workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,37 @@ jobs:
   release-main:
     if: github.ref_name == 'main'
     name: Main
-    uses: primer/.github/.github/workflows/release_with_app.yml@main
-    secrets:
-      npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
-      app-id: ${{ vars.PRIMER_APP_ID_SHARED }}
-      private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
-      client-id: ${{ vars.PRIMER_APP_CLIENT_ID_SHARED }}
-      client-secret: ${{ secrets.PRIMER_APP_CLIENT_SECRET_SHARED }}
-      installation-id: ${{ vars.PRIMER_APP_INSTALLATION_ID_SHARED }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create release pull request or publish to npm
+        id: changesets
+        # Uses SHA for security hardening
+        # Currently pointing at a commit for the v1.4.1 tag
+        # Please keep this up-to-date if you're changing the SHA below
+        uses: changesets/action@f13b1baaa620fde937751f5d2c3572b9da32af23
+        with:
+          title: Release tracking
+          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          publish: npm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.gh_token }}
+          NPM_TOKEN: ${{ secrets.npm_token }}
 
   release-next-major:
     if: github.ref_name == 'next-major'

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -10,10 +10,61 @@ jobs:
   release-candidate:
     if: github.ref_name == 'changeset-release/main'
     name: Candidate (@next)
-    uses: primer/.github/.github/workflows/release_candidate.yml@main
+    runs-on: ubuntu-latest
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Create .npmrc
+        run: |
+          registry="//registry.npmjs.org/"
+          cat << EOF > "$HOME/.npmrc"
+            $registry:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.npm_token }}
+
+      - name: Publish release candidate
+        run: |
+          pkg_json_path=packages/react/package.json
+          version=$(jq -r .version $pkg_json_path)
+          echo "$( jq ".version = \"$(echo $version)-rc.$(git rev-parse --short HEAD)\"" $pkg_json_path )" > $pkg_json_path
+          npx changeset publish --tag next
+        env:
+          GITHUB_TOKEN: ${{ secrets.gh_token }}
+
+      - name: Output candidate version
+        uses: actions/github-script@v4.0.2
+        with:
+          script: |
+            const package = require(`${process.env.GITHUB_WORKSPACE}/packages/react/package.json`)
+            github.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'success',
+              context: `Published ${package.name}`,
+              description: package.version,
+              target_url: `https://unpkg.com/${package.name}@${package.version}/`
+            })
 
   release-candidate-next-major:
     if: github.ref_name == 'changeset-release/next-major'


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update our `release` and `release_candidate` workflows to work with the new monorepo structure. Unfortunately, this means that we inline the shared workflows in order to unblock the current release. In the future, we can move to a shared workflow that works with multiple packages with the built-in `changesets` functionality

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `release.yml` with logic from shared workflow
- Update `release_canary.yml` with logic from shared workflow

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

Sadly I think we can only test this out during the release 😞 In the interim, we should scan through the code in this PR to confirm that:

- [ ] the version for the pre-release will no longer be `null`
- [ ] there are no more reference to workflow inputs
- [ ] all secrets are accounted for and included