### PR TITLE
Experimental SelectPanel: use radio visual for single selection

### DIFF
--- a/.changeset/lovely-llamas-obey.md
+++ b/.changeset/lovely-llamas-obey.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+experimental/SelectPanel: Use radio visual for single selection

--- a/packages/react/src/ActionList/ActionListContainerContext.tsx
+++ b/packages/react/src/ActionList/ActionListContainerContext.tsx
@@ -1,4 +1,4 @@
-/** This context can be used by components that compose ActionList inside a Menu */
+/** This context can be used by components that compose ActionList inside ActionMenu or SelectPanel */
 
 import React from 'react'
 import type {AriaRole} from '../utils/types'
@@ -14,6 +14,8 @@ type ContextProps = {
   // eslint-disable-next-line @typescript-eslint/ban-types
   afterSelect?: Function
   enableFocusZone?: boolean
+  // SelectPanel v2 uses a radio instead of checkmark
+  singleSelectionVisual?: 'check' | 'radio'
 }
 
 export const ActionListContainerContext = React.createContext<ContextProps>({})

--- a/packages/react/src/ActionList/Selection.tsx
+++ b/packages/react/src/ActionList/Selection.tsx
@@ -5,11 +5,14 @@ import {GroupContext} from './Group'
 import {type ActionListProps, type ActionListItemProps, ListContext} from './shared'
 import {LeadingVisualContainer} from './Visuals'
 import Box from '../Box'
+import {ActionListContainerContext} from './ActionListContainerContext'
+import {StyledRadio} from '../Radio/Radio'
 
 type SelectionProps = Pick<ActionListItemProps, 'selected'>
 export const Selection: React.FC<React.PropsWithChildren<SelectionProps>> = ({selected}) => {
   const {selectionVariant: listSelectionVariant, role: listRole} = React.useContext(ListContext)
   const {selectionVariant: groupSelectionVariant} = React.useContext(GroupContext)
+  const {singleSelectionVisual} = React.useContext(ActionListContainerContext)
 
   /** selectionVariant in Group can override the selectionVariant in List root */
   /** fallback to selectionVariant from container menu if any (ActionMenu, SelectPanel ) */
@@ -31,7 +34,14 @@ export const Selection: React.FC<React.PropsWithChildren<SelectionProps>> = ({se
 
   if (selectionVariant === 'single' || listRole === 'menu') {
     return (
-      <LeadingVisualContainer data-component="ActionList.Selection">{selected && <CheckIcon />}</LeadingVisualContainer>
+      <LeadingVisualContainer data-component="ActionList.Selection">
+        {/* we use StyledRadio instead of Radio because we should not add a radio input, only a visual radio  */}
+        {singleSelectionVisual === 'radio' ? (
+          <StyledRadio as="span" data-checked={selected ? true : undefined} />
+        ) : (
+          selected && <CheckIcon />
+        )}
+      </LeadingVisualContainer>
     )
   }
 

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -42,14 +42,15 @@ export type RadioProps = {
 } & InputHTMLAttributes<HTMLInputElement> &
   SxProp
 
-const StyledRadio = styled.input`
+export const StyledRadio = styled.input`
   ${sharedCheckboxAndRadioStyles};
   border-radius: var(--borderRadius-full, 100vh);
   transition:
     background-color,
     border-color 80ms cubic-bezier(0.33, 1, 0.68, 1); /* checked -> unchecked - add 120ms delay to fully see animation-out */
 
-  &:checked {
+  &:checked,
+  &[data-checked] {
     border-color: ${get('colors.accent.fg')};
     border-width: var(--base-size-4, 4px);
 

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.features.stories.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.features.stories.tsx
@@ -55,7 +55,37 @@ export const InstantSelectionVariant = () => {
   )
 }
 
-export const SingleSelection = () => <h1>TODO</h1>
+export const SingleSelection = () => {
+  const [selectedTag, setSelectedTag] = React.useState<string>()
+
+  const onSubmit = () => {
+    if (!selectedTag) return
+    data.ref = selectedTag // pretending to persist changes
+  }
+
+  const itemsToShow = data.tags
+
+  return (
+    <>
+      <h1>Instant selection variant</h1>
+
+      <SelectPanel title="Choose a tag" selectionVariant="single" onSubmit={onSubmit}>
+        <SelectPanel.Button leadingVisual={TagIcon}>{selectedTag || 'Choose a tag'}</SelectPanel.Button>
+
+        <ActionList>
+          {itemsToShow.map(tag => (
+            <ActionList.Item key={tag.id} onSelect={() => setSelectedTag(tag.id)} selected={selectedTag === tag.id}>
+              {tag.name}
+            </ActionList.Item>
+          ))}
+        </ActionList>
+        <SelectPanel.Footer>
+          <SelectPanel.SecondaryAction variant="button">Edit tags</SelectPanel.SecondaryAction>
+        </SelectPanel.Footer>
+      </SelectPanel>
+    </>
+  )
+}
 
 export const WithWarning = () => {
   /* Selection */

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -334,6 +334,7 @@ const Panel: React.FC<SelectPanelProps> = ({
                       afterSelect: internalAfterSelect,
                       listLabelledBy: `${panelId}--title`,
                       enableFocusZone: true, // Arrow keys navigation for list items
+                      singleSelectionVisual: 'radio',
                     }}
                   >
                     {childrenInBody}


### PR DESCRIPTION
- Part of https://github.com/github/primer/issues/3170

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

| Before | After |
|--------|--------|
| <img width="392" alt="single selection with checkmark" src="https://github.com/primer/react/assets/1863771/363514b9-be47-4fce-a179-5773566f7d7c"> | <img width="392" alt="single selection with radio" src="https://github.com/primer/react/assets/1863771/6e39afe5-b2b3-4cd4-96b6-017a2f55d26d"> |



### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [x] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md)): No instances of selectionVariant=single on production

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
