### PR TITLE
Adding aria-invalid="true" to TextInput when error

### DIFF
--- a/.changeset/gold-baboons-live.md
+++ b/.changeset/gold-baboons-live.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Adding aria-invalid="true" to TextInput when error.

--- a/package-lock.json
+++ b/package-lock.json
@@ -448,7 +448,7 @@
     "examples/app-router": {
       "name": "example-app-router",
       "dependencies": {
-        "@primer/react": "36.9.0",
+        "@primer/react": "36.10.0",
         "next": "^14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -530,7 +530,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^18.2.0",
-        "@primer/react": "36.9.0",
+        "@primer/react": "36.10.0",
         "next": "^14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -60327,7 +60327,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "36.9.0",
+      "version": "36.10.0",
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.1.5",

--- a/packages/react/src/TextInput/TextInput.tsx
+++ b/packages/react/src/TextInput/TextInput.tsx
@@ -149,6 +149,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
           aria-required={required}
           {...inputProps}
           data-component="input"
+          aria-invalid={validationStatus === 'error' ? 'true' : undefined}
         />
         <TextInputInnerVisualSlot
           visualPosition="trailing"

--- a/packages/react/src/__tests__/TextInput.test.tsx
+++ b/packages/react/src/__tests__/TextInput.test.tsx
@@ -1,6 +1,6 @@
 import {SearchIcon} from '@primer/octicons-react'
 import userEvent from '@testing-library/user-event'
-import {render as HTMLRender, fireEvent} from '@testing-library/react'
+import {render as HTMLRender, fireEvent, screen} from '@testing-library/react'
 import {axe} from 'jest-axe'
 import React from 'react'
 import {TextInput} from '..'
@@ -37,6 +37,11 @@ describe('TextInput', () => {
 
   it('renders error', () => {
     expect(render(<TextInput name="zipcode" validationStatus="error" />)).toMatchSnapshot()
+  })
+
+  it('renders sets aria-invalid="true" on error', () => {
+    HTMLRender(<TextInput name="zipcode" validationStatus="error" data-testid="zipcodeInput" />)
+    expect(screen.getByTestId('zipcodeInput')).toHaveAttribute('aria-invalid', 'true')
   })
 
   it('renders contrast', () => {

--- a/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -526,6 +526,7 @@ exports[`TextInput renders error 1`] = `
   onClick={[Function]}
 >
   <input
+    aria-invalid="true"
     className="c2"
     data-component="input"
     name="zipcode"


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3076

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

When `validationStatus` is of type `error` add the aria-invalid attribute to the rendered text input.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
