### PR TITLE
Remove live region from `FormControl` validation

### DIFF
--- a/.changeset/grumpy-masks-relax.md
+++ b/.changeset/grumpy-masks-relax.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Removes live region from `FormControl` validation

--- a/packages/react/src/internal/components/InputValidation.tsx
+++ b/packages/react/src/internal/components/InputValidation.tsx
@@ -48,7 +48,6 @@ const InputValidation: React.FC<React.PropsWithChildren<Props>> = ({children, id
         },
         ...sx,
       }}
-      aria-live="polite"
     >
       {IconComponent && (
         <Box as="span" alignItems="center" display="flex" minHeight={iconBoxMinHeight} mr={1} aria-hidden="true">


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Unblocks: https://github.com/github/accessibility-audits/issues/6883, https://github.com/github/accessibility-audits/issues/6881, https://github.com/github/accessibility-audits/issues/5728

We've received [feedback from the Accessibility team](https://github.com/github/accessibility-audits/issues/6883#issuecomment-2115858770) that it may be less than ideal for the `FormControl` component to have a live region for validation, as the `aria-describedby` [should suffice in most scenarios](https://github.com/github/accessibility-audits/issues/6883#issuecomment-2200728486). Consumers of this component may still provide a live region, but it will no longer be included by default. 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

<!-- List of things removed in this PR -->
* Removes `aria-live` from `FormControl.Validation`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
