### PR TITLE
Create a release event datadog tracking workflow

### DIFF
--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -1,0 +1,19 @@
+name: Release Event Tracking
+# Measure a datadog event every time a release occurs
+
+on:
+  pull_request:
+    types:
+      - closed
+      - opened
+      - reopened
+
+  release:
+    types: [published]
+
+jobs:
+  release-tracking:
+    name: Release Tracking
+    uses: primer/.github/.github/workflows/release_tracking.yml@create_release_tracking_workflow
+    secrets:
+      datadog_api_key: ${{ secrets.DATADOG_API_KEY }}


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/3181

This Pull creates a `release_tracking` workflow that will track when releases are created and published. These will be tracked on the Deployments dashboard https://app.datadoghq.com/dashboard/ckz-5jr-6f4/primer-deployments