### PR TITLE
Use `getGlobalFocusStyles` in ToggleSwitch

### DIFF
--- a/.changeset/light-zebras-mix.md
+++ b/.changeset/light-zebras-mix.md
@@ -2,4 +2,4 @@
 '@primer/react': patch
 ---
 
-Utilize `getGlobalFocusStyle` to prevent `outline-offset` from being overridden by global styles
+Utilize `getGlobalFocusStyle` to prevent `outline-offset` from being overridden by default browser styles

--- a/.changeset/light-zebras-mix.md
+++ b/.changeset/light-zebras-mix.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Utilize `getGlobalFocusStyle` to prevent `outline-offset` from being overridden by global styles

--- a/packages/react/src/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/react/src/ToggleSwitch/ToggleSwitch.tsx
@@ -9,6 +9,7 @@ import {get} from '../constants'
 import {useProvidedStateOrCreate} from '../hooks'
 import type {BetterSystemStyleObject, SxProp} from '../sx'
 import sx from '../sx'
+import getGlobalFocusStyles from '../internal/utils/getGlobalFocusStyles'
 import type {CellAlignment} from '../DataTable/column'
 
 const TRANSITION_DURATION = '80ms'
@@ -94,9 +95,10 @@ const SwitchButton = styled.button<SwitchButtonProps>`
   display: block;
   height: 32px;
   width: 64px;
-  outline-offset: 3px;
   position: relative;
   overflow: hidden;
+
+  ${getGlobalFocusStyles('3px')};
 
   @media (pointer: coarse) {
     &:before {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Related: https://github.com/github/accessibility-audits/issues/7420, https://github.com/github/accessibility-audits/issues/6706

Utilizes `getGlobalFocusStyles` in ToggleSwitch to override any global `outline-offset` styles that would apply to it. 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->
Applies `outline-offset` via [`getGlobalFocusStyles`](https://github.com/primer/react/blob/main/packages/react/src/internal/utils/getGlobalFocusStyles.ts).

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
