### PR TITLE
test(e2e): update test-e2e script to read playwright version automatically

### DIFF
--- a/script/test-e2e
+++ b/script/test-e2e
@@ -2,9 +2,11 @@
 
 set -x
 
+PLAYWRIGHT_VERSION=$(npm --json list @playwright/test | jq --raw-output '.dependencies["@playwright/test"].version')
+
 docker run --rm \
   --network host \
   -v $(pwd):/workspace \
   -w /workspace \
-  -it mcr.microsoft.com/playwright:v1.43.0-jammy \
+  -it "mcr.microsoft.com/playwright:v$PLAYWRIGHT_VERSION-jammy" \
   /bin/bash -c "npm install && STORYBOOK_URL=http://host.docker.internal:6006 npx playwright test $@"


### PR DESCRIPTION


<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->



<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Small quality of life update to our local `test-e2e` script to automatically infer the version of `@playwright/test` to be used in the Docker image. This helps to prevent us from having to change this file when the dependency is updated.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `script/test-e2e` to infer the version of `@playwright/test` to be used in the Docker image


#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to an internal test helper.