### PR TITLE
fix(SelectPanel2): only bind keydown event when necessary

### DIFF
--- a/.changeset/good-bugs-grab.md
+++ b/.changeset/good-bugs-grab.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+SelectPanel2: Minor optimization for escape key event listener binding

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.test.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.test.tsx
@@ -179,6 +179,38 @@ describe('SelectPanel', () => {
     expect(mockOnSubmit).toHaveBeenCalledTimes(0)
   })
 
+  it('should not call addEventListener on each render for Escape key handling when onCancel has not changed', async () => {
+    const onCancel = jest.fn()
+    const container = render(
+      <SelectPanel title="title" onCancel={onCancel}>
+        child
+      </SelectPanel>,
+    )
+    const addEventListenerSpy = jest.spyOn(globalThis.EventTarget.prototype, 'addEventListener')
+    const removeEventListenerSpy = jest.spyOn(globalThis.EventTarget.prototype, 'removeEventListener')
+
+    container.rerender(
+      <SelectPanel title="title" onCancel={onCancel}>
+        child
+      </SelectPanel>,
+    )
+    expect(addEventListenerSpy).not.toHaveBeenCalled()
+    expect(removeEventListenerSpy).not.toHaveBeenCalled()
+  })
+
+  it('Escape key closes the dialog and calls onCancel', async () => {
+    const mockOnSubmit = jest.fn()
+    const mockOnCancel = jest.fn()
+    const {container, user} = await getFixtureWithOpenContainer({mockOnSubmit, mockOnCancel})
+    selectUnselectedOption(container, user)
+
+    await user.keyboard('{Escape}')
+
+    expect(container.queryByRole('dialog')).toBeNull()
+    expect(mockOnCancel).toHaveBeenCalledTimes(1)
+    expect(mockOnSubmit).toHaveBeenCalledTimes(0)
+  })
+
   it('SelectPanel within FormControl should be labelled by FormControl.Label', async () => {
     const component = render(<SelectPanelWithinForm />)
     const buttonByRole = component.getByRole('button')

--- a/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
+++ b/packages/react/src/drafts/SelectPanel2/SelectPanel.tsx
@@ -136,10 +136,10 @@ const Panel: React.FC<SelectPanelProps> = ({
     if (propsOpen === undefined) setInternalOpen(false)
   }, [internalOpen, propsOpen])
 
-  const onInternalCancel = () => {
+  const onInternalCancel = React.useCallback(() => {
     onInternalClose()
     if (typeof propsOnCancel === 'function') propsOnCancel()
-  }
+  }, [onInternalClose, propsOnCancel])
 
   const onInternalSubmit = (event?: React.FormEvent<HTMLFormElement>) => {
     event?.preventDefault() // there is no event with selectionVariant=instant
@@ -199,7 +199,7 @@ const Panel: React.FC<SelectPanelProps> = ({
     }
     dialogEl?.addEventListener('keydown', handler)
     return () => dialogEl?.removeEventListener('keydown', handler)
-  })
+  }, [onInternalCancel])
 
   // Autofocus hack: React doesn't support autoFocus for dialog: https://github.com/facebook/react/issues/23301
   // tl;dr: react takes over autofocus instead of letting the browser handle it,


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #4581

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->
- Adds additional `jest` test coverage for the `SelectPanel`

#### Changed

- Adds optimization to `SelectPanel` so that event listeners are not added and removed on each render, but only when the effect dependencies change.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- One of the `SelectPanel` jest test should fail if changes to `SelectPanel` are reverted.
- RT1: Regression Test 1: Panel should close when opened and escape is pressed
  - Visit the `SelectPanel` in storybook (http://<storybook-origin>/?path=/story/drafts-components-selectpanel--default)
  - Click the button, assert panel opens
  - Press the `Escape` key on the keyboard, assert panel closes

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Storybook)~
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
  - I'm not sure about this one. Because hooks with dependencies are in use already, this code change shouldn't introduce any issues. I didn't test though, which is why I'm not checking this box.
- [x] Tested in Chrome (ran RT1 above on Chrome 124.0.6367.207)
- [x] Tested in Firefox (ran RT1 above on Firefox 126.0)
- [x] Tested in Safari (ran RT1 on Safari 17.4.1)
- [x] Tested in Edge (ran RT1 on Edge 124.0.2478.105)
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
