### PR TITLE
ActionBar: Make aria-label mandatory

### DIFF
--- a/.changeset/lucky-zebras-stare.md
+++ b/.changeset/lucky-zebras-stare.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+ActionBar: Make it such that either aria-label or aria-labelledby is present

--- a/packages/react/src/drafts/ActionBar/ActionBar.stories.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.stories.tsx
@@ -30,7 +30,7 @@ export default {
 } as Meta<typeof ActionBar>
 
 export const Default = () => (
-  <ActionBar>
+  <ActionBar aria-label="Toolbar">
     <ActionBar.IconButton icon={BoldIcon} aria-label="Default"></ActionBar.IconButton>
     <ActionBar.IconButton icon={ItalicIcon} aria-label="Default"></ActionBar.IconButton>
     <ActionBar.IconButton icon={CodeIcon} aria-label="Default"></ActionBar.IconButton>
@@ -48,7 +48,7 @@ export const Default = () => (
 )
 
 export const SmallActionBar = () => (
-  <ActionBar size="small">
+  <ActionBar size="small" aria-label="Toolbar">
     <ActionBar.IconButton icon={BoldIcon} aria-label="Default"></ActionBar.IconButton>
     <ActionBar.IconButton icon={ItalicIcon} aria-label="Default"></ActionBar.IconButton>
     <ActionBar.IconButton icon={CodeIcon} aria-label="Default"></ActionBar.IconButton>
@@ -103,7 +103,7 @@ export const CommentBox = () => {
           />
         </Box>
         <Box sx={{width: '50%'}}>
-          <ActionBar>
+          <ActionBar aria-label="Toolbar">
             <ActionBar.IconButton icon={HeadingIcon} aria-label="Heading"></ActionBar.IconButton>
             <ActionBar.IconButton icon={BoldIcon} aria-label="Bold"></ActionBar.IconButton>
             <ActionBar.IconButton icon={ItalicIcon} aria-label="Italic"></ActionBar.IconButton>
@@ -152,7 +152,7 @@ export const ActionBarWithMenuTrigger = () => {
 
   return (
     <Box>
-      <ActionBar>
+      <ActionBar aria-label="Toolbar">
         <ActionBar.IconButton icon={BoldIcon} aria-label="Bold"></ActionBar.IconButton>
         <ActionBar.IconButton icon={ItalicIcon} aria-label="Italic"></ActionBar.IconButton>
         <ActionBar.IconButton icon={CodeIcon} aria-label="Code"></ActionBar.IconButton>

--- a/packages/react/src/drafts/ActionBar/ActionBar.stories.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.stories.tsx
@@ -59,7 +59,10 @@ export const SmallActionBar = () => (
   </ActionBar>
 )
 
-export const CommentBox = () => {
+type CommentBoxProps = {'aria-label': string}
+
+export const CommentBox = (props: CommentBoxProps) => {
+  const {'aria-label': ariaLabel} = props
   const [view, setView] = React.useState<MarkdownViewMode>('edit')
   const loadPreview = React.useCallback(() => {
     //console.log('loadPreview')
@@ -67,6 +70,7 @@ export const CommentBox = () => {
   const [value, setValue] = React.useState('')
   const [isOpen, setIsOpen] = React.useState(false)
   const buttonRef = React.useRef(null)
+  const toolBarLabel = `${ariaLabel} toolbar`
   return (
     <Box
       sx={{
@@ -103,7 +107,7 @@ export const CommentBox = () => {
           />
         </Box>
         <Box sx={{width: '50%'}}>
-          <ActionBar aria-label="Toolbar">
+          <ActionBar aria-label={toolBarLabel}>
             <ActionBar.IconButton icon={HeadingIcon} aria-label="Heading"></ActionBar.IconButton>
             <ActionBar.IconButton icon={BoldIcon} aria-label="Bold"></ActionBar.IconButton>
             <ActionBar.IconButton icon={ItalicIcon} aria-label="Italic"></ActionBar.IconButton>
@@ -242,7 +246,7 @@ export const ActionbarToggle = () => {
       <Box sx={bottomSectionStyles}>
         {showEditView ? (
           <Box>
-            <CommentBox />
+            <CommentBox aria-label="Comment box" />
             <Box sx={{display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', p: 2, gap: 2}}>
               <Button
                 variant="primary"
@@ -273,7 +277,7 @@ export const MultipleActionBars = () => {
       <Box sx={{p: 3}}>
         {showFirstCommentBox ? (
           <Box>
-            <CommentBox key={1} />
+            <CommentBox aria-label="First Comment Box" />
             <Box sx={{display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', p: 2, gap: 2}}>
               <Button
                 variant="primary"
@@ -295,7 +299,7 @@ export const MultipleActionBars = () => {
       <Box sx={{p: 3}}>
         {showSecondCommentBox ? (
           <Box>
-            <CommentBox key={2} />
+            <CommentBox aria-label="Second Comment Box" />
             <Box sx={{display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', p: 2, gap: 2}}>
               <Button
                 variant="primary"

--- a/packages/react/src/drafts/ActionBar/ActionBar.stories.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.stories.tsx
@@ -31,31 +31,29 @@ export default {
 
 export const Default = () => (
   <ActionBar aria-label="Toolbar">
-    <ActionBar.IconButton icon={BoldIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={ItalicIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={CodeIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={LinkIcon} aria-label="Default"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={BoldIcon} aria-label="Bold"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={ItalicIcon} aria-label="Italic"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={CodeIcon} aria-label="Code"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={LinkIcon} aria-label="Link"></ActionBar.IconButton>
     <ActionBar.Divider />
-    <ActionBar.IconButton icon={FileAddedIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={SearchIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={FileAddedIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={SearchIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={FileAddedIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={SearchIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={FileAddedIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={SearchIcon} aria-label="Default"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={FileAddedIcon} aria-label="File Added"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={SearchIcon} aria-label="Search"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={QuoteIcon} aria-label="Insert Quote"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={ListUnorderedIcon} aria-label="Unordered List"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={ListOrderedIcon} aria-label="Ordered List"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={TasklistIcon} aria-label="Task List"></ActionBar.IconButton>
   </ActionBar>
 )
 
 export const SmallActionBar = () => (
   <ActionBar size="small" aria-label="Toolbar">
-    <ActionBar.IconButton icon={BoldIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={ItalicIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={CodeIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={LinkIcon} aria-label="Default"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={BoldIcon} aria-label="Bold"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={ItalicIcon} aria-label="Italic"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={CodeIcon} aria-label="Code"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={LinkIcon} aria-label="Link"></ActionBar.IconButton>
     <ActionBar.Divider />
-    <ActionBar.IconButton icon={FileAddedIcon} aria-label="Default"></ActionBar.IconButton>
-    <ActionBar.IconButton icon={SearchIcon} aria-label="Default"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={FileAddedIcon} aria-label="File Added"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={SearchIcon} aria-label="Search"></ActionBar.IconButton>
   </ActionBar>
 )
 

--- a/packages/react/src/drafts/ActionBar/ActionBar.test.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.test.tsx
@@ -7,7 +7,7 @@ import ActionBar from './'
 import {BoldIcon, CodeIcon, ItalicIcon, LinkIcon} from '@primer/octicons-react'
 
 const SimpleActionBar = () => (
-  <ActionBar>
+  <ActionBar aria-label="Toolbar">
     <ActionBar.IconButton icon={BoldIcon} aria-label="Default"></ActionBar.IconButton>
     <ActionBar.IconButton icon={ItalicIcon} aria-label="Default"></ActionBar.IconButton>
     <ActionBar.Divider />

--- a/packages/react/src/drafts/ActionBar/ActionBar.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.tsx
@@ -1,5 +1,5 @@
 import type {RefObject, MutableRefObject} from 'react'
-import React, {useState, useCallback, useRef, forwardRef} from 'react'
+import React, {useState, useEffect, useCallback, useRef, forwardRef} from 'react'
 import {KebabHorizontalIcon} from '@primer/octicons-react'
 import {ActionList} from '../../ActionList'
 import useIsomorphicLayoutEffect from '../../utils/useIsomorphicLayoutEffect'
@@ -15,6 +15,7 @@ import {IconButton} from '../../Button'
 import Box from '../../Box'
 import {ActionMenu} from '../../ActionMenu'
 import {useFocusZone, FocusKeys} from '../../hooks/useFocusZone'
+import {invariant} from '../../utils/invariant'
 
 type ChildSize = {
   text: string
@@ -230,6 +231,13 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
     bindKeys: FocusKeys.ArrowHorizontal | FocusKeys.HomeAndEnd,
     focusOutBehavior: 'wrap',
   })
+
+  if (__DEV__) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEffect(() => {
+      invariant(ariaLabel, 'Use the `aria-label` prop to provide an accessible label for assistive technology')
+    })
+  }
 
   return (
     <ActionBarContext.Provider value={{size, setChildrenWidth}}>

--- a/packages/react/src/drafts/ActionBar/ActionBar.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.tsx
@@ -37,11 +37,14 @@ small (28px), medium (32px), large (40px)
 */
 type Size = 'small' | 'medium' | 'large'
 
+type A11yProps =
+  | {'aria-label': React.AriaAttributes['aria-label']; 'aria-labelledby'?: undefined}
+  | {'aria-label'?: undefined; 'aria-labelledby': React.AriaAttributes['aria-labelledby']}
+
 export type ActionBarProps = {
   size?: Size
-  'aria-label': React.AriaAttributes['aria-label']
   children: React.ReactNode
-}
+} & A11yProps
 
 export type ActionBarIconButtonProps = IconButtonProps
 
@@ -231,13 +234,6 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
     bindKeys: FocusKeys.ArrowHorizontal | FocusKeys.HomeAndEnd,
     focusOutBehavior: 'wrap',
   })
-
-  if (__DEV__) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
-      invariant(ariaLabel, 'Use the `aria-label` prop to provide an accessible label for assistive technology')
-    })
-  }
 
   return (
     <ActionBarContext.Provider value={{size, setChildrenWidth}}>

--- a/packages/react/src/drafts/ActionBar/ActionBar.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.tsx
@@ -38,7 +38,7 @@ type Size = 'small' | 'medium' | 'large'
 
 export type ActionBarProps = {
   size?: Size
-  'aria-label'?: React.AriaAttributes['aria-label']
+  'aria-label': React.AriaAttributes['aria-label']
   children: React.ReactNode
 }
 

--- a/packages/react/src/drafts/ActionBar/ActionBar.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.tsx
@@ -1,5 +1,5 @@
 import type {RefObject, MutableRefObject} from 'react'
-import React, {useState, useEffect, useCallback, useRef, forwardRef} from 'react'
+import React, {useState, useCallback, useRef, forwardRef} from 'react'
 import {KebabHorizontalIcon} from '@primer/octicons-react'
 import {ActionList} from '../../ActionList'
 import useIsomorphicLayoutEffect from '../../utils/useIsomorphicLayoutEffect'
@@ -15,7 +15,6 @@ import {IconButton} from '../../Button'
 import Box from '../../Box'
 import {ActionMenu} from '../../ActionMenu'
 import {useFocusZone, FocusKeys} from '../../hooks/useFocusZone'
-import {invariant} from '../../utils/invariant'
 
 type ChildSize = {
   text: string


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes # (Didn't create an issue)

Voiceover announcement was wonky without a mandatory `aria-label` on the `ActionBar` component.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
