### PR TITLE
Update NavList to use the new GroupHeading API and add an `as` prop to specify the heading level (h3 to match with the default)

### DIFF
--- a/.changeset/calm-insects-boil.md
+++ b/.changeset/calm-insects-boil.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Update NavList to use the new ActionList.GroupHeading API and Add an "as" prop to specify the heading level as default h3. (No changes expected in the rendered HTML)

--- a/packages/react/src/NavList/NavList.tsx
+++ b/packages/react/src/NavList/NavList.tsx
@@ -259,7 +259,9 @@ const Group: React.FC<NavListGroupProps> = ({title, children, sx: sxProp = defau
     <>
       {/* Hide divider if the group is the first item in the list */}
       <ActionList.Divider sx={{'&:first-child': {display: 'none'}}} />
-      <ActionList.Group {...props} title={title} sx={sxProp}>
+      <ActionList.Group {...props} sx={sxProp}>
+        {/* Setting up the default value for the heading level. TODO: API update to give flexibility to NavList.Group */}
+        <ActionList.GroupHeading as="h3">{title}</ActionList.GroupHeading>
         {children}
       </ActionList.Group>
     </>

--- a/packages/react/src/NavList/NavList.tsx
+++ b/packages/react/src/NavList/NavList.tsx
@@ -260,7 +260,7 @@ const Group: React.FC<NavListGroupProps> = ({title, children, sx: sxProp = defau
       {/* Hide divider if the group is the first item in the list */}
       <ActionList.Divider sx={{'&:first-child': {display: 'none'}}} />
       <ActionList.Group {...props} sx={sxProp}>
-        {/* Setting up the default value for the heading level. TODO: API update to give flexibility to NavList.Group */}
+        {/* Setting up the default value for the heading level. TODO: API update to give flexibility to NavList.Group title's heading level */}
         <ActionList.GroupHeading as="h3">{title}</ActionList.GroupHeading>
         {children}
       </ActionList.Group>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

While fixing tests on the eslint upgrade PR https://github.com/primer/react/pull/4592, I realised that `<NavList.Group title="title">` is uses `<ActionList.Group title="title">` under the hood and with eslint upgrade updating that usage to use the new `ActionList.GroupHeading` API, it throws an error as it requires an `as` prop to specify the heading level. 

This PR, updates the old API to the new one on Navlist and specifies the heading level as h3 as per the default value. **There shouldn't be any changes in the rendered HTML since [we render the same HTML both for old and the new API for backward compatibility](https://github.com/primer/react/blob/main/packages/react/src/ActionList/Group.tsx#L170)**

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->
1. On NavList, removed the `title` prop from the `ActionList.Group title={title}` and used `<ActionList.GroupHeading>{title}</ActionList.GroupHeading>`
2. Add an explicit `as` prop to the `<ActionList.GroupHeading>{title}</ActionList.GroupHeading>` since we require it for pure lists, meaning lists that are not in the context of menu or listbox.  The value it the default value, h3.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
Make sure there is no snapshot changes in the rendered HTML.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
