### PR TITLE
docs(Banner): add story for dismissing banner

### DIFF
--- a/packages/react/src/Banner/Banner.examples.stories.tsx
+++ b/packages/react/src/Banner/Banner.examples.stories.tsx
@@ -153,7 +153,7 @@ export const Multiline = () => {
 
 export const DismissBanner = () => {
   const ref = React.useRef<React.ElementRef<'h2'>>(null)
-  const [banner, setBanner] = React.useState({
+  const [banner, setBanner] = React.useState<React.ComponentPropsWithoutRef<typeof Banner> | null>({
     title: 'Info',
     description: (
       <>

--- a/packages/react/src/Banner/Banner.examples.stories.tsx
+++ b/packages/react/src/Banner/Banner.examples.stories.tsx
@@ -150,3 +150,40 @@ export const Multiline = () => {
     />
   )
 }
+
+export const DismissBanner = () => {
+  const ref = React.useRef<React.ElementRef<'h2'>>(null)
+  const [banner, setBanner] = React.useState({
+    title: 'Info',
+    description: (
+      <>
+        GitHub users are{' '}
+        <Link inline underline href="#">
+          now required
+        </Link>{' '}
+        to enable two-factor authentication as an additional security measure.
+      </>
+    ),
+  })
+
+  return (
+    <>
+      <main>
+        {banner ? (
+          <Banner
+            title={banner.title}
+            description={banner.description}
+            onDismiss={() => {
+              setBanner(null)
+              ref.current?.focus()
+            }}
+          />
+        ) : null}
+        <h2 ref={ref} tabIndex={-1}>
+          Example page title
+        </h2>
+        <p>Example page content</p>
+      </main>
+    </>
+  )
+}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Was going through the stories for accessibility sign-off and wanted to make sure we had an example for what happens when you dismiss a banner

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add example story for dismissing a banner

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- [ ] Verify that the story added has no accessibility violations
- [ ] Verify that focus is restored to the heading when banner dismiss is activated
- [ ] Is this a good example for demonstrating this type of behavior? 😅 