### PR TITLE
Storybook: Autocomplete story should not submit the form

### DIFF
--- a/packages/react/src/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/react/src/Autocomplete/Autocomplete.stories.tsx
@@ -229,7 +229,7 @@ export const Default = (args: FormControlArgs<AutocompleteArgs>) => {
   }
 
   return (
-    <Box as="form" sx={{p: 3}}>
+    <Box as="form" sx={{p: 3}} onSubmit={event => event.preventDefault()}>
       <FormControl {...parentArgs}>
         <FormControl.Label id="autocompleteLabel" {...labelArgs} />
         <Autocomplete>


### PR DESCRIPTION
Thanks for @JoyceZhu for reporting this bug!

#### Reproduction:

Open this url in firefox: https://primer.style/react/storybook/?path=/story/components-autocomplete--default, it redirects to an empty page.

Turns out this happens because `Autocomplete.play` runs on load and [submits the form in the story by simulating the `Enter` key](https://github.com/primer/react/pull/4551/files#diff-b695b5ea2c1438072bf5c5103e0c712dd2c12e0afe2bddb737d5cada75ee3947R262) on the input. Chrome and Safari block this form submit because it happens without the user's action/permission. But, Firefox allows it.

Submitting the form without an action reloads the page without the query params required to inform storybook which story to load

#### Changed

Added a prevent default on form submit 😇 

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; Only affects the test

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
