### PR TITLE
Bug: `aria-invalid` is overriden in TextInput

### DIFF
--- a/.changeset/grumpy-shirts-march.md
+++ b/.changeset/grumpy-shirts-march.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Bugfix: `aria-invalid` is overriden in TextInput

--- a/packages/react/src/TextInput/TextInput.tsx
+++ b/packages/react/src/TextInput/TextInput.tsx
@@ -147,9 +147,9 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
           onBlur={handleInputBlur}
           type={type}
           aria-required={required}
+          aria-invalid={validationStatus === 'error' ? 'true' : undefined}
           {...inputProps}
           data-component="input"
-          aria-invalid={validationStatus === 'error' ? 'true' : undefined}
         />
         <TextInputInnerVisualSlot
           visualPosition="trailing"

--- a/packages/react/src/__tests__/TextInput.test.tsx
+++ b/packages/react/src/__tests__/TextInput.test.tsx
@@ -232,7 +232,8 @@ describe('TextInput', () => {
   })
 
   it('should not override prop aria-invalid', () => {
-    const {getByRole} = HTMLRender(<TextInput aria-invalid="true" value="" />)
-    expect(getByRole('textinput')).toHaveAttribute('aria-invalid', 'true')
+    const onChange = jest.fn()
+    const {getByRole} = HTMLRender(<TextInput onChange={onChange} aria-invalid="true" value="" />)
+    expect(getByRole('textbox')).toHaveAttribute('aria-invalid', 'true')
   })
 })

--- a/packages/react/src/__tests__/TextInput.test.tsx
+++ b/packages/react/src/__tests__/TextInput.test.tsx
@@ -230,4 +230,9 @@ describe('TextInput', () => {
   it('should render a password input', () => {
     expect(render(<TextInput name="password" type="password" />)).toMatchSnapshot()
   })
+
+  it('should not override prop aria-invalid', () => {
+    const {getByRole} = HTMLRender(<TextInput aria-invalid="true" value="" />)
+    expect(getByRole('textinput')).toHaveAttribute('aria-invalid', 'true')
+  })
 })


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

For release 36.11.0, we see that integration tests are failing. 
If we look closer into https://github.com/github/github/actions/runs/8180619423/job/22369116712?pr=315110
the root cause seems to be that the provided `aria-invalid` prop is being overriden by `TextInput`. This is introduced in https://github.com/primer/react/commit/15c078dda93ae8579a858efcce3b6a2f97204373#diff-02ef2a0d53f758cb1d0e24c286118bae352cfdae3d88635258903638aca68d04

This PR will change the order of the props to fix it. No visual changes.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
