### PR TITLE
Make sure Link is underlined when `inline={true}`

### DIFF
--- a/.changeset/fifty-ravens-repeat.md
+++ b/.changeset/fifty-ravens-repeat.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Underline Link if the `inline` property is set to `true` even if no `data-a11y-link-underlines` attribute is provided.

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -27,16 +27,21 @@ const hoverColor = system({
 const StyledLink = styled.a<StyledLinkProps>`
   color: ${props => (props.muted ? get('colors.fg.muted')(props) : get('colors.accent.fg')(props))};
 
-  /* By default, Link does not have underline */
+  /* By default, Link is not underlined. */
   text-decoration: none;
 
-  /* You can add one by setting underline={true} */
+  /* If inline or underline are set to true Link is underlined. */
   text-decoration: ${props => (props.underline ? 'underline' : undefined)};
+  text-decoration: ${props => (props.inline ? 'underline' : undefined)};
 
-  /* Inline links (inside a text block), however, should have underline based on accessibility setting set in data-attribute */
-  /* Note: setting underline={false} does not override this */
+  /* Inline links, adjacent to text, can be controlled using a data-attribute. */
+  /* This way the inline property can be overwritten based on the attribute.
+  /* On github.com this is used for a user preference in the accessibility settings. */
   [data-a11y-link-underlines='true'] &[data-inline='true'] {
     text-decoration: underline;
+  }
+  [data-a11y-link-underlines='false'] &[data-inline='true'] {
+    text-decoration: none;
   }
 
   &:hover {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Related to https://github.com/github/primer/issues/2099

Currently, the `inline` property only works in combination with the `data-a11y-link-underlines` attribute. However, the link should always be underlined if `inline` is set to true and no attribute is provided.

### Changelog

#### Changed

If `inline` is set to `true`, the Link will be underlined even if not using the `data-a11y-link-underlines` attribute.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
