### PR TITLE
PageHeader: Move `variant` prop of `PageHeader.Title` to the parent `PageHeader` component to prevent layout shift

### DIFF
--- a/.changeset/rude-wombats-buy.md
+++ b/.changeset/rude-wombats-buy.md
@@ -1,6 +1,5 @@
 ---
 "@primer/react": patch
-"docs": patch
 ---
 
 This is technically a breaking API change.

--- a/.changeset/rude-wombats-buy.md
+++ b/.changeset/rude-wombats-buy.md
@@ -1,0 +1,7 @@
+---
+"@primer/react": patch
+"docs": patch
+---
+
+This is technically a breaking API change.
+Move `variant` prop of `PageHeader.TitleArea` to the parent `PageHeader` component as `titleVariant` to prevent layout shifts

--- a/packages/react/src/PageHeader/PageHeader.dev.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.dev.stories.tsx
@@ -18,19 +18,27 @@ export default meta
 
 export const LargeVariantWithMultilineTitle = () => (
   <Box sx={{padding: 3}}>
-    <PageHeader>
+    <PageHeader titleVariant="large">
       <PageHeader.LeadingAction>
         <IconButton aria-label="Edit" icon={PencilIcon} variant="invisible" />
       </PageHeader.LeadingAction>
-      <PageHeader.TitleArea variant="large">
+      <PageHeader.TitleArea>
         <PageHeader.LeadingVisual>
           <GitBranchIcon />
         </PageHeader.LeadingVisual>
-        <PageHeader.Title>
+        <PageHeader.Title
+          sx={{
+            // lineHeight: '1.25',
+            fontWeight: 'normal',
+            // fontSize: '32px',
+            fontSize: ['26px', '26px', '32px', '32px'],
+            // fontSize: ['26px', '26px', 'var(--text-title-size-large, 32px)', 'var(--text-title-size-large, 32px)'], // it doesn't support this format right now.
+          }}
+        >
           Title long title some extra loooong looong words here some extra loooong looong words here some extra loooong
           looong words here some extra loooong looong words here some extra loooong looong words here
         </PageHeader.Title>
-        <PageHeader.TrailingVisual>
+        <PageHeader.TrailingVisual sx={{height: '120px'}}>
           <Label>Beta</Label>
         </PageHeader.TrailingVisual>
       </PageHeader.TitleArea>

--- a/packages/react/src/PageHeader/PageHeader.dev.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.dev.stories.tsx
@@ -26,19 +26,11 @@ export const LargeVariantWithMultilineTitle = () => (
         <PageHeader.LeadingVisual>
           <GitBranchIcon />
         </PageHeader.LeadingVisual>
-        <PageHeader.Title
-          sx={{
-            // lineHeight: '1.25',
-            fontWeight: 'normal',
-            // fontSize: '32px',
-            fontSize: ['26px', '26px', '32px', '32px'],
-            // fontSize: ['26px', '26px', 'var(--text-title-size-large, 32px)', 'var(--text-title-size-large, 32px)'], // it doesn't support this format right now.
-          }}
-        >
+        <PageHeader.Title>
           Title long title some extra loooong looong words here some extra loooong looong words here some extra loooong
           looong words here some extra loooong looong words here some extra loooong looong words here
         </PageHeader.Title>
-        <PageHeader.TrailingVisual sx={{height: '120px'}}>
+        <PageHeader.TrailingVisual>
           <Label>Beta</Label>
         </PageHeader.TrailingVisual>
       </PageHeader.TitleArea>

--- a/packages/react/src/PageHeader/PageHeader.docs.json
+++ b/packages/react/src/PageHeader/PageHeader.docs.json
@@ -19,6 +19,12 @@
       "description": "Whether the content is hidden."
     },
     {
+      "name": "titleVariant",
+      "type": "| 'subtitle' | 'medium' | 'large' | { narrow?: | 'subtitle' | 'medium' | 'large' regular?: | 'subtitle' | 'medium' | 'large' wide?: | 'subtitle' | 'medium' | 'large' }",
+      "defaultValue": "medium",
+      "description": "Handles the title size and styles as well as the other elements' height. Default title (medium) is the most common page title size. Use for static titles in most situations. \nLarge variant should be used for user-generated content such as issues, pull requests, or discussions. \nSubtitle variant can be used when a PageHeader.Title is already present in the page, such as in a SplitPageLayout."
+    },
+    {
       "name": "sx",
       "type": "SystemStyleObject"
     },
@@ -103,12 +109,6 @@
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",
           "description": "Whether the content is hidden."
-        },
-        {
-          "name": "variant",
-          "type": "| 'subtitle' | 'medium' | 'large' | { narrow?: | 'subtitle' | 'medium' | 'large' regular?: | 'subtitle' | 'medium' | 'large' wide?: | 'subtitle' | 'medium' | 'large' }",
-          "defaultValue": "medium",
-          "description": "Default title (medium) is the most common page title size. Use for static titles in most situations. \nLarge variant should be used for user-generated content such as issues, pull requests, or discussions. \nSubtitle variant can be used when a PageHeader.Title is already present in the page, such as in a SplitPageLayout."
         },
         {
           "name": "sx",

--- a/packages/react/src/PageHeader/PageHeader.features.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.features.stories.tsx
@@ -41,8 +41,8 @@ export const HasTitleOnly = () => (
 
 export const HasLargeTitle = () => (
   <Box sx={{padding: 3}}>
-    <PageHeader>
-      <PageHeader.TitleArea variant="large">
+    <PageHeader titleVariant="large">
+      <PageHeader.TitleArea>
         <PageHeader.Title>Title</PageHeader.Title>
       </PageHeader.TitleArea>
     </PageHeader>

--- a/packages/react/src/PageHeader/PageHeader.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.stories.tsx
@@ -189,14 +189,14 @@ export default meta
 
 export const Playground: Story = args => (
   <Box sx={{padding: 3}}>
-    <PageHeader>
-      <PageHeader.TitleArea
-        variant={{
-          narrow: args['Title.variant'],
-          regular: args['Title.variant'],
-          wide: args['Title.variant'],
-        }}
-      >
+    <PageHeader
+      variant={{
+        narrow: args['Title.variant'],
+        regular: args['Title.variant'],
+        wide: args['Title.variant'],
+      }}
+    >
+      <PageHeader.TitleArea>
         <PageHeader.LeadingVisual hidden={!args.hasLeadingVisual}>{<args.LeadingVisual />}</PageHeader.LeadingVisual>
         <PageHeader.Title as={args['Title.as']} hidden={!args.hasTitle}>
           {args.Title}

--- a/packages/react/src/PageHeader/PageHeader.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.stories.tsx
@@ -190,7 +190,7 @@ export default meta
 export const Playground: Story = args => (
   <Box sx={{padding: 3}}>
     <PageHeader
-      variant={{
+      titleVariant={{
         narrow: args['Title.variant'],
         regular: args['Title.variant'],
         wide: args['Title.variant'],

--- a/packages/react/src/PageHeader/PageHeader.test.tsx
+++ b/packages/react/src/PageHeader/PageHeader.test.tsx
@@ -138,8 +138,8 @@ describe('PageHeader', () => {
   })
   it('respects the title variant prop', () => {
     const {getByText} = render(
-      <PageHeader>
-        <PageHeader.TitleArea variant="large">
+      <PageHeader titleVariant="large">
+        <PageHeader.TitleArea>
           <PageHeader.Title>Title</PageHeader.Title>
         </PageHeader.TitleArea>
         <PageHeader.ContextArea>ContextArea</PageHeader.ContextArea>

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -321,40 +321,33 @@ const ContextAreaActions: React.FC<React.PropsWithChildren<ChildrenPropTypes>> =
     </Box>
   )
 }
-
-type TitleAreaProps = {
-  // variant?: 'subtitle' | 'medium' | 'large' | ResponsiveValue<'subtitle' | 'medium' | 'large'>
-} & ChildrenPropTypes
 // PageHeader.TitleArea: The main title area of the page. Visible on all viewports.
 // PageHeader.TitleArea Sub Components: PageHeader.LeadingVisual, PageHeader.Title, PageTitle.TrailingVisual
 // ---------------------------------------------------------------------
 
-const TitleArea = React.forwardRef<HTMLDivElement, React.PropsWithChildren<TitleAreaProps>>(
-  ({children, sx = {}, hidden = false}, forwardedRef) => {
-    return (
-      <Box
-        ref={forwardedRef}
-        data-component="TitleArea"
-        sx={merge<BetterSystemStyleObject>(
-          {
-            gridRow: GRID_ROW_ORDER.TitleArea,
-            gridArea: 'title-area',
-            display: 'flex',
-            gap: '0.5rem',
-            ...getBreakpointDeclarations(hidden, 'display', value => {
-              return value ? 'none' : 'flex'
-            }),
-            flexDirection: 'row',
-            alignItems: 'flex-start',
-          },
-          sx,
-        )}
-      >
-        {children}
-      </Box>
-    )
-  },
-) as PolymorphicForwardRefComponent<'div', TitleAreaProps>
+const TitleArea: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({children, sx = {}, hidden = false}) => {
+  return (
+    <Box
+      data-component="TitleArea"
+      sx={merge<BetterSystemStyleObject>(
+        {
+          gridRow: GRID_ROW_ORDER.TitleArea,
+          gridArea: 'title-area',
+          display: 'flex',
+          gap: '0.5rem',
+          ...getBreakpointDeclarations(hidden, 'display', value => {
+            return value ? 'none' : 'flex'
+          }),
+          flexDirection: 'row',
+          alignItems: 'flex-start',
+        },
+        sx,
+      )}
+    >
+      {children}
+    </Box>
+  )
+}
 
 // PageHeader.LeadingAction and PageHeader.TrailingAction should only be visible on regular viewports.
 // So they come as hidden on narrow viewports by default and their visibility can be managed by their `hidden` prop.


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->
Reported internally [on Slack (Hubbers link only)](https://github.slack.com/archives/C01L618AEP9/p1717754823228669) - Please note this is the fix of the`PageHeader.Actions` layout shift issue in the PageHeader component. Not the font size which I am still working on it. 

This is technically a breaking API change but PageHeader is still an experimental component and we got feedback about the layout shift after shipping https://github.com/primer/react/pull/4358. 

It is caused by setting the `data-size-variant={titleVariant}` on PageHeader component  (to set height for other sub elements such as leading and trailing visual and actions) in the useeffect. We had to do it this way in the useeffect because we only get the value of the `variant` prop _after_ rendering the `PageHeader.TitleArea` component. This PR moves the `variant` prop to the parent `PageHeader` component to prevent layout shift.

Let me know if you have a different idea to handle this.

Video describes the layout shift issue in the prod storybook and how this PR fixes it on the local environment. Especially  the actions on the right side jumps quite visibly. 

https://github.com/primer/react/assets/1446503/63211e18-6442-44c7-8d73-c2ec40665c5f

I noticed this layout shift issue but thought it is due to the slowness of the storybook but unfortunately it is quite visible in the real life too :/ 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Move the `variant` prop from `PageHeader.TitleArea` to `PageHeader` and rename it to `titleVariant`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
