### PR TITLE
feat(components-json): update parser to support StoryObj from storybook

### DIFF
--- a/packages/react/script/components-json/build.ts
+++ b/packages/react/script/components-json/build.ts
@@ -158,19 +158,35 @@ function getStorySourceCode(filepath: string) {
     ExportNamedDeclaration(path) {
       const varDeclaration = path.node.declaration
 
-      let id: Identifier
-      let func: ArrowFunctionExpression | FunctionDeclaration
+      let id: Identifier | null = null
+      let func: ArrowFunctionExpression | FunctionDeclaration | null = null
 
       if (varDeclaration?.type === 'VariableDeclaration') {
         id = varDeclaration.declarations[0].id as Identifier
         const init = varDeclaration.declarations[0].init
-        if (init?.type === 'ArrowFunctionExpression') func = init
-        else return // not a function = not story
+        if (init?.type === 'ArrowFunctionExpression') {
+          func = init
+        } else if (init?.type === 'ObjectExpression') {
+          const renderProperty = init.properties.find(property => {
+            if (property.type === 'ObjectProperty') {
+              if (property.key.type === 'Identifier') {
+                return property.key.name === 'render'
+              }
+            }
+            return false
+          })
+
+          if (renderProperty?.type === 'ObjectProperty' && renderProperty.value.type === 'ArrowFunctionExpression') {
+            func = renderProperty.value
+          }
+        }
       } else if (varDeclaration?.type === 'FunctionDeclaration') {
         id = varDeclaration.id as Identifier
         func = varDeclaration
-      } else {
-        return // not a function = not story
+      }
+
+      if (!id || !func) {
+        return
       }
 
       const code = prettier


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->


<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Update our parser to support the `StoryObj` type from `storybook` so that stories are generated in docs that use this feature.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update built script to generate stories for StoryObj exports

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to our internal build script for generating story metadata
