### PR TITLE
Update release.yml to use tagged dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
   release-next-major:
     if: github.ref_name == 'next-major'
     name: Next major
-    uses: primer/.github/.github/workflows/release_with_app.yml@main
+    uses: primer/.github/.github/workflows/release_with_app.yml@v1.0.0
     with:
       title: Release tracking (next major)
     secrets:


### PR DESCRIPTION
This should have no impact. The dependency is not changed, but this reference is more secure and allows us to modify `primer/.github/.github/workflows/release_with_app.yml` without breaking consumers code.