### PR TITLE
Revert "Trigger onClose when Dialog backdrop is clicked (#4565)"

### DIFF
--- a/.changeset/popular-jokes-kiss.md
+++ b/.changeset/popular-jokes-kiss.md
@@ -1,5 +1,0 @@
----
-'@primer/react': minor
----
-
-`Dialog` and `ConfirmationDialog` can now be closed by clicking on the backdrop surrounding the dialog. This will cause `onClose` to be called with a new `'backdrop'` gesture.

--- a/docs/content/drafts/Dialog.mdx
+++ b/docs/content/drafts/Dialog.mdx
@@ -157,13 +157,13 @@ render(<ShorthandExample2 />)
 
 ### ConfirmationDialogProps
 
-| Prop name            | Type                                             | Default                        | Description                                                                                               |
-| :------------------- | :----------------------------------------------- | :----------------------------- | :-------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| title                | `React.ReactNode`                                |                                | Required. Sets the title of the dialog, which by default is also used as the `aria-labelledby` attribute. |
-| onClose              | `(gesture: 'confirm' │ 'cancel' │ 'close-button' | 'backdrop │ 'escape') => void` |                                                                                                           | Required. This callback is invoked when a gesture to close the dialog is performed. The first argument indicates the gesture. |
-| cancelButtonContent  | `React.ReactNode`                                | `"Cancel"`                     | The content to use for the cancel button.                                                                 |
-| confirmButtonContent | `React.ReactNode`                                | `"OK"`                         | The content to use for the confirm button.                                                                |
-| confirmButtonType    | `"normal" │ "primary" │ "danger"`                | `Button`                       | The type of button to use for the confirm button.                                                         |
+| Prop name            | Type                                                                  | Default    | Description                                                                                                                   |
+| :------------------- | :-------------------------------------------------------------------- | :--------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| title                | `React.ReactNode`                                                     |            | Required. Sets the title of the dialog, which by default is also used as the `aria-labelledby` attribute.                     |
+| onClose              | `(gesture: 'confirm' │ 'cancel' │ 'close-button' │ 'escape') => void` |            | Required. This callback is invoked when a gesture to close the dialog is performed. The first argument indicates the gesture. |
+| cancelButtonContent  | `React.ReactNode`                                                     | `"Cancel"` | The content to use for the cancel button.                                                                                     |
+| confirmButtonContent | `React.ReactNode`                                                     | `"OK"`     | The content to use for the confirm button.                                                                                    |
+| confirmButtonType    | `"normal" │ "primary" │ "danger"`                                     | `Button`   | The type of button to use for the confirm button.                                                                             |
 
 ### ConfirmOptions
 

--- a/packages/react/src/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/react/src/ConfirmationDialog/ConfirmationDialog.tsx
@@ -19,7 +19,7 @@ export interface ConfirmationDialogProps {
    * Required. This callback is invoked when a gesture to close the dialog
    * is performed. The first argument indicates the gesture.
    */
-  onClose: (gesture: 'confirm' | 'close-button' | 'backdrop' | 'cancel' | 'escape') => void
+  onClose: (gesture: 'confirm' | 'close-button' | 'cancel' | 'escape') => void
 
   /**
    * Required. The title of the ConfirmationDialog. This is usually a brief

--- a/packages/react/src/Dialog/Dialog.test.tsx
+++ b/packages/react/src/Dialog/Dialog.test.tsx
@@ -67,22 +67,7 @@ describe('Dialog', () => {
 
     await user.click(getByLabelText('Close'))
 
-    expect(onClose).toHaveBeenCalledWith('close-button')
-    expect(onClose).toHaveBeenCalledTimes(1) // Ensure it's not called with a backdrop gesture as well
-  })
-
-  it('calls `onClose` when clicking the backdrop', async () => {
-    const user = userEvent.setup()
-    const onClose = jest.fn()
-    const {getByRole} = render(<Dialog onClose={onClose}>Pay attention to me</Dialog>)
-
-    expect(onClose).not.toHaveBeenCalled()
-
-    const dialog = getByRole('dialog')
-    const backdrop = dialog.parentElement!
-    await user.click(backdrop)
-
-    expect(onClose).toHaveBeenCalledWith('backdrop')
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('calls `onClose` when keying "Escape"', async () => {
@@ -95,7 +80,7 @@ describe('Dialog', () => {
 
     await user.keyboard('{Escape}')
 
-    expect(onClose).toHaveBeenCalledWith('escape')
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('changes the <body> style for `overflow` if it is not set to "hidden"', () => {

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef, useState, type SyntheticEvent} from 'react'
+import React, {useCallback, useEffect, useRef, useState} from 'react'
 import styled from 'styled-components'
 import type {ButtonProps} from '../Button'
 import {Button} from '../Button'
@@ -98,11 +98,11 @@ export interface DialogProps extends SxProp {
 
   /**
    * This method is invoked when a gesture to close the dialog is used (either
-   * an Escape key press, clicking the backdrop, or clicking the "X" in the top-right corner). The
+   * an Escape key press or clicking the "X" in the top-right corner). The
    * gesture argument indicates the gesture that was used to close the dialog
-   * ('close-button', 'backdrop', or 'escape').
+   * (either 'close-button' or 'escape').
    */
-  onClose: (gesture: 'close-button' | 'backdrop' | 'escape') => void
+  onClose: (gesture: 'close-button' | 'escape') => void
 
   /**
    * Default: "dialog". The ARIA role to assign to this dialog.
@@ -414,14 +414,6 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
     }
   }
   const defaultedProps = {...props, title, subtitle, role, dialogLabelId, dialogDescriptionId}
-  const onBackdropClick = useCallback(
-    (e: SyntheticEvent) => {
-      if (e.target === e.currentTarget) {
-        onClose('backdrop')
-      }
-    },
-    [onClose],
-  )
 
   const dialogRef = useRef<HTMLDivElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, dialogRef)
@@ -473,7 +465,7 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
   return (
     <>
       <Portal>
-        <Backdrop ref={backdropRef} {...positionDataAttributes} onClick={onBackdropClick}>
+        <Backdrop ref={backdropRef} {...positionDataAttributes}>
           <StyledDialog
             width={width}
             height={height}


### PR DESCRIPTION
This reverts commit 564db1dbc6f588bee56ab4ba362771fb7c1edc1e.

<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This reverts the changes to `Dialog` closing on backdrop click while we explore the best way to roll this out.

[Context in Slack](https://github.slack.com/archives/C02NUUQ9C30/p1715278567750369)

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

- Revert #4565 