### PR TITLE
spike navlist

### DIFF
--- a/packages/react/src/NavList/NavList.stories.tsx
+++ b/packages/react/src/NavList/NavList.stories.tsx
@@ -224,4 +224,25 @@ export const WithInactiveItems: Story = () => (
   </PageLayout>
 )
 
+export const WithShowMoreItems = () => (
+  <PageLayout>
+    <PageLayout.Pane position="start">
+      <NavList>
+        <NavList.Item defaultItemsVisible={3}>
+          Show more
+          <NavList.ShowMoreItemsNav>
+            <NavList.Item href="#">Item 1</NavList.Item>
+            <NavList.Item href="#">Item 2</NavList.Item>
+            <NavList.Item href="#">Item 3</NavList.Item>
+            <NavList.Item href="#">Item 4</NavList.Item>
+            <NavList.Item href="#">Item 5</NavList.Item>
+            <NavList.Item href="#">Item 6</NavList.Item>
+          </NavList.ShowMoreItemsNav>
+        </NavList.Item>
+      </NavList>
+    </PageLayout.Pane>
+    <PageLayout.Content></PageLayout.Content>
+  </PageLayout>
+)
+
 export default meta


### PR DESCRIPTION
TODO:

* [ ] The Primer Rails version is implemented so that "Show more" will show some specified number of items, rather than showing all hidden items upon click. Is this the approach we'd want to take in Primer React as well? How long do these lists get? (Showing all hidden items would be more straightforward). Would the client have access to all the items up front, or would these need to be fetched (like how the Rails one is implemented)
* [ ] The current `NavList` markup is odd. I would expect the `<button>` to be rendered outside the `<ul>` but `NavList` is currently implemented such that everything will always get nested inside of a `<ul>`. 

<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
