### PR TITLE
Remove redundant aria-label attribute from TextInput.Action

### DIFF
--- a/.changeset/mighty-pears-deny.md
+++ b/.changeset/mighty-pears-deny.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+TextInput: Remove redundant `aria-label` attribute from `TextInput.Action` when it already has an `aria-labelledby`.

--- a/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -2177,7 +2177,6 @@ exports[`TextInput renders trailingAction icon button 1`] = `
     className="c3 TextInput-action"
   >
     <button
-      aria-label="Icon label"
       aria-labelledby=":r1:"
       className="c4"
       data-block={null}

--- a/packages/react/src/internal/components/TextInputInnerAction.tsx
+++ b/packages/react/src/internal/components/TextInputInnerAction.tsx
@@ -96,17 +96,8 @@ const TextInputAction = forwardRef<HTMLButtonElement, TextInputActionProps>(
       <Box as="span" className="TextInput-action" marginLeft={1} marginRight={1} lineHeight="0">
         {icon && !children ? (
           <Tooltip direction={tooltipDirection ?? 's'} text={ariaLabel ?? ''} type="label">
-            <IconButton
-              variant={variant}
-              type="button"
-              icon={icon}
-              size="small"
-              sx={sx}
-              {...rest}
-              aria-label={ariaLabel as unknown as string}
-              aria-labelledby={undefined}
-              ref={forwardedRef}
-            />
+            {/* @ts-ignore we intentionally do add aria-label to IconButton because Tooltip v2 adds an aria-labelledby instead. */}
+            <IconButton variant={variant} type="button" icon={icon} size="small" sx={sx} {...rest} ref={forwardedRef} />
           </Tooltip>
         ) : (
           <ConditionalTooltip aria-label={ariaLabel}>


### PR DESCRIPTION
- Companion to https://github.com/primer/react/pull/4097
- In TextInput.Action, button element has an `aria-label` attribute + Tooltip v2 adds `aria-labelledby` to the same element, which fails [validation rules from Tooltip v2](https://github.com/primer/react/blob/main/packages/react/src/TooltipV2/Tooltip.tsx#L229-L232)
- We can remove Tooltip completely after https://github.com/primer/react/pull/4224