### PR TITLE
Add support for nested submenus to `ActionMenu`

### DIFF
--- a/packages/react/src/ActionMenu/ActionMenu.docs.json
+++ b/packages/react/src/ActionMenu/ActionMenu.docs.json
@@ -10,7 +10,7 @@
       "type": "React.ReactElement[]",
       "defaultValue": "",
       "required": true,
-      "description": "Recommended: `ActionMenu.Button` or `ActionMenu.Anchor` with `ActionMenu.Overlay`"
+      "description": "Recommended: `ActionMenu.Button`, `ActionMenu.MenuItemAnchor`, or `ActionMenu.Anchor`, with `ActionMenu.Overlay`"
     },
     {
       "name": "open",
@@ -46,6 +46,22 @@
       "passthrough": {
         "element": "Button",
         "url": "/react/Button"
+      }
+    },
+    {
+      "name": "ActionMenu.MenuItemAnchor",
+      "props": [
+        {
+          "name": "children",
+          "type": "React.ReactElement",
+          "defaultValue": "",
+          "required": true,
+          "description": ""
+        }
+      ],
+      "passthrough": {
+        "element": "ActionList.Item",
+        "url": "/react/ActionList"
       }
     },
     {

--- a/packages/react/src/ActionMenu/ActionMenu.examples.stories.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.examples.stories.tsx
@@ -483,3 +483,38 @@ export const OnlyInactiveItems = () => (
     </ActionMenu.Overlay>
   </ActionMenu>
 )
+
+export const WithSubmenus = () => (
+  <ActionMenu>
+    <ActionMenu.Button>Edit</ActionMenu.Button>
+    <ActionMenu.Overlay width="medium" side="outside-right">
+      <ActionList>
+        <ActionList.Item onSelect={() => alert('Copy link clicked')}>
+          Copy
+          <ActionList.TrailingVisual>⌘C</ActionList.TrailingVisual>
+        </ActionList.Item>
+        <ActionList.Item onSelect={() => alert('Quote reply clicked')}>
+          Paste
+          <ActionList.TrailingVisual>⌘V</ActionList.TrailingVisual>
+        </ActionList.Item>
+
+        <ActionMenu>
+          <ActionMenu.MenuItemAnchor>Paste as</ActionMenu.MenuItemAnchor>
+
+          <ActionMenu.Overlay>
+            <ActionList>
+              <ActionList.Item onSelect={() => alert('Paste as plain text clicked')}>
+                Plain text
+                <ActionList.TrailingVisual>⌘V</ActionList.TrailingVisual>
+              </ActionList.Item>
+              <ActionList.Item onSelect={() => alert('Paste as rich text clicked')}>
+                Rich text
+                <ActionList.TrailingVisual>⌘V</ActionList.TrailingVisual>
+              </ActionList.Item>
+            </ActionList>
+          </ActionMenu.Overlay>
+        </ActionMenu>
+      </ActionList>
+    </ActionMenu.Overlay>
+  </ActionMenu>
+)

--- a/packages/react/src/ActionMenu/ActionMenu.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.tsx
@@ -194,7 +194,7 @@ type MenuOverlayProps = Partial<OverlayProps> &
 const Overlay: React.FC<React.PropsWithChildren<MenuOverlayProps>> = ({
   children,
   align = 'start',
-  side = 'outside-bottom',
+  side,
   'aria-labelledby': ariaLabelledby,
   ...overlayProps
 }) => {
@@ -222,7 +222,7 @@ const Overlay: React.FC<React.PropsWithChildren<MenuOverlayProps>> = ({
       onOpen={onOpen}
       onClose={onClose}
       align={align}
-      side={side}
+      side={side ?? (isSubmenu ? 'outside-right' : 'outside-bottom')}
       overlayProps={overlayProps}
       focusZoneSettings={{focusOutBehavior: 'wrap'}}
     >

--- a/packages/react/src/ActionMenu/ActionMenu.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.tsx
@@ -116,7 +116,7 @@ const Menu: React.FC<React.PropsWithChildren<ActionMenuProps>> = ({
         renderAnchor = anchorProps => React.cloneElement(child, anchorProps)
       }
       return null
-    } else if (child.type === MenuButton) {
+    } else if (child.type === MenuButton || child.type === MenuItemAnchor) {
       renderAnchor = anchorProps => React.cloneElement(child, anchorProps)
       return null
     } else {
@@ -164,10 +164,12 @@ const MenuItemAnchor = React.forwardRef(({children, onKeyDown: externalOnKeyDown
   const anchorRef = React.useRef<HTMLLIElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, anchorRef)
 
+  const {onOpen} = React.useContext(MenuContext)
+
   /** Treat right arrow key press as click. */
   const onKeyDown: React.KeyboardEventHandler<HTMLLIElement> = event => {
     externalOnKeyDown?.(event)
-    if (event.key === 'ArrowRight' && !event.defaultPrevented) anchorRef.current?.click()
+    if (event.key === 'ArrowRight' && !event.defaultPrevented) onOpen?.('anchor-key-press')
   }
 
   return (

--- a/packages/react/src/__tests__/ActionMenu.test.tsx
+++ b/packages/react/src/__tests__/ActionMenu.test.tsx
@@ -1,4 +1,4 @@
-import {render as HTMLRender, waitFor, act} from '@testing-library/react'
+import {render as HTMLRender, waitFor, act, within} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {axe} from 'jest-axe'
 import React from 'react'
@@ -68,6 +68,56 @@ function ExampleWithTooltipV2(actionMenuTrigger: React.ReactElement): JSX.Elemen
             <ActionMenu.Overlay>
               <ActionList>
                 <ActionList.Item>New file</ActionList.Item>
+              </ActionList>
+            </ActionMenu.Overlay>
+          </ActionMenu>
+        </BaseStyles>
+      </SSRProvider>
+    </ThemeProvider>
+  )
+}
+
+function ExampleWithSubmenus(): JSX.Element {
+  return (
+    <ThemeProvider theme={theme}>
+      <SSRProvider>
+        <BaseStyles>
+          <ActionMenu>
+            <ActionMenu.Button>Toggle Menu</ActionMenu.Button>
+            <ActionMenu.Overlay>
+              <ActionList>
+                <ActionList.Item>New file</ActionList.Item>
+                <ActionList.Divider />
+                <ActionList.Item>Copy link</ActionList.Item>
+                <ActionList.Item>Edit file</ActionList.Item>
+                <ActionList.Divider />
+                <ActionList.Item>Paste</ActionList.Item>
+                <ActionMenu>
+                  <ActionMenu.MenuItemAnchor>Paste special</ActionMenu.MenuItemAnchor>
+                  <ActionMenu.Overlay>
+                    <ActionList>
+                      <ActionList.Item>Paste plain text</ActionList.Item>
+                      <ActionList.Item>Paste formulas</ActionList.Item>
+                      <ActionList.Item>Paste with formatting</ActionList.Item>
+                      <ActionMenu>
+                        <ActionMenu.MenuItemAnchor>Paste from</ActionMenu.MenuItemAnchor>
+                        <ActionMenu.Overlay>
+                          <ActionList>
+                            <ActionList.Item
+                              onSelect={() => {
+                                /*noop*/
+                              }}
+                            >
+                              Current clipboard
+                            </ActionList.Item>
+                            <ActionList.Item>History</ActionList.Item>
+                            <ActionList.Item>Another device</ActionList.Item>
+                          </ActionList>
+                        </ActionMenu.Overlay>
+                      </ActionMenu>
+                    </ActionList>
+                  </ActionMenu.Overlay>
+                </ActionMenu>
               </ActionList>
             </ActionMenu.Overlay>
           </ActionMenu>
@@ -397,5 +447,118 @@ describe('ActionMenu', () => {
     const button = component.getByRole('button')
 
     expect(button.id).toBe(buttonId)
+  })
+
+  describe('submenus', () => {
+    it('sets `aria-haspopup` and `aria-expanded` on submenu anchors', async () => {
+      const component = HTMLRender(<ExampleWithSubmenus />)
+      const user = userEvent.setup()
+
+      const baseAnchor = component.getByRole('button', {name: 'Toggle Menu'})
+      await user.click(baseAnchor)
+
+      const submenuAnchor = component.getByRole('menuitem', {name: 'Paste special'})
+      expect(submenuAnchor).toHaveAttribute('aria-haspopup')
+      await user.click(submenuAnchor)
+      expect(submenuAnchor).toHaveAttribute('aria-expanded')
+
+      const subSubmenuAnchor = component.getByRole('menuitem', {name: 'Paste from'})
+      expect(subSubmenuAnchor).toHaveAttribute('aria-haspopup')
+      await user.click(subSubmenuAnchor)
+      expect(subSubmenuAnchor).toHaveAttribute('aria-expanded')
+    })
+
+    it('sets labels on submenus', async () => {
+      const component = HTMLRender(<ExampleWithSubmenus />)
+      const user = userEvent.setup()
+
+      const baseAnchor = component.getByRole('button', {name: 'Toggle Menu'})
+      await user.click(baseAnchor)
+
+      const submenuAnchor = component.getByRole('menuitem', {name: 'Paste special'})
+      await user.click(submenuAnchor)
+      const submenu = component.getByRole('menu', {name: 'Paste special'})
+      expect(submenu).toBeVisible()
+
+      const subSubmenuAnchor = within(submenu).getByRole('menuitem', {name: 'Paste from'})
+      await user.click(subSubmenuAnchor)
+      const subSubmenu = component.getByRole('menu', {name: 'Paste from'})
+      expect(subSubmenu).toBeVisible()
+    })
+
+    it('does not open top-level menu on right arrow key press', async () => {
+      const component = HTMLRender(<ExampleWithSubmenus />)
+      const user = userEvent.setup()
+
+      const baseAnchor = component.getByRole('button', {name: 'Toggle Menu'})
+      baseAnchor.focus()
+
+      await user.keyboard('{ArrowRight}')
+      expect(component.queryByRole('menu')).not.toBeInTheDocument()
+      expect(baseAnchor).not.toHaveAttribute('aria-expanded')
+    })
+
+    it('opens submenus on enter or right arrow key press', async () => {
+      const component = HTMLRender(<ExampleWithSubmenus />)
+      const user = userEvent.setup()
+
+      const baseAnchor = component.getByRole('button', {name: 'Toggle Menu'})
+      await user.click(baseAnchor)
+
+      const submenuAnchor = component.getByRole('menuitem', {name: 'Paste special'})
+      expect(submenuAnchor).toHaveAttribute('aria-haspopup')
+      submenuAnchor.focus()
+      await user.keyboard('{Enter}')
+      expect(submenuAnchor).toHaveAttribute('aria-expanded')
+
+      const subSubmenuAnchor = component.getByRole('menuitem', {name: 'Paste from'})
+      subSubmenuAnchor.focus()
+      await user.keyboard('{ArrowRight}')
+      expect(subSubmenuAnchor).toHaveAttribute('aria-expanded')
+    })
+
+    it('closes top menu on escape or left arrow key press', async () => {
+      const component = HTMLRender(<ExampleWithSubmenus />)
+      const user = userEvent.setup()
+
+      const baseAnchor = component.getByRole('button', {name: 'Toggle Menu'})
+      await user.click(baseAnchor)
+
+      const submenuAnchor = component.getByRole('menuitem', {name: 'Paste special'})
+      await user.click(submenuAnchor)
+
+      const subSubmenuAnchor = component.getByRole('menuitem', {name: 'Paste from'})
+      await user.click(subSubmenuAnchor)
+
+      expect(subSubmenuAnchor).toHaveAttribute('aria-expanded')
+
+      await user.keyboard('{Escape}')
+      expect(subSubmenuAnchor).not.toHaveAttribute('aria-expanded')
+      expect(submenuAnchor).toHaveAttribute('aria-expanded')
+
+      await user.keyboard('{ArrowLeft}')
+      expect(submenuAnchor).not.toHaveAttribute('aria-expanded')
+
+      expect(baseAnchor).toHaveAttribute('aria-expanded')
+    })
+
+    it('closes all menus when an item is selected', async () => {
+      const component = HTMLRender(<ExampleWithSubmenus />)
+      const user = userEvent.setup()
+
+      const baseAnchor = component.getByRole('button', {name: 'Toggle Menu'})
+      await user.click(baseAnchor)
+
+      const submenuAnchor = component.getByRole('menuitem', {name: 'Paste special'})
+      await user.click(submenuAnchor)
+
+      const subSubmenuAnchor = component.getByRole('menuitem', {name: 'Paste from'})
+      await user.click(subSubmenuAnchor)
+
+      const subSubmenuItem = component.getByRole('menuitem', {name: 'Current clipboard'})
+      await user.click(subSubmenuItem)
+
+      expect(baseAnchor).not.toHaveAttribute('aria-expanded')
+    })
   })
 })

--- a/packages/react/src/hooks/useMenuKeyboardNavigation.ts
+++ b/packages/react/src/hooks/useMenuKeyboardNavigation.ts
@@ -2,7 +2,7 @@ import React from 'react'
 import {iterateFocusableElements} from '@primer/behaviors/utils'
 import {useMenuInitialFocus} from './useMenuInitialFocus'
 import {useMnemonics} from './useMnemonics'
-import type {MenuContextProps} from '../ActionMenu'
+import type {MenuCloseHandler} from '../ActionMenu'
 
 /**
  * Keyboard navigation is a mix of 4 hooks
@@ -13,14 +13,16 @@ import type {MenuContextProps} from '../ActionMenu'
  */
 export const useMenuKeyboardNavigation = (
   open: boolean,
-  onClose: MenuContextProps['onClose'],
+  onClose: MenuCloseHandler | undefined,
   containerRef: React.RefObject<HTMLElement>,
   anchorRef: React.RefObject<HTMLElement>,
+  isSubmenu: boolean,
 ) => {
   useMenuInitialFocus(open, containerRef, anchorRef)
   useMnemonics(open, containerRef)
   useCloseMenuOnTab(open, onClose, containerRef, anchorRef)
   useMoveFocusToMenuItem(open, containerRef, anchorRef)
+  useCloseSubmenuOnArrow(open, isSubmenu, onClose, containerRef)
 }
 
 /**
@@ -29,7 +31,7 @@ export const useMenuKeyboardNavigation = (
  */
 const useCloseMenuOnTab = (
   open: boolean,
-  onClose: MenuContextProps['onClose'],
+  onClose: MenuCloseHandler | undefined,
   containerRef: React.RefObject<HTMLElement>,
   anchorRef: React.RefObject<HTMLElement>,
 ) => {
@@ -48,6 +50,29 @@ const useCloseMenuOnTab = (
       anchor?.removeEventListener('keydown', handler)
     }
   }, [open, onClose, containerRef, anchorRef])
+}
+
+/**
+ * Close submenu when left arrow key is pressed.
+ */
+const useCloseSubmenuOnArrow = (
+  open: boolean,
+  isSubmenu: boolean,
+  onClose: MenuCloseHandler | undefined,
+  containerRef: React.RefObject<HTMLElement>,
+) => {
+  React.useEffect(() => {
+    const container = containerRef.current
+
+    const handler = (event: KeyboardEvent) => {
+      if (open && isSubmenu && event.key === 'ArrowLeft') onClose?.('arrow-left')
+    }
+
+    container?.addEventListener('keydown', handler)
+    return () => {
+      container?.removeEventListener('keydown', handler)
+    }
+  }, [open, onClose, containerRef, isSubmenu])
 }
 
 /**


### PR DESCRIPTION
`ActionMenu` has [Primer designs and docs](https://primer.style/components/action-menu) for nesting, but has never actually supported it. Nested submenus should meet the following spec:

1. The anchor should match surrounding menu items but render a visual indicator of a submenu
2. When activated, the anchor menu item should open a submenu and keep the root menu open
3. Menus should be navigable by left/right arrow keys, opening submenus with right and closing them with left
4. The entire stack of menus should close when the user presses <kbd>Tab</kbd> or activates a menu item
5. Only the top menu should close when the user presses <kbd>Escape</kbd>
6. The anchor menu item should have `aria-haspopup` and `aria-expanded` (when expanded)

Fortunately meeting these requirements with the existing `ActionMenu` architecture is actually pretty straightforward, so I went ahead and just did it:

- A new component `ActionMenu.MenuItemAnchor` renders an `ActionList.Item` with a trailing visual as the menu's anchor
- Using context, `ActionMenu` internally determines if it is a submenu in order to close parent menus when necessary and to bind left/right navigation
- Everything else is pretty much taken care of by existing logic - ie, `AnchoredOverlay` already assigns the right ARIA attributes to the menu item anchor

The result is an intuitive submenu API that 'just works':

```jsx
<ActionMenu>
  <ActionMenu.Button>Edit</ActionMenu.Button>
  <ActionMenu.Overlay>
    <ActionList>
      <ActionList.Item>Copy</ActionList.Item>
      <ActionList.Item>Cut</ActionList.Item>
      <ActionList.Item>Paste</ActionList.Item>
      <ActionMenu>
        <ActionMenu.MenuItemAnchor>Paste special</ActionMenu.MenuItemAnchor>
        <ActionMenu.Overlay>
          <ActionList>
            <ActionList.Item>Paste plain text</ActionList.Item>
            <ActionList.Item>Paste formulas</ActionList.Item>
            <ActionList.Item>Paste with formatting</ActionList.Item>
            <ActionMenu>
              <ActionMenu.MenuItemAnchor>Paste from</ActionMenu.MenuItemAnchor>
              <ActionMenu.Overlay>
                <ActionList>
                  <ActionList.Item>Current clipboard</ActionList.Item>
                  <ActionList.Item>History</ActionList.Item>
                  <ActionList.Item>Another device</ActionList.Item>
                </ActionList>
              </ActionMenu.Overlay>
            </ActionMenu>
          </ActionList>
        </ActionMenu.Overlay>
      </ActionMenu>
    </ActionList>
  </ActionMenu.Overlay>
</ActionMenu>
```

The only thing I'm not so sure of is the naming of `ActionMenu.MenuItemAnchor`. It's not consistent with `ActionMenu.Button`, but I figured just calling it `ActionMenu.MenuItem` would be confusing. Open to suggestions here.

- Related: https://github.com/github/primer/issues/3120

### Changelog

#### New

- Adds support for nested submenus in `ActionMenu`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
