### PR TITLE
fix(FilteredActionList): label listbox by input

### DIFF
--- a/packages/react/src/FilteredActionList/FilteredActionList.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionList.tsx
@@ -63,6 +63,7 @@ export function FilteredActionList({
   const inputRef = useProvidedRefOrCreate<HTMLInputElement>(providedInputRef)
   const activeDescendantRef = useRef<HTMLElement>()
   const listId = useId()
+  const inputId = useId(textInputProps?.id)
   const inputDescriptionTextId = useId()
   const onInputKeyPress: KeyboardEventHandler = useCallback(
     event => {
@@ -125,6 +126,7 @@ export function FilteredActionList({
           aria-controls={listId}
           aria-describedby={inputDescriptionTextId}
           {...textInputProps}
+          id={inputId}
         />
       </StyledHeader>
       <VisuallyHidden id={inputDescriptionTextId}>Items will be filtered as you type</VisuallyHidden>
@@ -134,7 +136,14 @@ export function FilteredActionList({
             <Spinner />
           </Box>
         ) : (
-          <ActionList ref={listContainerRef} items={items} {...listProps} role="listbox" id={listId} />
+          <ActionList
+            ref={listContainerRef}
+            aria-labelledby={inputId}
+            items={items}
+            {...listProps}
+            role="listbox"
+            id={listId}
+          />
         )}
       </Box>
     </Box>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3408

Fixes https://dequeuniversity.com/rules/axe/4.7/aria-input-field-name for `FilteredActionList` and `SelectPanel` by labeling the listbox by the input

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add `id` to input for FilteredActionList
- Label listbox by input id

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- [ ] Verify that the axe violation for this no longer occurs