### PR TITLE
chore(eslint): add primer_react_ to list of allowed camelcase names

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,7 +68,11 @@ module.exports = {
     camelcase: [
       'error',
       {
-        allow: ['dark_dimmed'],
+        allow: [
+          'dark_dimmed',
+          // Allow feature flag names that start with `primer_react_`
+          '^primer_react_',
+        ],
       },
     ],
     'primer-react/no-deprecated-colors': ['warn', {checkAllStrings: true}],


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

As we're starting to roll out feature flag changes, we noticed that these names would be flagged by ESLint since they will not be camelCase. This change updates our eslint config to allow `primer_react_*` names.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update eslint to allow `primer_react_*`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to internal tooling

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- [ ] Pull down the PR
- [ ] Use `FeatureFlags` in some component or test fixture
- [ ] Add a feature flag like `primer_react_actionlist_semantics` to the `flags` prop
- [ ] Verify that eslint does not warn
- [ ] Add a different flag without that prefix, like `should_not_work` and verify that eslint errors as expected