### PR TITLE
experimental/SelectPanel: Only render children when open

### DIFF
--- a/.changeset/fair-cooks-return.md
+++ b/.changeset/fair-cooks-return.md
@@ -2,4 +2,4 @@
 "@primer/react": patch
 ---
 
-experimental/SelectPanel: Only render dialog in the dom when it is open
+experimental/SelectPanel: Do not render closed `<dialog>` in the dom

--- a/.changeset/fair-cooks-return.md
+++ b/.changeset/fair-cooks-return.md
@@ -2,4 +2,4 @@
 "@primer/react": patch
 ---
 
-experimental/SelectPanel: Do not render closed `<dialog>` in the dom
+experimental/SelectPanel: Do not render children of `<dialog>` when closed

--- a/.changeset/fair-cooks-return.md
+++ b/.changeset/fair-cooks-return.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+experimental/SelectPanel: Only render dialog in the dom when it is open

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -216,89 +216,91 @@ const Panel: React.FC<SelectPanelProps> = ({
     <>
       {Anchor}
 
-      <StyledOverlay
-        as="dialog"
-        ref={dialogRef}
-        aria-labelledby={`${panelId}--title`}
-        aria-describedby={description ? `${panelId}--description` : undefined}
-        width={width}
-        height="fit-content"
-        maxHeight={maxHeight}
-        sx={{
-          '--max-height': heightMap[maxHeight],
-          // reset dialog default styles
-          border: 'none',
-          padding: 0,
-          '&[open]': {display: 'flex'}, // to fit children
+      {internalOpen && (
+        <StyledOverlay
+          as="dialog"
+          ref={dialogRef}
+          aria-labelledby={`${panelId}--title`}
+          aria-describedby={description ? `${panelId}--description` : undefined}
+          width={width}
+          height="fit-content"
+          maxHeight={maxHeight}
+          sx={{
+            '--max-height': heightMap[maxHeight],
+            // reset dialog default styles
+            border: 'none',
+            padding: 0,
+            '&[open]': {display: 'flex'}, // to fit children
 
-          ...(variant === 'anchored' ? {margin: 0, top: position?.top, left: position?.left} : {}),
-          '::backdrop': {backgroundColor: variant === 'anchored' ? 'transparent' : 'primer.canvas.backdrop'},
+            ...(variant === 'anchored' ? {margin: 0, top: position?.top, left: position?.left} : {}),
+            '::backdrop': {backgroundColor: variant === 'anchored' ? 'transparent' : 'primer.canvas.backdrop'},
 
-          '@keyframes selectpanel-gelatine': {
-            '0%': {transform: 'scale(1, 1)'},
-            '25%': {transform: 'scale(0.9, 1.1)'},
-            '50%': {transform: 'scale(1.1, 0.9)'},
-            '75%': {transform: 'scale(0.95, 1.05)'},
-            '100%': {transform: 'scale(1, 1)'},
-          },
-        }}
-        {...props}
-        onClick={event => {
-          if (event.target === event.currentTarget) onClickOutside()
-        }}
-      >
-        <SelectPanelContext.Provider
-          value={{
-            panelId,
-            title,
-            description,
-            onCancel: onInternalCancel,
-            onClearSelection: propsOnClearSelection ? onInternalClearSelection : undefined,
-            searchQuery,
-            setSearchQuery,
-            selectionVariant,
-            moveFocusToList,
+            '@keyframes selectpanel-gelatine': {
+              '0%': {transform: 'scale(1, 1)'},
+              '25%': {transform: 'scale(0.9, 1.1)'},
+              '50%': {transform: 'scale(1.1, 0.9)'},
+              '75%': {transform: 'scale(0.95, 1.05)'},
+              '100%': {transform: 'scale(1, 1)'},
+            },
+          }}
+          {...props}
+          onClick={event => {
+            if (event.target === event.currentTarget) onClickOutside()
           }}
         >
-          <Box
-            as="form"
-            method="dialog"
-            onSubmit={onInternalSubmit}
-            sx={{display: 'flex', flexDirection: 'column', width: '100%'}}
+          <SelectPanelContext.Provider
+            value={{
+              panelId,
+              title,
+              description,
+              onCancel: onInternalCancel,
+              onClearSelection: propsOnClearSelection ? onInternalClearSelection : undefined,
+              searchQuery,
+              setSearchQuery,
+              selectionVariant,
+              moveFocusToList,
+            }}
           >
-            {slots.header ?? /* render default header as fallback */ <SelectPanelHeader />}
-
             <Box
-              as="div"
-              ref={listContainerRef as React.RefObject<HTMLDivElement>}
-              sx={{
-                flexShrink: 1,
-                flexGrow: 1,
-                overflow: 'hidden',
-
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'space-between',
-                ul: {overflowY: 'auto', flexGrow: 1},
-              }}
+              as="form"
+              method="dialog"
+              onSubmit={onInternalSubmit}
+              sx={{display: 'flex', flexDirection: 'column', width: '100%'}}
             >
-              <ActionListContainerContext.Provider
-                value={{
-                  container: 'SelectPanel',
-                  listRole: 'listbox',
-                  selectionAttribute: 'aria-selected',
-                  selectionVariant: selectionVariant === 'instant' ? 'single' : selectionVariant,
-                  afterSelect: internalAfterSelect,
-                  listLabelledBy: `${panelId}--title`,
+              {slots.header ?? /* render default header as fallback */ <SelectPanelHeader />}
+
+              <Box
+                as="div"
+                ref={listContainerRef as React.RefObject<HTMLDivElement>}
+                sx={{
+                  flexShrink: 1,
+                  flexGrow: 1,
+                  overflow: 'hidden',
+
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'space-between',
+                  ul: {overflowY: 'auto', flexGrow: 1},
                 }}
               >
-                {childrenInBody}
-              </ActionListContainerContext.Provider>
+                <ActionListContainerContext.Provider
+                  value={{
+                    container: 'SelectPanel',
+                    listRole: 'listbox',
+                    selectionAttribute: 'aria-selected',
+                    selectionVariant: selectionVariant === 'instant' ? 'single' : selectionVariant,
+                    afterSelect: internalAfterSelect,
+                    listLabelledBy: `${panelId}--title`,
+                  }}
+                >
+                  {childrenInBody}
+                </ActionListContainerContext.Provider>
+              </Box>
+              {slots.footer}
             </Box>
-            {slots.footer}
-          </Box>
-        </SelectPanelContext.Provider>
-      </StyledOverlay>
+          </SelectPanelContext.Provider>
+        </StyledOverlay>
+      )}
     </>
   )
 }

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -216,91 +216,93 @@ const Panel: React.FC<SelectPanelProps> = ({
     <>
       {Anchor}
 
-      {internalOpen && (
-        <StyledOverlay
-          as="dialog"
-          ref={dialogRef}
-          aria-labelledby={`${panelId}--title`}
-          aria-describedby={description ? `${panelId}--description` : undefined}
-          width={width}
-          height="fit-content"
-          maxHeight={maxHeight}
-          sx={{
-            '--max-height': heightMap[maxHeight],
-            // reset dialog default styles
-            border: 'none',
-            padding: 0,
-            '&[open]': {display: 'flex'}, // to fit children
+      <StyledOverlay
+        as="dialog"
+        ref={dialogRef}
+        aria-labelledby={`${panelId}--title`}
+        aria-describedby={description ? `${panelId}--description` : undefined}
+        width={width}
+        height="fit-content"
+        maxHeight={maxHeight}
+        sx={{
+          '--max-height': heightMap[maxHeight],
+          // reset dialog default styles
+          border: 'none',
+          padding: 0,
+          '&[open]': {display: 'flex'}, // to fit children
 
-            ...(variant === 'anchored' ? {margin: 0, top: position?.top, left: position?.left} : {}),
-            '::backdrop': {backgroundColor: variant === 'anchored' ? 'transparent' : 'primer.canvas.backdrop'},
+          ...(variant === 'anchored' ? {margin: 0, top: position?.top, left: position?.left} : {}),
+          '::backdrop': {backgroundColor: variant === 'anchored' ? 'transparent' : 'primer.canvas.backdrop'},
 
-            '@keyframes selectpanel-gelatine': {
-              '0%': {transform: 'scale(1, 1)'},
-              '25%': {transform: 'scale(0.9, 1.1)'},
-              '50%': {transform: 'scale(1.1, 0.9)'},
-              '75%': {transform: 'scale(0.95, 1.05)'},
-              '100%': {transform: 'scale(1, 1)'},
-            },
-          }}
-          {...props}
-          onClick={event => {
-            if (event.target === event.currentTarget) onClickOutside()
-          }}
-        >
-          <SelectPanelContext.Provider
-            value={{
-              panelId,
-              title,
-              description,
-              onCancel: onInternalCancel,
-              onClearSelection: propsOnClearSelection ? onInternalClearSelection : undefined,
-              searchQuery,
-              setSearchQuery,
-              selectionVariant,
-              moveFocusToList,
-            }}
-          >
-            <Box
-              as="form"
-              method="dialog"
-              onSubmit={onInternalSubmit}
-              sx={{display: 'flex', flexDirection: 'column', width: '100%'}}
+          '@keyframes selectpanel-gelatine': {
+            '0%': {transform: 'scale(1, 1)'},
+            '25%': {transform: 'scale(0.9, 1.1)'},
+            '50%': {transform: 'scale(1.1, 0.9)'},
+            '75%': {transform: 'scale(0.95, 1.05)'},
+            '100%': {transform: 'scale(1, 1)'},
+          },
+        }}
+        {...props}
+        onClick={event => {
+          if (event.target === event.currentTarget) onClickOutside()
+        }}
+      >
+        {internalOpen && (
+          <>
+            <SelectPanelContext.Provider
+              value={{
+                panelId,
+                title,
+                description,
+                onCancel: onInternalCancel,
+                onClearSelection: propsOnClearSelection ? onInternalClearSelection : undefined,
+                searchQuery,
+                setSearchQuery,
+                selectionVariant,
+                moveFocusToList,
+              }}
             >
-              {slots.header ?? /* render default header as fallback */ <SelectPanelHeader />}
-
               <Box
-                as="div"
-                ref={listContainerRef as React.RefObject<HTMLDivElement>}
-                sx={{
-                  flexShrink: 1,
-                  flexGrow: 1,
-                  overflow: 'hidden',
-
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'space-between',
-                  ul: {overflowY: 'auto', flexGrow: 1},
-                }}
+                as="form"
+                method="dialog"
+                onSubmit={onInternalSubmit}
+                sx={{display: 'flex', flexDirection: 'column', width: '100%'}}
               >
-                <ActionListContainerContext.Provider
-                  value={{
-                    container: 'SelectPanel',
-                    listRole: 'listbox',
-                    selectionAttribute: 'aria-selected',
-                    selectionVariant: selectionVariant === 'instant' ? 'single' : selectionVariant,
-                    afterSelect: internalAfterSelect,
-                    listLabelledBy: `${panelId}--title`,
+                {slots.header ?? /* render default header as fallback */ <SelectPanelHeader />}
+
+                <Box
+                  as="div"
+                  ref={listContainerRef as React.RefObject<HTMLDivElement>}
+                  sx={{
+                    flexShrink: 1,
+                    flexGrow: 1,
+                    overflow: 'hidden',
+
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'space-between',
+                    ul: {overflowY: 'auto', flexGrow: 1},
                   }}
                 >
-                  {childrenInBody}
-                </ActionListContainerContext.Provider>
+                  <ActionListContainerContext.Provider
+                    value={{
+                      container: 'SelectPanel',
+                      listRole: 'listbox',
+                      selectionAttribute: 'aria-selected',
+                      selectionVariant: selectionVariant === 'instant' ? 'single' : selectionVariant,
+                      afterSelect: internalAfterSelect,
+                      listLabelledBy: `${panelId}--title`,
+                    }}
+                  >
+                    {childrenInBody}
+                  </ActionListContainerContext.Provider>
+                </Box>
+                {slots.footer}
               </Box>
-              {slots.footer}
-            </Box>
-          </SelectPanelContext.Provider>
-        </StyledOverlay>
-      )}
+            </SelectPanelContext.Provider>
+          </>
+        )}
+      </StyledOverlay>
     </>
   )
 }


### PR DESCRIPTION
By default a `<dialog>` renders as `open="false"`, but it does exist in the dom. This can be unintuitive in the react paradigm where you expect dialog to not be rendered in the dom until it's visible.

Places where this shows up: 
1. Data fetching: Data that is meant to be fetched only when the Dialog is open might be fetched early
2. Testing: When there are multiple dialogs on the page, unless you are more specific, getting element by role dialog returns the first dialog, not the open dialog. `screen.getByRole('dialog')`
3. Imperative code: When there are multiple dialogs on the page, querySelector for dialog would return the first dialog, not necessarily the open dialog.

Before:

```html
<!-- closed state: -->
<button type="button" aria-haspopup="true" aria-expanded="false"></button>
<dialog></dialog>
```
```html
<!-- open state -->
<button type="button" aria-haspopup="true" aria-expanded="true"></button>
<dialog open></dialog>
```

After:

```diff
<!-- closed state: -->
<button type="button" aria-haspopup="true" aria-expanded="false"></button>
- <dialog></dialog>
```
```html
<!-- open state -->
<button type="button" aria-haspopup="true" aria-expanded="true"></button>
<dialog open></dialog>
```