### PR TITLE
NavList: Only render the group title if title exists

### DIFF
--- a/packages/react/src/NavList/NavList.tsx
+++ b/packages/react/src/NavList/NavList.tsx
@@ -261,7 +261,7 @@ const Group: React.FC<NavListGroupProps> = ({title, children, sx: sxProp = defau
       <ActionList.Divider sx={{'&:first-child': {display: 'none'}}} />
       <ActionList.Group {...props} sx={sxProp}>
         {/* Setting up the default value for the heading level. TODO: API update to give flexibility to NavList.Group title's heading level */}
-        <ActionList.GroupHeading as="h3">{title}</ActionList.GroupHeading>
+        {title ? <ActionList.GroupHeading as="h3">{title}</ActionList.GroupHeading> : null}
         {children}
       </ActionList.Group>
     </>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

While testing PageHeader integration at dotcom, I came across an axe violation error ([internally accessible only](https://github.com/github/github/actions/runs/9122665793/job/25083829075))

```
Headings should not be empty (empty-heading)
```

and realised that it was introduced by https://github.com/primer/react/pull/4593 (Apologies!) - This PR fixes it. 

Disclaimer: I don't think the `title` prop should be optional in terms of the accessibility requirements since each group needs to have a heading regardless it is visible or not but I'll raise an issue for this.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->
- Conditionally render the heading component. I.e. only when title exists

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; Since [the main PR](https://github.com/primer/react/pull/4593) hasn't released yet and it has a changeset, I think it is fine to skip changeset here. 

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
