### PR TITLE
fix(DataTable): sort table on initial render with `initialSortColumn` or `initialSortDirection` props

### DIFF
--- a/.changeset/calm-terms-matter.md
+++ b/.changeset/calm-terms-matter.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+DataTable: Fix sort on initial render. Sort using initialSortColumn and initialSortDirection props.

--- a/packages/react/src/DataTable/useTable.ts
+++ b/packages/react/src/DataTable/useTable.ts
@@ -49,7 +49,7 @@ export function useTable<Data extends UniqueRow>({
   initialSortDirection,
 }: TableConfig<Data>): Table<Data> {
   const [rowOrder, setRowOrder] = useState(data)
-  const [prevData, setPrevData] = useState(data)
+  const [prevData, setPrevData] = useState<typeof data | null>(null)
   const [prevColumns, setPrevColumns] = useState(columns)
   const [sortByColumn, setSortByColumn] = useState<ColumnSortState>(() => {
     return getInitialSortState(columns, initialSortColumn, initialSortDirection)


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #3951

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- The `useTable` hook is responsible to sort the data for the `DataTable`. If the data changes, then it sorts according to the current sort state. It should also sort data on initial render. This PR updates the initial state of `useTable` so that the data is sorted on initial render.
- DRY up the test by extracting functions that read headers and rows.
- Add Jest tests

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

Answering this question led to a questions about the purpose/intended use of this component. In my experience with data tables, consumers either have all the data on the client and want to render it in the table, or consumers do not have all the data, and may need to fetch more.

If consumers have all the data, then it's possible to sort and filter on the client, and then render correct results. I'll name this "completeData" mode. I wouldn't use this name as part of the API, but it works for this discussion.

If consumers do not have all the data, then it's not possible to sort and filter on the client, because all client side sorts and filters operate on a partial data set. For correct results, the sort and filter must be done on the server, where the complete data set is known. I'll name this "partialData" mode.

Why discuss these two different usages in this PR?

Prior to this change, on initial render only, the data table would not sort the passed in data. For consumers with partial data, this is the desired behavior. After this change, consumers that are using this component with partial data will notice that the data is now sorted on the client on initial render.

Based on the current `DataTable` API, I think this component was designed for "completeData" mode, because any sorting and renders after the initial render only sort the data that's in the component state.

To support "partialData" mode, this component would need to allow consumers to pass in the "sortColumn" and "sortDirection", and also expose callbacks so consumers can respond to sort change like `onSortChange`.

To handle the "partialData" and "completeData" modes of a table, it could make sense to build a ["controlled" version](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components) of the `DataTable`, maybe something like `StatelessDataTable`, and then the `DataTable` can remain the "uncontrolled" version that adds state to the `StatelessDataTable`. 

After looking at more of the components in `DataTable`, for the "partialData" mode, consumers could use `Table` directly with `import { Table } from '@primer/react/experimental'`.

Apologies for the lengthy discussion. I suspect that the authors already know all of this, so this is mostly me trying to convince myself that this change should be considered a patch, because the `DataTable` is designed for the "completeData" mode, and consumers are probably not expecting the buggy behavior.

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Visit `http://<storybookurl>/?path=/story/drafts-components-datatable-features--with-custom-sorting`, assert data is sorted by updated at, click the updated at column, assert data is sorted in opposite direction, click `Repository` header, assert data is sorted by `Repository`, click `Repository` again, assert sort changes direction

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome (version 124.0.6367.207)
- [x] Tested in Firefox (version 126.0)
- [x] Tested in Safari (version 17.4.1)
- [x] Tested in Edge (version 124.0.2478.109)
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
