### PR TITLE
Tooltipv2: Check if tooltip has `popover` attribute before opening or closing the popover

### DIFF
--- a/.changeset/dirty-pots-rule.md
+++ b/.changeset/dirty-pots-rule.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+TooltipV2: Check if tooltip element has `popover` attribute before calling `showPopover` and `hidePopover`

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -196,7 +196,12 @@ export const Tooltip = React.forwardRef(
     const [calculatedDirection, setCalculatedDirection] = useState<TooltipDirection>(direction)
 
     const openTooltip = () => {
-      if (tooltipElRef.current && triggerRef.current && !tooltipElRef.current.matches(':popover-open')) {
+      if (
+        tooltipElRef.current &&
+        triggerRef.current &&
+        tooltipElRef.current.hasAttribute('popover') &&
+        !tooltipElRef.current.matches(':popover-open')
+      ) {
         const tooltip = tooltipElRef.current
         const trigger = triggerRef.current
         tooltip.showPopover()
@@ -216,7 +221,12 @@ export const Tooltip = React.forwardRef(
       }
     }
     const closeTooltip = () => {
-      if (tooltipElRef.current && triggerRef.current && tooltipElRef.current.matches(':popover-open')) {
+      if (
+        tooltipElRef.current &&
+        triggerRef.current &&
+        tooltipElRef.current.hasAttribute('popover') &&
+        tooltipElRef.current.matches(':popover-open')
+      ) {
         tooltipElRef.current.hidePopover()
       }
     }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

I realised this issue on dotcom storybook when I was testing [one of the tooltip PRs (Hubbers only link)](https://github.com/github/github/pull/318903) and it happens on [a storybook interaction story (Hubbers only link)](https://ui.githubapp.com/storybook/?path=/story/apps-global-nav-create-menu--all-links) where a menu button is clicked and the menu is opened. 

I found out that there is a race condition going on here. Because effects run after the render and we set the popover attribute in the effect, it complains about the lack of popover attribute in the initial render when opening the tooltip (when menu button is clicked). 

<img width="930" alt="Failed to execute 'showPopover' on 'HTMLElement': Not supported on elements that do not have a valid value for the 'popover' attribute." src="https://github.com/primer/react/assets/1446503/a1a30bb8-bc70-4d33-877a-0dc6f6e1c2c8">

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Before calling `tooltip.showPopover()` and `tooltip.hidePopover()` I make sure they have `popover` attribute

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

You can add a play function that clicks the trigger on the default story and observe that there is no error.  (If you comment out the `tooltipElRef.current.hasAttribute('popover')` piece, you can see the error)

```jsx
Default.play = async ({canvasElement}: {canvasElement: HTMLElement}) => {
  const canvas = within(canvasElement)
  await userEvent.click(canvas.getByRole('button'))
}
```

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
