### PR TITLE
refactor(VisuallyHidden): update base element from div to span

### DIFF
--- a/.changeset/thick-jars-count.md
+++ b/.changeset/thick-jars-count.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Update internal VisuallyHidden helper to use a `span` by default over a `div` to support more nesting scenarios by default

--- a/packages/react/src/Spinner/Spinner.tsx
+++ b/packages/react/src/Spinner/Spinner.tsx
@@ -57,11 +57,7 @@ function Spinner({size: sizeKey = 'medium', srText = 'Loading', 'aria-label': ar
           vectorEffect="non-scaling-stroke"
         />
       </svg>
-      {hasHiddenLabel ? (
-        <VisuallyHidden as="span" id={labelId}>
-          {srText}
-        </VisuallyHidden>
-      ) : null}
+      {hasHiddenLabel ? <VisuallyHidden id={labelId}>{srText}</VisuallyHidden> : null}
     </Box>
   )
 }

--- a/packages/react/src/internal/components/VisuallyHidden.tsx
+++ b/packages/react/src/internal/components/VisuallyHidden.tsx
@@ -12,7 +12,7 @@ import sx from '../../sx'
  *
  * @see https://www.scottohara.me/blog/2023/03/21/visually-hidden-hack.html
  */
-export const VisuallyHidden = styled.div<SxProp>`
+export const VisuallyHidden = styled.span<SxProp>`
   &:not(:focus):not(:active):not(:focus-within) {
     clip-path: inset(50%);
     height: 1px;


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update our internal utility `VisuallyHidden` to use a `<span>` by default over a `<div>`. This is due to the fact that a `<div>` is not allowable in all contexts, for example a `<div>` cannot be rendered within a `<p>`. As a result, this helper may not work as intended if a component is within a specific context. Moving over to a `span` by default will help with this as it it allowed in all contexts (hopefully).

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Change base element from `div` to `span` for `VisuallyHidden`
- Update Spinner to no longer have to specify `span` in `as`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->


- [x] Minor release
