### PR TITLE
experimental/SelectPanel: Recalculate position when panel opens

### DIFF
--- a/.changeset/curvy-fireants-promise.md
+++ b/.changeset/curvy-fireants-promise.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+experimental/SelectPanel: Fix anchored position inside a Dialog

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.examples.stories.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.examples.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import {SelectPanel} from './SelectPanel'
 import {ActionList, ActionMenu, Avatar, Box, Button, Text} from '../../index'
-import {ArrowRightIcon, EyeIcon, GitBranchIcon, TriangleDownIcon, GearIcon} from '@primer/octicons-react'
+import {Dialog} from '../../drafts'
+import {ArrowRightIcon, EyeIcon, GitBranchIcon, TriangleDownIcon, GearIcon, TagIcon} from '@primer/octicons-react'
 import data from './mock-story-data'
 
 export default {
@@ -661,6 +662,47 @@ export const ShortSelectPanel = () => {
         </ActionList>
         <SelectPanel.Footer />
       </SelectPanel>
+    </>
+  )
+}
+
+export const InsideSidebar = () => {
+  const [selectedTag, setSelectedTag] = React.useState<string>()
+  const [sidebarOpen, setSidebarOpen] = React.useState(false)
+
+  return (
+    <>
+      <h1>Opening SelectPanel inside a sidebar</h1>
+
+      <Button onClick={() => setSidebarOpen(true)}>Open sidebar</Button>
+      {sidebarOpen && (
+        <Dialog position="right" title="Sidebar" onClose={() => setSidebarOpen(false)}>
+          <Box p={3}>
+            <SelectPanel
+              title="Choose a tag"
+              selectionVariant="instant"
+              onSubmit={() => {
+                if (!selectedTag) return
+                data.ref = selectedTag // pretending to persist changes
+              }}
+            >
+              <SelectPanel.Button leadingVisual={TagIcon}>{selectedTag || 'Choose a tag'}</SelectPanel.Button>
+
+              <ActionList>
+                {data.tags.map(tag => (
+                  <ActionList.Item
+                    key={tag.id}
+                    onSelect={() => setSelectedTag(tag.id)}
+                    selected={selectedTag === tag.id}
+                  >
+                    {tag.name}
+                  </ActionList.Item>
+                ))}
+              </ActionList>
+            </SelectPanel>
+          </Box>
+        </Dialog>
+      )}
     </>
   )
 }

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -203,7 +203,7 @@ const Panel: React.FC<SelectPanelProps> = ({
       side: 'outside-bottom',
       align: 'start',
     },
-    [anchorRef.current, dialogRef.current],
+    [internalOpen, anchorRef.current, dialogRef.current],
   )
 
   /* 


### PR DESCRIPTION
| Before | After |
|--------|--------|
| Panel is not positioned correctly inside a Dialog | Panel is positioned correctly inside a Dialog |
| <img width="300" alt="Panel is not positioned correctly inside another Dialog" src="https://github.com/primer/react/assets/1863771/c1c8bb87-14ed-4afd-89cf-25b6079890b1"> | <img width="300" alt="Panel is positioned correctly" src="https://github.com/primer/react/assets/1863771/5610b695-961c-41a6-a46d-eac458998ea9"> |

It's a one line change :)

When SelectPanel is inside a component that's not already on the screen, the position is calculated while the parent element is still animating in. This can be fixed easily by forcing a re-calculation when the dialog is opened

```diff
const {position} = useAnchoredPosition(
    settings,
-   [anchorRef.current, dialogRef.current],
+   [internalOpen, anchorRef.current, dialogRef.current],
  )
```