### PR TITLE
Tooltip: Take the `position:absolute` back and make sure the v1 and v2 ids are same for new docs

### DIFF
--- a/.changeset/tall-spiders-pay.md
+++ b/.changeset/tall-spiders-pay.md
@@ -2,4 +2,4 @@
 '@primer/react': major
 ---
 
-Tooltip: Take position:absolute back that was introduced in https://github.com/primer/react/pull/4250 since causing flickering issues
+Tooltip: Take position:absolute back that was introduced in https://github.com/primer/react/pull/4250 since causing flickering issues and update v2 id to be the same with v1 for the new docs site.

--- a/.changeset/tall-spiders-pay.md
+++ b/.changeset/tall-spiders-pay.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': major
+---
+
+Tooltip: Take position:absolute back that was introduced in https://github.com/primer/react/pull/4250 since causing flickering issues

--- a/.changeset/tall-spiders-pay.md
+++ b/.changeset/tall-spiders-pay.md
@@ -1,5 +1,5 @@
 ---
-'@primer/react': major
+'@primer/react': patch
 ---
 
 Tooltip: Take position:absolute back that was introduced in https://github.com/primer/react/pull/4250 since causing flickering issues and update v2 id to be the same with v1 for the new docs site.

--- a/docs/content/TooltipV2.mdx
+++ b/docs/content/TooltipV2.mdx
@@ -1,5 +1,5 @@
 ---
-componentId: tooltip_v2
+componentId: tooltip
 title: Tooltip v2
 status: Beta
 a11yReviewed: true

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -44,12 +44,10 @@ const StyledTooltip = styled.div`
   }
   /* class name in chrome is :popover-open */
   &[popover]:popover-open {
-    position: absolute;
     display: block;
   }
   /* class name in firefox and safari is \:popover-open */
   &[popover].\\:popover-open {
-    position: absolute;
     display: block;
   }
 

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -23,7 +23,6 @@ const StyledTooltip = styled.div`
   /* Overriding the default popover styles */
   display: none;
   &[popover] {
-    position: absolute;
     padding: 0.5em 0.75em;
     width: max-content;
     margin: auto;
@@ -45,10 +44,12 @@ const StyledTooltip = styled.div`
   }
   /* class name in chrome is :popover-open */
   &[popover]:popover-open {
+    position: absolute;
     display: block;
   }
   /* class name in firefox and safari is \:popover-open */
   &[popover].\\:popover-open {
+    position: absolute;
     display: block;
   }
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

`position:absolute` on the tooltip element was introduced to in https://github.com/primer/react/pull/4250 to fix an issue on the [Tooltip V2 react docs](https://primer-c47bc7bb55-13348165.drafts.github.io/TooltipV2) (tooltip is not visible) but it ended up causing a problem at dotcom (specifically memex), flickering and shifting when the tooltip appears. Without this change, everything except [the docs](https://primer-c47bc7bb55-13348165.drafts.github.io/TooltipV2) is working fine. I think the issue is not on the tooltip but on docs, maybe? I'd like to take this change back to unblock the version upgrade and can look into further later. Though, all react docs is going to be migrated over to the new docs and the way that examples are rendered differently (from stories) on the new site so I'll see if the same issue persistent on the new docs first.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

- Updated the tooltip v2's id to be the same as v1 for consolidation on the new docs site
<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->
- Removed `position: absolute` from the tooltip element.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Can view the stories and make sure the tooltip appears correctly
- Unfortunately, (as far as I know) there is no way of testing docs changes in the new site until the release is out

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
