### PR TITLE
Fix up manually published 36.14.0 (accidently)

### DIFF
--- a/.changeset/dirty-pots-rule.md
+++ b/.changeset/dirty-pots-rule.md
@@ -1,5 +1,0 @@
----
-"@primer/react": patch
----
-
-TooltipV2: Check if tooltip element has `popover` attribute before calling `showPopover` and `hidePopover`

--- a/.changeset/light-zebras-mix.md
+++ b/.changeset/light-zebras-mix.md
@@ -1,5 +1,0 @@
----
-'@primer/react': patch
----
-
-Utilize `getGlobalFocusStyle` to prevent `outline-offset` from being overridden by default browser styles

--- a/.changeset/smart-chefs-fail.md
+++ b/.changeset/smart-chefs-fail.md
@@ -1,7 +1,0 @@
----
-'@primer/react': minor
----
-
-IconButton: introduce tooltips on icon buttons behind the `unsafeDisableTooltip` prop for an incremental rollout.
-
-In the next release, we plan to update the default value of `unsafeDisableTooltip` to `false` so that the tooltip behaviour becomes the default. 

--- a/.changeset/stale-ties-cover.md
+++ b/.changeset/stale-ties-cover.md
@@ -1,5 +1,0 @@
----
-"@primer/react": patch
----
-
-Tooltipv2: Prevent closing other overlays when tooltip has the focus when ESC is hit

--- a/.changeset/ten-candles-melt.md
+++ b/.changeset/ten-candles-melt.md
@@ -1,5 +1,0 @@
----
- "@primer/react": patch
- ---
-
- Add our react template to the README.md

--- a/.changeset/thick-bats-cough.md
+++ b/.changeset/thick-bats-cough.md
@@ -1,5 +1,0 @@
----
-"@primer/react": patch
----
-
-TreeView: Toggle subtree via Space key (in addition to Enter key)

--- a/.changeset/two-ravens-prove.md
+++ b/.changeset/two-ravens-prove.md
@@ -1,5 +1,0 @@
----
-"@primer/react": patch
----
-
-ThemeProvider + SSR: Fix incorrect theme with multiple ThemeProviders on page

--- a/.changeset/young-countries-confess.md
+++ b/.changeset/young-countries-confess.md
@@ -1,5 +1,0 @@
----
-"@primer/react": minor
----
-
-Dialog v2: Add support for `returnFocusRef`

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@primer/octicons-react": "^18.2.0",
-    "@primer/react": "36.13.0",
+    "@primer/react": "36.14.0",
     "next": "^14.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -412,6 +412,66 @@
         "rimraf": "^5.0.5"
       }
     },
+    "examples/app-router/node_modules/@primer/react": {
+      "version": "36.13.0",
+      "resolved": "https://registry.npmjs.org/@primer/react/-/react-36.13.0.tgz",
+      "integrity": "sha512-SBpqU+jTTGF2ezOKjA9R+7+zlxYlaO/VgchMzSBlXT5DooGM0/FD+t/njTavyl4KNrZyFkVU1Q/SrsiYQTmmVg==",
+      "dependencies": {
+        "@github/combobox-nav": "^2.1.5",
+        "@github/markdown-toolbar-element": "^2.1.0",
+        "@github/paste-markdown": "^1.4.0",
+        "@github/relative-time-element": "^4.1.2",
+        "@github/tab-container-element": "4.5.0",
+        "@lit-labs/react": "1.2.1",
+        "@oddbird/popover-polyfill": "^0.3.1",
+        "@primer/behaviors": "^1.5.1",
+        "@primer/live-region-element": "^0.2.0",
+        "@primer/octicons-react": "^19.9.0",
+        "@primer/primitives": "^7.15.14",
+        "@styled-system/css": "^5.1.5",
+        "@styled-system/props": "^5.1.5",
+        "@styled-system/theme-get": "^5.1.2",
+        "@types/react-is": "^18.2.1",
+        "@types/styled-system": "^5.1.12",
+        "@types/styled-system__css": "^5.0.16",
+        "@types/styled-system__theme-get": "^5.0.1",
+        "clsx": "^1.2.1",
+        "color2k": "^2.0.3",
+        "deepmerge": "^4.2.2",
+        "focus-visible": "^5.2.0",
+        "fzy.js": "^0.4.1",
+        "history": "^5.0.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isobject": "^3.0.2",
+        "react-intersection-observer": "^9.4.3",
+        "react-is": "^18.2.0",
+        "react-markdown": "8.0.7",
+        "styled-system": "^5.1.5"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=7"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "@types/styled-components": "^5.1.11",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "styled-components": "5.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "@types/styled-components": {
+          "optional": true
+        }
+      }
+    },
     "examples/codesandbox": {
       "version": "0.0.0",
       "dependencies": {
@@ -474,7 +534,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^18.2.0",
-        "@primer/react": "36.13.0",
+        "@primer/react": "36.14.0",
         "next": "^14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4789,6 +4849,11 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.3.1.tgz",
       "integrity": "sha512-zL79nlhZVCg7x2Pf/HT5MB0mowmErE71VXpF10/3Wy8dQwkninNO1M9aOizh2wKC5LkSpDXqNYjDZwbH0/bcSg=="
+    },
+    "node_modules/@github/tab-container-element": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@github/tab-container-element/-/tab-container-element-4.5.0.tgz",
+      "integrity": "sha512-8pzFJVg7AyPFqOjKFoiHwVQbo4MdTPpUfQwW91Hgj+OOvySZVmw4PU8ejU4qTHbb2oA2ajYMRuXuAvhfMgnS1Q=="
     },
     "node_modules/@graphql-tools/batch-execute": {
       "version": "7.1.2",
@@ -62070,7 +62135,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "36.13.0",
+      "version": "36.14.0",
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.1.5",
@@ -62235,10 +62300,6 @@
           "optional": true
         }
       }
-    },
-    "packages/react/node_modules/@github/tab-container-element": {
-      "version": "4.5.0",
-      "license": "MIT"
     },
     "packages/react/node_modules/@rollup/plugin-commonjs": {
       "version": "25.0.4",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @primer/react
 
+## 36.14.0
+
+### Minor Changes
+
+- [#4224](https://github.com/primer/react/pull/4224) [`8e9267fbc77946c65844a5cb3a714ba57291fc5c`](https://github.com/primer/react/commit/8e9267fbc77946c65844a5cb3a714ba57291fc5c) Thanks [@broccolinisoup](https://github.com/broccolinisoup)! - IconButton: introduce tooltips on icon buttons behind the `unsafeDisableTooltip` prop for an incremental rollout.
+
+  In the next release, we plan to update the default value of `unsafeDisableTooltip` to `false` so that the tooltip behaviour becomes the default.
+
+- [#4425](https://github.com/primer/react/pull/4425) [`6682d28bbb8fe5aa2c959f8013cbcfc4f3c7030e`](https://github.com/primer/react/commit/6682d28bbb8fe5aa2c959f8013cbcfc4f3c7030e) Thanks [@siddharthkp](https://github.com/siddharthkp)! - Dialog v2: Add support for `returnFocusRef`
+
+### Patch Changes
+
+- [#4463](https://github.com/primer/react/pull/4463) [`4b001296005e1fa2c11afe0b41bc852f44a5b905`](https://github.com/primer/react/commit/4b001296005e1fa2c11afe0b41bc852f44a5b905) Thanks [@broccolinisoup](https://github.com/broccolinisoup)! - TooltipV2: Check if tooltip element has `popover` attribute before calling `showPopover` and `hidePopover`
+
+- [#4451](https://github.com/primer/react/pull/4451) [`2f4939375a9d3b81f7f618ad2ea6f1a77cad187e`](https://github.com/primer/react/commit/2f4939375a9d3b81f7f618ad2ea6f1a77cad187e) Thanks [@TylerJDev](https://github.com/TylerJDev)! - Utilize `getGlobalFocusStyle` to prevent `outline-offset` from being overridden by default browser styles
+
+- [#4471](https://github.com/primer/react/pull/4471) [`aa8b6d83467ebd0d18939fc375340471a585deea`](https://github.com/primer/react/commit/aa8b6d83467ebd0d18939fc375340471a585deea) Thanks [@broccolinisoup](https://github.com/broccolinisoup)! - Tooltipv2: Prevent closing other overlays when tooltip has the focus when ESC is hit
+
+- [#4393](https://github.com/primer/react/pull/4393) [`57e1742c1538be83b208e08ff97b31df02acb5fa`](https://github.com/primer/react/commit/57e1742c1538be83b208e08ff97b31df02acb5fa) Thanks [@maximedegreve](https://github.com/maximedegreve)! - Add our react template to the README.md
+
+- [#4270](https://github.com/primer/react/pull/4270) [`ae14db7378efa90cad8623d6729747f0ca8f098b`](https://github.com/primer/react/commit/ae14db7378efa90cad8623d6729747f0ca8f098b) Thanks [@lukeed](https://github.com/lukeed)! - TreeView: Toggle subtree via Space key (in addition to Enter key)
+
+- [#4477](https://github.com/primer/react/pull/4477) [`054de02df44c2f1144db58e9778350d7bc0fb863`](https://github.com/primer/react/commit/054de02df44c2f1144db58e9778350d7bc0fb863) Thanks [@siddharthkp](https://github.com/siddharthkp)! - ThemeProvider + SSR: Fix incorrect theme with multiple ThemeProviders on page
+
 ## 36.13.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/react",
-  "version": "36.13.0",
+  "version": "36.14.0",
   "description": "An implementation of GitHub's Primer Design System using React",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

V36.14.0 https://www.npmjs.com/package/@primer/react/v/36.14.0 is published manually, not with changeset so this PR cleans up the versions and changelog.md

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

- current version of primer/react
- cahngelog.md

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why
