### PR TITLE
ActionBar: Overflow menu items should be able to trigger dialogs

### DIFF
--- a/.changeset/beige-crews-flow.md
+++ b/.changeset/beige-crews-flow.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+ActionBar: Overflow menu items should be able to trigger dialogs

--- a/packages/react/src/drafts/ActionBar/ActionBar.stories.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.stories.tsx
@@ -13,11 +13,13 @@ import {
   ListUnorderedIcon,
   ListOrderedIcon,
   TasklistIcon,
+  ReplyIcon,
 } from '@primer/octicons-react'
 import {MarkdownInput} from '../MarkdownEditor/_MarkdownInput'
 import {ViewSwitch} from '../MarkdownEditor/_ViewSwitch'
 import type {MarkdownViewMode} from '../MarkdownEditor/_ViewSwitch'
-import {Box} from '../..'
+import {Box, Dialog, Button} from '../..'
+import {Divider} from '../../deprecated/ActionList/Divider'
 
 export default {
   title: 'Drafts/Components/ActionBar',
@@ -59,6 +61,8 @@ export const CommentBox = () => {
     //console.log('loadPreview')
   }, [])
   const [value, setValue] = React.useState('')
+  const [isOpen, setIsOpen] = React.useState(false)
+  const buttonRef = React.useRef(null)
   return (
     <Box
       sx={{
@@ -106,6 +110,12 @@ export const CommentBox = () => {
             <ActionBar.IconButton icon={ListUnorderedIcon} aria-label="Unordered List"></ActionBar.IconButton>
             <ActionBar.IconButton icon={ListOrderedIcon} aria-label="Ordered List"></ActionBar.IconButton>
             <ActionBar.IconButton icon={TasklistIcon} aria-label="Task List"></ActionBar.IconButton>
+            <ActionBar.IconButton
+              ref={buttonRef}
+              onClick={() => setIsOpen(true)}
+              icon={ReplyIcon}
+              aria-label="Saved Replies"
+            ></ActionBar.IconButton>
           </ActionBar>
         </Box>
       </Box>
@@ -122,6 +132,40 @@ export const CommentBox = () => {
         monospace={false}
         pasteUrlsAsPlainText={false}
       />
+      <Dialog aria-labelledby="header" returnFocusRef={buttonRef} isOpen={isOpen} onDismiss={() => setIsOpen(false)}>
+        <Dialog.Header id="header">Select a reply</Dialog.Header>
+        <Box p={3}>Show saved replies</Box>
+        <Divider />
+        <Button variant="invisible">Create your own saved reply</Button>
+      </Dialog>
+    </Box>
+  )
+}
+
+export const ActionBarWithMenuTrigger = () => {
+  const [isOpen, setIsOpen] = React.useState(false)
+  const buttonRef = React.useRef(null)
+
+  return (
+    <Box>
+      <ActionBar>
+        <ActionBar.IconButton icon={BoldIcon} aria-label="Bold"></ActionBar.IconButton>
+        <ActionBar.IconButton icon={ItalicIcon} aria-label="Italic"></ActionBar.IconButton>
+        <ActionBar.IconButton icon={CodeIcon} aria-label="Code"></ActionBar.IconButton>
+        <ActionBar.IconButton
+          ref={buttonRef}
+          onClick={() => setIsOpen(true)}
+          icon={ReplyIcon}
+          aria-label="Saved Replies"
+        ></ActionBar.IconButton>
+      </ActionBar>
+
+      <Dialog aria-labelledby="header" returnFocusRef={buttonRef} isOpen={isOpen} onDismiss={() => setIsOpen(false)}>
+        <Dialog.Header id="header">Select a reply</Dialog.Header>
+        <Box p={3}>Show saved replies</Box>
+        <Divider />
+        <Button variant="invisible">Create your own saved reply</Button>
+      </Dialog>
     </Box>
   )
 }

--- a/packages/react/src/drafts/ActionBar/ActionBar.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.tsx
@@ -280,7 +280,7 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
                     const {
                       children: menuItemChildren,
                       //'aria-current': ariaCurrent,
-                      onSelect,
+                      onClick,
                       icon: Icon,
                       'aria-label': ariaLabel,
                     } = menuItem.props
@@ -293,7 +293,7 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
                         ) => {
                           closeOverlay()
                           focusOnMoreMenuBtn()
-                          typeof onSelect === 'function' && onSelect(event)
+                          typeof onClick === 'function' && onClick(event)
                         }}
                       >
                         {Icon ? (


### PR DESCRIPTION


Closes https://github.com/github/primer/issues/3097


https://github.com/primer/react/assets/417268/80889682-d194-49c0-9977-55852840c012





### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
