### PR TITLE
Fix replacement URL for React getting started

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -4,7 +4,7 @@ title: Getting started
 
 import DeprecationBanner from '../components/DeprecationBanner'
 
-<DeprecationBanner replacementUrl={'/design/guides/development/react'} />
+<DeprecationBanner replacementUrl={'/guides/react'} />
 
 ## Installation
 


### PR DESCRIPTION
#### Changed

The existing link shown with the deprecation banner on https://primer.style/react/getting-started points to https://primer.style/design/guides/development/react which is incorrect and results in a 404 not found.

This updates the replacement URL to the correct value of https://primer.style/guides/react ✨ 

### Rollout strategy

- [x] None; if selected, include a brief description as to why

### Merge checklist

- [x] Added/updated documentation

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
