### PR TITLE
docs(Banner): update status for Banner so storybook urls are generated correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -287,7 +287,7 @@
     "examples/app-router": {
       "name": "example-app-router",
       "dependencies": {
-        "@primer/react": "36.24.0",
+        "@primer/react": "36.25.0",
         "next": "^14.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -306,7 +306,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "36.24.0",
+        "@primer/react": "36.25.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
@@ -349,7 +349,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "19.x",
-        "@primer/react": "36.24.0",
+        "@primer/react": "36.25.0",
         "next": "^14.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -58973,7 +58973,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "36.24.0",
+      "version": "36.25.0",
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.1.5",

--- a/packages/react/src/Banner/Banner.docs.json
+++ b/packages/react/src/Banner/Banner.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "banner",
   "name": "Banner",
-  "status": "alpha",
+  "status": "draft",
   "a11yReviewed": true,
   "importPath": "@primer/react/experimental",
   "stories": [],


### PR DESCRIPTION

<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->



<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

When testing: https://github.com/primer/design/pull/818 it seems like the storybook URL that is generated for Banner is incorrect. This PR updates the status of the component so that the URLs are generated correctly

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `Banner.docs.json` to set status to `draft`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This should be able to roll into a release as it's related to the metadata for PRC

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- [ ] Run `npm run build:components.json` in `packages/react`
- [ ] Verify that the URLs for Banner are correct 
