### PR TITLE
Add 36.9.0 to changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # @primer/components
 
+## 36.9.0
+
+### Minor Changes
+
+-   [#4250](https://github.com/primer/react/pull/4250) [`f064534bf6f15261a3b381ce1f7b3828daf98c84`](https://github.com/primer/react/commit/f064534bf6f15261a3b381ce1f7b3828daf98c84) Thanks [@broccolinisoup](https://github.com/broccolinisoup)! - Add a new entry point 'next' and export the Tooltip v2 from it with an updated documentation
+
+-   [#4214](https://github.com/primer/react/pull/4214) [`3dd498e6a7c28a1ec39b56912f76579f6674e022`](https://github.com/primer/react/commit/3dd498e6a7c28a1ec39b56912f76579f6674e022) Thanks [@langermank](https://github.com/langermank)! - Dialog component: add new `position` prop to support fullscreen and bottom sheets on narrow screens
+
+-   [#4236](https://github.com/primer/react/pull/4236) [`14a2776f18cf8f4a360b1887db64f8d5e904bc9d`](https://github.com/primer/react/commit/14a2776f18cf8f4a360b1887db64f8d5e904bc9d) Thanks [@joshblack](https://github.com/joshblack)! - Refactor project to avoid circular dependencies
+
+### Patch Changes
+
+-   [#4199](https://github.com/primer/react/pull/4199) [`b6e58079a1517d2f1d31098b4e484b94625deabd`](https://github.com/primer/react/commit/b6e58079a1517d2f1d31098b4e484b94625deabd) Thanks [@siddharthkp](https://github.com/siddharthkp)! - experimental/SelectPanel: Improve keyboard navigation from search input
+
+-   [#4200](https://github.com/primer/react/pull/4200) [`dc988141216b91561a0ea0943b2cbff03be95029`](https://github.com/primer/react/commit/dc988141216b91561a0ea0943b2cbff03be95029) Thanks [@broccolinisoup](https://github.com/broccolinisoup)! - Tooltip v2: Allow external id to be passed down in tooltip so that the trigger can be labelled/described by the that id
+
+-   [#4246](https://github.com/primer/react/pull/4246) [`2aced1c61f26513ef2f7a5a4d05485c6fe7ec1ff`](https://github.com/primer/react/commit/2aced1c61f26513ef2f7a5a4d05485c6fe7ec1ff) Thanks [@siddharthkp](https://github.com/siddharthkp)! - Dialog v1: Fix font-family for title
+
+-   [#4265](https://github.com/primer/react/pull/4265) [`19c716f7f1ec44f1f1ee4a135b828208f2be058a`](https://github.com/primer/react/commit/19c716f7f1ec44f1f1ee4a135b828208f2be058a) Thanks [@siddharthkp](https://github.com/siddharthkp)! - SelectPanel2: Submit panel when an item is selected with `Enter` key
+
+-   [#4166](https://github.com/primer/react/pull/4166) [`c66b808cbefdbdd7482be752e5d311d2db4d23d8`](https://github.com/primer/react/commit/c66b808cbefdbdd7482be752e5d311d2db4d23d8) Thanks [@pksjce](https://github.com/pksjce)! - Fix focus styles in ActionList Item to support more than focus-visible
+
+-   [#4259](https://github.com/primer/react/pull/4259) [`c9fbef6438131cf358e2eaff3d866cf4398e622c`](https://github.com/primer/react/commit/c9fbef6438131cf358e2eaff3d866cf4398e622c) Thanks [@siddharthkp](https://github.com/siddharthkp)! - ActionList: Prevent scroll when an item is selected with `Space`
+
+-   [#4245](https://github.com/primer/react/pull/4245) [`d79a419116ea9e669c1ce598144a4b61ae15c52d`](https://github.com/primer/react/commit/d79a419116ea9e669c1ce598144a4b61ae15c52d) Thanks [@siddharthkp](https://github.com/siddharthkp)! - experimental/SelectPanel: Automatically adjust height based on contents
+
+-   [#4204](https://github.com/primer/react/pull/4204) [`da4469d9d958733e1b1dd32d6cd1a1bd0661ff91`](https://github.com/primer/react/commit/da4469d9d958733e1b1dd32d6cd1a1bd0661ff91) Thanks [@dylanatsmith](https://github.com/dylanatsmith)! - Increase Tooltip border-radius to match Primer View Components
+
+-   [#4205](https://github.com/primer/react/pull/4205) [`ff354604f70fc900cb79fe4c58eaee541a813d9f`](https://github.com/primer/react/commit/ff354604f70fc900cb79fe4c58eaee541a813d9f) Thanks [@pablonete](https://github.com/pablonete)! - Bugfix: Dialog.Header ignored the sx provided
+
+
 ## 36.7.1
 
 ### Patch Changes


### PR DESCRIPTION
Sync https://github.com/primer/react/releases/tag/%40primer%2Freact%4036.9.0 with changelog.md

We don't usually do this manually, only this one time when the tooling got confused.