### PR TITLE
Use dynamic height and width for dialogs

### DIFF
--- a/.changeset/tall-forks-bathe.md
+++ b/.changeset/tall-forks-bathe.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Use dynamic view height/width for dialogs. This allows available visible space to be properly computed on iOS devices.

--- a/.changeset/tall-forks-bathe.md
+++ b/.changeset/tall-forks-bathe.md
@@ -2,4 +2,4 @@
 '@primer/react': patch
 ---
 
-Use dynamic view height/width for dialogs. This allows available visible space to be properly computed on iOS devices.
+Dialog: Use dynamic view height/width. This allows available visible space to be properly computed on iOS devices.

--- a/packages/react/src/Dialog.tsx
+++ b/packages/react/src/Dialog.tsx
@@ -33,10 +33,10 @@ const DialogBase = styled.div<StyledDialogBaseProps>`
   outline: none;
 
   @media screen and (max-width: 750px) {
-    width: 100vw;
+    width: 100dvw;
     margin: 0;
     border-radius: 0;
-    height: 100vh;
+    height: 100dvh;
   }
 
   ${sx};

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -239,8 +239,8 @@ const StyledDialog = styled.div<StyledDialogProps>`
   width: ${props => widthMap[props.width ?? ('xlarge' as const)]};
   height: ${props => heightMap[props.height ?? ('auto' as const)]};
   min-width: 296px;
-  max-width: calc(100vw - 64px);
-  max-height: calc(100vh - 64px);
+  max-width: calc(100dvw - 64px);
+  max-height: calc(100dvh - 64px);
   border-radius: 12px;
   opacity: 1;
 
@@ -257,7 +257,7 @@ const StyledDialog = styled.div<StyledDialogProps>`
   }
 
   &[data-position-regular='left'] {
-    height: 100vh;
+    height: 100dvh;
     max-height: unset;
     border-radius: var(--borderRadius-large, 0.75rem);
     border-top-left-radius: 0;
@@ -269,7 +269,7 @@ const StyledDialog = styled.div<StyledDialogProps>`
   }
 
   &[data-position-regular='right'] {
-    height: 100vh;
+    height: 100dvh;
     max-height: unset;
     border-radius: var(--borderRadius-large, 0.75rem);
     border-top-right-radius: 0;
@@ -288,10 +288,10 @@ const StyledDialog = styled.div<StyledDialogProps>`
     }
 
     &[data-position-narrow='bottom'] {
-      width: 100vw;
+      width: 100dvw;
       height: auto;
-      max-width: 100vw;
-      max-height: calc(100vh - 64px);
+      max-width: 100dvw;
+      max-height: calc(100dvh - 64px);
       border-radius: var(--borderRadius-large, 0.75rem);
       border-bottom-right-radius: 0;
       border-bottom-left-radius: 0;
@@ -303,9 +303,9 @@ const StyledDialog = styled.div<StyledDialogProps>`
 
     &[data-position-narrow='fullscreen'] {
       width: 100%;
-      max-width: 100vw;
+      max-width: 100dvw;
       height: 100%;
-      max-height: 100vh;
+      max-height: 100dvh;
       border-radius: unset !important;
       flex-grow: 1;
 


### PR DESCRIPTION
<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Dialog v2 in right/left position currently flows off the top of the screen on iOS devices. This is because we use `100vh`, which can be _larger_ than the visible view port. I'd like to fix this so dialogs never get cut off on iOS.

I updated both Dialogs to use `100dvh` and `100dvw` instead of `100vh` and `100vw`. These are supported on Safari 15+, which is all that we officially support on dotcom today.

| Before | After |
|--------|--------|
| <img src="https://github.com/primer/react/assets/3026298/8f6737b0-a900-45c3-85d4-a98e1e73fa19" alt="A right positioned dialog with the header and footer cut off on iOS" /> | <img src="https://github.com/primer/react/assets/3026298/193fda8b-1545-4d78-82e9-d2dd538cfb79" alt="A right positioned dialog with header and footer fully in view" /> | 

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

Use dynamic view height/width for dialogs. This allows available visible space to be properly computed on iOS devices.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
