### PR TITLE
npm package: Add changelog.md to files published

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -76,7 +76,7 @@
     "!lib-esm/__tests__",
     "!lib-esm/stories",
     "generated",
-    "CHANGELOG.md"
+    ".changeset"
   ],
   "author": "GitHub, Inc.",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -75,7 +75,8 @@
     "!lib/stories",
     "!lib-esm/__tests__",
     "!lib-esm/stories",
-    "generated"
+    "generated",
+    "CHANGELOG.md"
   ],
   "author": "GitHub, Inc.",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -76,7 +76,7 @@
     "!lib-esm/__tests__",
     "!lib-esm/stories",
     "generated",
-    ".changeset"
+    "CHANGELOG.md"
   ],
   "author": "GitHub, Inc.",
   "license": "MIT",


### PR DESCRIPTION
Publishing changelog,md to npm would help us debug what changesets are published in canary and release candidate versions

Is this a good idea? Would this be actually helpful?