### PR TITLE
Tooltip V2: Update the threshold value to match with the offset

### DIFF
--- a/.changeset/old-shirts-train.md
+++ b/.changeset/old-shirts-train.md
@@ -1,0 +1,6 @@
+---
+"@primer/react": patch
+---
+
+Tooltipv2: Update the threshold value to match with the offset
+

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -62,7 +62,7 @@ const StyledTooltip = styled.span`
     display: block;
     right: 0;
     left: 0;
-    height: 8px;
+    height: var(--overlay-offset, 0.25rem);
     content: '';
   }
 

--- a/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1984,7 +1984,7 @@ exports[`TextInput renders trailingAction icon button 1`] = `
   display: block;
   right: 0;
   left: 0;
-  height: 8px;
+  height: var(--overlay-offset,0.25rem);
   content: '';
 }
 
@@ -3032,7 +3032,7 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
   display: block;
   right: 0;
   left: 0;
-  height: 8px;
+  height: var(--overlay-offset,0.25rem);
   content: '';
 }
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Reported in the communities (https://github.com/orgs/community/discussions/113546) and also internally that the elements that have tooltips on are not fully clickable. The reported issue is on PVC tooltip but React doesn't have the right value either. We think this is happening because the threshold (12px) is higher than the offset value (4px) and tooltip ends up blocking out the bottom part of its trigger. 

Corresponding PVC PR: https://github.com/primer/view_components/pull/2733

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->
Updated the height of the after pseudo element (Between tooltip and its trigger) to match with the offset value ([default](https://github.com/primer/behaviors/blob/main/src/anchored-position.ts#L250)) so that tooltip don't overlap with its trigger.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
