### PR TITLE
UnderlineNav: Use anchoredPosition to position overflow menu

### DIFF
--- a/.changeset/quick-icons-agree.md
+++ b/.changeset/quick-icons-agree.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+UnderlineNav: Fix position of overflow menu for small screens

--- a/packages/react/src/UnderlineNav/UnderlineNav.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNav.tsx
@@ -4,6 +4,7 @@ import Box from '../Box'
 import type {BetterSystemStyleObject, SxProp} from '../sx'
 import sx, {merge} from '../sx'
 import {UnderlineNavContext} from './UnderlineNavContext'
+import {useAnchoredPosition, useOnEscapePress, useOnOutsideClick, useId} from '../hooks'
 import type {ResizeObserverEntry} from '../hooks/useResizeObserver'
 import {useResizeObserver} from '../hooks/useResizeObserver'
 import {useTheme} from '../ThemeProvider'
@@ -13,9 +14,6 @@ import {moreBtnStyles, getDividerStyle, getNavStyles, ulStyles, menuStyles, menu
 import styled from 'styled-components'
 import {Button} from '../Button'
 import {TriangleDownIcon} from '@primer/octicons-react'
-import {useOnEscapePress} from '../hooks/useOnEscapePress'
-import {useOnOutsideClick} from '../hooks/useOnOutsideClick'
-import {useId} from '../hooks/useId'
 import {ActionList} from '../ActionList'
 import {defaultSxProp} from '../utils/defaultSxProp'
 import CounterLabel from '../CounterLabel'
@@ -295,6 +293,11 @@ export const UnderlineNav = forwardRef(
         )
     }, navRef as RefObject<HTMLElement>)
 
+    const {position: overflowMenuPosition} = useAnchoredPosition(
+      {anchorElementRef: moreMenuBtnRef, floatingElementRef: containerRef, align: 'end'},
+      [menuItems.length > 0, isWidgetOpen],
+    )
+
     return (
       <UnderlineNavContext.Provider
         value={{
@@ -342,7 +345,7 @@ export const UnderlineNav = forwardRef(
                   ref={containerRef}
                   id={disclosureWidgetId}
                   sx={menuStyles}
-                  style={{display: isWidgetOpen ? 'block' : 'none'}}
+                  style={{display: isWidgetOpen ? 'block' : 'none', ...overflowMenuPosition}}
                 >
                   {menuItems.map((menuItem, index) => {
                     const {

--- a/packages/react/src/UnderlineNav/styles.ts
+++ b/packages/react/src/UnderlineNav/styles.ts
@@ -139,8 +139,6 @@ export const menuItemStyles = {
 export const menuStyles = {
   position: 'absolute',
   zIndex: 1,
-  top: '90%',
-  right: '0',
   boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24)',
   borderRadius: '12px',
   backgroundColor: 'canvas.overlay',


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

- Fixes part of https://github.com/primer/react/issues/4404

Instead of keeping the position fixed, adjust the position based on the space available (by using anchoredPosition)

Prefers aligning left towards the other link, but switches to right when there is not enough space: 

https://github.com/primer/react/assets/1863771/c584a29d-883c-4b59-8049-cb577d5f886e

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
