### PR TITLE
TextInput: Refactor `TextInputInnerAction` to use the default icon button tooltip

### DIFF
--- a/.changeset/modern-carrots-check.md
+++ b/.changeset/modern-carrots-check.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+TextInput: Refactor TextInputInnerAction to use the default icon button tooltip (No changes in the behaviour or DOM is expected)

--- a/packages/react/src/internal/components/TextInputInnerAction.tsx
+++ b/packages/react/src/internal/components/TextInputInnerAction.tsx
@@ -79,7 +79,16 @@ const ConditionalTooltip: React.FC<
 
 const TextInputAction = forwardRef<HTMLButtonElement, TextInputActionProps>(
   (
-    {'aria-label': ariaLabel, tooltipDirection, children, icon, sx: sxProp, variant = 'invisible', ...rest},
+    {
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
+      tooltipDirection,
+      children,
+      icon,
+      sx: sxProp,
+      variant = 'invisible',
+      ...rest
+    },
     forwardedRef,
   ) => {
     const sx =
@@ -92,13 +101,28 @@ const TextInputAction = forwardRef<HTMLButtonElement, TextInputActionProps>(
       console.warn('Use the `aria-label` prop to provide an accessible label for assistive technology')
     }
 
+    const accessibleLabel = ariaLabel
+      ? {'aria-label': ariaLabel}
+      : ariaLabelledBy
+      ? {'aria-labelledby': ariaLabelledBy}
+      : {
+          'aria-label': '',
+        }
+
     return (
       <Box as="span" className="TextInput-action" marginLeft={1} marginRight={1} lineHeight="0">
-        {icon && !children ? (
-          <Tooltip direction={tooltipDirection ?? 's'} text={ariaLabel ?? ''} type="label">
-            {/* @ts-ignore we intentionally do add aria-label to IconButton because Tooltip v2 adds an aria-labelledby instead. */}
-            <IconButton variant={variant} type="button" icon={icon} size="small" sx={sx} {...rest} ref={forwardedRef} />
-          </Tooltip>
+        {icon && !children && ariaLabel ? (
+          <IconButton
+            {...accessibleLabel}
+            tooltipDirection={tooltipDirection ?? 's'}
+            variant={variant}
+            type="button"
+            icon={icon}
+            size="small"
+            sx={sx}
+            {...rest}
+            ref={forwardedRef}
+          />
         ) : (
           <ConditionalTooltip aria-label={ariaLabel}>
             <Button variant={variant} type="button" sx={sx} {...rest} ref={forwardedRef}>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/4696

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

<!-- List of things added in this PR -->

#### Changed

- Updated `IconButton` in the `TextInputInnerAction` component to have the right a11y props (`aria-label` and `aria-labelledby`) and add `tooltipDirection` to specify the direction of the tooltip

<!-- List of things changed in this PR -->

#### Removed

- External Tooltip that wraps the `IconButton` in the `TextInputInnerAction` 

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
