### PR TITLE
Adds `aria-expanded="false"` back to `AnchoredOverlay`

### DIFF
--- a/.changeset/chatty-phones-admire.md
+++ b/.changeset/chatty-phones-admire.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Adds full `aria-expanded` (true/false) state to `AnchoredOverlay`, and components that consume it

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,7 +184,7 @@
     "examples/app-router": {
       "name": "example-app-router",
       "dependencies": {
-        "@primer/react": "36.10.0",
+        "@primer/react": "36.11.0",
         "next": "^14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -247,7 +247,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^18.2.0",
-        "@primer/react": "36.10.0",
+        "@primer/react": "36.11.0",
         "next": "^14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -59871,7 +59871,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "36.10.0",
+      "version": "36.11.0",
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.1.5",

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -172,7 +172,7 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
           ref: anchorRef,
           id: anchorId,
           'aria-haspopup': 'true',
-          'aria-expanded': open ? 'true' : undefined,
+          'aria-expanded': open,
           tabIndex: 0,
           onClick: onAnchorClick,
           onKeyDown: onAnchorKeyDown,


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Will resolve: https://github.com/github/accessibility-audits/issues/6932

We have an open accessibility issue related to how we handle `aria-expanded` within `AnchoredOverlay`. We did not apply `aria-expanded` when a menu was open since it was redundant, and it was very unlikely that there'd be navigation outside of the menu before it was closed. We've [received feedback](https://github.com/github/accessibility-audits/issues/6932#issuecomment-1912430045) that this may cause an unintended effect for users using specific devices/AT that makes it difficult to leave the menu.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->
* Adds full `aria-expanded` state to `AnchoredOverlay`.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
