### PR TITLE
Update release_tracking to v2.1.0

### DIFF
--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -3,6 +3,8 @@ name: Release Event Tracking
 
 on:
   pull_request:
+    branches:
+      - 'changeset-release/main'
     types:
       - closed
       - opened
@@ -14,6 +16,6 @@ on:
 jobs:
   release-tracking:
     name: Release Tracking
-    uses: primer/.github/.github/workflows/release_tracking.yml@create_release_tracking_workflow
+    uses: primer/.github/.github/workflows/release_tracking.yml@v2.1.0
     secrets:
       datadog_api_key: ${{ secrets.DATADOG_API_KEY }}


### PR DESCRIPTION
This updates the release_tracking workflow to an actual release and only runs the workflow on changeset prs