### PR TITLE
Remove release event tracking branch check

### DIFF
--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -3,8 +3,6 @@ name: Release Event Tracking
 
 on:
   pull_request:
-    branches:
-      - 'changeset-release/main'
     types:
       - closed
       - opened


### PR DESCRIPTION
Update the primer-release-workflow to remove the branches check. This references the target branch not the head 🤦🏻 
