### PR TITLE
ci(release): update concurrency group to no longer cancel wip

### DIFF
--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -6,6 +6,10 @@ on:
       - 'next-major'
       - 'changeset-release/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     concurrency:

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   release:
-    concurrency: npm-canary
+    concurrency:
+      group: npm-canary
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This is a slight change to our canary release workflow to no longer cancel in-progress workflows in the same concurrency group (in this case `npm-canary`). The workflow will cancel changes to itself if the PR is updated.

This will help when we have multiple PRs (or merge groups) attempting to publish a canary version at the same time.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add concurrency group for release canary workflow to cancel updates to the same PR
- Update concurrency options for publishing to no longer cancel in flight publish steps

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why
