### PR TITLE
ci: add arethetypeswrong action

### DIFF
--- a/.github/actions/arethetypeswrong/action.yml
+++ b/.github/actions/arethetypeswrong/action.yml
@@ -15,13 +15,18 @@ runs:
         node-version: 20
         cache: 'npm'
     - run: npm i -g npm@^10.5.1
+      shell: bash
     - name: Install dependencies
       run: npm ci
+      shell: bash
     - name: Build project
       run: npm run build
+      shell: bash
     - name: Run arethetypeswrong
       working-directory: ${{ inputs.workspace }}
       run: npx @arethetypeswrong/cli --pack .
+      shell: bash
     - name: Run publint
       working-directory: ${{ inputs.workspace }}
       run: npx publint . --strict
+      shell: bash

--- a/.github/actions/arethetypeswrong/action.yml
+++ b/.github/actions/arethetypeswrong/action.yml
@@ -7,21 +7,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20
-        cache: 'npm'
-    - run: npm i -g npm@^10.5.1
-      shell: bash
-    - name: Install dependencies
-      run: npm ci
-      shell: bash
-    - name: Build project
-      run: npm run build
-      shell: bash
     - name: Run arethetypeswrong
       working-directory: ${{ inputs.workspace }}
       run: npx @arethetypeswrong/cli --pack .

--- a/.github/actions/arethetypeswrong/action.yml
+++ b/.github/actions/arethetypeswrong/action.yml
@@ -1,0 +1,27 @@
+name: 'Are the Types Wrong'
+description: 'Check the exported TypeScript declaration files for a package'
+inputs:
+  workspace:
+    description: 'Specify the workspace which publishes types to check'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+    - run: npm i -g npm@^10.5.1
+    - name: Install dependencies
+      run: npm ci
+    - name: Build project
+      run: npm run build
+    - name: Run arethetypeswrong
+      working-directory: ${{ inputs.workspace }}
+      run: npx @arethetypeswrong/cli --pack .
+    - name: Run publint
+      working-directory: ${{ inputs.workspace }}
+      run: npx publint . --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
         run: npm run build
       - name: Type check
         run: npm run type-check
+      - uses: './.github/actions/arethetypeswrong'
+        with:
+          workspace: packages/react
 
   examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,8 @@ jobs:
         run: npm run build
       - name: Type check
         run: npm run type-check
-      - uses: './.github/actions/arethetypeswrong'
+      - name: Check published types
+        uses: './.github/actions/arethetypeswrong'
         with:
           workspace: packages/react
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Add a custom action to run the "arethetypeswrong" CLI along with publint. This should help to verify that the way we publish types are compatible with all the various ways folks can configure TypeScript.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add shared `arethetypeswrong` custom action

#### Changed

<!-- List of things changed in this PR -->

- Update `type-check` job in CI to use `arethetypeswrong` custom action

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This only updates our CI workflows.
