### PR TITLE
fix(SegmentedControl): explicitly set the `type` attribute for `SegmentedControl.Button`

### DIFF
--- a/.changeset/few-paws-confess.md
+++ b/.changeset/few-paws-confess.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Explicitly set the `type` attribute for `SegmentedControl.Button`

--- a/packages/react/src/SegmentedControl/SegmentedControlButton.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControlButton.tsx
@@ -38,6 +38,7 @@ const SegmentedControlButton: React.FC<React.PropsWithChildren<SegmentedControlB
       <SegmentedControlButtonStyled
         aria-current={selected}
         sx={getSegmentedControlButtonStyles({selected, children})}
+        type="button"
         {...rest}
       >
         <span className="segmentedControl-content">


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3308

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Explicitly set the `type` attribute of the `SegmentedControl.Button` component to "button" to prevent automatic submission in `form` elements

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- [ ] Verify that the `SegmentedControl.Button` component renders a `<button>` element with `type="button"`