### PR TITLE
Allow user to override `Button` and `IconButton` `aria-disabled`

### DIFF
--- a/.changeset/smart-cameras-sip.md
+++ b/.changeset/smart-cameras-sip.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fixes a bug where consumers cannot override buttons' aria-disabled attribute

--- a/packages/react/src/Button/ButtonBase.tsx
+++ b/packages/react/src/Button/ButtonBase.tsx
@@ -89,6 +89,7 @@ const ButtonBase = forwardRef(
         <StyledButton
           as={Component}
           sx={sxStyles}
+          aria-disabled={loading ? true : undefined}
           {...rest}
           ref={innerRef}
           data-block={block ? 'block' : null}
@@ -96,7 +97,6 @@ const ButtonBase = forwardRef(
           data-loading={Boolean(loading)}
           data-no-visuals={!LeadingVisual && !TrailingVisual && !TrailingAction ? true : undefined}
           data-size={size === 'small' || size === 'large' ? size : undefined}
-          aria-disabled={loading ? true : undefined}
           aria-describedby={[loadingAnnouncementID, ariaDescribedBy]
             .filter(descriptionID => Boolean(descriptionID))
             .join(' ')}

--- a/packages/react/src/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/Button/__tests__/Button.test.tsx
@@ -238,6 +238,12 @@ describe('Button', () => {
     }, 0)
   })
 
+  it('allows the consumer to override `aria-disabled`', () => {
+    const container = render(<Button aria-disabled>content</Button>)
+
+    expect(container.getByRole('button')).toHaveAttribute('aria-disabled', 'true')
+  })
+
   it('should preserve the accessible button name when the button is in a loading state', () => {
     const container = render(<Button loading>content</Button>)
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/3991

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

It looks like in https://github.com/primer/react/pull/3582 we added support for `aria-disabled` styling on button components, which is awesome! Except that we accidentally introduced a regression where consumers cannot set the `aria-disabled` attribute on these components. This is because we are setting `aria-disabled` in `ButtonBase` _after_ we spread the consumer's props.

The fix here is simply to move this line earlier, so the consumer can override the attribute.

Alternatively, we could instead force `aria-disabled` to be `true` when `loading`, regardless of what the consumer sets, but then respect the consumer's prop all other times. That's not a hard change to make if we prefer to go that route.

### Changelog

#### Changed

- Fixes a bug where consumers cannot override buttons' `aria-disabled` attribute

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
