### PR TITLE
fix(react): update minimum version for @primer/live-region-element

### DIFF
--- a/.changeset/bright-bees-juggle.md
+++ b/.changeset/bright-bees-juggle.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Update minimum version for @primer/live-region-element

--- a/examples/app-router/package.json
+++ b/examples/app-router/package.json
@@ -9,7 +9,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@primer/react": "36.13.0",
+    "@primer/react": "36.x",
     "next": "^14.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,8 +9,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@primer/octicons-react": "^18.2.0",
-    "@primer/react": "36.17.0",
+    "@primer/octicons-react": "19.x",
+    "@primer/react": "36.x",
     "next": "^14.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -332,7 +332,7 @@
     "examples/app-router": {
       "name": "example-app-router",
       "dependencies": {
-        "@primer/react": "36.13.0",
+        "@primer/react": "36.x",
         "next": "^14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -342,66 +342,6 @@
       "devDependencies": {
         "@next/eslint-plugin-next": "14.1.0",
         "rimraf": "^5.0.5"
-      }
-    },
-    "examples/app-router/node_modules/@primer/react": {
-      "version": "36.13.0",
-      "resolved": "https://registry.npmjs.org/@primer/react/-/react-36.13.0.tgz",
-      "integrity": "sha512-SBpqU+jTTGF2ezOKjA9R+7+zlxYlaO/VgchMzSBlXT5DooGM0/FD+t/njTavyl4KNrZyFkVU1Q/SrsiYQTmmVg==",
-      "dependencies": {
-        "@github/combobox-nav": "^2.1.5",
-        "@github/markdown-toolbar-element": "^2.1.0",
-        "@github/paste-markdown": "^1.4.0",
-        "@github/relative-time-element": "^4.1.2",
-        "@github/tab-container-element": "4.5.0",
-        "@lit-labs/react": "1.2.1",
-        "@oddbird/popover-polyfill": "^0.3.1",
-        "@primer/behaviors": "^1.5.1",
-        "@primer/live-region-element": "^0.2.0",
-        "@primer/octicons-react": "^19.9.0",
-        "@primer/primitives": "^7.15.14",
-        "@styled-system/css": "^5.1.5",
-        "@styled-system/props": "^5.1.5",
-        "@styled-system/theme-get": "^5.1.2",
-        "@types/react-is": "^18.2.1",
-        "@types/styled-system": "^5.1.12",
-        "@types/styled-system__css": "^5.0.16",
-        "@types/styled-system__theme-get": "^5.0.1",
-        "clsx": "^1.2.1",
-        "color2k": "^2.0.3",
-        "deepmerge": "^4.2.2",
-        "focus-visible": "^5.2.0",
-        "fzy.js": "^0.4.1",
-        "history": "^5.0.0",
-        "lodash.isempty": "^4.4.0",
-        "lodash.isobject": "^3.0.2",
-        "react-intersection-observer": "^9.4.3",
-        "react-is": "^18.2.0",
-        "react-markdown": "8.0.7",
-        "styled-system": "^5.1.5"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=7"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.0.0",
-        "@types/react-dom": "^18.0.0",
-        "@types/styled-components": "^5.1.11",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "styled-components": "5.x"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "@types/styled-components": {
-          "optional": true
-        }
       }
     },
     "examples/codesandbox": {
@@ -465,23 +405,12 @@
       "name": "example-nextjs",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/octicons-react": "^18.2.0",
-        "@primer/react": "36.17.0",
+        "@primer/octicons-react": "19.x",
+        "@primer/react": "36.x",
         "next": "^14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "styled-components": "5.x"
-      }
-    },
-    "examples/nextjs/node_modules/@primer/octicons-react": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-18.3.0.tgz",
-      "integrity": "sha512-kOoc4wrBw3bPe2ZPj9BmCwXdEkw8hxUX/tFCvcjOsZ6eywaQXm3PR0yZnPZxZ8o4RFj2tdg/cwGr4+cU83weHw==",
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": ">=15"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -9676,14 +9605,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@primer/live-region-element": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@primer/live-region-element/-/live-region-element-0.2.0.tgz",
-      "integrity": "sha512-3zE1ipoMMxdmAkgB49dX+CIVpIXCGQGYwq5EF4kUIcMLjE4nAUOWkEMlcTCrDAlvfrv71YRx+h+AjRX70urLRg==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "node_modules/@primer/octicons-react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61973,7 +61973,7 @@
         "@lit-labs/react": "1.2.1",
         "@oddbird/popover-polyfill": "^0.3.1",
         "@primer/behaviors": "^1.5.1",
-        "@primer/live-region-element": "^0.2.0",
+        "@primer/live-region-element": "^0.6.1",
         "@primer/octicons-react": "^19.9.0",
         "@primer/primitives": "^7.16.0",
         "@styled-system/css": "^5.1.5",
@@ -62126,6 +62126,14 @@
         "@types/styled-components": {
           "optional": true
         }
+      }
+    },
+    "packages/react/node_modules/@primer/live-region-element": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@primer/live-region-element/-/live-region-element-0.6.1.tgz",
+      "integrity": "sha512-UvJ29igIhOzCfPgUJHPKgr2bY84niHYZagE2LC90ewXQfEFLC3q3ug+vYOzOpCqxspCvEpwPyQlnaOLu4mu87w==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "packages/react/node_modules/@rollup/plugin-commonjs": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -93,7 +93,7 @@
     "@lit-labs/react": "1.2.1",
     "@oddbird/popover-polyfill": "^0.3.1",
     "@primer/behaviors": "^1.5.1",
-    "@primer/live-region-element": "^0.2.0",
+    "@primer/live-region-element": "^0.6.1",
     "@primer/octicons-react": "^19.9.0",
     "@primer/primitives": "^7.16.0",
     "@styled-system/css": "^5.1.5",

--- a/packages/react/src/drafts/SelectPanel2/__tests__/SelectPanelLoading.test.tsx
+++ b/packages/react/src/drafts/SelectPanel2/__tests__/SelectPanelLoading.test.tsx
@@ -5,19 +5,19 @@ import {SelectPanel} from '../'
 jest.useFakeTimers()
 
 describe('SelectPanel.Loading', () => {
-  it('should announce a default message when no children are provided', () => {
-    render(<SelectPanel.Loading />)
-
-    const liveRegion = document.querySelector('live-region')!
-    jest.runAllTimers()
-    expect(liveRegion.getMessage('polite')).toBe('Fetching items...')
-  })
-
   it('should announce children as a polite message', () => {
     render(<SelectPanel.Loading>test</SelectPanel.Loading>)
 
     const liveRegion = document.querySelector('live-region')!
     jest.runAllTimers()
     expect(liveRegion.getMessage('polite')).toBe('test')
+  })
+
+  it('should announce a default message when no children are provided', () => {
+    render(<SelectPanel.Loading />)
+
+    const liveRegion = document.querySelector('live-region')!
+    jest.runAllTimers()
+    expect(liveRegion.getMessage('polite')).toBe('Fetching items...')
   })
 })

--- a/packages/react/src/drafts/SelectPanel2/__tests__/SelectPanelLoading.test.tsx
+++ b/packages/react/src/drafts/SelectPanel2/__tests__/SelectPanelLoading.test.tsx
@@ -2,18 +2,22 @@ import {render} from '@testing-library/react'
 import React from 'react'
 import {SelectPanel} from '../'
 
+jest.useFakeTimers()
+
 describe('SelectPanel.Loading', () => {
-  it('should announce children as a polite message', () => {
-    render(<SelectPanel.Loading>test</SelectPanel.Loading>)
-
-    const liveRegion = document.querySelector('live-region')!
-    expect(liveRegion.getMessage('polite')).toBe('test')
-  })
-
   it('should announce a default message when no children are provided', () => {
     render(<SelectPanel.Loading />)
 
     const liveRegion = document.querySelector('live-region')!
+    jest.runAllTimers()
     expect(liveRegion.getMessage('polite')).toBe('Fetching items...')
+  })
+
+  it('should announce children as a polite message', () => {
+    render(<SelectPanel.Loading>test</SelectPanel.Loading>)
+
+    const liveRegion = document.querySelector('live-region')!
+    jest.runAllTimers()
+    expect(liveRegion.getMessage('polite')).toBe('test')
   })
 })


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update our dependency on `@primer/live-region-element` to the version that addresses ESM module interop errors when using older version of the package.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update range for `@primer/live-region-element` to `^0.6.1`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
