### PR TITLE
add classname prop support to PageHeader component and its children

### DIFF
--- a/.changeset/two-snakes-brush.md
+++ b/.changeset/two-snakes-brush.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Adds support for `className` prop to PageHeader component and its children.

--- a/packages/react/src/PageHeader/PageHeader.docs.json
+++ b/packages/react/src/PageHeader/PageHeader.docs.json
@@ -13,6 +13,12 @@
       "description": "A unique label for the rendered main landmark"
     },
     {
+      "name": "className",
+      "type": "string | undefined",
+      "defaultValue": "",
+      "description": "CSS string"
+    },
+    {
       "name": "hidden",
       "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
       "defaultValue": "false",
@@ -33,6 +39,12 @@
       "name": "PageHeader.ContextArea",
       "props": [
         {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
+        {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",
@@ -47,6 +59,12 @@
     {
       "name": "PageHeader.ParentLink",
       "props": [
+        {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
         {
           "name": "href",
           "type": "string",
@@ -69,6 +87,12 @@
       "name": "PageHeader.ContextBar",
       "props": [
         {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
+        {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",
@@ -84,6 +108,12 @@
       "name": "PageHeader.ContextAreaActions",
       "props": [
         {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
+        {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",
@@ -98,6 +128,12 @@
     {
       "name": "PageHeader.TitleArea",
       "props": [
+        {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
         {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
@@ -120,6 +156,12 @@
       "name": "PageHeader.LeadingAction",
       "props": [
         {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
+        {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",
@@ -135,6 +177,12 @@
       "name": "PageHeader.LeadingVisual",
       "props": [
         {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
+        {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",
@@ -149,6 +197,12 @@
     {
       "name": "PageHeader.Title",
       "props": [
+        {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
         {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
@@ -170,6 +224,12 @@
       "name": "PageHeader.TrailingVisual",
       "props": [
         {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
+        {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",
@@ -184,6 +244,12 @@
     {
       "name": "PageHeader.TrailingAction",
       "props": [
+        {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
         {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
@@ -200,6 +266,12 @@
       "name": "PageHeader.Actions",
       "props": [
         {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
+        {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",
@@ -214,6 +286,12 @@
     {
       "name": "PageHeader.Description",
       "props": [
+        {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
+        },
         {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
@@ -244,6 +322,12 @@
           "type": "div | nav",
           "defaultValue": "\"div\"",
           "description": "The HTML element used to render the navigation."
+        },
+        {
+          "name": "className",
+          "type": "string | undefined",
+          "defaultValue": "",
+          "description": "CSS string"
         },
         {
           "name": "hidden",

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -42,6 +42,7 @@ const LARGE_TITLE_HEIGHT = '3rem'
 
 // Types that are shared between PageHeader children components
 export type ChildrenPropTypes = {
+  className?: string
   hidden?: boolean | ResponsiveValue<boolean>
 } & SxProp
 
@@ -64,10 +65,11 @@ const hiddenOnNarrow = {
 export type PageHeaderProps = {
   'aria-label'?: React.AriaAttributes['aria-label']
   as?: React.ElementType | 'header' | 'div'
+  className?: string
 } & SxProp
 
 const Root = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageHeaderProps>>(
-  ({children, sx = {}, as = 'div'}, forwardedRef) => {
+  ({children, className, sx = {}, as = 'div'}, forwardedRef) => {
     const rootStyles = {
       display: 'grid',
       // We have max 5 columns.
@@ -156,7 +158,13 @@ const Root = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageHeader
       }
     }, [children, rootRef, hasContextArea, hasLeadingAction])
     return (
-      <Box ref={rootRef} as={as} sx={merge<BetterSystemStyleObject>(rootStyles, sx)} data-size-variant={titleVariant}>
+      <Box
+        ref={rootRef}
+        as={as}
+        className={className}
+        sx={merge<BetterSystemStyleObject>(rootStyles, sx)}
+        data-size-variant={titleVariant}
+      >
         {children}
       </Box>
     )
@@ -169,6 +177,7 @@ const Root = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageHeader
 // ---------------------------------------------------------------------
 const ContextArea: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
   children,
+  className,
   hidden = hiddenOnRegularAndWide,
   sx = {},
 }) => {
@@ -186,7 +195,11 @@ const ContextArea: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
     }),
   }
 
-  return <Box sx={merge<BetterSystemStyleObject>(contentNavStyles, sx)}>{children}</Box>
+  return (
+    <Box className={className} sx={merge<BetterSystemStyleObject>(contentNavStyles, sx)}>
+      {children}
+    </Box>
+  )
 }
 type LinkProps = Pick<
   React.AnchorHTMLAttributes<HTMLAnchorElement> & BaseLinkProps,
@@ -198,7 +211,7 @@ export type ParentLinkProps = React.PropsWithChildren<ChildrenPropTypes & LinkPr
 
 // PageHeader.ParentLink : Only visible on narrow viewports by default to let users navigate up in the hierarchy.
 const ParentLink = React.forwardRef<HTMLAnchorElement, ParentLinkProps>(
-  ({children, sx = {}, href, 'aria-label': ariaLabel, as = 'a', hidden = hiddenOnRegularAndWide}, ref) => {
+  ({children, className, sx = {}, href, 'aria-label': ariaLabel, as = 'a', hidden = hiddenOnRegularAndWide}, ref) => {
     return (
       <>
         <Link
@@ -206,6 +219,7 @@ const ParentLink = React.forwardRef<HTMLAnchorElement, ParentLinkProps>(
           as={as}
           aria-label={ariaLabel}
           muted
+          className={className}
           sx={merge<BetterSystemStyleObject>(
             {
               display: 'flex',
@@ -234,11 +248,13 @@ const ParentLink = React.forwardRef<HTMLAnchorElement, ParentLinkProps>(
 
 const ContextBar: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
   children,
+  className,
   sx = {},
   hidden = hiddenOnRegularAndWide,
 }) => {
   return (
     <Box
+      className={className}
       sx={merge<BetterSystemStyleObject>(
         {
           display: 'flex',
@@ -259,11 +275,13 @@ const ContextBar: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
 // ---------------------------------------------------------------------
 const ContextAreaActions: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
   children,
+  className,
   sx = {},
   hidden = hiddenOnRegularAndWide,
 }) => {
   return (
     <Box
+      className={className}
       sx={merge<BetterSystemStyleObject>(
         {
           display: 'flex',
@@ -293,7 +311,7 @@ type TitleAreaProps = {
 // ---------------------------------------------------------------------
 
 const TitleArea = React.forwardRef<HTMLDivElement, React.PropsWithChildren<TitleAreaProps>>(
-  ({children, sx = {}, hidden = false, variant = 'medium'}, forwardedRef) => {
+  ({children, className, sx = {}, hidden = false, variant = 'medium'}, forwardedRef) => {
     const titleAreaRef = useProvidedRefOrCreate<HTMLDivElement>(forwardedRef as React.RefObject<HTMLDivElement>)
     const currentVariant = useResponsiveValue(variant, 'medium')
     const [fontSize, setFontSize] = useState<string | null | number | string[]>(null)
@@ -317,6 +335,7 @@ const TitleArea = React.forwardRef<HTMLDivElement, React.PropsWithChildren<Title
     }, [titleAreaRef])
     return (
       <Box
+        className={className}
         ref={titleAreaRef}
         data-component="TitleArea"
         data-size-variant={currentVariant}
@@ -363,6 +382,7 @@ const TitleArea = React.forwardRef<HTMLDivElement, React.PropsWithChildren<Title
 // So they come as hidden on narrow viewports by default and their visibility can be managed by their `hidden` prop.
 const LeadingAction: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
   children,
+  className,
   sx = {},
   hidden = hiddenOnNarrow,
 }) => {
@@ -372,6 +392,7 @@ const LeadingAction: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
   if (height) style['--custom-height'] = height
   return (
     <Box
+      className={className}
       data-component="PH_LeadingAction"
       sx={merge<BetterSystemStyleObject>(
         {
@@ -394,9 +415,15 @@ const LeadingAction: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
 }
 
 // This is reserved for only breadcrumbs.
-const Breadcrumbs: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({children, sx = {}, hidden = false}) => {
+const Breadcrumbs: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
+  children,
+  className,
+  sx = {},
+  hidden = false,
+}) => {
   return (
     <Box
+      className={className}
       data-component="PH_Breadcrumbs"
       sx={merge<BetterSystemStyleObject>(
         {
@@ -418,13 +445,19 @@ const Breadcrumbs: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({chil
 }
 
 // PageHeader.LeadingVisual and PageHeader.TrailingVisual should remain visible on narrow viewports.
-const LeadingVisual: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({children, sx = {}, hidden = false}) => {
+const LeadingVisual: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
+  children,
+  className,
+  sx = {},
+  hidden = false,
+}) => {
   const style: CSSCustomProperties = {}
   // @ts-ignore sx has height attribute
   const {height} = sx
   if (height) style['--custom-height'] = height
   return (
     <Box
+      className={className}
       data-component="PH_LeadingVisual"
       sx={merge<BetterSystemStyleObject>(
         {
@@ -449,7 +482,13 @@ export type TitleProps = {
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 } & ChildrenPropTypes
 
-const Title: React.FC<React.PropsWithChildren<TitleProps>> = ({children, sx = {}, hidden = false, as = 'h2'}) => {
+const Title: React.FC<React.PropsWithChildren<TitleProps>> = ({
+  children,
+  className,
+  sx = {},
+  hidden = false,
+  as = 'h2',
+}) => {
   const style: CSSCustomProperties = {}
   // @ts-ignore sxProp can have color attribute
   const {fontSize, lineHeight, fontWeight} = sx
@@ -459,6 +498,7 @@ const Title: React.FC<React.PropsWithChildren<TitleProps>> = ({children, sx = {}
 
   return (
     <Heading
+      className={className}
       data-component="PH_Title"
       as={as}
       style={style}
@@ -480,13 +520,19 @@ const Title: React.FC<React.PropsWithChildren<TitleProps>> = ({children, sx = {}
 }
 
 // PageHeader.LeadingVisual and PageHeader.TrailingVisual should remain visible on narrow viewports.
-const TrailingVisual: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({children, sx = {}, hidden = false}) => {
+const TrailingVisual: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
+  children,
+  className,
+  sx = {},
+  hidden = false,
+}) => {
   const style: CSSCustomProperties = {}
   // @ts-ignore sx has height attribute
   const {height} = sx
   if (height) style['--custom-height'] = height
   return (
     <Box
+      className={className}
       data-component="PH_TrailingVisual"
       sx={merge<BetterSystemStyleObject>(
         {
@@ -509,6 +555,7 @@ const TrailingVisual: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({c
 
 const TrailingAction: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
   children,
+  className,
   sx = {},
   hidden = hiddenOnNarrow,
 }) => {
@@ -518,6 +565,7 @@ const TrailingAction: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
   if (height) style['--custom-height'] = height
   return (
     <Box
+      className={className}
       data-component="PH_TrailingAction"
       sx={merge<BetterSystemStyleObject>(
         {
@@ -539,13 +587,19 @@ const TrailingAction: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
   )
 }
 
-const Actions: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({children, sx = {}, hidden = false}) => {
+const Actions: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
+  children,
+  className,
+  sx = {},
+  hidden = false,
+}) => {
   const style: CSSCustomProperties = {}
   // @ts-ignore sx has height attribute
   const {height} = sx
   if (height) style['--custom-height'] = height
   return (
     <Box
+      className={className}
       data-component="PH_Actions"
       sx={merge<BetterSystemStyleObject>(
         {
@@ -572,9 +626,15 @@ const Actions: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({children
 }
 
 // PageHeader.Description: The description area of the header. Visible on all viewports
-const Description: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({children, sx = {}, hidden = false}) => {
+const Description: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
+  children,
+  className,
+  sx = {},
+  hidden = false,
+}) => {
   return (
     <Box
+      className={className}
       sx={merge<BetterSystemStyleObject>(
         {
           gridRow: GRID_ROW_ORDER.Description,
@@ -605,6 +665,7 @@ export type NavigationProps = {
 // PageHeader.Navigation: The local navigation area of the header. Visible on all viewports
 const Navigation: React.FC<React.PropsWithChildren<NavigationProps>> = ({
   children,
+  className,
   sx = {},
   hidden = false,
   as,
@@ -622,6 +683,7 @@ const Navigation: React.FC<React.PropsWithChildren<NavigationProps>> = ({
       // Render `aria-label` and `aria-labelledby` only on `nav` elements
       aria-label={as === 'nav' ? ariaLabel : undefined}
       aria-labelledby={as === 'nav' ? ariaLabelledBy : undefined}
+      className={className}
       sx={merge<BetterSystemStyleObject>(
         {
           gridRow: GRID_ROW_ORDER.Navigation,


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3331

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

This pull request introduces support for styling via CSS utility classes on the `PageHeader` component and its children by adding support for an optional `className` prop, allowing for more flexible customization without relying on [Styled System props](https://github.com/styled-system/styled-system) (`sx`). Full context: my team is currently in the process of deprecating our use of `sx`, so this change will allow us to safely incrementally replace `sx` props with `className` props.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- **Adds optional `className` prop**: All `PageHeader` components now accept a `className` prop. This prop is applied to the root element of each component.
- **Maintains backward compatibility**: The addition of the `className` prop is optional and does not affect existing implementations that do not use this prop.
- **Updates TypeScript types**: The TypeScript definitions for `PageHeader` components have been updated to include the new `className` prop, ensuring type safety for TypeScript users.
- **Updates documentation**: The `PageHeader` component documentation has been updated to include information about the new `className` prop.

#### Changed

<!-- List of things changed in this PR -->

N/A

#### Removed

<!-- List of things removed in this PR -->
N/A

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

#### Prerequisites

1. Open this branch locally or in a codespace
1. Run `npm run setup` to setup dependencies

#### Click testing

1. Run `npm start` to start the Storybook server
1. Navigate to the `PageHeader` component in Storybook
1. Review examples

#### Automated testing

1. Run `npx playwright install --with-deps` to install dependencies
1. Run `npx playwright test --grep @vrt` to run visual regression tests
1. Run `npx playwright test --grep @art` to run accessibility tests
1. Review test results


### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
- [x] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md)) - see https://github.com/github/github/actions/runs/9475842136

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
