### PR TITLE
chore: Bump release event tracking to 2.1.1

### DIFF
--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -14,6 +14,6 @@ on:
 jobs:
   release-tracking:
     name: Release Tracking
-    uses: primer/.github/.github/workflows/release_tracking.yml@v2.1.0
+    uses: primer/.github/.github/workflows/release_tracking.yml@v2.1.1
     secrets:
       datadog_api_key: ${{ secrets.DATADOG_API_KEY }}


### PR DESCRIPTION
#### New

Bump the release event tracking workflow to version 2.1.1. 

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

actions workflow change
