### PR TITLE
Focus-visible `ActionMenu` link fix

### DIFF
--- a/.changeset/fluffy-pugs-care.md
+++ b/.changeset/fluffy-pugs-care.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Switches focus styles to target `a.focus-visible` instead of `a:focus-visible`.

--- a/packages/react/src/ActionList/Item.tsx
+++ b/packages/react/src/ActionList/Item.tsx
@@ -174,7 +174,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
           color: getVariantStyles(variant, disabled, inactive).hoverColor,
           boxShadow: `inset 0 0 0 max(1px, 0.0625rem) ${theme?.colors.actionListItem.default.activeBorder}`,
         },
-        '&:focus-visible, > a:focus-visible, &:focus.focus-visible': {
+        '&:focus-visible, > a.focus-visible, &:focus.focus-visible': {
           outline: 'none',
           border: `2 solid`,
           boxShadow: `0 0 0 2px ${theme?.colors.accent.emphasis}`,

--- a/packages/react/src/ActionList/Item.tsx
+++ b/packages/react/src/ActionList/Item.tsx
@@ -186,7 +186,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       },
 
       '@media (forced-colors: active)': {
-        ':focus, &:focus-visible, > a:focus-visible': {
+        ':focus, &:focus-visible, > a.focus-visible': {
           // Support for Windows high contrast https://sarahmhigley.com/writing/whcm-quick-tips
           outline: 'solid 1px transparent !important',
         },

--- a/packages/react/src/ActionMenu/ActionMenu.examples.stories.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.examples.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Box, ActionMenu, ActionList, Button, IconButton} from '../'
+import {Box, ActionMenu, ActionList, Button, IconButton, FormControl, TextInput} from '../'
 import {
   GearIcon,
   MilestoneIcon,
@@ -184,6 +184,15 @@ export const ShortcutMenu = () => {
       <br />
 
       {/**
+       * This is used to demonstrate mouse/keyboard modality
+       * and how it might affect `:focus-visible` styles in the menu.
+       */}
+      <FormControl>
+        <FormControl.Label>Default label</FormControl.Label>
+        <TextInput />
+      </FormControl>
+
+      {/**
        * Even though the state is controlled externally,
        * we can pass an Anchor for the menu to "anchor to"
        */}
@@ -209,6 +218,7 @@ export const ShortcutMenu = () => {
               Edit comment
               <ActionList.TrailingVisual>⌘E</ActionList.TrailingVisual>
             </ActionList.Item>
+            <ActionList.LinkItem href="#">View file</ActionList.LinkItem>
             <ActionList.Divider />
             <ActionList.Item variant="danger">
               Delete file

--- a/packages/react/src/NavList/__snapshots__/NavList.test.tsx.snap
+++ b/packages/react/src/NavList/__snapshots__/NavList.test.tsx.snap
@@ -261,7 +261,7 @@ exports[`NavList renders a simple list 1`] = `
   }
 
   .c2:focus-visible,
-  .c2 > a:focus-visible,
+  .c2 > a.focus-visible,
   .c2:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -277,7 +277,7 @@ exports[`NavList renders a simple list 1`] = `
 @media (forced-colors:active) {
   .c2:focus,
   .c2:focus-visible,
-  .c2 > a:focus-visible {
+  .c2 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -290,7 +290,7 @@ exports[`NavList renders a simple list 1`] = `
   }
 
   .c7:focus-visible,
-  .c7 > a:focus-visible,
+  .c7 > a.focus-visible,
   .c7:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -306,7 +306,7 @@ exports[`NavList renders a simple list 1`] = `
 @media (forced-colors:active) {
   .c7:focus,
   .c7:focus-visible,
-  .c7 > a:focus-visible {
+  .c7 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -691,7 +691,7 @@ exports[`NavList renders with groups 1`] = `
   }
 
   .c6:focus-visible,
-  .c6 > a:focus-visible,
+  .c6 > a.focus-visible,
   .c6:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -707,7 +707,7 @@ exports[`NavList renders with groups 1`] = `
 @media (forced-colors:active) {
   .c6:focus,
   .c6:focus-visible,
-  .c6 > a:focus-visible {
+  .c6 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -720,7 +720,7 @@ exports[`NavList renders with groups 1`] = `
   }
 
   .c11:focus-visible,
-  .c11 > a:focus-visible,
+  .c11 > a.focus-visible,
   .c11:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -736,7 +736,7 @@ exports[`NavList renders with groups 1`] = `
 @media (forced-colors:active) {
   .c11:focus,
   .c11:focus-visible,
-  .c11 > a:focus-visible {
+  .c11 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -1162,7 +1162,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
   }
 
   .c11:focus-visible,
-  .c11 > a:focus-visible,
+  .c11 > a.focus-visible,
   .c11:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -1178,7 +1178,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
 @media (forced-colors:active) {
   .c11:focus,
   .c11:focus-visible,
-  .c11 > a:focus-visible {
+  .c11 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -1191,7 +1191,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
   }
 
   .c4:focus-visible,
-  .c4 > a:focus-visible,
+  .c4 > a.focus-visible,
   .c4:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -1207,7 +1207,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
 @media (forced-colors:active) {
   .c4:focus,
   .c4:focus-visible,
-  .c4 > a:focus-visible {
+  .c4 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -1647,7 +1647,7 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
   }
 
   .c11:focus-visible,
-  .c11 > a:focus-visible,
+  .c11 > a.focus-visible,
   .c11:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -1663,7 +1663,7 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
 @media (forced-colors:active) {
   .c11:focus,
   .c11:focus-visible,
-  .c11 > a:focus-visible {
+  .c11 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -1684,7 +1684,7 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
   }
 
   .c4:focus-visible,
-  .c4 > a:focus-visible,
+  .c4 > a.focus-visible,
   .c4:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -1700,7 +1700,7 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
 @media (forced-colors:active) {
   .c4:focus,
   .c4:focus-visible,
-  .c4 > a:focus-visible {
+  .c4 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }

--- a/packages/react/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -771,7 +771,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
   }
 
   .c3:focus-visible,
-  .c3 > a:focus-visible,
+  .c3 > a.focus-visible,
   .c3:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -787,7 +787,7 @@ exports[`snapshots renders a menu that contains an item to add to the menu 1`] =
 @media (forced-colors:active) {
   .c3:focus,
   .c3:focus-visible,
-  .c3 > a:focus-visible {
+  .c3 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -1524,7 +1524,7 @@ exports[`snapshots renders a multiselect input 1`] = `
   }
 
   .c3:focus-visible,
-  .c3 > a:focus-visible,
+  .c3 > a.focus-visible,
   .c3:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -1540,7 +1540,7 @@ exports[`snapshots renders a multiselect input 1`] = `
 @media (forced-colors:active) {
   .c3:focus,
   .c3:focus-visible,
-  .c3 > a:focus-visible {
+  .c3 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -2336,7 +2336,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
   }
 
   .c3:focus-visible,
-  .c3 > a:focus-visible,
+  .c3 > a.focus-visible,
   .c3:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -2352,7 +2352,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
 @media (forced-colors:active) {
   .c3:focus,
   .c3:focus-visible,
-  .c3 > a:focus-visible {
+  .c3 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -2365,7 +2365,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
   }
 
   .c8:focus-visible,
-  .c8 > a:focus-visible,
+  .c8 > a.focus-visible,
   .c8:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -2381,7 +2381,7 @@ exports[`snapshots renders a multiselect input with selected menu items 1`] = `
 @media (forced-colors:active) {
   .c8:focus,
   .c8:focus-visible,
-  .c8 > a:focus-visible {
+  .c8 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -3015,7 +3015,7 @@ exports[`snapshots renders a single select input 1`] = `
   }
 
   .c3:focus-visible,
-  .c3 > a:focus-visible,
+  .c3 > a.focus-visible,
   .c3:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -3031,7 +3031,7 @@ exports[`snapshots renders a single select input 1`] = `
 @media (forced-colors:active) {
   .c3:focus,
   .c3:focus-visible,
-  .c3 > a:focus-visible {
+  .c3 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }
@@ -3471,7 +3471,7 @@ exports[`snapshots renders with a custom text input component 1`] = `
   }
 
   .c3:focus-visible,
-  .c3 > a:focus-visible,
+  .c3 > a.focus-visible,
   .c3:focus.focus-visible {
     outline: none;
     border: 2 solid;
@@ -3487,7 +3487,7 @@ exports[`snapshots renders with a custom text input component 1`] = `
 @media (forced-colors:active) {
   .c3:focus,
   .c3:focus-visible,
-  .c3 > a:focus-visible {
+  .c3 > a.focus-visible {
     outline: solid 1px transparent !important;
   }
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This fix continues from #4166, but changes the selector for links to target the class instead of `:focus-visible` pseudo selector. This is because, if the input modality isn't already keyboard in Safari, `:focus-visible` styles may not be applied, so we need to rely on our `.focus-visible` for now.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->
* Switched pseudo selector target to class selector (i.e. `a:focus-visible` to `a.focus-visible`)
* Added onto `ActionMenu` Storybook example

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
