### PR TITLE
eslint: Really enable primer-react/no-system-props

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -238,7 +238,7 @@ module.exports = {
         '@typescript-eslint/no-unnecessary-condition': 'off',
         '@typescript-eslint/no-unused-vars': 'off',
         'primer-react/no-deprecated-colors': ['error', {skipImportCheck: true}],
-        'primer-react/no-system-props': ['warn', {skipImportCheck: true}],
+        'primer-react/no-system-props': ['warn', {skipImportCheck: true, ignoreNames: ['Placeholder']}],
         'no-redeclare': 'off',
         'ssr-friendly/no-dom-globals-in-module-scope': 'off',
         'ssr-friendly/no-dom-globals-in-react-fc': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
       },
     ],
     'primer-react/no-deprecated-colors': ['warn', {checkAllStrings: true}],
+    'primer-react/no-system-props': ['warn', {skipImportCheck: true}],
 
     // Overrides from updating plugin:github
     'filenames/match-regex': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -192,7 +192,7 @@ module.exports = {
         project: 'tsconfig.json',
       },
       extends: ['plugin:playwright/jest-playwright'],
-      rules: {},
+      rules: {'primer-react/no-system-props': ['warn', {skipImportCheck: true}]},
     },
 
     // rules which apply only to Markdown

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -182,7 +182,9 @@ module.exports = {
     {
       files: ['**/*.stories.{ts,tsx}'],
       extends: ['plugin:storybook/recommended'],
-      rules: {},
+      rules: {
+        'primer-react/no-system-props': ['warn', {skipImportCheck: true, ignoreNames: ['Placeholder']}],
+      },
     },
 
     // e2e tests

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,7 +72,6 @@ module.exports = {
       },
     ],
     'primer-react/no-deprecated-colors': ['warn', {checkAllStrings: true}],
-    'primer-react/no-system-props': ['warn', {skipImportCheck: true}],
 
     // Overrides from updating plugin:github
     'filenames/match-regex': 'off',
@@ -208,6 +207,7 @@ module.exports = {
         'prettier/prettier': 'off',
         'react/jsx-no-undef': 'off',
         'primer-react/direct-slot-children': 'off',
+        'primer-react/no-system-props': ['warn', {skipImportCheck: true}],
       },
     },
 
@@ -238,6 +238,7 @@ module.exports = {
         '@typescript-eslint/no-unnecessary-condition': 'off',
         '@typescript-eslint/no-unused-vars': 'off',
         'primer-react/no-deprecated-colors': ['error', {skipImportCheck: true}],
+        'primer-react/no-system-props': ['warn', {skipImportCheck: true}],
         'no-redeclare': 'off',
         'ssr-friendly/no-dom-globals-in-module-scope': 'off',
         'ssr-friendly/no-dom-globals-in-react-fc': 'off',

--- a/docs/content/AnchoredOverlay.mdx
+++ b/docs/content/AnchoredOverlay.mdx
@@ -39,8 +39,8 @@ See also [Overlay positioning](/Overlay#positioning).
           <p>
             This menu automatically receives a focus trap and focus zone. Use up/down keys to navigate between buttons
           </p>
-          <Button mb={1}>Button 1</Button>
-          <Button mb={1}>Button 2</Button>
+          <Button sx={{mb: 1}}>Button 1</Button>
+          <Button sx={{mb: 1}}>Button 2</Button>
           <Button>Button 3</Button>
         </Box>
       </AnchoredOverlay>

--- a/docs/content/Header.mdx
+++ b/docs/content/Header.mdx
@@ -20,7 +20,7 @@ All items directly under the Header component should be a `Header.Item` componen
 ```jsx live
 <Header>
   <Header.Item>
-    <Header.Link href="#" fontSize={2}>
+    <Header.Link href="#" sx={{fontSize: 2}}>
       <Octicon icon={MarkGithubIcon} size={32} sx={{mr: 2}} />
       <span>GitHub</span>
     </Header.Link>
@@ -37,7 +37,7 @@ All items directly under the Header component should be a `Header.Item` componen
 ```jsx live
 <Header>
   <Header.Item>Item 1</Header.Item>
-  <Header.Item full border={1} borderStyle="solid">
+  <Header.Item full sx={{border: 1, borderStyle: 'solid'}}>
     Item 2
   </Header.Item>
   <Header.Item sx={{mr: 0}}>Item 3</Header.Item>

--- a/docs/content/PointerBox.mdx
+++ b/docs/content/PointerBox.mdx
@@ -14,7 +14,7 @@ import DeprecationBanner from '../components/DeprecationBanner'
 ## Examples
 
 ```jsx live
-<PointerBox minHeight={100} sx={{m: 4, p: 2, bg: 'success.subtle', borderColor: 'success.emphasis'}}>
+<PointerBox sx={{m: 4, p: 2, bg: 'success.subtle', borderColor: 'success.emphasis', minHeight: 100}}>
   PointerBox
 </PointerBox>
 ```
@@ -33,9 +33,8 @@ function PointerBoxDemo(props) {
       <CaretSelector current={pos} onChange={setPos} />
       <Box position="relative">
         <PointerBox
-          minHeight={100}
           caret={pos}
-          sx={{m: 4, p: 2, bg: 'success.subtle', borderColor: 'success.emphasis'}}
+          sx={{m: 4, p: 2, bg: 'success.subtle', borderColor: 'success.emphasis', minHeight: 100}}
         >
           Content
         </PointerBox>

--- a/docs/content/SubNav.mdx
+++ b/docs/content/SubNav.mdx
@@ -65,7 +65,7 @@ import DeprecationBanner from '../components/DeprecationBanner'
         </ActionList>
       </ActionMenu.Overlay>
     </ActionMenu>
-    <TextInput type="search" leadingVisual={SearchIcon} width={320} />
+    <TextInput type="search" leadingVisual={SearchIcon} sx={{width: 320}} />
   </FilteredSearch>
   <SubNav.Links>
     <SubNav.Link href="#home" selected>

--- a/docs/content/Timeline.mdx
+++ b/docs/content/Timeline.mdx
@@ -67,7 +67,7 @@ of the child `Octicon` if necessary.
   </Timeline.Item>
   <Timeline.Item>
     <Timeline.Badge sx={{bg: 'danger.emphasis'}}>
-      <Octicon icon={FlameIcon} color="fg.onEmphasis" />
+      <Octicon icon={FlameIcon} sx={{color: 'fg.onEmphasis'}} />
     </Timeline.Badge>
     <Timeline.Body>Background when opened or passed events occur</Timeline.Body>
   </Timeline.Item>
@@ -109,7 +109,7 @@ To create a visual break in the timeline, use Timeline.Break. This adds a horizo
 <Timeline>
   <Timeline.Item>
     <Timeline.Badge sx={{bg: 'danger.emphasis'}}>
-      <Octicon icon={FlameIcon} color="fg.onEmphasis" />
+      <Octicon icon={FlameIcon} sx={{color: 'fg.onEmphasis'}} />
     </Timeline.Badge>
     <Timeline.Body>Background used when closed events occur</Timeline.Body>
   </Timeline.Item>

--- a/docs/content/Timeline.mdx
+++ b/docs/content/Timeline.mdx
@@ -29,7 +29,7 @@ The Timeline.Item component is used to display items on a vertical timeline, con
       created one <Link href="#" sx={{fontWeight: 'bold', color: 'fg.default', mr: 1}} muted>
         hot potato
       </Link>
-      <Link href="#" color="fg.muted" muted>
+      <Link href="#" muted sx={{color: 'fg.muted'}}>
         Just now
       </Link>
     </Timeline.Body>

--- a/docs/content/deprecated/Buttons.mdx
+++ b/docs/content/deprecated/Buttons.mdx
@@ -28,7 +28,7 @@ To create a button group, wrap `Button` elements in the `ButtonGroup` element. `
   <ButtonInvisible>Button invisible</ButtonInvisible>
   <ButtonClose onClick={() => window.alert('button clicked')} />
 
-  <ButtonGroup display="block" my={2}>
+  <ButtonGroup sx={{display: 'block', my: 2}}>
     <Button>Button</Button>
     <Button>Button</Button>
     <Button>Button</Button>

--- a/docs/content/deprecated/SideNav.md
+++ b/docs/content/deprecated/SideNav.md
@@ -37,7 +37,7 @@ Use [NavList](/components/nav-list/react/latest) instead.
 ## Default example
 
 ```jsx live
-<SideNav bordered maxWidth={360} aria-label="Main">
+<SideNav bordered aria-label="Main" sx={{maxWidth: 360}}>
   <SideNav.Link href="#account">
     <Text>Account</Text>
   </SideNav.Link>
@@ -60,12 +60,12 @@ Different kinds of content can be added inside a SideNav item. Use system props 
 Add the `variant='full'` prop to a `SideNav.Link` to spread child elements across the link, which is useful for status icons, labels, and the like.
 
 ```jsx live
-<SideNav bordered maxWidth={360} aria-label="Main">
+<SideNav bordered aria-label="Main" sx={{maxWidth: 360}}>
   <SideNav.Link href="#url">
     <Text>Text Only</Text>
   </SideNav.Link>
   <SideNav.Link href="#url">
-    <Avatar size={16} mr={2} src="https://avatars.githubusercontent.com/hubot?s=32" />
+    <Avatar size={16} src="https://avatars.githubusercontent.com/hubot?s=32" sx={{mr: 2}} />
     <Text>With an avatar</Text>
   </SideNav.Link>
   <SideNav.Link href="#url">
@@ -74,7 +74,7 @@ Add the `variant='full'` prop to a `SideNav.Link` to spread child elements acros
   </SideNav.Link>
   <SideNav.Link href="#url" variant="full" selected>
     <Text>With a status icon</Text>
-    <Octicon sx={{mr: 2}} size={16} icon={DotIcon} color="success.fg" />
+    <Octicon sx={{mr: 2, color: 'success.fg'}} size={16} icon={DotIcon} />
   </SideNav.Link>
   <SideNav.Link href="#url" variant="full">
     <Text>With a label</Text>
@@ -116,7 +116,7 @@ Add the `variant="lightweight"` prop to `SideNav` to render an alternative, more
     mb={2}
     pb={1}
   >
-    <Heading as="h5" fontSize={1} color="fg.muted">
+    <Heading as="h5" sx={{fontSize: 1, color: 'fg.muted'}}>
       Menu
     </Heading>
   </Box>
@@ -140,17 +140,17 @@ Add the `variant="lightweight"` prop to `SideNav` to render an alternative, more
 It can also appear nested, as a sub navigation. Use margin/padding [System Props](/system-props) to add indentation.
 
 ```jsx live
-<SideNav bordered maxWidth={360}>
+<SideNav bordered sx={{maxWidth: 360}}>
   <SideNav.Link href="#url">
     <Octicon size={16} icon={PersonIcon} />
     <Text>Account</Text>
   </SideNav.Link>
   <SideNav.Link href="#url" selected>
-    <Octicon mr={2} size={16} icon={SmileyIcon} />
+    <Octicon size={16} icon={SmileyIcon} sx={{mr: 2}} />
     <Text>Profile</Text>
   </SideNav.Link>
 
-  <SideNav bordered variant="lightweight" py={3} pl={6} backgroundColor="sidenav.selectedBg">
+  <SideNav bordered variant="lightweight" sx={{py: 3, pl: 6, backgroundColor: 'sidenav.selectedBg'}}>
     <SideNav.Link href="#url" selected>
       <Text>Sub item 1</Text>
     </SideNav.Link>
@@ -163,7 +163,7 @@ It can also appear nested, as a sub navigation. Use margin/padding [System Props
   </SideNav>
 
   <SideNav.Link href="#url">
-    <Octicon mr={2} size={16} icon={MailIcon} />
+    <Octicon size={16} icon={MailIcon} sx={{mr: 2}} />
     <Text>Emails</Text>
   </SideNav.Link>
 </SideNav>

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-mdx": "3.0.0",
         "eslint-plugin-playwright": "0.15.1",
         "eslint-plugin-prettier": "5.0.0",
-        "eslint-plugin-primer-react": "4.1.1",
+        "eslint-plugin-primer-react": "4.1.2",
         "eslint-plugin-react": "7.32.2",
         "eslint-plugin-react-hooks": "4.6.0",
         "eslint-plugin-ssr-friendly": "1.2.0",
@@ -29839,9 +29839,9 @@
       }
     },
     "node_modules/eslint-plugin-primer-react": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-primer-react/-/eslint-plugin-primer-react-4.1.1.tgz",
-      "integrity": "sha512-+ebD1+vkFuAc9DV+H1JgmF9yz8h/JqamoO8Ai/I4B0ld+ztEqK4Wiit2lVPH2b52d/oMJc6YKT1yjDc7Zeczrg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-primer-react/-/eslint-plugin-primer-react-4.1.2.tgz",
+      "integrity": "sha512-tU/1bFOyownGDz194dajR1AuFyHNlnrX1QN6L/ia3+1Veafx3aJDfx+pLEAXJ0aL++d6atRDZSr+8qkmoj/+mQ==",
       "dev": true,
       "dependencies": {
         "@styled-system/props": "^5.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-mdx": "3.0.0",
         "eslint-plugin-playwright": "0.15.1",
         "eslint-plugin-prettier": "5.0.0",
-        "eslint-plugin-primer-react": "4.0.2",
+        "eslint-plugin-primer-react": "4.1.1",
         "eslint-plugin-react": "7.32.2",
         "eslint-plugin-react-hooks": "4.6.0",
         "eslint-plugin-ssr-friendly": "1.2.0",
@@ -29839,12 +29839,12 @@
       }
     },
     "node_modules/eslint-plugin-primer-react": {
-      "version": "4.0.2",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-primer-react/-/eslint-plugin-primer-react-4.1.1.tgz",
+      "integrity": "sha512-+ebD1+vkFuAc9DV+H1JgmF9yz8h/JqamoO8Ai/I4B0ld+ztEqK4Wiit2lVPH2b52d/oMJc6YKT1yjDc7Zeczrg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@styled-system/props": "^5.1.5",
-        "eslint-plugin-github": "^4.9.2",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-traverse": "^1.0.0",
         "lodash": "^4.17.21",
@@ -29852,7 +29852,7 @@
       },
       "peerDependencies": {
         "@primer/primitives": ">=4.6.2",
-        "eslint": "^8.0.1"
+        "eslint": "^8.42.0"
       }
     },
     "node_modules/eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-mdx": "3.0.0",
     "eslint-plugin-playwright": "0.15.1",
     "eslint-plugin-prettier": "5.0.0",
-    "eslint-plugin-primer-react": "4.0.2",
+    "eslint-plugin-primer-react": "4.1.1",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-ssr-friendly": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-mdx": "3.0.0",
     "eslint-plugin-playwright": "0.15.1",
     "eslint-plugin-prettier": "5.0.0",
-    "eslint-plugin-primer-react": "4.1.1",
+    "eslint-plugin-primer-react": "4.1.2",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-ssr-friendly": "1.2.0",

--- a/packages/react/src/ActionList/Item.tsx
+++ b/packages/react/src/ActionList/Item.tsx
@@ -154,6 +154,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
         cursor: 'not-allowed',
         '[data-component="ActionList.Checkbox"]': {
           cursor: 'not-allowed',
+          // eslint-disable-next-line primer-react/new-color-css-vars
           bg: selected ? 'fg.muted' : 'var(--color-input-disabled-bg, rgba(175, 184, 193, 0.2))',
           borderColor: selected ? 'fg.muted' : 'var(--color-input-disabled-bg, rgba(175, 184, 193, 0.2))',
         },

--- a/packages/react/src/ActionMenu/ActionMenu.examples.stories.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.examples.stories.tsx
@@ -416,7 +416,7 @@ export const SettingMaxHeight = () => {
   return (
     <ActionMenu>
       <ActionMenu.Button>Open menu</ActionMenu.Button>
-      <ActionMenu.Overlay width="auto" maxHeight="large" overflow="auto">
+      <ActionMenu.Overlay width="auto" maxHeight="large" sx={{overflow: 'auto'}}>
         <ActionList>
           {Array.from({length: 100}, (_, i) => (
             <ActionList.Item key={`item-${i}`} onSelect={() => alert(`Item ${i + 1} clicked`)}>

--- a/packages/react/src/drafts/MarkdownEditor/Toolbar.tsx
+++ b/packages/react/src/drafts/MarkdownEditor/Toolbar.tsx
@@ -28,6 +28,7 @@ const Divider = () => {
         display: 'inline-grid',
         margin: '0 var(--controlStack-medium-gap-condensed, 8px)',
         height: 'calc(var(--control-medium-size, 32px)/2)',
+        // eslint-disable-next-line primer-react/new-color-css-vars-have-fallback
         borderLeft: 'var(--borderWidth-thin, 1px) solid var(--borderColor-muted)',
       }}
     />

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.playground.stories.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.playground.stories.tsx
@@ -98,7 +98,7 @@ export const Playground: StoryFn = args => {
         onCancel={onCancel}
         onClearSelection={onClearSelection}
         width={args.width}
-        height={args.height}
+        maxHeight={args.maxHeight}
       >
         <SelectPanel.Button>Assign label</SelectPanel.Button>
 

--- a/packages/react/src/stories/deprecated/ActionList.stories.tsx
+++ b/packages/react/src/stories/deprecated/ActionList.stories.tsx
@@ -327,6 +327,7 @@ export function SizeStressTestingStory(): JSX.Element {
   return (
     <>
       <h1>Size Stress Testing</h1>
+      {/* eslint-disable-next-line primer-react/no-system-props */}
       <ErsatzOverlay maxWidth="300px">
         <ActionList
           items={[

--- a/packages/react/src/stories/useAnchoredPosition.stories.tsx
+++ b/packages/react/src/stories/useAnchoredPosition.stories.tsx
@@ -117,20 +117,19 @@ export const UseAnchoredPosition = (args: any) => {
   return (
     <Box position="relative" m={2}>
       <Anchor
-        top={args.anchorY ?? 0}
-        left={args.anchorX ?? 0}
-        width={args.anchorWidth}
-        height={args.anchorHeight}
         ref={anchorElementRef as React.RefObject<HTMLDivElement>}
+        sx={{top: args.anchorY ?? 0, left: args.anchorX ?? 0, width: args.anchorWidth, height: args.anchorHeight}}
       >
         Anchor Element
       </Anchor>
       <Float
-        top={position?.top ?? 0}
-        left={position?.left ?? 0}
-        width={args.floatWidth ?? 150}
-        height={args.floatHeight ?? 150}
         ref={floatingElementRef as React.RefObject<HTMLDivElement>}
+        sx={{
+          top: position?.top ?? 0,
+          left: position?.left ?? 0,
+          width: args.floatWidth ?? 150,
+          height: args.floatHeight ?? 150,
+        }}
       >
         Floating element
       </Float>
@@ -154,8 +153,7 @@ export const CenteredOnScreen = () => {
     >
       <Float
         ref={floatingElementRef as React.RefObject<HTMLDivElement>}
-        top={position?.top ?? 0}
-        left={position?.left ?? 0}
+        sx={{top: position?.top ?? 0, left: position?.left ?? 0}}
       >
         <p>Screen-Centered Floating Element </p>
         <p>
@@ -208,11 +206,8 @@ export const ComplexAncestry = () => {
             Floating element container. Position=static and overflow=hidden to show that overflow-hidden on a
             statically-positioned element will not have any effect.
             <Float
-              top={position?.top ?? 0}
-              left={position?.left ?? 0}
-              width={150}
-              height={220}
               ref={floatingElementRef as React.RefObject<HTMLDivElement>}
+              sx={{top: position?.top ?? 0, left: position?.left ?? 0, width: 150, height: 220}}
             >
               Floating element
             </Float>

--- a/packages/react/src/stories/useAnchoredPosition.stories.tsx
+++ b/packages/react/src/stories/useAnchoredPosition.stories.tsx
@@ -315,9 +315,7 @@ export const WithPortal = () => {
               <Float
                 ref={floatingElementRef as React.RefObject<HTMLDivElement>}
                 style={{top: `${position?.top ?? 0}px`, left: `${position?.left ?? 0}px`}}
-                width={250}
-                height={400}
-                sx={{visibility: position ? 'visible' : 'hidden'}}
+                sx={{visibility: position ? 'visible' : 'hidden', width: 250, height: 400}}
               >
                 An un-constrained overlay!
               </Float>


### PR DESCRIPTION
`primer-react/no-system-props` was not checking stories because it did not consider the import to be from `@primer/react`

- Fully expecting [a bunch of linting errors](https://github.com/primer/react/actions/runs/8189291072/job/22393719678?pr=4366)

some of them will be fixed by
- https://github.com/primer/eslint-plugin-primer-react/pull/148
- https://github.com/primer/eslint-plugin-primer-react/pull/149
- https://github.com/primer/eslint-plugin-primer-react/pull/151
- https://github.com/primer/eslint-plugin-primer-react/pull/152

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

Internal only.

### Merge checklist

- NA Added/updated tests
- NA Added/updated documentation
- NA Added/updated previews (Storybook)
- NA Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- NA Tested in Chrome
- NA Tested in Firefox
- NA Tested in Safari
- NA Tested in Edge
- NA (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
