### PR TITLE
Exploration for announcements in SelectPanel for results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,26 @@
         "@rollup/rollup-linux-x64-gnu": "^4.9.6"
       }
     },
+    "../live-region-element/packages/live-region-element": {
+      "name": "@primer/live-region-element",
+      "version": "0.3.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      },
+      "devDependencies": {
+        "@custom-elements-manifest/analyzer": "^0.9.3",
+        "@rollup/plugin-inject": "^5.0.5",
+        "@rollup/plugin-replace": "^5.0.5",
+        "jsdom": "^24.0.0",
+        "publint": "^0.2.7",
+        "rimraf": "^5.0.5",
+        "rollup-plugin-esbuild": "^6.1.1",
+        "rollup-plugin-typescript2": "^0.36.0",
+        "typescript": "^5.4.3"
+      }
+    },
     "docs": {
       "version": "1.0.0",
       "dependencies": {
@@ -9681,14 +9701,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@primer/live-region-element": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@primer/live-region-element/-/live-region-element-0.2.0.tgz",
-      "integrity": "sha512-3zE1ipoMMxdmAkgB49dX+CIVpIXCGQGYwq5EF4kUIcMLjE4nAUOWkEMlcTCrDAlvfrv71YRx+h+AjRX70urLRg==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "node_modules/@primer/octicons-react": {
@@ -62307,7 +62319,7 @@
         "@lit-labs/react": "1.2.1",
         "@oddbird/popover-polyfill": "^0.3.1",
         "@primer/behaviors": "^1.5.1",
-        "@primer/live-region-element": "^0.2.0",
+        "@primer/live-region-element": "^0.4.0",
         "@primer/octicons-react": "^19.9.0",
         "@primer/primitives": "^7.15.3",
         "@styled-system/css": "^5.1.5",
@@ -62461,6 +62473,14 @@
         "@types/styled-components": {
           "optional": true
         }
+      }
+    },
+    "packages/react/node_modules/@primer/live-region-element": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@primer/live-region-element/-/live-region-element-0.4.0.tgz",
+      "integrity": "sha512-JROI+DyoQZtVQLut08KG1BKdh7MLb07DuHKrRZrDgF51unkyZn2ie9ZPsi2AphyxBvOC7psO5svPWO4htQT0eQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     }
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -92,7 +92,7 @@
     "@lit-labs/react": "1.2.1",
     "@oddbird/popover-polyfill": "^0.3.1",
     "@primer/behaviors": "^1.5.1",
-    "@primer/live-region-element": "^0.2.0",
+    "@primer/live-region-element": "^0.4.0",
     "@primer/octicons-react": "^19.9.0",
     "@primer/primitives": "^7.15.3",
     "@styled-system/css": "^5.1.5",

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.stories.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.stories.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import {SelectPanel} from './SelectPanel'
 import {ActionList, Box} from '../../index'
 import data from './mock-story-data'
+import {VisuallyHidden} from '../../internal/components/VisuallyHidden'
+import {Status} from '../../internal/components/Status'
+import {useAnnounce} from '../../internal/components/LiveRegionNext'
 
 export default {
   title: 'Drafts/Components/SelectPanel',
@@ -9,6 +12,7 @@ export default {
 }
 
 export const Default = () => {
+  const [announce, cancel] = useAnnounce()
   const initialSelectedLabels = data.issue.labelIds // mock initial state: has selected labels
   const [selectedLabelIds, setSelectedLabelIds] = React.useState<string[]>(initialSelectedLabels)
 
@@ -36,20 +40,27 @@ export const Default = () => {
   const onSearchInputChange: React.ChangeEventHandler<HTMLInputElement> = event => {
     const query = event.currentTarget.value
     setQuery(query)
+    cancel()
 
-    if (query === '') setFilteredLabels(data.labels)
-    else {
-      setFilteredLabels(
-        data.labels
-          .map(label => {
-            if (label.name.toLowerCase().startsWith(query)) return {priority: 1, label}
-            else if (label.name.toLowerCase().includes(query)) return {priority: 2, label}
-            else if (label.description?.toLowerCase().includes(query)) return {priority: 3, label}
-            else return {priority: -1, label}
-          })
-          .filter(result => result.priority > 0)
-          .map(result => result.label),
-      )
+    if (query === '') {
+      setFilteredLabels(data.labels)
+      announce(`${data.labels} results available`, {
+        delayMs: 500,
+      })
+    } else {
+      const labels = data.labels
+        .map(label => {
+          if (label.name.toLowerCase().startsWith(query)) return {priority: 1, label}
+          else if (label.name.toLowerCase().includes(query)) return {priority: 2, label}
+          else if (label.description?.toLowerCase().includes(query)) return {priority: 3, label}
+          else return {priority: -1, label}
+        })
+        .filter(result => result.priority > 0)
+        .map(result => result.label)
+      setFilteredLabels(labels)
+      announce(`${labels.length} results available`, {
+        delayMs: 500,
+      })
     }
   }
 

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -13,6 +13,7 @@ import {invariant} from '../../utils/invariant'
 import {Status} from '../../internal/components/Status'
 import {useResponsiveValue} from '../../hooks/useResponsiveValue'
 import type {ResponsiveValue} from '../../hooks/useResponsiveValue'
+import {LiveRegionProvider, LiveRegion} from '../../internal/components/LiveRegionNext'
 
 const SelectPanelContext = React.createContext<{
   title: string
@@ -223,115 +224,118 @@ const Panel: React.FC<SelectPanelProps> = ({
     <>
       {Anchor}
 
-      <StyledOverlay
-        as="dialog"
-        ref={dialogRef}
-        aria-labelledby={`${panelId}--title`}
-        aria-describedby={description ? `${panelId}--description` : undefined}
-        width={width}
-        height="fit-content"
-        maxHeight={maxHeight}
-        data-variant={currentVariant}
-        sx={{
-          '--max-height': heightMap[maxHeight],
-          // reset dialog default styles
-          border: 'none',
-          padding: 0,
-          '&[open]': {display: 'flex'}, // to fit children
+      <LiveRegionProvider>
+        <StyledOverlay
+          as="dialog"
+          ref={dialogRef}
+          aria-labelledby={`${panelId}--title`}
+          aria-describedby={description ? `${panelId}--description` : undefined}
+          width={width}
+          height="fit-content"
+          maxHeight={maxHeight}
+          data-variant={currentVariant}
+          sx={{
+            '--max-height': heightMap[maxHeight],
+            // reset dialog default styles
+            border: 'none',
+            padding: 0,
+            '&[open]': {display: 'flex'}, // to fit children
 
-          '&[data-variant="anchored"], &[data-variant="full-screen"]': {
-            margin: 0,
-            top: position?.top,
-            left: position?.left,
-            '::backdrop': {backgroundColor: 'transparent'},
-          },
-          '&[data-variant="modal"]': {
-            '::backdrop': {backgroundColor: 'primer.canvas.backdrop'},
-          },
-          '&[data-variant="full-screen"]': {
-            margin: 0,
-            top: 0,
-            left: 0,
-            width: '100%',
-            maxWidth: '100vw',
-            height: '100%',
-            maxHeight: '100vh',
-            '--max-height': '100vh',
-            borderRadius: 'unset',
-          },
-          '&[data-variant="bottom-sheet"]': {
-            margin: 0,
-            top: 'auto',
-            bottom: 0,
-            left: 0,
-            width: '100%',
-            maxWidth: '100vw',
-            maxHeight: 'calc(100vh - 64px)',
-            '--max-height': 'calc(100vh - 64px)',
-            borderBottomRightRadius: 0,
-            borderBottomLeftRadius: 0,
-          },
-        }}
-        {...props}
-        onClick={event => {
-          if (event.target === event.currentTarget) onClickOutside()
-        }}
-      >
-        {internalOpen && (
-          <>
-            <SelectPanelContext.Provider
-              value={{
-                panelId,
-                title,
-                description,
-                onCancel: onInternalCancel,
-                onClearSelection: propsOnClearSelection ? onInternalClearSelection : undefined,
-                searchQuery,
-                setSearchQuery,
-                selectionVariant,
-                moveFocusToList,
-              }}
-            >
-              <Box
-                as="form"
-                method="dialog"
-                onSubmit={onInternalSubmit}
-                sx={{display: 'flex', flexDirection: 'column', width: '100%'}}
+            '&[data-variant="anchored"], &[data-variant="full-screen"]': {
+              margin: 0,
+              top: position?.top,
+              left: position?.left,
+              '::backdrop': {backgroundColor: 'transparent'},
+            },
+            '&[data-variant="modal"]': {
+              '::backdrop': {backgroundColor: 'primer.canvas.backdrop'},
+            },
+            '&[data-variant="full-screen"]': {
+              margin: 0,
+              top: 0,
+              left: 0,
+              width: '100%',
+              maxWidth: '100vw',
+              height: '100%',
+              maxHeight: '100vh',
+              '--max-height': '100vh',
+              borderRadius: 'unset',
+            },
+            '&[data-variant="bottom-sheet"]': {
+              margin: 0,
+              top: 'auto',
+              bottom: 0,
+              left: 0,
+              width: '100%',
+              maxWidth: '100vw',
+              maxHeight: 'calc(100vh - 64px)',
+              '--max-height': 'calc(100vh - 64px)',
+              borderBottomRightRadius: 0,
+              borderBottomLeftRadius: 0,
+            },
+          }}
+          {...props}
+          onClick={event => {
+            if (event.target === event.currentTarget) onClickOutside()
+          }}
+        >
+          {internalOpen && (
+            <>
+              <SelectPanelContext.Provider
+                value={{
+                  panelId,
+                  title,
+                  description,
+                  onCancel: onInternalCancel,
+                  onClearSelection: propsOnClearSelection ? onInternalClearSelection : undefined,
+                  searchQuery,
+                  setSearchQuery,
+                  selectionVariant,
+                  moveFocusToList,
+                }}
               >
-                {slots.header ?? /* render default header as fallback */ <SelectPanelHeader />}
-
                 <Box
-                  as="div"
-                  sx={{
-                    flexShrink: 1,
-                    flexGrow: 1,
-                    overflow: 'hidden',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'space-between',
-                    ul: {overflowY: 'auto', flexGrow: 1},
-                  }}
+                  as="form"
+                  method="dialog"
+                  onSubmit={onInternalSubmit}
+                  sx={{display: 'flex', flexDirection: 'column', width: '100%'}}
                 >
-                  <ActionListContainerContext.Provider
-                    value={{
-                      container: 'SelectPanel',
-                      listRole: 'listbox',
-                      selectionAttribute: 'aria-selected',
-                      selectionVariant: selectionVariant === 'instant' ? 'single' : selectionVariant,
-                      afterSelect: internalAfterSelect,
-                      listLabelledBy: `${panelId}--title`,
-                      enableFocusZone: true, // Arrow keys navigation for list items
+                  {slots.header ?? /* render default header as fallback */ <SelectPanelHeader />}
+
+                  <Box
+                    as="div"
+                    sx={{
+                      flexShrink: 1,
+                      flexGrow: 1,
+                      overflow: 'hidden',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'space-between',
+                      ul: {overflowY: 'auto', flexGrow: 1},
                     }}
                   >
-                    {childrenInBody}
-                  </ActionListContainerContext.Provider>
+                    <ActionListContainerContext.Provider
+                      value={{
+                        container: 'SelectPanel',
+                        listRole: 'listbox',
+                        selectionAttribute: 'aria-selected',
+                        selectionVariant: selectionVariant === 'instant' ? 'single' : selectionVariant,
+                        afterSelect: internalAfterSelect,
+                        listLabelledBy: `${panelId}--title`,
+                        enableFocusZone: true, // Arrow keys navigation for list items
+                      }}
+                    >
+                      {childrenInBody}
+                    </ActionListContainerContext.Provider>
+                  </Box>
+                  {slots.footer}
                 </Box>
-                {slots.footer}
-              </Box>
-            </SelectPanelContext.Provider>
-          </>
-        )}
-      </StyledOverlay>
+              </SelectPanelContext.Provider>
+            </>
+          )}
+          <LiveRegion />
+        </StyledOverlay>
+      </LiveRegionProvider>
     </>
   )
 }

--- a/packages/react/src/internal/components/LiveRegionNext.tsx
+++ b/packages/react/src/internal/components/LiveRegionNext.tsx
@@ -1,0 +1,65 @@
+import '@primer/live-region-element'
+import {announce as globalAnnounce, type LiveRegionElement} from '@primer/live-region-element'
+import React from 'react'
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'live-region': React.DetailedHTMLProps<React.HTMLAttributes<LiveRegionElement>, LiveRegionElement>
+    }
+  }
+}
+
+const LiveRegionContext = React.createContext<LiveRegionElement | null>(null)
+const SetLiveRegionContext = React.createContext<React.Dispatch<React.SetStateAction<LiveRegionElement | null>> | null>(
+  null,
+)
+
+export function LiveRegionProvider({children}: React.PropsWithChildren) {
+  const [liveRegion, setLiveRegion] = React.useState<LiveRegionElement | null>(null)
+
+  return (
+    <LiveRegionContext.Provider value={liveRegion}>
+      <SetLiveRegionContext.Provider value={setLiveRegion}>{children}</SetLiveRegionContext.Provider>
+    </LiveRegionContext.Provider>
+  )
+}
+
+export function LiveRegion() {
+  const setLiveRegion = React.useContext(SetLiveRegionContext)
+  return <live-region ref={setLiveRegion} />
+}
+
+export function useLiveRegion() {
+  return React.useContext(LiveRegionContext)
+}
+
+export function useAnnounce(): [typeof globalAnnounce, () => void] {
+  const liveRegion = useLiveRegion()
+  const savedCancel = React.useRef<ReturnType<typeof globalAnnounce> | null>(null)
+  const announce = React.useCallback(
+    (...args: Parameters<typeof globalAnnounce>) => {
+      if (liveRegion) {
+        savedCancel.current = liveRegion.announce(...args)
+      } else {
+        savedCancel.current = globalAnnounce(...args)
+      }
+      return cancel
+    },
+    [liveRegion],
+  )
+  const cancel = React.useCallback(() => {
+    if (savedCancel.current !== null) {
+      savedCancel.current()
+      savedCancel.current = null
+    }
+  }, [])
+
+  React.useEffect(() => {
+    return () => {
+      cancel()
+    }
+  }, [])
+
+  return [announce, cancel]
+}


### PR DESCRIPTION
This is a work-in-progress / prototype for the different ways we could communicate results in `SelectPanel`. At a high-level, we would like to notify the user about the number of results available. These announcements should likely be debounced/delayed until the user stops typing in the input. There are two approaches we could consider:

- Use `announce()` when the input changes
  - One technique uses `debounce` to defer announcing
  - One technique uses the `cancel` method from `announce()` plus a delay
- Use `Status` to announce when the message it is given changes
  - This technique requires skipping the first announcement


## Using `announce()`

The `@primer/live-region-element` package provides two ways to leverage `announce()`, either as a global import or as a method on a `<live-region>` element. In general, we want to either:

- Use the global `announce()` with the `from` option so that we can find/create the correct live-region element within a `dialog`
- Use a hook, like `useAnnounce()` that will find a live region defined in context using `LiveRegionContext` and `LiveRegion`

If we would like to use the first option, then we would need to support a `ref` on SelectPanel that would point to the `dialog` element

### With debounce

The `announce()` helper from either source (global or hook) could be debounced using a custom hook. This would likely take on the shape:

```ts
const debouncedAnnounce = useMemo(() => {
  return debounce(announce, delayMs);
}, [announce]);
```

And then you could call `debouncedAnnounce()` the way you would `announce()`

### With cancel

The `announce()` helper returns a function which allows you to cancel the announcement if it has not already been made. As a result, another pattern is to call `announce()` with a delay and then `cancel` if another announcement is being made. For example:

```ts
function onChange(event) {
  cancel();
  announce(`This is an announcement`, { delayMs: 300 });
}
```

This method would be made available from the hook, most likely, since it can be cumbersome to pass around the return value of `announce`

```ts
const [announce, cancel] = useAnnounce();
```

## Using `Status`

The `Status` component will announce its children similar to an element with `role="status"`.  It also supports delaying messages through `delayMs` and will cancel any pending messages if a change occurs before the message is announced.

```tsx
<Status delayMs={300}>This is a message</Status>
```

This component can be hidden when wrapped in `VisuallyHidden` and also provides a stable node that can be used for labeling or describing an item.

One challenge with results is that you often do not want this component to announce the first message it receives. As a result, this component needs either a `skipFirstAnnouncement` prop to configure this behavior or the user will need to conditionally pass in the method _after_ results start to come up (which may be a good indicator to use `announce()`).

Another challenge is how this will interop with other messages at play. Since it is a component, you have no ability to cancel messages in flight.

## Implementation details

- A dialog should have a `live-region` element within it to make sure announcements are made consistently