### PR TITLE
feat(SelectPanel): add support for announcements to SelectPanel.Message

### DIFF
--- a/.changeset/late-buttons-teach.md
+++ b/.changeset/late-buttons-teach.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Add support for announcements to SelectPanel.Message

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,7 +184,7 @@
     "examples/app-router": {
       "name": "example-app-router",
       "dependencies": {
-        "@primer/react": "36.10.0",
+        "@primer/react": "36.12.0",
         "next": "^14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -247,7 +247,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^18.2.0",
-        "@primer/react": "36.10.0",
+        "@primer/react": "36.12.0",
         "next": "^14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -59871,7 +59871,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "36.10.0",
+      "version": "36.12.0",
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.1.5",

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -12,6 +12,7 @@ import type {OverlayProps} from '../../Overlay/Overlay'
 import {StyledOverlay, heightMap} from '../../Overlay/Overlay'
 import InputLabel from '../../internal/components/InputLabel'
 import {invariant} from '../../utils/invariant'
+import {Status} from '../../internal/components/Status'
 
 const SelectPanelContext = React.createContext<{
   title: string
@@ -566,14 +567,34 @@ export type SelectPanelMessageProps = {children: React.ReactNode} & (
   | {
       size?: 'full'
       title: string // title is required with size:full
-      variant: 'warning' | 'error' | 'empty' // default: warning
+      /**
+       * @default warning
+       */
+      variant?: 'warning' | 'error' | 'empty'
     }
   | {
       size?: 'inline'
       title?: never // title is invalid with size:inline
-      variant: 'warning' | 'error' // variant:empty + size:inline = invalid combination
+      /**
+       * @default warning
+       */
+      variant?: 'warning' | 'error' // variant:empty + size:inline = invalid combination
     }
 )
+
+const inlineVariantStyles = {
+  empty: {},
+  warning: {
+    backgroundColor: 'attention.subtle',
+    color: 'attention.fg',
+    borderBottomColor: 'attention.muted',
+  },
+  error: {
+    backgroundColor: 'danger.subtle',
+    color: 'danger.fg',
+    borderColor: 'danger.muted',
+  },
+}
 
 const SelectPanelMessage: React.FC<SelectPanelMessageProps> = ({
   variant = 'warning',
@@ -583,8 +604,7 @@ const SelectPanelMessage: React.FC<SelectPanelMessageProps> = ({
 }) => {
   if (size === 'full') {
     return (
-      <Box
-        aria-live={variant === 'empty' ? undefined : 'polite'}
+      <Status
         sx={{
           display: 'flex',
           flexDirection: 'column',
@@ -603,44 +623,29 @@ const SelectPanelMessage: React.FC<SelectPanelMessageProps> = ({
         {variant !== 'empty' ? (
           <Octicon icon={AlertIcon} sx={{color: variant === 'error' ? 'danger.fg' : 'attention.fg', marginBottom: 2}} />
         ) : null}
-        <Text sx={{fontSize: 1, fontWeight: 'semibold'}}>{title}</Text>
+        <Text sx={{fontSize: 1, fontWeight: 'semibold'}}>{title} </Text>
         <Text sx={{fontSize: 1, color: 'fg.muted'}}>{children}</Text>
-      </Box>
-    )
-  } else {
-    const inlineVariantStyles = {
-      empty: {},
-      warning: {
-        backgroundColor: 'attention.subtle',
-        color: 'attention.fg',
-        borderBottomColor: 'attention.muted',
-      },
-      error: {
-        backgroundColor: 'danger.subtle',
-        color: 'danger.fg',
-        borderColor: 'danger.muted',
-      },
-    }
-
-    return (
-      <Box
-        aria-live={variant === 'empty' ? undefined : 'polite'}
-        sx={{
-          display: 'flex',
-          gap: 2,
-          paddingX: 3,
-          paddingY: '12px',
-          fontSize: 0,
-          borderBottom: '1px solid',
-          a: {color: 'inherit', textDecoration: 'underline'},
-          ...inlineVariantStyles[variant],
-        }}
-      >
-        <AlertIcon size={16} />
-        <Box>{children}</Box>
-      </Box>
+      </Status>
     )
   }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 2,
+        paddingX: 3,
+        paddingY: '12px',
+        fontSize: 0,
+        borderBottom: '1px solid',
+        a: {color: 'inherit', textDecoration: 'underline'},
+        ...inlineVariantStyles[variant],
+      }}
+    >
+      <AlertIcon size={16} />
+      <Status>{children}</Status>
+    </Box>
+  )
 }
 
 export const SelectPanel = Object.assign(Panel, {

--- a/packages/react/src/drafts/SelectPanel2/__tests__/SelectPanel.test.tsx
+++ b/packages/react/src/drafts/SelectPanel2/__tests__/SelectPanel.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import {ThemeProvider, ActionList} from '../../'
+import {ThemeProvider, ActionList} from '../../../'
 import type {RenderResult} from '@testing-library/react'
 import {render} from '@testing-library/react'
 import type {UserEvent} from '@testing-library/user-event'
 import userEvent from '@testing-library/user-event'
-import data from './mock-story-data'
-import type {SelectPanelProps} from './SelectPanel'
-import {SelectPanel} from './SelectPanel'
+import data from '../mock-story-data'
+import type {SelectPanelProps} from '../SelectPanel'
+import {SelectPanel} from '../SelectPanel'
 
 const Fixture = ({onSubmit, onCancel}: Pick<SelectPanelProps, 'onSubmit' | 'onCancel'>) => {
   const initialSelectedLabels = data.issue.labelIds // mock initial state: has selected labels

--- a/packages/react/src/drafts/SelectPanel2/__tests__/SelectPanelMessage.test.tsx
+++ b/packages/react/src/drafts/SelectPanel2/__tests__/SelectPanelMessage.test.tsx
@@ -1,0 +1,49 @@
+import {render, screen} from '@testing-library/react'
+import React from 'react'
+import type {LiveRegionElement} from '@primer/live-region-element'
+import {SelectPanel} from '../'
+
+describe('SelectPanel.Message', () => {
+  it('should require a title when size="full"', () => {
+    render(
+      <SelectPanel.Message title="Title" size="full">
+        message
+      </SelectPanel.Message>,
+    )
+
+    expect(screen.getByText('Title')).toBeInTheDocument()
+    expect(screen.getByText('message')).toBeInTheDocument()
+  })
+
+  it('should not require a title when size="inline"', () => {
+    render(<SelectPanel.Message size="inline">message</SelectPanel.Message>)
+
+    expect(screen.getByText('message')).toBeInTheDocument()
+  })
+
+  it('should announce the title and message when size="full"', () => {
+    render(
+      <SelectPanel.Message title="Title" size="full">
+        message
+      </SelectPanel.Message>,
+    )
+
+    const liveRegion = getLiveRegion()
+    expect(liveRegion.getMessage('polite')).toBe('Title message')
+  })
+
+  it('should announce the message when size="inline"', () => {
+    render(<SelectPanel.Message size="inline">message</SelectPanel.Message>)
+
+    const liveRegion = getLiveRegion()
+    expect(liveRegion.getMessage('polite')).toBe('message')
+  })
+})
+
+function getLiveRegion(): LiveRegionElement {
+  const liveRegion = document.querySelector('live-region')
+  if (liveRegion) {
+    return liveRegion
+  }
+  throw new Error('Expected <live-region> element to be defined')
+}

--- a/packages/react/src/drafts/SelectPanel2/__tests__/SelectPanelMessage.types.test.tsx
+++ b/packages/react/src/drafts/SelectPanel2/__tests__/SelectPanelMessage.types.test.tsx
@@ -1,0 +1,28 @@
+import {SelectPanel} from '../'
+
+export function titleRequiredWithSizeFull() {
+  return (
+    // @ts-expect-error title is required
+    <SelectPanel.Message size="full" variant="empty">
+      test
+    </SelectPanel.Message>
+  )
+}
+
+export function titleInvalidWithInline() {
+  return (
+    // @ts-expect-error title is invalid with inline
+    <SelectPanel.Message size="inline" title="test">
+      test
+    </SelectPanel.Message>
+  )
+}
+
+export function emptyInvalidWithInline() {
+  return (
+    // @ts-expect-error empty is invalid with inline
+    <SelectPanel.Message size="inline" variant="empty">
+      test
+    </SelectPanel.Message>
+  )
+}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Context https://github.com/github/primer/issues/3104

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

This PR integrates `Status` with `SelectPanel.Message` to announce the different variants of messages that can be rendered within a `SelectPanel`. This also adds some tests for `SelectPanel.Message`

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add test file for SelectPanel.Message

#### Changed

<!-- List of things changed in this PR -->

- Update SelectPanel.Message to announce its contents using the `Status` helper

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->


- [x] Minor release

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Verify that in stories with errors and warnings that they get announced by screen readers