### PR TITLE
Revert "Adds `aria-expanded="false"` back to `AnchoredOverlay`"

### DIFF
--- a/.changeset/chatty-phones-admire.md
+++ b/.changeset/chatty-phones-admire.md
@@ -1,5 +1,0 @@
----
-'@primer/react': patch
----
-
-Adds full `aria-expanded` (true/false) state to `AnchoredOverlay`, and components that consume it

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -172,7 +172,7 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
           ref: anchorRef,
           id: anchorId,
           'aria-haspopup': 'true',
-          'aria-expanded': open,
+          'aria-expanded': open ? 'true' : undefined,
           tabIndex: 0,
           onClick: onAnchorClick,
           onKeyDown: onAnchorKeyDown,


### PR DESCRIPTION
- Reverts primer/react#4394
- Found [integration tests](https://github.com/github/github/pull/317915) failing because of this change

The failures are of 2 kinds:
1. failing storybook axe tests: ([example](https://github.com/github/github/actions/runs/8522980348/job/23344372506?pr=317915#step:15:2729)) These errors are related to incorrect usage. There are some triggers that are not buttons, adding an aria-expanded to them leads to axe errors. We need to fix the incorrect usage first.
2. failing jest tests: ([example](https://github.com/github/github/actions/runs/8522980348/job/23344371036?pr=317915#step:15:453)) There are tests that expect aria-expanded to be undefined instead of false. We need to update these tests in a branch that we can merge into the integration branch

#### Next steps:

1. After this PR is merged, please revert this pull request to bring back your changes in a new PR.
2. Mark as ready to review once you have tested with dotcom

#### How to we avoid reverts like this in the future?

Follow this guide to run integration tests for your pull request in dotcom: https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md