### PR TITLE
Only sets aria-labelledby to button label node only if `loading` is true

### DIFF
--- a/.changeset/rude-chefs-admire.md
+++ b/.changeset/rude-chefs-admire.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+Button and IconButton only use aria-labelledby to preserve the button label in a loading state OR if aria-labelledBy was explicitly passed.
+
+<!-- Changed components: Button, IconButton -->

--- a/packages/react/src/Button/ButtonBase.tsx
+++ b/packages/react/src/Button/ButtonBase.tsx
@@ -62,7 +62,6 @@ const ButtonBase = forwardRef(
     }, [baseStyles, sxProp])
     const uuid = useId(id)
     const loadingAnnouncementID = `${uuid}-loading-announcement`
-    const buttonLabelID = ariaLabelledBy || `${uuid}-label`
 
     if (__DEV__) {
       /**
@@ -103,7 +102,7 @@ const ButtonBase = forwardRef(
           // aria-labelledby is needed because the accessible name becomes unset when the button is in a loading state.
           // We only set it when the button is in a loading state because it will supercede the aria-label when the screen
           // reader announces the button name.
-          aria-labelledby={loading ? buttonLabelID : undefined}
+          aria-labelledby={loading ? `${uuid}-label` : ariaLabelledBy}
           id={id}
           onClick={loading ? undefined : onClick}
         >
@@ -119,7 +118,7 @@ const ButtonBase = forwardRef(
                 {loading && !LeadingVisual && !TrailingVisual && renderVisual(Spinner, loading, 'loadingSpinner')}
                 {LeadingVisual && renderVisual(LeadingVisual, loading, 'leadingVisual')}
                 {children && (
-                  <span data-component="text" id={buttonLabelID}>
+                  <span data-component="text" id={loading ? `${uuid}-label` : undefined}>
                     {children}
                     {count !== undefined && !TrailingVisual && (
                       <CounterLabel data-component="ButtonCounter" sx={{ml: 2}}>

--- a/packages/react/src/Button/ButtonBase.tsx
+++ b/packages/react/src/Button/ButtonBase.tsx
@@ -100,8 +100,10 @@ const ButtonBase = forwardRef(
           aria-describedby={[loadingAnnouncementID, ariaDescribedBy]
             .filter(descriptionID => Boolean(descriptionID))
             .join(' ')}
-          // aria-labelledby is needed because the accessible name becomes unset when the button is in a loading state
-          aria-labelledby={buttonLabelID}
+          // aria-labelledby is needed because the accessible name becomes unset when the button is in a loading state.
+          // We only set it when the button is in a loading state because it will supercede the aria-label when the screen
+          // reader announces the button name.
+          aria-labelledby={loading ? buttonLabelID : undefined}
           id={id}
           onClick={loading ? undefined : onClick}
         >

--- a/packages/react/src/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -264,7 +264,6 @@ exports[`Button respects block prop 1`] = `
 
 <button
   aria-describedby="test-button-loading-announcement"
-  aria-labelledby="test-button-label"
   class="c0"
   data-block="block"
   data-loading="false"
@@ -278,7 +277,6 @@ exports[`Button respects block prop 1`] = `
   >
     <span
       data-component="text"
-      id="test-button-label"
     >
       Block
     </span>
@@ -550,7 +548,6 @@ exports[`Button respects the alignContent prop 1`] = `
 
 <button
   aria-describedby="test-button-loading-announcement"
-  aria-labelledby="test-button-label"
   class="c0"
   data-loading="false"
   data-no-visuals="true"
@@ -563,7 +560,6 @@ exports[`Button respects the alignContent prop 1`] = `
   >
     <span
       data-component="text"
-      id="test-button-label"
     >
       Align start
     </span>
@@ -835,7 +831,6 @@ exports[`Button respects the large size prop 1`] = `
 
 <button
   aria-describedby="test-button-loading-announcement"
-  aria-labelledby="test-button-label"
   class="c0"
   data-loading="false"
   data-no-visuals="true"
@@ -849,7 +844,6 @@ exports[`Button respects the large size prop 1`] = `
   >
     <span
       data-component="text"
-      id="test-button-label"
     >
       Smol
     </span>
@@ -1121,7 +1115,6 @@ exports[`Button respects the small size prop 1`] = `
 
 <button
   aria-describedby="test-button-loading-announcement"
-  aria-labelledby="test-button-label"
   class="c0"
   data-loading="false"
   data-no-visuals="true"
@@ -1135,7 +1128,6 @@ exports[`Button respects the small size prop 1`] = `
   >
     <span
       data-component="text"
-      id="test-button-label"
     >
       Smol
     </span>
@@ -1410,7 +1402,6 @@ exports[`Button styles danger button appropriately 1`] = `
 
 <button
   aria-describedby="test-button-loading-announcement"
-  aria-labelledby="test-button-label"
   class="c0"
   data-loading="false"
   data-no-visuals="true"
@@ -1423,7 +1414,6 @@ exports[`Button styles danger button appropriately 1`] = `
   >
     <span
       data-component="text"
-      id="test-button-label"
     >
       Danger
     </span>
@@ -1707,7 +1697,6 @@ exports[`Button styles invisible button appropriately 1`] = `
 
 <button
   aria-describedby="test-button-loading-announcement"
-  aria-labelledby="test-button-label"
   class="c0"
   data-loading="false"
   data-no-visuals="true"
@@ -1720,7 +1709,6 @@ exports[`Button styles invisible button appropriately 1`] = `
   >
     <span
       data-component="text"
-      id="test-button-label"
     >
       Invisible
     </span>
@@ -1991,7 +1979,6 @@ exports[`Button styles primary button appropriately 1`] = `
 
 <button
   aria-describedby="test-button-loading-announcement"
-  aria-labelledby="test-button-label"
   class="c0"
   data-loading="false"
   data-no-visuals="true"
@@ -2004,7 +1991,6 @@ exports[`Button styles primary button appropriately 1`] = `
   >
     <span
       data-component="text"
-      id="test-button-label"
     >
       Primary
     </span>

--- a/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -2681,7 +2681,6 @@ exports[`TextInput renders trailingAction text button 1`] = `
   >
     <button
       aria-describedby=":r0:-loading-announcement"
-      aria-labelledby=":r0:-label"
       className="c4"
       data-block={null}
       data-loading={false}
@@ -2696,7 +2695,6 @@ exports[`TextInput renders trailingAction text button 1`] = `
       >
         <span
           data-component="text"
-          id=":r0:-label"
         >
           Clear
         </span>
@@ -3249,7 +3247,6 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
   >
     <button
       aria-describedby=":r2:-loading-announcement :r1:"
-      aria-labelledby=":r2:-label"
       className="c4"
       data-block={null}
       data-loading={false}
@@ -3268,7 +3265,6 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
       >
         <span
           data-component="text"
-          id=":r2:-label"
         >
           Clear
         </span>


### PR DESCRIPTION
### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

N/A

#### Changed

`Button` and `IconButton` only use `aria-labelledby` to preserve the button label in a loading state OR if `aria-labelledBy` was explicitly passed.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [N/A] Added/updated documentation
- [N/A] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
