### PR TITLE
Revert "chore(actions): Disable npm package publishing for canary versions (temporarily) "

### DIFF
--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -1,62 +1,62 @@
-# name: Canary Release
-# on:
-#   push:
-#     branches-ignore:
-#       - 'main'
-#       - 'next-major'
-#       - 'changeset-release/**'
+name: Canary Release
+on:
+  push:
+    branches-ignore:
+      - 'main'
+      - 'next-major'
+      - 'changeset-release/**'
 
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-# jobs:
-#   release:
-#     concurrency:
-#       group: npm-canary
-#       cancel-in-progress: false
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout repository
-#         uses: actions/checkout@v4
-#         with:
-#           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-#           fetch-depth: 0
-#       - name: Set up Node
-#         uses: actions/setup-node@v4
-#         with:
-#           node-version: 20
-#           cache: 'npm'
-#       - run: npm i -g npm@^10.5.1
-#       - name: Install dependencies
-#         run: npm ci
-#       - name: Build
-#         run: npm run build --if-present
-#       - name: Create .npmrc
-#         run: |
-#           cat << EOF > "$HOME/.npmrc"
-#             //registry.npmjs.org/:_authToken=$NPM_TOKEN
-#           EOF
-#         env:
-#           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
-#       - name: Publish canary release
-#         run: |
-#           echo -e "---\n$( jq .name packages/react/package.json ): patch\n---\n\nFake entry to force publishing" > .changeset/force-snapshot-release.md
-#           npx changeset version --snapshot
-#           npx changeset publish --tag canary
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#       - name: Output canary version
-#         uses: actions/github-script@v4.0.2
-#         with:
-#           script: |
-#             const package = require(`${process.env.GITHUB_WORKSPACE}/packages/react/package.json`)
-#             github.repos.createCommitStatus({
-#               owner: context.repo.owner,
-#               repo: context.repo.repo,
-#               sha: context.sha,
-#               state: 'success',
-#               context: `Published ${package.name}`,
-#               description: package.version,
-#               target_url: `https://unpkg.com/${package.name}@${package.version}/`
-#             })
+jobs:
+  release:
+    concurrency:
+      group: npm-canary
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm i -g npm@^10.5.1
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build --if-present
+      - name: Create .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
+      - name: Publish canary release
+        run: |
+          echo -e "---\n$( jq .name packages/react/package.json ): patch\n---\n\nFake entry to force publishing" > .changeset/force-snapshot-release.md
+          npx changeset version --snapshot
+          npx changeset publish --tag canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Output canary version
+        uses: actions/github-script@v4.0.2
+        with:
+          script: |
+            const package = require(`${process.env.GITHUB_WORKSPACE}/packages/react/package.json`)
+            github.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'success',
+              context: `Published ${package.name}`,
+              description: package.version,
+              target_url: `https://unpkg.com/${package.name}@${package.version}/`
+            })


### PR DESCRIPTION
Reverts primer/react#4492

Thanks to @joshblack that I found out we don't need to comment out the workflow to disable it. We can do so in the UI and avoid errors https://github.com/primer/react/actions/workflows/release_canary.yml