### PR TITLE
feat: Adding custom property fallback plugin to postcss css module processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36462,6 +36462,18 @@
       "version": "1.2.4",
       "license": "MIT"
     },
+    "node_modules/is-url-superb": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-valid-domain": {
       "version": "0.1.6",
       "license": "MIT",
@@ -47869,6 +47881,19 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/postcss-custom-properties-fallback": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties-fallback/-/postcss-custom-properties-fallback-1.0.2.tgz",
+      "integrity": "sha512-UrPr99bo03c1iX4iqjBBYo3W+EsXfxrozp2LNvRN34Y95n/7R2RupcMhGlc+C/RQxknDXiP+bptyhmb8nFYzeQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0",
+        "postcss-values-parser": "^6.0.2"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
     "node_modules/postcss-custom-selectors": {
       "version": "7.1.10",
       "dev": true,
@@ -48841,6 +48866,29 @@
       "version": "4.2.0",
       "license": "MIT"
     },
+    "node_modules/postcss-values-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
+      "integrity": "sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "is-url-superb": "^4.0.0",
+        "quote-unquote": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.9"
+      }
+    },
+    "node_modules/postcss-values-parser/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.2",
       "license": "MIT",
@@ -49403,6 +49451,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/quote-unquote": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
+      "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==",
+      "dev": true
     },
     "node_modules/ramda": {
       "version": "0.29.0",
@@ -58753,6 +58807,7 @@
         "mdast-util-to-string": "4.0.0",
         "micromark-extension-frontmatter": "2.0.0",
         "micromark-extension-mdxjs": "3.0.0",
+        "postcss-custom-properties-fallback": "1.0.2",
         "postcss-preset-env": "9.5.14",
         "react": "18.3.1",
         "react-dnd": "14.0.4",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -203,6 +203,7 @@
     "mdast-util-to-string": "4.0.0",
     "micromark-extension-frontmatter": "2.0.0",
     "micromark-extension-mdxjs": "3.0.0",
+    "postcss-custom-properties-fallback": "1.0.2",
     "postcss-preset-env": "9.5.14",
     "react": "18.3.1",
     "react-dnd": "14.0.4",

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -133,25 +133,21 @@ const baseConfig = {
         customPropertiesFallback({
           importFrom: [
             () => {
-              const primitiveFallbacks = [
-                'color-fallbacks.json',
-                'base/size/size.json',
-                'base/typography/typography.json',
-                'functional/size/border.json',
-                'functional/size/breakpoints.json',
-                'functional/size/size-coarse.json',
-                'functional/size/size-fine.json',
-                'functional/size/size.json',
-                'functional/size/viewport.json',
-                'functional/typography/typography.json',
-              ]
               let customProperties = {}
-              for (const filePath of primitiveFallbacks) {
+              const filePaths = glob.sync(['**/*.json'], {
+                cwd: path.join(__dirname, '../../node_modules/@primer/primitives/dist/fallbacks/'),
+                ignore: ['color-fallbacks.json'],
+              })
+
+              for (const filePath of filePaths) {
                 const fileData = fs.readFileSync(
                   path.join(__dirname, '../../node_modules/@primer/primitives/dist/fallbacks/', filePath),
                   'utf8',
                 )
-                customProperties = {...customProperties, ...JSON.parse(fileData)}
+                customProperties = {
+                  ...customProperties,
+                  ...JSON.parse(fileData),
+                }
               }
 
               return {customProperties}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Part of https://github.com/github/primer/issues/3159

This adds the [postcss-custom-properties-fallback](https://github.com/stipsan/postcss-custom-properties-fallback) plugin to the postcss config plugins. 

This plugin will add fallbacks to the compiled output for all primitive values used in the component CSS files. There are two major advantages to using this plugin.

1. This will ensure that the component styles are displayed correctly when primitives might not be included properly.
2. This will allow us to convert all styled system code to CSS modules without having to account for the styled dictionary lookup that is currently used. ie `var(--borderColor-default, ${get('colors.border.default')})`.

Here's an example of the compiled changes

```diff
.prc-Blankslate-Blankslate-7GPW- {
-  --blankslate-outer-padding-block: var(--base-size-32);
-  --blankslate-outer-padding-inline: var(--base-size-32);
+  --blankslate-outer-padding-block: var(--base-size-32,2rem);
+  --blankslate-outer-padding-inline: var(--base-size-32,2rem);
  display: grid;
  justify-items: center;
  padding: var(--blankslate-outer-padding-block) var(--blankslate-outer-padding-inline);
}
```