### PR TITLE
Wrap storybook previews in <Profiler> component

### DIFF
--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -6,6 +6,7 @@ import clsx from 'clsx'
 
 import './storybook.css'
 import './primitives-v8.css'
+import {Profiler} from 'react'
 
 let storybookViewports = {}
 Object.entries(PrimerBreakpoints).forEach(([viewport, value]) => {
@@ -219,17 +220,23 @@ export const decorators = [
         </ThemeProvider>
       ))
     ) : (
-      <ThemeProvider dayScheme={context.globals.colorScheme} nightScheme={context.globals.colorScheme} colorMode="day">
-        <div className={clsx('story-wrap')}>
-          <BaseStyles>
-            {showSurroundingElements ? <a href="https://github.com/primer/react">Primer documentation</a> : ''}
-            <FeatureFlags flags={{primer_react_action_list_item_as_button: true}}>
-              <Story {...context} />
-            </FeatureFlags>
-            {showSurroundingElements ? <a href="https://github.com/primer/react">Primer documentation</a> : ''}
-          </BaseStyles>
-        </div>
-      </ThemeProvider>
+      <Profiler id="storybook-preview">
+        <ThemeProvider
+          dayScheme={context.globals.colorScheme}
+          nightScheme={context.globals.colorScheme}
+          colorMode="day"
+        >
+          <div className={clsx('story-wrap')}>
+            <BaseStyles>
+              {showSurroundingElements ? <a href="https://github.com/primer/react">Primer documentation</a> : ''}
+              <FeatureFlags flags={{primer_react_action_list_item_as_button: true}}>
+                <Story {...context} />
+              </FeatureFlags>
+              {showSurroundingElements ? <a href="https://github.com/primer/react">Primer documentation</a> : ''}
+            </BaseStyles>
+          </div>
+        </ThemeProvider>
+      </Profiler>
     )
   },
 ]


### PR DESCRIPTION
This wraps the storybook preview in the react `<Profiler>` component https://react.dev/reference/react/Profiler

It will allow us to run flamegraphs on single components, which will be useful as we're evaluating performance gains of switching to CSS modules.

### Testing & Reviewing

Open a component preview in storybook:

![CleanShot 2024-07-17 at 17 42 02@2x](https://github.com/user-attachments/assets/9c80a071-62cb-40ec-a9f7-df03b629c50a)

Open canvas in new tab

![CleanShot 2024-07-17 at 17 42 21@2x](https://github.com/user-attachments/assets/aed59ce8-1209-4737-b930-4db6e8e818f6)

Open devtools and select Profiler tab, click record session then stop recording and view results

![CleanShot 2024-07-17 at 17 42 42@2x](https://github.com/user-attachments/assets/07301f8d-e8f5-48ae-8fe1-bfcfdc6b5bc2)


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
