### PR TITLE
ThemeProvider + SSR: Fix incorrect theme with multiple ThemeProviders on page

### DIFF
--- a/.changeset/two-ravens-prove.md
+++ b/.changeset/two-ravens-prove.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+ThemeProvider + SSR: Fix incorrect theme with multiple ThemeProviders on page

--- a/packages/react/src/NavList/__snapshots__/NavList.test.tsx.snap
+++ b/packages/react/src/NavList/__snapshots__/NavList.test.tsx.snap
@@ -331,10 +331,10 @@ exports[`NavList renders a simple list 1`] = `
       >
         <a
           aria-current="page"
-          aria-labelledby=":r1:--label "
+          aria-labelledby=":r2:--label "
           class="c3 c4"
           href="/"
-          id=":r1:"
+          id=":r2:"
           tabindex="0"
         >
           <div
@@ -343,7 +343,7 @@ exports[`NavList renders a simple list 1`] = `
           >
             <span
               class="c6"
-              id=":r1:--label"
+              id=":r2:--label"
             >
               Home
             </span>
@@ -354,32 +354,9 @@ exports[`NavList renders a simple list 1`] = `
         class="c1 c7"
       >
         <a
-          aria-labelledby=":r2:--label "
-          class="c3 c4"
-          href="/about"
-          id=":r2:"
-          tabindex="0"
-        >
-          <div
-            class="c5"
-            data-component="ActionList.Item--DividerContainer"
-          >
-            <span
-              class="c8"
-              id=":r2:--label"
-            >
-              About
-            </span>
-          </div>
-        </a>
-      </li>
-      <li
-        class="c1 c7"
-      >
-        <a
           aria-labelledby=":r3:--label "
           class="c3 c4"
-          href="/contact"
+          href="/about"
           id=":r3:"
           tabindex="0"
         >
@@ -390,6 +367,29 @@ exports[`NavList renders a simple list 1`] = `
             <span
               class="c8"
               id=":r3:--label"
+            >
+              About
+            </span>
+          </div>
+        </a>
+      </li>
+      <li
+        class="c1 c7"
+      >
+        <a
+          aria-labelledby=":r4:--label "
+          class="c3 c4"
+          href="/contact"
+          id=":r4:"
+          tabindex="0"
+        >
+          <div
+            class="c5"
+            data-component="ActionList.Item--DividerContainer"
+          >
+            <span
+              class="c8"
+              id=":r4:--label"
             >
               Contact
             </span>
@@ -774,12 +774,12 @@ exports[`NavList renders with groups 1`] = `
       >
         <h3
           class="c3"
-          id=":r5:"
+          id=":r7:"
         >
           Overview
         </h3>
         <ul
-          aria-labelledby=":r5:"
+          aria-labelledby=":r7:"
           class="c4"
         >
           <li
@@ -787,10 +787,10 @@ exports[`NavList renders with groups 1`] = `
           >
             <a
               aria-current="page"
-              aria-labelledby=":r6:--label "
+              aria-labelledby=":r8:--label "
               class="c7 c8"
               href="/getting-started"
-              id=":r6:"
+              id=":r8:"
               tabindex="0"
             >
               <div
@@ -799,7 +799,7 @@ exports[`NavList renders with groups 1`] = `
               >
                 <span
                   class="c10"
-                  id=":r6:--label"
+                  id=":r8:--label"
                 >
                   Getting started
                 </span>
@@ -818,22 +818,22 @@ exports[`NavList renders with groups 1`] = `
       >
         <h3
           class="c3"
-          id=":r7:"
+          id=":r9:"
         >
           Components
         </h3>
         <ul
-          aria-labelledby=":r7:"
+          aria-labelledby=":r9:"
           class="c4"
         >
           <li
             class="c5 c11"
           >
             <a
-              aria-labelledby=":r8:--label "
+              aria-labelledby=":ra:--label "
               class="c7 c8"
               href="/Avatar"
-              id=":r8:"
+              id=":ra:"
               tabindex="0"
             >
               <div
@@ -842,7 +842,7 @@ exports[`NavList renders with groups 1`] = `
               >
                 <span
                   class="c12"
-                  id=":r8:--label"
+                  id=":ra:--label"
                 >
                   Avatar
                 </span>
@@ -1244,15 +1244,15 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
       class="c0"
     >
       <li
-        aria-labelledby=":r1v:"
+        aria-labelledby=":r23:"
         class="c1 c2"
       >
         <button
-          aria-controls=":r20:"
+          aria-controls=":r24:"
           aria-expanded="true"
-          aria-labelledby=":r1v:--label "
+          aria-labelledby=":r23:--label "
           class="c3 c4"
-          id=":r1v:"
+          id=":r23:"
           tabindex="0"
         >
           <div
@@ -1264,7 +1264,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
             >
               <span
                 class="c1 c7"
-                id=":r1v:--label"
+                id=":r23:--label"
               >
                 Item
               </span>
@@ -1291,19 +1291,19 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
         </button>
         <div>
           <ul
-            aria-labelledby=":r1v:"
+            aria-labelledby=":r23:"
             class="c1 c10"
-            id=":r20:"
+            id=":r24:"
           >
             <li
               class="c3 c11"
             >
               <a
                 aria-current="page"
-                aria-labelledby=":r22:--label "
+                aria-labelledby=":r26:--label "
                 class="c12 c13"
                 href="#"
-                id=":r22:"
+                id=":r26:"
                 tabindex="0"
               >
                 <div
@@ -1312,7 +1312,7 @@ exports[`NavList.Item with NavList.SubNav does not have active styles if SubNav 
                 >
                   <span
                     class="c1 c14"
-                    id=":r22:--label"
+                    id=":r26:--label"
                   >
                     Sub Item
                   </span>
@@ -1736,15 +1736,15 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
       class="c0"
     >
       <li
-        aria-labelledby=":r1q:"
+        aria-labelledby=":r1t:"
         class="c1 c2"
       >
         <button
-          aria-controls=":r1r:"
+          aria-controls=":r1u:"
           aria-expanded="false"
-          aria-labelledby=":r1q:--label "
+          aria-labelledby=":r1t:--label "
           class="c3 c4"
-          id=":r1q:"
+          id=":r1t:"
           tabindex="0"
         >
           <div
@@ -1756,7 +1756,7 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
             >
               <span
                 class="c1 c7"
-                id=":r1q:--label"
+                id=":r1t:--label"
               >
                 Item
               </span>
@@ -1783,19 +1783,19 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
         </button>
         <div>
           <ul
-            aria-labelledby=":r1q:"
+            aria-labelledby=":r1t:"
             class="c1 c10"
-            id=":r1r:"
+            id=":r1u:"
           >
             <li
               class="c3 c11"
             >
               <a
                 aria-current="page"
-                aria-labelledby=":r1t:--label "
+                aria-labelledby=":r20:--label "
                 class="c12 c13"
                 href="#"
-                id=":r1t:"
+                id=":r20:"
                 tabindex="0"
               >
                 <div
@@ -1804,7 +1804,7 @@ exports[`NavList.Item with NavList.SubNav has active styles if SubNav contains t
                 >
                   <span
                     class="c1 c7"
-                    id=":r1t:--label"
+                    id=":r20:--label"
                   >
                     Sub Item
                   </span>

--- a/packages/react/src/ThemeProvider.tsx
+++ b/packages/react/src/ThemeProvider.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import {ThemeProvider as SCThemeProvider} from 'styled-components'
 import defaultTheme from './theme'
 import deepmerge from 'deepmerge'
+import {useId} from './hooks'
 
 export const defaultColorMode = 'day'
 const defaultDayScheme = 'light'
@@ -39,9 +40,9 @@ const ThemeContext = React.createContext<{
 })
 
 // inspired from __NEXT_DATA__, we use application/json to avoid CSRF policy with inline scripts
-const getServerHandoff = () => {
+const getServerHandoff = (id: string) => {
   try {
-    const serverData = document.getElementById('__PRIMER_DATA__')?.textContent
+    const serverData = document.getElementById(`__PRIMER_DATA_${id}__`)?.textContent
     if (serverData) return JSON.parse(serverData)
   } catch (error) {
     // if document/element does not exist or JSON is invalid, supress error
@@ -61,7 +62,8 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>
   // Initialize state
   const theme = props.theme ?? fallbackTheme ?? defaultTheme
 
-  const {resolvedServerColorMode} = getServerHandoff()
+  const uniqueDataId = useId()
+  const {resolvedServerColorMode} = getServerHandoff(uniqueDataId)
   const resolvedColorModePassthrough = React.useRef(resolvedServerColorMode)
 
   const [colorMode, setColorMode] = React.useState(props.colorMode ?? fallbackColorMode ?? defaultColorMode)
@@ -135,7 +137,7 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>
         {props.preventSSRMismatch ? (
           <script
             type="application/json"
-            id="__PRIMER_DATA__"
+            id={`__PRIMER_DATA_${uniqueDataId}__`}
             dangerouslySetInnerHTML={{__html: JSON.stringify({resolvedServerColorMode: resolvedColorMode})}}
           />
         ) : null}

--- a/packages/react/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`AnchoredOverlay should render consistently when open 1`] = `
       aria-expanded="true"
       aria-haspopup="true"
       class="c1 c2"
-      id=":r6:"
+      id=":rd:"
       tabindex="0"
     >
       Anchor Button

--- a/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -2176,7 +2176,7 @@ exports[`TextInput renders trailingAction icon button 1`] = `
     className="c3 TextInput-action"
   >
     <button
-      aria-labelledby=":r1:"
+      aria-labelledby=":rl:"
       className="c4"
       data-block={null}
       data-component="IconButton"
@@ -2215,7 +2215,7 @@ exports[`TextInput renders trailingAction icon button 1`] = `
       aria-hidden={true}
       className="c5"
       data-direction="s"
-      id=":r1:"
+      id=":rl:"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >
@@ -3170,7 +3170,7 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
     className="c3 TextInput-action"
   >
     <button
-      aria-describedby=":r0:"
+      aria-describedby=":rj:"
       className="c4"
       data-block={null}
       data-no-visuals={true}
@@ -3196,7 +3196,7 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
     <span
       className="c6"
       data-direction="s"
-      id=":r0:"
+      id=":rj:"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       role="tooltip"


### PR DESCRIPTION
- Fixes https://github.com/github/primer/issues/3175
- Reported on slack: https://github.slack.com/archives/C01L618AEP9/p1712157856202369

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

Add unique id to server handoff to avoid collisions when there are multiple ThemeProvider on one page

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- [x] Tested with github/github
- [x] Tested with github/docs-internal

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
