### PR TITLE
RelativeTime: prefer children if passed (fix #4305)

### DIFF
--- a/packages/react/src/RelativeTime/RelativeTime.tsx
+++ b/packages/react/src/RelativeTime/RelativeTime.tsx
@@ -6,11 +6,11 @@ import {createComponent} from '../utils/custom-element'
 const RelativeTimeComponent = createComponent(RelativeTimeElement, 'relative-time')
 
 const localeOptions: Intl.DateTimeFormatOptions = {month: 'short', day: 'numeric', year: 'numeric'}
-function RelativeTime({date, datetime, ...props}: RelativeTimeProps) {
+function RelativeTime({date, datetime, children, ...props}: RelativeTimeProps) {
   if (datetime) date = new Date(datetime)
   return (
     <RelativeTimeComponent {...props} date={date}>
-      {date?.toLocaleDateString('en', localeOptions) || ''}
+      {children || date?.toLocaleDateString('en', localeOptions) || ''}
     </RelativeTimeComponent>
   )
 }

--- a/packages/react/src/__tests__/RelativeTime.test.tsx
+++ b/packages/react/src/__tests__/RelativeTime.test.tsx
@@ -30,4 +30,11 @@ describe('RelativeTime', () => {
     const date = new Date('2024-03-07T12:22:48.123Z')
     expect(render(<RelativeTime datetime={date.toJSON()} />).children).toEqual(['Mar 7, 2024'])
   })
+
+  it('renders children if passed', () => {
+    const date = new Date('2024-03-07T12:22:48.123Z')
+    expect(render(<RelativeTime date={date}>server rendered date</RelativeTime>).children).toEqual([
+      'server rendered date',
+    ])
+  })
 })


### PR DESCRIPTION
### Changelog

- In #4305, we render the render as a child. This however overwrites children if they were passed. Found this integration tests for dotcom
- I talked to @keithamus and the ideal fix would be to update instances of RelativeTime, carefully remove children and then disallow children from the props
- To unblock the release, we can make the backwards compatible change of rendering children if they were passed instead of our default
- skipping changeset because this patches an unreleased PR

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; Patches an unreleased change

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
