### PR TITLE
Check integration test results

### DIFF
--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -19,14 +19,14 @@ jobs:
           client-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_CLIENT_ID_FOR_GITHUB }}
           client-secret: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_CLIENT_SECRET_FOR_GITHUB }}
           installation-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_INSTALLATION_ID_FOR_GITHUB }}
-
       - name: Get workflow run
         uses: actions/github-script@v7
         env:
           # BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
           BRANCH: "prc-integration-test-for-4484"
           WORKFLOW_ID: "primer-react-pr-test.yml"
-          GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
+          # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
+          GH_TOKEN: ${{secrets.TEMP_SID_PAT}}
         with:
           script: |
             const { BRANCH, WORKFLOW_ID } = process.env;

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -29,8 +29,8 @@ jobs:
           BRANCH: "prc-integration-test-for-4358"
           WORKFLOW_ID: "primer-react-pr-test.yml"
           RUN_NAME: 'GitHub CI - Actions'
-          # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
         with:
+          # github-token: ${{ steps.get-github-access-token.outputs.access-token }}
           github-token: ${{ secrets.TEMP_SID_PAT }}
           script: |
             const { BRANCH, WORKFLOW_ID, RUN_NAME } = process.env;
@@ -42,15 +42,15 @@ jobs:
             });
 
             const run = data.workflow_runs.find(run => run.name === RUN_NAME)
-            return run.id
+            return {id: run.id, html_url: run.html_url}
       - id: get-golden-jobs-results
         name: Get golden-jobs-results
         uses: actions/github-script@v7
         env:
-          RUN_ID: ${{steps.get-workflow-run.outputs.result}}
+          RUN_ID: ${{steps.get-workflow-run.outputs.result.id}}
           JOB_NAME: 'golden-jobs-results'
-          # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
         with:
+          # github-token: ${{ steps.get-github-access-token.outputs.access-token }}
           github-token: ${{ secrets.TEMP_SID_PAT }}
           script: |
             const { RUN_ID, JOB_NAME } = process.env;

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -22,6 +22,7 @@ jobs:
           client-secret: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_CLIENT_SECRET_FOR_GITHUB }}
           installation-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_INSTALLATION_ID_FOR_GITHUB }}
       - id : get-workflow-run
+        name: Get workflow run
         uses: actions/github-script@v7
         env:
           # BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
@@ -41,11 +42,13 @@ jobs:
             });
 
             const runId = data.workflow_runs.find(run => run.name === RUN_NAME)
+            console.log(runId)
             return runId
-      - id: get-run-jobs
+      - id: get-golden-jobs-results
+        name: Get golden-jobs-results
         uses: actions/github-script@v7
         env:
-          RUN_ID: echo "${{steps.set-result.outputs.result}}"
+          RUN_ID: ${{steps.set-result.outputs.result}}
           # GH_TOKEN: ${{ steps.get-workflow-run.outputs.access-token }}
         with:
           github-token: ${{ secrets.TEMP_SID_PAT }}

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -27,6 +27,7 @@ jobs:
           # BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
           BRANCH: "prc-integration-test-for-4358"
           WORKFLOW_ID: "primer-react-pr-test.yml"
+          RUN_NAME: 'GitHub CI - Actions'
           # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
         with:
           github-token: ${{ secrets.TEMP_SID_PAT }}
@@ -39,4 +40,5 @@ jobs:
               branch: BRANCH
             });
 
-            console.log(workflow_runs)
+            const workflowId = workflow_runs.filter(run => run.name === $RUN_NAME)
+            console.log(workflowId)

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -21,6 +21,33 @@ jobs:
           client-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_CLIENT_ID_FOR_GITHUB }}
           client-secret: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_CLIENT_SECRET_FOR_GITHUB }}
           installation-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_INSTALLATION_ID_FOR_GITHUB }}
+      - id: check-if-branch-exists
+        name: Check if branch exists
+        uses: actions/github-script@v7
+        env:
+          # BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
+          BRANCH: "prc-integration-test-for-4358"
+        with:
+          # github-token: ${{ steps.get-github-access-token.outputs.access-token }}
+          github-token: ${{ secrets.TEMP_SID_PAT }}
+          script: |
+            const { BRANCH } = process.env;
+            try {
+              const { data } = await github.rest.repos.getBranch({
+                owner: 'github',
+                repo: 'github',
+                branch: BRANCH
+              });
+            } catch (error) {
+              // TODO: add comment that branch does not exist yet
+              core.setFailed(`
+                ${BRANCH} does not exist. 
+                Please make sure you have run the integration tests workflow. 
+                See guide here: https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md
+              `);
+            }
+
+            core.setOutput('branch', BRANCH);
       - id : get-workflow-run
         name: Get workflow run
         uses: actions/github-script@v7

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           github-token: ${{ secrets.TEMP_SID_PAT }}
           script: |
-            const { BRANCH, WORKFLOW_ID } = process.env;
+            const { BRANCH, WORKFLOW_ID, RUN_NAME } = process.env;
 
             const { data } = await github.rest.actions.listWorkflowRunsForRepo({
               owner: 'github',
@@ -40,5 +40,5 @@ jobs:
               branch: BRANCH
             });
 
-            const workflowId = data.workflow_runs.filter(run => run.name === '${{$RUN_NAME}})'
+            const workflowId = data.workflow_runs.filter(run => run.name === RUN_NAME)
             console.log(workflowId)

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -21,12 +21,12 @@ jobs:
           client-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_CLIENT_ID_FOR_GITHUB }}
           client-secret: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_CLIENT_SECRET_FOR_GITHUB }}
           installation-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_INSTALLATION_ID_FOR_GITHUB }}
-      - id: check-if-branch-exists
-        name: Check if branch exists
+      - id: check-if-branch-exists-in-gh
+        name: Check if branch exists in gh/gh
         uses: actions/github-script@v7
         env:
           # BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
-          BRANCH: "prc-integration-test-for-4358-failing-case"
+          BRANCH: "prc-integration-test-for-4358"
         with:
           # github-token: ${{ steps.get-github-access-token.outputs.access-token }}
           github-token: ${{ secrets.TEMP_SID_PAT }}
@@ -38,22 +38,20 @@ jobs:
                 repo: 'github',
                 branch: BRANCH
               });
+              core.setOutput('branch', BRANCH);
             } catch (error) {
-              // TODO: add comment that branch does not exist yet
+              core.summary.addRaw('Testing summary content', true)
               core.setFailed(`
-                ${BRANCH} does not exist. 
+                branch "${BRANCH}" does not exist. 
                 Please make sure you have run the integration tests workflow. 
                 See guide here: https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md
               `);
             }
-
-            core.setOutput('branch', BRANCH);
       - id : get-workflow-run
         name: Get workflow run
         uses: actions/github-script@v7
         env:
-          # BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
-          BRANCH: "prc-integration-test-for-4358"
+          BRANCH: ${{steps.check-if-branch-exists-in-gh.outputs.branch}}
           WORKFLOW_ID: "primer-react-pr-test.yml"
           RUN_NAME: 'GitHub CI - Actions'
         with:

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           github-token: ${{ secrets.TEMP_SID_PAT }}
           script: |
-            const { RUN_ID } = process.env;
+            const { RUN_ID, JOB_NAME } = process.env;
 
             const { data } = await github.rest.actions.listJobsForWorkflowRun({
               owner: 'github',

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -48,7 +48,7 @@ jobs:
         name: Get golden-jobs-results
         uses: actions/github-script@v7
         env:
-          RUN_ID: ${{steps.get-workflow-run.outputs.result.id}}
+          RUN_ID: ${{steps.get-workflow-run.outputs.id}}
           JOB_NAME: 'golden-jobs-results'
         with:
           # github-token: ${{ steps.get-github-access-token.outputs.access-token }}

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -31,10 +31,9 @@ jobs:
           script: |
             const { BRANCH, WORKFLOW_ID } = process.env;
 
-            const { data: workflow_runs } = await github.rest.actions.listWorkflowRuns({
+            const { data: workflow_runs } = await github.rest.actions.listWorkflowRunsForRepo({
               owner: 'github',
               repo: 'github',
-              workflow_id: WORKFLOW_ID,
               branch: BRANCH
             });
 

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -40,5 +40,5 @@ jobs:
               branch: BRANCH
             });
 
-            const workflowId = data.workflow_runs.filter(run => run.name === $RUN_NAME)
+            const workflowId = data.workflow_runs.filter(run => run.name === '${{$RUN_NAME}})'
             console.log(workflowId)

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           # BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
-          BRANCH: "prc-integration-test-for-4358"
+          BRANCH: "prc-integration-test-for-4358-failing-case"
         with:
           # github-token: ${{ steps.get-github-access-token.outputs.access-token }}
           github-token: ${{ secrets.TEMP_SID_PAT }}

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -42,7 +42,8 @@ jobs:
             });
 
             const run = data.workflow_runs.find(run => run.name === RUN_NAME)
-            return {id: run.id, html_url: run.html_url}
+            core.setOutput('id', run.id);
+            core.setOutput('html_url', run.html_url);
       - id: get-golden-jobs-results
         name: Get golden-jobs-results
         uses: actions/github-script@v7

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -41,9 +41,8 @@ jobs:
               branch: BRANCH
             });
 
-            const runId = data.workflow_runs.find(run => run.name === RUN_NAME)
-            console.log(runId)
-            return runId
+            const run = data.workflow_runs.find(run => run.name === RUN_NAME)
+            return run.id
       - id: get-golden-jobs-results
         name: Get golden-jobs-results
         uses: actions/github-script@v7

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -21,7 +21,7 @@ jobs:
           client-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_CLIENT_ID_FOR_GITHUB }}
           client-secret: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_CLIENT_SECRET_FOR_GITHUB }}
           installation-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_INSTALLATION_ID_FOR_GITHUB }}
-      - name: Get workflow run
+      - id : get-workflow-run
         uses: actions/github-script@v7
         env:
           # BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
@@ -40,5 +40,24 @@ jobs:
               branch: BRANCH
             });
 
-            const workflowId = data.workflow_runs.filter(run => run.name === RUN_NAME)
-            console.log(workflowId)
+            const runId = data.workflow_runs.find(run => run.name === RUN_NAME)
+            return runId
+      - id: get-run-jobs
+        uses: actions/github-script@v7
+        env:
+          RUN_ID: echo "${{steps.set-result.outputs.result}}"
+          # GH_TOKEN: ${{ steps.get-workflow-run.outputs.access-token }}
+        with:
+          github-token: ${{ secrets.TEMP_SID_PAT }}
+          script: |
+            const { RUN_ID } = process.env;
+
+            const { data } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: 'github',
+              repo: 'github',
+              run_id: RUN_ID,
+              per_page: 100,
+              page: 2,
+            });
+
+            console.log(data)

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -29,7 +29,7 @@ jobs:
           WORKFLOW_ID: "primer-react-pr-test.yml"
           # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
         with:
-          github-token: ${{ steps.get-github-access-token.outputs.access-token }}
+          github-token: ${{ secrets.TEMP_SID_PAT }}
           script: |
             const { BRANCH, WORKFLOW_ID } = process.env;
 

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -34,11 +34,11 @@ jobs:
           script: |
             const { BRANCH, WORKFLOW_ID } = process.env;
 
-            const { data: workflow_runs } = await github.rest.actions.listWorkflowRunsForRepo({
+            const { data } = await github.rest.actions.listWorkflowRunsForRepo({
               owner: 'github',
               repo: 'github',
               branch: BRANCH
             });
 
-            const workflowId = workflow_runs.filter(run => run.name === $RUN_NAME)
+            const workflowId = data.workflow_runs.filter(run => run.name === $RUN_NAME)
             console.log(workflowId)

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -40,9 +40,10 @@ jobs:
               });
               core.setOutput('branch', BRANCH);
             } catch (error) {
+              // TODO: instead of checking branch, we could also check if the pr-test-workflow has finished running without errors
               core.setFailed(`
                 branch "${BRANCH}" does not exist. 
-                Please make sure you have run the integration tests workflow. 
+                Please make sure you have run the integration tests workflow and it has finished running.
                 See guide here: https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md
               `);
             }
@@ -71,7 +72,7 @@ jobs:
               core.setOutput('id', run.id);
               core.setOutput('html_url', run.html_url);
               // TODO: the workflow run might exist, but it might still be pending / running
-              // = no jobs
+              // = no results job, should count as a pending/fail state
             } else {
               // TODO: if the branch exists, is it still possible that workflow run doesn't exist?
             }
@@ -87,15 +88,19 @@ jobs:
           script: |
             const { RUN_ID, JOB_NAME } = process.env;
 
-            const { data } = await github.rest.actions.listJobsForWorkflowRun({
+            const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
               owner: 'github',
               repo: 'github',
               run_id: RUN_ID,
               per_page: 100,
-              page: 2,
+              page: 2, // this is silly but we know golden-jobs-results is generated right at the end
             });
 
-            const {status, conclusion, html_url} = data.jobs.find(job => job.name === JOB_NAME)
-
-            console.log({status, conclusion, html_url})
-            return {status, conclusion, html_url}
+            const job = jobs.find(job => job.name === JOB_NAME)
+            if (job) {
+              const {status, conclusion, html_url} = job
+              console.log({status, conclusion, html_url})
+              return {status, conclusion, html_url}
+            } else {
+              // TODO: is it possible that the workflow completed, but the job results still don't exist?
+            }

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   report-results:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - id: get-github-access-token
         uses: camertron/github-app-installation-auth-action@v1

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -27,7 +27,7 @@ jobs:
           WORKFLOW_ID: "primer-react-pr-test.yml"
           # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
         with:
-          github-token: ${{ secrets.TEMP_SID_PAT }}
+          github-token: ${{ steps.get-github-access-token.outputs.access-token }}
           script: |
             const { BRANCH, WORKFLOW_ID } = process.env;
 

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -31,7 +31,7 @@ jobs:
           RUN_NAME: 'GitHub CI - Actions'
           # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
         with:
-          github-token: ${{ steps.get-github-access-token.outputs.access-token }}
+          github-token: ${{ secrets.TEMP_SID_PAT }}
           script: |
             const { BRANCH, WORKFLOW_ID, RUN_NAME } = process.env;
 
@@ -63,7 +63,7 @@ jobs:
               page: 2,
             });
 
-            const job = data.jobs.find(job => job.name === JOB_NAME)
-            console.log({status: job.status})
-            console.log({conclusion: job.conclusion})
-            console.log({html_url: job.html_url})
+            const {status, conclusion, html_url} = data.jobs.find(job => job.name === JOB_NAME)
+
+            console.log({status, conclusion, html_url})
+            return {status, conclusion, html_url}

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -31,7 +31,7 @@ jobs:
           RUN_NAME: 'GitHub CI - Actions'
           # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
         with:
-          github-token: ${{ secrets.TEMP_SID_PAT }}
+          github-token: ${{ steps.get-github-access-token.outputs.access-token }}
           script: |
             const { BRANCH, WORKFLOW_ID, RUN_NAME } = process.env;
 

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -47,8 +47,8 @@ jobs:
         name: Get golden-jobs-results
         uses: actions/github-script@v7
         env:
-          RUN_ID: ${{steps.set-result.outputs.result}}
-          # GH_TOKEN: ${{ steps.get-workflow-run.outputs.access-token }}
+          RUN_ID: ${{steps.get-workflow-run.outputs.result}}
+          # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
         with:
           github-token: ${{ secrets.TEMP_SID_PAT }}
           script: |

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           # BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
-          BRANCH: "prc-integration-test-for-4484"
+          BRANCH: "prc-integration-test-for-4358"
           WORKFLOW_ID: "primer-react-pr-test.yml"
           # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
           GH_TOKEN: ${{secrets.TEMP_SID_PAT}}

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -26,8 +26,8 @@ jobs:
           BRANCH: "prc-integration-test-for-4358"
           WORKFLOW_ID: "primer-react-pr-test.yml"
           # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
-          GH_TOKEN: ${{secrets.TEMP_SID_PAT}}
         with:
+          github-token: ${{ secrets.TEMP_SID_PAT }}
           script: |
             const { BRANCH, WORKFLOW_ID } = process.env;
 

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -40,7 +40,6 @@ jobs:
               });
               core.setOutput('branch', BRANCH);
             } catch (error) {
-              core.summary.addRaw('Testing summary content', true)
               core.setFailed(`
                 branch "${BRANCH}" does not exist. 
                 Please make sure you have run the integration tests workflow. 
@@ -60,15 +59,22 @@ jobs:
           script: |
             const { BRANCH, WORKFLOW_ID, RUN_NAME } = process.env;
 
-            const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+            const { data: {workflow_runs} } = await github.rest.actions.listWorkflowRunsForRepo({
               owner: 'github',
               repo: 'github',
               branch: BRANCH
             });
 
-            const run = data.workflow_runs.find(run => run.name === RUN_NAME)
-            core.setOutput('id', run.id);
-            core.setOutput('html_url', run.html_url);
+            const run = workflow_runs.find(run => run.name === RUN_NAME)
+
+            if (run) {
+              core.setOutput('id', run.id);
+              core.setOutput('html_url', run.html_url);
+              // TODO: the workflow run might exist, but it might still be pending / running
+              // = no jobs
+            } else {
+              // TODO: if the branch exists, is it still possible that workflow run doesn't exist?
+            }
       - id: get-golden-jobs-results
         name: Get golden-jobs-results
         uses: actions/github-script@v7

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -2,6 +2,8 @@ name: Report results of integration tests
 
 # using label for now, will think about this a little more
 on:
+  # temporary so I can test this
+  push:
   pull_request:
     types: [labeled]
 
@@ -21,7 +23,8 @@ jobs:
       - name: Get workflow run
         uses: actions/github-script@v7
         env:
-          BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
+          # BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
+          BRANCH: "prc-integration-test-for-4484"
           WORKFLOW_ID: "primer-react-pr-test.yml"
           GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
         with:

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -1,0 +1,38 @@
+name: Report results of integration tests
+
+# using label for now, will think about this a little more
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  report-results:
+    runs-on: ubuntu-latest
+    steps:
+      - id: get-github-access-token
+        uses: camertron/github-app-installation-auth-action@v1
+        with:
+          app-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_ID_FOR_GITHUB }}
+          private-key: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_PRIVATE_KEY_FOR_GITHUB }}
+          client-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_CLIENT_ID_FOR_GITHUB }}
+          client-secret: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_CLIENT_SECRET_FOR_GITHUB }}
+          installation-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_INSTALLATION_ID_FOR_GITHUB }}
+
+      - name: Get workflow run
+        uses: actions/github-script@v7
+        env:
+          BRANCH: "prc-integration-test-for-${{github.event.pull_request.number}}"
+          WORKFLOW_ID: "primer-react-pr-test.yml"
+          GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
+        with:
+          script: |
+            const { BRANCH, WORKFLOW_ID } = process.env;
+
+            const { data: workflow_runs } = await github.rest.actions.listWorkflowRuns({
+              owner: 'github',
+              repo: 'github',
+              workflow_id: WORKFLOW_ID,
+              branch: BRANCH
+            });
+
+            console.log(workflow_runs)

--- a/.github/workflows/report-integration-results.yml
+++ b/.github/workflows/report-integration-results.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           RUN_ID: ${{steps.get-workflow-run.outputs.result}}
+          JOB_NAME: 'golden-jobs-results'
           # GH_TOKEN: ${{ steps.get-github-access-token.outputs.access-token }}
         with:
           github-token: ${{ secrets.TEMP_SID_PAT }}
@@ -62,4 +63,7 @@ jobs:
               page: 2,
             });
 
-            console.log(data)
+            const job = data.jobs.find(job => job.name === JOB_NAME)
+            console.log({status: job.status})
+            console.log({conclusion: job.conclusion})
+            console.log({html_url: job.html_url})


### PR DESCRIPTION
<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Context

I'd like to fetch and report the result of `golden-jobs-results` on the PR as a CI check and comment.

Strategy 1: Pull (implemented here)
1. Check if there is a PR related to current branch 
2. Check if the CI workflows have run
3. Check if `golden-jobs-results` has completed yet
4. Check results of `golden-jobs-results`

Strategy 2: Push (probably better!)
1. Inform PR has been created (based on label)
2. (maybe) inform `golden-jobs-results` has started/expected
3. Inform `golden-jobs-results` has completed with results (based on label)

Questions I need to think more about:
1. What triggers this workflow?
2. Can this workflow be re-triggered manually?
3. Is it workflow required or just recommended?
4. What happens when this workflow fails for reasons not related to your PR/change
5. Pushing another commit should invalidate the results, right?

### Rollout strategy

- [x] None; workflow only change.

