### PR TITLE
ActionBar: Add minwidth=0 to toolbar flexbox to make sure contents don't leak

### DIFF
--- a/packages/react/src/drafts/ActionBar/ActionBar.tsx
+++ b/packages/react/src/drafts/ActionBar/ActionBar.tsx
@@ -52,6 +52,7 @@ const GAP = 8
 
 const listStyles = {
   display: 'flex',
+  minWidth: 0,
   listStyle: 'none',
   whiteSpace: 'nowrap',
   paddingY: 0,


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #https://github.com/github/primer/issues/3216

The overflow is more controlled and looks more sane with this fix.

**Before -**
<img width="702" alt="Screenshot 2024-04-17 at 1 20 22 PM" src="https://github.com/primer/react/assets/417268/fcc85b9d-8939-4795-bf39-7df25bd1a41a">


**After -** 
<img width="630" alt="Screenshot 2024-04-17 at 1 19 36 PM" src="https://github.com/primer/react/assets/417268/af4791d2-0645-49ee-b4fe-39549a36b567">



https://github.com/primer/react/assets/417268/5b3a0e17-429d-4c19-8d31-3526d3861c65



### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
