### PR TITLE
fix(DataTable): add position: relative to scrollable region

### DIFF
--- a/.changeset/orange-geese-search.md
+++ b/.changeset/orange-geese-search.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Update DataTable to avoid layout overflow when visually hidden selectors are used in Table headers

--- a/packages/react/src/internal/components/ScrollableRegion.tsx
+++ b/packages/react/src/internal/components/ScrollableRegion.tsx
@@ -7,6 +7,15 @@ type ScrollableRegionProps = React.PropsWithChildren<{
   className?: string
 }>
 
+const defaultStyles = {
+  // When setting overflow, we also set `position: relative` to avoid
+  // `position: absolute` items breaking out of the container and causing
+  // scrollabrs on the page. This can occur with common classes like `sr-only`
+  // and can cause difficult to track down layout issues
+  position: 'relative',
+  overflow: 'auto',
+}
+
 export function ScrollableRegion({'aria-labelledby': labelledby, children, ...rest}: ScrollableRegionProps) {
   const ref = React.useRef(null)
   const hasOverflow = useOverflow(ref)
@@ -19,7 +28,7 @@ export function ScrollableRegion({'aria-labelledby': labelledby, children, ...re
     : {}
 
   return (
-    <Box {...rest} {...regionProps} ref={ref} sx={{overflow: 'auto'}}>
+    <Box {...rest} {...regionProps} ref={ref} sx={defaultStyles}>
       {children}
     </Box>
   )


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/2865

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Update our internal `ScrollableRegion` component to include `position: relative` to prevent blowout when an element with `position: absolute` is included (like with `sr-only` classes)

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add `position: relative` to `ScrollableRegion`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- [ ] Visit the `With Row Action Menu` story in Storybook
- [ ] Verify that resizing the window that overflow only occurs on the table and not the page