### PR TITLE
Update CODEOWNERS to give playwright snapshot ownership to primer/design-reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 # All changes should be reviewed by a member of the @react-reviewers team
 * @primer/engineer-reviewers
 ./src/legacy-theme/ @langermank
+.playwright/snapshots/components @primer/design-reviewers


### PR DESCRIPTION
Ref: https://github.com/primer/view_components/pull/2670
Ref: https://github.com/github/entitlements/pull/79524

This adds ownership of playwright snapshot changes to @primer/design-reviewers so they can verify when design changes happen.

