### PR TITLE
use display name for styled custom element

### DIFF
--- a/.changeset/loud-drinks-happen.md
+++ b/.changeset/loud-drinks-happen.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Improve display names for React components built from Custom Elements

--- a/packages/react/src/utils/custom-element.ts
+++ b/packages/react/src/utils/custom-element.ts
@@ -13,18 +13,23 @@ export const createComponent = <I extends HTMLElement, E extends EventNames = {}
   events: E | undefined = undefined,
 ) => {
   const output = Object.assign(
-    styled(
-      create<I, E>({
-        tagName,
-        elementClass,
-        react: React,
-        events,
-      }),
-    ),
+    Object.assign(
+      styled(
+        create<I, E>({
+          tagName,
+          elementClass,
+          react: React,
+          events,
+        }),
+      ),
+      {
+        displayName: rename(tagName),
+      },
+    )(sx),
     {
       displayName: rename(tagName),
     },
-  )(sx)
+  )
 
   return output
 }

--- a/packages/react/src/utils/custom-element.ts
+++ b/packages/react/src/utils/custom-element.ts
@@ -20,11 +20,11 @@ export const createComponent = <I extends HTMLElement, E extends EventNames = {}
         react: React,
         events,
       }),
-    )(sx),
+    ),
     {
       displayName: rename(tagName),
     },
-  )
+  )(sx)
 
   return output
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/4402

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

This moves the `displayName` value set to before `styled()` so that styled components don't prepend the `custom-element__createComponent-` prefix. By doing this, a class like `custom-element__createComponent-sc-192p0ln-0` becomes just `sc-192p0ln-0`.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->
Custom Element React wrapper now outputs cleaner class names

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
