### PR TITLE
PageHeader: Fix shrinking `Actions` sub component in Safari

### DIFF
--- a/.changeset/slow-rivers-know.md
+++ b/.changeset/slow-rivers-know.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+PageHeader: Fix shrinking Actions sub component in Safari

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -577,7 +577,7 @@ const Actions: React.FC<React.PropsWithChildren<ChildrenPropTypes>> = ({
           flexDirection: 'row',
           paddingLeft: '0.5rem',
           gap: '0.5rem',
-          flexGrow: '1',
+          minWidth: 'max-content',
           justifyContent: 'right',
           alignItems: 'center',
         },


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Internally reported on [Slack](https://github.slack.com/archives/C01L618AEP9/p1720798970670879). Team has a proposed solution at dotcom but it also works in the component, so I upstreamed the solution. 

Please see the screenshot in the [issue](https://github.com/github/issues/issues/11109). (It is internally shared)

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add `min-width: 'max-content'` to the Actions sub component to prevent Safari from shrinking the actions part of the PageHeader. 

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [x] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
