### PR TITLE
Add fallback from `dist` folder

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -95,7 +95,7 @@
     "@primer/behaviors": "^1.5.1",
     "@primer/live-region-element": "^0.2.0",
     "@primer/octicons-react": "^19.9.0",
-    "@primer/primitives": "^7.15.14",
+    "@primer/primitives": "^7.16.0",
     "@styled-system/css": "^5.1.5",
     "@styled-system/props": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",

--- a/packages/react/postcss.config.js
+++ b/packages/react/postcss.config.js
@@ -11,7 +11,7 @@ module.exports = {
     }),
     require('postcss-custom-properties-fallback')({
       importFrom: {
-        customProperties: require('@primer/primitives/tokens-next-private/fallbacks/color-fallbacks.json'),
+        customProperties: require('@primer/primitives/dist/fallbacks/color-fallbacks.json'),
       },
     }),
   ],


### PR DESCRIPTION
This is needed so we can remove the remove the `tokens-next-private` folder.
It does not have any effect on the output.

We need to cut this release https://github.com/primer/primitives/pull/855 before we can merge.
