### PR TITLE
docs: Update React version referenced in contributor docs

### DIFF
--- a/contributor-docs/CONTRIBUTING.md
+++ b/contributor-docs/CONTRIBUTING.md
@@ -45,7 +45,7 @@ As this is a public repo, please be careful not to include details or screenshot
 
 We primarily use [Storybook](https://storybook.js.org/) as a workspace to develop new components or make changes to existing components.
 
-Before running storybook locally, make sure to install [Node.js](https://nodejs.org/en/) v16 (we recommend using [nvm](https://github.com/nvm-sh/nvm)). Next, run the following command to setup your environment:
+Before running storybook locally, make sure to install [Node.js](https://nodejs.org/en/) v20 (we recommend using [nvm](https://github.com/nvm-sh/nvm)). Next, run the following command to setup your environment:
 
 ```sh
 npm run setup


### PR DESCRIPTION
Node.js 16 is unsupported, and the current [`.nvmrc`](https://github.com/primer/react/blob/main/.nvmrc) references Node.js 20.
