### PR TITLE
Generate the component name in the story id based on import path

### DIFF
--- a/packages/react/script/components-json/build.ts
+++ b/packages/react/script/components-json/build.ts
@@ -15,6 +15,12 @@ import outputSchema from './output.schema.json'
 type Component = {
   name: string
   status: 'draft' | 'experimental' | 'alpha' | 'beta' | 'stable' | 'deprecated'
+  importPath:
+    | '@primer/react'
+    | '@primer/react/next'
+    | '@primer/react/deprecated'
+    | '@primer/react/experimental'
+    | '@primer/react/drafts'
   stories: Array<{id: string; code?: string}>
 }
 
@@ -48,8 +54,12 @@ const components = docsFiles.map(docsFilepath => {
   // Example: src/components/Box/Box.docs.json -> src/components/Box/Box.stories.tsx
   const defaultStoryFilepath = docsFilepath.replace(/\.docs\.json$/, '.stories.tsx')
 
+  const isComponentV2 = docs.importPath === '@primer/react/next'
+  const docsName = String(docs.name).toLowerCase()
+  const componentName = isComponentV2 ? `${docsName}v2` : docsName
+
   // Get the default story id
-  const defaultStoryId = `${storyPrefix[docs.status]}components-${String(docs.name).toLowerCase()}--default`
+  const defaultStoryId = `${storyPrefix[docs.status]}components-${componentName}--default`
 
   // Get source code for default story
   const {Default: defaultStoryCode} = getStorySourceCode(defaultStoryFilepath)

--- a/packages/react/src/TooltipV2/Tooltip.docs.json
+++ b/packages/react/src/TooltipV2/Tooltip.docs.json
@@ -1,6 +1,6 @@
 {
   "id": "tooltip_v2",
-  "name": "TooltipV2",
+  "name": "Tooltip",
   "docsId": "tooltip",
   "status": "beta",
   "a11yReviewed": true,


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

As a part of fixing Tooltip docs on the new docs site, we have been experimenting multiple things with the name change and looks like we need to go back to naming the component as same as the exported name. I.e. `Tooltip` for both v1 and v2 vs `Tooltip` and `Tooltipv2` . We named the v2 component to be `TooltipV2` mainly to generate story ids correctly ([PR reference](https://github.com/primer/react/pull/4458/files#diff-a7fff0528e775b2dba37aed9e5b548d000e60c54a57dfba2066ae7c0fcc4dbd2)) but this resulted with the wrong import path in the new docs side `import {TooltipV2} from '@primer/react/next'` so I am taking the name back to its original state and alter the function that we generate story ids. 

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->
- Component name: From being `TooltipV2` -> `Tooltip`
- alter the function that we generate story ids based on the importPath

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why - Docs change

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
