### PR TITLE
Tooltip2: Render tooltip element as `span`

### DIFF
--- a/.changeset/wicked-rings-prove.md
+++ b/.changeset/wicked-rings-prove.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Tooltip2: Render tooltip element as `span` instead of `div`

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -19,7 +19,7 @@ const animationStyles = `
   animation-delay: 0s;
 `
 
-const StyledTooltip = styled.div`
+const StyledTooltip = styled.span`
   /* Overriding the default popover styles */
   display: none;
   &[popover] {

--- a/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -2213,7 +2213,7 @@ exports[`TextInput renders trailingAction icon button 1`] = `
         />
       </svg>
     </button>
-    <div
+    <span
       aria-hidden={true}
       className="c5"
       data-direction="s"
@@ -2222,7 +2222,7 @@ exports[`TextInput renders trailingAction icon button 1`] = `
       onMouseLeave={[Function]}
     >
       Icon label
-    </div>
+    </span>
   </span>
 </span>
 `;
@@ -3194,7 +3194,7 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
         </span>
       </span>
     </button>
-    <div
+    <span
       className="c6"
       data-direction="s"
       id=":r0:"
@@ -3203,7 +3203,7 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
       role="tooltip"
     >
       Clear input
-    </div>
+    </span>
   </span>
 </span>
 `;


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Tooltip is rendered as `div` however it ends up creating an invalid nested elements 

`Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.`

([integration test fail](https://github.com/github/github/actions/runs/8165769938/job/22323482587?pr=315110))

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

render tooltip as `span` instead of `div`

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
