### PR TITLE
Update TreeView default story to use prop `label` on TrailingVisual

### DIFF
--- a/packages/react/src/TreeView/TreeView.features.stories.tsx
+++ b/packages/react/src/TreeView/TreeView.features.stories.tsx
@@ -966,8 +966,8 @@ export const WithoutIndentation: Story = () => (
           <FileIcon />
         </TreeView.LeadingVisual>
         Avatar.tsx
-        <TreeView.TrailingVisual>
-          <Octicon icon={DiffAddedIcon} color="success.fg" aria-label="Added" />
+        <TreeView.TrailingVisual label="Added">
+          <Octicon icon={DiffAddedIcon} color="success.fg" />
         </TreeView.TrailingVisual>
       </TreeView.Item>
       <TreeView.Item id="src/Button.tsx" current>
@@ -975,8 +975,8 @@ export const WithoutIndentation: Story = () => (
           <FileIcon />
         </TreeView.LeadingVisual>
         Button.tsx
-        <TreeView.TrailingVisual>
-          <Octicon icon={DiffModifiedIcon} color="attention.fg" aria-label="Modified" />
+        <TreeView.TrailingVisual label="Modified">
+          <Octicon icon={DiffModifiedIcon} color="attention.fg" />
         </TreeView.TrailingVisual>
       </TreeView.Item>
       <TreeView.Item id="package.json">
@@ -984,8 +984,8 @@ export const WithoutIndentation: Story = () => (
           <FileIcon />
         </TreeView.LeadingVisual>
         package.json
-        <TreeView.TrailingVisual>
-          <Octicon icon={DiffModifiedIcon} color="attention.fg" aria-label="Modified" />
+        <TreeView.TrailingVisual label="Modified">
+          <Octicon icon={DiffModifiedIcon} color="attention.fg" />
         </TreeView.TrailingVisual>
       </TreeView.Item>
     </TreeView>
@@ -1057,8 +1057,8 @@ export const MultilineItems: Story = () => (
               <FileIcon />
             </TreeView.LeadingVisual>
             Avatar.tsx
-            <TreeView.TrailingVisual>
-              <Octicon icon={DiffAddedIcon} color="success.fg" aria-label="Added" />
+            <TreeView.TrailingVisual label="Added">
+              <Octicon icon={DiffAddedIcon} color="success.fg" />
             </TreeView.TrailingVisual>
           </TreeView.Item>
         </TreeView.SubTree>
@@ -1070,8 +1070,8 @@ export const MultilineItems: Story = () => (
         <div style={{whiteSpace: 'wrap'}}>
           this is a medium directory name that we wrap over 2 lines to demonstrate alignment
         </div>
-        <TreeView.TrailingVisual>
-          <Octicon icon={DiffAddedIcon} color="success.fg" aria-label="Added" />
+        <TreeView.TrailingVisual label="Added">
+          <Octicon icon={DiffAddedIcon} color="success.fg" />
         </TreeView.TrailingVisual>
         <TreeView.SubTree>
           <TreeView.Item id="src/Avatar.tsx">
@@ -1079,8 +1079,8 @@ export const MultilineItems: Story = () => (
               <FileIcon />
             </TreeView.LeadingVisual>
             Avatar.tsx
-            <TreeView.TrailingVisual>
-              <Octicon icon={DiffAddedIcon} color="success.fg" aria-label="Added" />
+            <TreeView.TrailingVisual label="Added">
+              <Octicon icon={DiffAddedIcon} color="success.fg" />
             </TreeView.TrailingVisual>
           </TreeView.Item>
         </TreeView.SubTree>
@@ -1097,8 +1097,8 @@ export const MultilineItems: Story = () => (
               <FileIcon />
             </TreeView.LeadingVisual>
             Avatar.tsx
-            <TreeView.TrailingVisual>
-              <Octicon icon={DiffAddedIcon} color="success.fg" aria-label="Added" />
+            <TreeView.TrailingVisual label="Added">
+              <Octicon icon={DiffAddedIcon} color="success.fg" />
             </TreeView.TrailingVisual>
           </TreeView.Item>
         </TreeView.SubTree>
@@ -1114,8 +1114,8 @@ export const MultilineItems: Story = () => (
               <FileIcon />
             </TreeView.LeadingVisual>
             Avatar.tsx
-            <TreeView.TrailingVisual>
-              <Octicon icon={DiffAddedIcon} color="success.fg" aria-label="Added" />
+            <TreeView.TrailingVisual label="Added">
+              <Octicon icon={DiffAddedIcon} color="success.fg" />
             </TreeView.TrailingVisual>
           </TreeView.Item>
         </TreeView.SubTree>

--- a/packages/react/src/TreeView/TreeView.stories.tsx
+++ b/packages/react/src/TreeView/TreeView.stories.tsx
@@ -33,8 +33,8 @@ export const Default: Story = () => (
               <FileIcon />
             </TreeView.LeadingVisual>
             Avatar.tsx
-            <TreeView.TrailingVisual>
-              <Octicon icon={DiffAddedIcon} color="success.fg" aria-label="Added" />
+            <TreeView.TrailingVisual label="Added">
+              <Octicon icon={DiffAddedIcon} color="success.fg" />
             </TreeView.TrailingVisual>
           </TreeView.Item>
           <TreeView.Item id="src/Button.tsx" current>
@@ -42,8 +42,8 @@ export const Default: Story = () => (
               <FileIcon />
             </TreeView.LeadingVisual>
             Button.tsx
-            <TreeView.TrailingVisual>
-              <Octicon icon={DiffModifiedIcon} color="attention.fg" aria-label="Modified" />
+            <TreeView.TrailingVisual label="Modified">
+              <Octicon icon={DiffModifiedIcon} color="attention.fg" />
             </TreeView.TrailingVisual>
           </TreeView.Item>
         </TreeView.SubTree>
@@ -53,8 +53,8 @@ export const Default: Story = () => (
           <FileIcon />
         </TreeView.LeadingVisual>
         package.json
-        <TreeView.TrailingVisual>
-          <Octicon icon={DiffModifiedIcon} color="attention.fg" aria-label="Modified" />
+        <TreeView.TrailingVisual label="Modified">
+          <Octicon icon={DiffModifiedIcon} color="attention.fg" />
         </TreeView.TrailingVisual>
       </TreeView.Item>
     </TreeView>


### PR DESCRIPTION
### What

The `aria-label` on the Octicon in the default TreeView story is lost. The TrailingVisual only use the prop `label` as a means of aria-describing  TreeView `li` component.

<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
