### PR TITLE
docs: add template for ADRs

### DIFF
--- a/contributor-docs/adrs/adr-000-template.md
+++ b/contributor-docs/adrs/adr-000-template.md
@@ -1,0 +1,20 @@
+# Title
+
+## Status
+
+| Stage    | Status      |
+| -------- | ----------- |
+| Approved | <!-- ✅ --> |
+| Adopted  | <!-- 🚧 --> |
+
+## Context
+
+<!-- Provide background information needed for this ADR -->
+
+## Decision
+
+<!-- Provide information about the decision made by this ADR -->
+
+### Impact
+
+<!-- Describe the impact of the decision -->

--- a/contributor-docs/adrs/adr-001-typescript.md
+++ b/contributor-docs/adrs/adr-001-typescript.md
@@ -1,4 +1,4 @@
-# ADR 1: TypeScript
+# TypeScript
 
 ## Status
 

--- a/contributor-docs/adrs/adr-002-behavior-isolation.md
+++ b/contributor-docs/adrs/adr-002-behavior-isolation.md
@@ -1,4 +1,4 @@
-# ADR 2: Isolating behaviors through custom clements and vanilla JavaScript
+# Isolating behaviors through custom clements and vanilla JavaScript
 
 ## Status
 

--- a/contributor-docs/adrs/adr-003-prop-norms.md
+++ b/contributor-docs/adrs/adr-003-prop-norms.md
@@ -1,4 +1,4 @@
-# ADR 003: Prop norms in Primer React Components
+# Prop norms in Primer React Components
 
 ## Status
 

--- a/contributor-docs/adrs/adr-004-children-as-api.md
+++ b/contributor-docs/adrs/adr-004-children-as-api.md
@@ -1,4 +1,4 @@
-# ADR 004: Strict props or Composite components
+# Strict props or Composite components
 
 ## Status
 

--- a/contributor-docs/adrs/adr-005-box-sx.md
+++ b/contributor-docs/adrs/adr-005-box-sx.md
@@ -1,4 +1,4 @@
-# ADR 005: Use Box as a building block for all other components
+# Use Box as a building block for all other components
 
 ## Status
 

--- a/contributor-docs/adrs/adr-006-drafts.md
+++ b/contributor-docs/adrs/adr-006-drafts.md
@@ -1,4 +1,4 @@
-# ADR 6: Parallel experimental track & plan for deprecated components
+# Parallel experimental track & plan for deprecated components
 
 ## Status
 

--- a/contributor-docs/adrs/adr-007-experimental-components.md
+++ b/contributor-docs/adrs/adr-007-experimental-components.md
@@ -1,4 +1,4 @@
-# ADR 008: Lowering the barrier to entry for experimental components
+# Lowering the barrier to entry for experimental components
 
 ## Status
 

--- a/contributor-docs/adrs/adr-008-interaction-tests.md
+++ b/contributor-docs/adrs/adr-008-interaction-tests.md
@@ -1,4 +1,4 @@
-# ADR 009: Use Interaction testing in storybook to maintain components
+# Use Interaction testing in storybook to maintain components
 
 > **Warning**
 > This ADR is superceded by [`ADR 018`](./adr-018-interaction-tests-revisited.md)

--- a/contributor-docs/adrs/adr-009-behavior-isolation.md
+++ b/contributor-docs/adrs/adr-009-behavior-isolation.md
@@ -1,4 +1,4 @@
-# ADR 010: Isolating behaviors through custom elements and vanilla JavaScript
+# Isolating behaviors through custom elements and vanilla JavaScript
 
 ## Status
 

--- a/contributor-docs/adrs/adr-010-drafts-are-experimental.md
+++ b/contributor-docs/adrs/adr-010-drafts-are-experimental.md
@@ -1,4 +1,4 @@
-# ADR 010: Merge drafts status into experimental
+# Merge drafts status into experimental
 
 ## Status
 

--- a/contributor-docs/adrs/adr-011-snapshot-tests.md
+++ b/contributor-docs/adrs/adr-011-snapshot-tests.md
@@ -1,4 +1,4 @@
-# ADR 011: Snapshot tests
+# Snapshot tests
 
 ## Status
 

--- a/contributor-docs/adrs/adr-012-development-warnings.md
+++ b/contributor-docs/adrs/adr-012-development-warnings.md
@@ -1,4 +1,4 @@
-# ADR 012: Development Warnings
+# Development Warnings
 
 ## Status
 

--- a/contributor-docs/adrs/adr-013-file-structure.md
+++ b/contributor-docs/adrs/adr-013-file-structure.md
@@ -1,4 +1,4 @@
-# ADR 12: File structure
+# File structure
 
 ## Status
 

--- a/contributor-docs/adrs/adr-014-npm-workspaces.md
+++ b/contributor-docs/adrs/adr-014-npm-workspaces.md
@@ -1,4 +1,4 @@
-# ADR 015: NPM Workspaces
+# NPM Workspaces
 
 ## Status
 

--- a/contributor-docs/adrs/adr-015-internal-modules.md
+++ b/contributor-docs/adrs/adr-015-internal-modules.md
@@ -1,4 +1,4 @@
-# ADR 016: Internal Modules
+# Internal Modules
 
 ## Status
 

--- a/contributor-docs/adrs/adr-016-css.md
+++ b/contributor-docs/adrs/adr-016-css.md
@@ -1,4 +1,4 @@
-# ADR 17: Styling with CSS
+# Styling with CSS
 
 ## Status
 

--- a/contributor-docs/adrs/adr-017-interaction-tests-revisited.md
+++ b/contributor-docs/adrs/adr-017-interaction-tests-revisited.md
@@ -1,4 +1,4 @@
-# ADR 018: Interaction testing (revisited)
+# Interaction testing (revisited)
 
 ## Status
 

--- a/contributor-docs/adrs/adr-018-responsive-values.md
+++ b/contributor-docs/adrs/adr-018-responsive-values.md
@@ -1,4 +1,4 @@
-# ADR 019: Responsive Values
+# Responsive Values
 
 ## Status
 

--- a/contributor-docs/adrs/adr-019-deprecating-props.md
+++ b/contributor-docs/adrs/adr-019-deprecating-props.md
@@ -1,4 +1,4 @@
-# ADR 020: Deprecating Props
+# Deprecating Props
 
 ## Status
 

--- a/contributor-docs/adrs/adr-020-live-regions.md
+++ b/contributor-docs/adrs/adr-020-live-regions.md
@@ -1,4 +1,4 @@
-# ADR 020: Live Regions
+# Live Regions
 
 ## Status
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Add template for ADRs. I also re-ordered them since we had some overlapping numbers 😅 In addition, when updating the file names I updated the titles of the ADRs so that they no longer include the number. Instead, the title is just the title of the ADR.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add ADR template

#### Changed

<!-- List of things changed in this PR -->

- Re-order and rename existing ADRs
- Update titles in ADRs to no longer contain the ADR prefix

#### Removed

<!-- List of things removed in this PR -->
