### PR TITLE
feat(useFocus): add support for a focus target callback

### DIFF
--- a/packages/react/src/internal/hooks/useFocus.ts
+++ b/packages/react/src/internal/hooks/useFocus.ts
@@ -1,21 +1,28 @@
-import {type RefObject, useEffect, useState} from 'react'
+import {type RefObject, useCallback, useEffect, useState} from 'react'
+
+type FocusTarget = HTMLElement | RefObject<HTMLElement> | (() => HTMLElement | undefined)
 
 export function useFocus() {
-  const [focusTarget, setFocusTarget] = useState<HTMLElement | RefObject<HTMLElement> | null>(null)
+  const [focusTarget, setFocusTarget] = useState<FocusTarget | null>(null)
 
   useEffect(() => {
     if (focusTarget === null) {
       return
     }
 
-    if (focusTarget instanceof HTMLElement) {
-      focusTarget.focus()
-    } else {
-      focusTarget.current?.focus()
-    }
+    const element =
+      typeof focusTarget === 'function'
+        ? focusTarget()
+        : focusTarget instanceof HTMLElement
+        ? focusTarget
+        : focusTarget.current
+
+    element?.focus()
 
     setFocusTarget(null)
   }, [focusTarget])
 
-  return setFocusTarget
+  return useCallback((target: FocusTarget) => {
+    setFocusTarget(() => target)
+  }, [])
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This is an experiment alongside https://github.com/primer/react/pull/4686 to show a potential addition to the `useFocus` hook to colocate focus management and event handlers when the focus target is dependent on state updates.

In this scenario, `useFocus()` now supports a callback that can be used to find the focus target that will run after React has renderer

```tsx
const focus = useFocus();

// ...

<button onClick={() => {
  setExpanded(true);
  focus(() => {
    return document.querySelector(`[data-show-more-group-id="${groupId}"`);
  });
}} />
```

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
