### PR TITLE
ci(release-conductor): remove previous conductor after assigning new one

### DIFF
--- a/.github/workflows/assign_release_conductor.yml
+++ b/.github/workflows/assign_release_conductor.yml
@@ -66,15 +66,6 @@ jobs:
               return user.login === PREV_RELEASE_CONDUCTOR;
             });
 
-            if (hasPreviousReviewer) {
-              await github.rest.pulls.removeRequestedReviewers({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: PR_NUMBER,
-                reviewers: [PREV_RELEASE_CONDUCTOR],
-              });
-            }
-
             // Add the current release conductor as an assignee if they are not currently assigned
             const hasAssignee = pull.assignees.find((assignee) => {
               return assignee.login === RELEASE_CONDUCTOR;
@@ -100,4 +91,13 @@ jobs:
                 pull_number: PR_NUMBER,
                 reviewers: [RELEASE_CONDUCTOR]
               })
+            }
+
+            if (hasPreviousReviewer) {
+              await github.rest.pulls.removeRequestedReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: PR_NUMBER,
+                reviewers: [PREV_RELEASE_CONDUCTOR],
+              });
             }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Context https://github.com/github/primer/issues/3277

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

This PR updates our logic to only remove the reviewer after the new reviewer has been added. This is to see if this prevents our validation error from occurring 👀 

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Remove the previous conductor, if one exists, after the new conductor has been added

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to an internal action

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Sadly the workflow_dispatch for this doesn't work so we'll have to run it manually once it's merged 😞 