### PR TITLE
ActionBar: Add new component for submenu

### DIFF
--- a/.changeset/rotten-horses-applaud.md
+++ b/.changeset/rotten-horses-applaud.md
@@ -1,0 +1,6 @@
+---
+"@primer/react": patch
+"docs": patch
+---
+
+ActionBar: Add new component for submenu

--- a/packages/react/src/drafts/ActionBar/ActionBar.docs.json
+++ b/packages/react/src/drafts/ActionBar/ActionBar.docs.json
@@ -54,6 +54,19 @@
     {
       "name": "ActionBar.Divider",
       "props": []
+    },
+    {
+      "name": "ActionBar.SubMenu",
+      "description": "Component to be used when having a menu in the actionbar. This facilitates smooth transition to submenu during overflow cases",
+      "props": [
+        {
+          "name": "anchor",
+          "type": "React.ReactElement",
+          "required": true,
+          "description": "This is the anchor element to be used as menu trigger. Ideally ActionBar.IconButton"
+        },
+        {"name": "children", "type": "React.ReactElement", "required": true}
+      ]
     }
   ]
 }

--- a/packages/react/src/drafts/ActionBar/ActionBar.stories.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.stories.tsx
@@ -120,6 +120,13 @@ export const CommentBox = () => {
               icon={ReplyIcon}
               aria-label="Saved Replies"
             ></ActionBar.IconButton>
+            <ActionBar.SubMenu anchor={<ActionBar.IconButton icon={ThreeBarsIcon} aria-label="Random Menu" />}>
+              <ActionList>
+                <ActionList.Item>First Item</ActionList.Item>
+                <ActionList.Item>Second Item</ActionList.Item>
+                <ActionList.Item>Third Item</ActionList.Item>
+              </ActionList>
+            </ActionBar.SubMenu>
           </ActionBar>
         </Box>
       </Box>

--- a/packages/react/src/drafts/ActionBar/ActionBar.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.tsx
@@ -14,6 +14,7 @@ import type {IconButtonProps} from '../../Button'
 import {IconButton} from '../../Button'
 import Box from '../../Box'
 import {ActionMenu} from '../../ActionMenu'
+import {Action} from 'history'
 
 type ChildSize = {
   text: string
@@ -264,6 +265,24 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
                   {menuItems.map((menuItem, index) => {
                     if (menuItem.type === ActionList.Divider) {
                       return <ActionList.Divider key={index} />
+                    } else if (menuItem.type === ActionBarSubMenu) {
+                      const {children: menuItemChildren, anchor} = menuItem.props
+                      const {icon: Icon, 'aria-label': ariaLabel} = anchor.props
+                      return (
+                        <ActionMenu>
+                          <ActionMenu.Anchor>
+                            <ActionList.Item>
+                              {Icon ? (
+                                <ActionList.LeadingVisual>
+                                  <Icon />
+                                </ActionList.LeadingVisual>
+                              ) : null}
+                              {ariaLabel}
+                            </ActionList.Item>
+                          </ActionMenu.Anchor>
+                          <ActionMenu.Overlay>{menuItemChildren}</ActionMenu.Overlay>
+                        </ActionMenu>
+                      )
                     } else {
                       const {
                         children: menuItemChildren,

--- a/packages/react/src/drafts/ActionBar/ActionBar.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.tsx
@@ -13,7 +13,7 @@ import {useOnOutsideClick} from '../../hooks/useOnOutsideClick'
 import type {IconButtonProps} from '../../Button'
 import {IconButton} from '../../Button'
 import Box from '../../Box'
-import {ActionMenu} from '../..'
+import {ActionMenu} from '../../ActionMenu'
 
 type ChildSize = {
   text: string
@@ -42,6 +42,31 @@ export type ActionBarProps = {
 }
 
 export type ActionBarIconButtonProps = IconButtonProps
+
+export const ActionBarIconButton = forwardRef((props: ActionBarIconButtonProps, forwardedRef) => {
+  const backupRef = useRef<HTMLElement>(null)
+  const ref = (forwardedRef ?? backupRef) as RefObject<HTMLAnchorElement>
+  const {size, setChildrenWidth} = React.useContext(ActionBarContext)
+  useIsomorphicLayoutEffect(() => {
+    const text = props['aria-label'] ? props['aria-label'] : ''
+    const domRect = (ref as MutableRefObject<HTMLElement>).current.getBoundingClientRect()
+    setChildrenWidth({text, width: domRect.width})
+  }, [ref, setChildrenWidth])
+  return <IconButton ref={ref} size={size} {...props} variant="invisible" />
+})
+
+export type ActionBarSubMenuProps = {anchor: React.ReactElement; children: React.ReactElement[] | React.ReactElement}
+
+export const ActionBarSubMenu = (props: ActionBarSubMenuProps) => {
+  const {anchor, children} = props
+
+  return (
+    <ActionMenu>
+      <ActionMenu.Anchor>{anchor}</ActionMenu.Anchor>
+      <ActionMenu.Overlay>{children}</ActionMenu.Overlay>
+    </ActionMenu>
+  )
+}
 
 const NavigationList = styled.div`
   ${sx};
@@ -278,18 +303,6 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
     </ActionBarContext.Provider>
   )
 }
-
-export const ActionBarIconButton = forwardRef((props: ActionBarIconButtonProps, forwardedRef) => {
-  const backupRef = useRef<HTMLElement>(null)
-  const ref = (forwardedRef ?? backupRef) as RefObject<HTMLAnchorElement>
-  const {size, setChildrenWidth} = React.useContext(ActionBarContext)
-  useIsomorphicLayoutEffect(() => {
-    const text = props['aria-label'] ? props['aria-label'] : ''
-    const domRect = (ref as MutableRefObject<HTMLElement>).current.getBoundingClientRect()
-    setChildrenWidth({text, width: domRect.width})
-  }, [ref, setChildrenWidth])
-  return <IconButton ref={ref} size={size} {...props} variant="invisible" />
-})
 
 const sizeToHeight = {
   small: '24px',

--- a/packages/react/src/drafts/ActionBar/index.ts
+++ b/packages/react/src/drafts/ActionBar/index.ts
@@ -1,8 +1,9 @@
-import {ActionBar as Bar, ActionBarIconButton, VerticalDivider} from './ActionBar'
+import {ActionBar as Bar, ActionBarIconButton, ActionBarSubMenu, VerticalDivider} from './ActionBar'
 export type {ActionBarProps} from './ActionBar'
 
 const ActionBar = Object.assign(Bar, {
   IconButton: ActionBarIconButton,
+  SubMenu: ActionBarSubMenu,
   Divider: VerticalDivider,
 })
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #https://github.com/github/primer/issues/3132

This makes use of new capability in ActionMenu to have Submenus. We can use it to make sure that menus are supported with IconButton trigger in the ActionBar. The intent is to be able to convert it into a SubMenu when the overflow behaviour kicks in.

#### New


https://github.com/primer/react/assets/417268/cb59f7c8-f634-47b7-8a3a-0c2c0f094daa




### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Check out the new submenu story.

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
