### PR TITLE
feat(FeatureFlags): loosen feature flag type to accept undefined

### DIFF
--- a/.changeset/grumpy-coats-worry.md
+++ b/.changeset/grumpy-coats-worry.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Loosen feature flag type for experimental FeatureFlags to accept undefined

--- a/packages/react/src/FeatureFlags/FeatureFlagScope.ts
+++ b/packages/react/src/FeatureFlags/FeatureFlagScope.ts
@@ -1,5 +1,5 @@
 export type FeatureFlags = {
-  [key: string]: boolean
+  [key: string]: boolean | undefined
 }
 
 export class FeatureFlagScope {
@@ -24,7 +24,10 @@ export class FeatureFlagScope {
   flags: Map<string, boolean>
 
   constructor(flags: FeatureFlags = {}) {
-    this.flags = new Map(Object.entries(flags))
+    this.flags = new Map()
+    for (const [key, value] of Object.entries(flags)) {
+      this.flags.set(key, value ?? false)
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This change makes it easier to integrate our `FeatureFlags` component in scenarios where a feature flag value may be `boolean | undefined`.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- The type of a flag has been loosened to `boolean | undefined`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Verify that `FeatureFlags` now accepts a `flags` prop where the values can be `undefined` and they are correctly initialized in `FeatureFlagScope`