### PR TITLE
Update Octicon.docs.json

### DIFF
--- a/packages/react/src/Octicon/Octicon.docs.json
+++ b/packages/react/src/Octicon/Octicon.docs.json
@@ -6,7 +6,7 @@
   "stories": [],
   "props": [
     {
-      "name": "ariaLabel",
+      "name": "aria-label",
       "type": "string",
       "defaultValue": "",
       "description": "Specifies the aria-label attribute, which is read verbatim by screen readers "


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This came up over in [Slack](https://github.slack.com/archives/C01L618AEP9/p1710262429785899)

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update the docs for `Octicon` to specify `aria-label` which is what the TS type is for octicons

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to component docs

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- [ ] Verify that the changes to `aria-label` mirror what is available in `OcticonProps`