### PR TITLE
Workflow: Add label "staff" to issues and PR to help prioritisation

### DIFF
--- a/.github/workflows/add_staff_label.yml
+++ b/.github/workflows/add_staff_label.yml
@@ -14,8 +14,10 @@ jobs:
     steps:
       - name: Check author
         id: check-author
+        env:
+          CONTEXT: ${{ toJson(github.event) }}
         run: |
-          echo ${{ github.event.issue }}
+          echo "$CONTEXT"
       - name: Add label
         if: ${{ steps.check-author.outputs.staff == 'true' }}
         run: |

--- a/.github/workflows/add_staff_label.yml
+++ b/.github/workflows/add_staff_label.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened, reopened]
   pull_request:
-    
+    types: [opened, reopened]
 
 jobs:
   add-staff-label:

--- a/.github/workflows/add_staff_label.yml
+++ b/.github/workflows/add_staff_label.yml
@@ -11,14 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ISSUE_URL: ${{ github.event.issue.html_url }}
+      PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
     steps:
-      - name: Check author
-        id: check-author
-        env:
-          CONTEXT: ${{ toJson(github.event) }}
-        run: |
-          echo "$CONTEXT"
-      - name: Add label
-        if: ${{ steps.check-author.outputs.staff == 'true' }}
+      - name: Add label to issue
+        if: ${{ github.event.issue.author_association == 'MEMBER' }}
         run: |
           gh issue edit $ISSUE_URL --add-label staff
+      - name: Add label to pull_request
+        if: ${{ github.event.pull_request.author_association == 'MEMBER' }}
+        run: |
+          gh pr edit $PULL_REQUEST_URL --add-label staff

--- a/.github/workflows/add_staff_label.yml
+++ b/.github/workflows/add_staff_label.yml
@@ -1,0 +1,22 @@
+name: Move new issues to inbox
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+
+jobs:
+  add-staff-label:
+    if: ${{ github.repository == 'primer/react' }}
+    runs-on: ubuntu-latest
+    env:
+      ISSUE_URL: ${{ github.event.issue.html_url }}
+    steps:
+      - name: Check author
+        id: check-author
+        run: |
+          echo ${{ github.event.issue }}
+      - name: Add label
+        if: ${{ steps.check-author.outputs.staff == 'true' }}
+        run: |
+          gh issue edit $ISSUE_URL --add-label staff

--- a/.github/workflows/add_staff_label.yml
+++ b/.github/workflows/add_staff_label.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened, reopened]
   pull_request:
-    types: [opened, reopened]
+    
 
 jobs:
   add-staff-label:

--- a/.github/workflows/add_staff_label.yml
+++ b/.github/workflows/add_staff_label.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Add label to issue
         if: ${{ github.event.issue.author_association == 'MEMBER' }}
         run: |
-          gh issue edit {{github.event.issue.html_url}} --add-label staff
+          gh issue edit ${{github.event.issue.html_url}} --add-label staff
       - name: Add label to pull_request
         if: ${{ github.event.pull_request.author_association == 'MEMBER' }}
         run: |
-          gh pr edit {{github.event.pull_request.html_url}} --add-label staff
+          gh pr edit ${{github.event.pull_request.html_url}} --add-label staff

--- a/.github/workflows/add_staff_label.yml
+++ b/.github/workflows/add_staff_label.yml
@@ -1,4 +1,4 @@
-name: Move new issues to inbox
+name: Add Staff Label
 
 on:
   issues:

--- a/.github/workflows/add_staff_label.yml
+++ b/.github/workflows/add_staff_label.yml
@@ -4,21 +4,20 @@ on:
   issues:
     types: [opened, reopened]
   pull_request:
+    types: [opened, reopened]
 
 jobs:
   add-staff-label:
     if: ${{ github.repository == 'primer/react' }}
     runs-on: ubuntu-latest
     env:
-      ISSUE_URL: ${{ github.event.issue.html_url }}
-      PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Add label to issue
         if: ${{ github.event.issue.author_association == 'MEMBER' }}
         run: |
-          gh issue edit $ISSUE_URL --add-label staff
+          gh issue edit {{github.event.issue.html_url}} --add-label staff
       - name: Add label to pull_request
         if: ${{ github.event.pull_request.author_association == 'MEMBER' }}
         run: |
-          gh pr edit $PULL_REQUEST_URL --add-label staff
+          gh pr edit {{github.event.pull_request.html_url}} --add-label staff

--- a/.github/workflows/add_staff_label.yml
+++ b/.github/workflows/add_staff_label.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       ISSUE_URL: ${{ github.event.issue.html_url }}
       PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Add label to issue
         if: ${{ github.event.issue.author_association == 'MEMBER' }}


### PR DESCRIPTION
This is very much an experiment to see if we like it, hoping this will help us prioritise issues and PRs to triage/review

When a new issue or pull request is opened, this workflow will add `staff` label if the author is a member of the repository. All GitHub staff are considered members of this repo.



Scope for improvement in the future:
- tag sub groups of staff as well like primer-design
- replace with priority levels/slas if/when we formalise them