### PR TITLE
[Storybook] Start deprecation of tooltip v1

### DIFF
--- a/e2e/components/Tooltip.test.ts
+++ b/e2e/components/Tooltip.test.ts
@@ -8,7 +8,7 @@ test.describe('Tooltip', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'components-tooltip--default',
+            id: 'deprecated-components-tooltip--default',
             globals: {
               colorScheme: theme,
             },
@@ -21,7 +21,7 @@ test.describe('Tooltip', () => {
 
         test('axe @aat', async ({page}) => {
           await visit(page, {
-            id: 'components-tooltip--default',
+            id: 'deprecated-components-tooltip--default',
             globals: {
               colorScheme: theme,
             },

--- a/e2e/components/Tooltip.test.ts
+++ b/e2e/components/Tooltip.test.ts
@@ -8,7 +8,7 @@ test.describe('Tooltip', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'deprecated-components-tooltipv1--default',
+            id: 'deprecated-components-tooltip--default',
             globals: {
               colorScheme: theme,
             },
@@ -21,7 +21,7 @@ test.describe('Tooltip', () => {
 
         test('axe @aat', async ({page}) => {
           await visit(page, {
-            id: 'deprecated-components-tooltipv1--default',
+            id: 'deprecated-components-tooltip--default',
             globals: {
               colorScheme: theme,
             },

--- a/e2e/components/Tooltip.test.ts
+++ b/e2e/components/Tooltip.test.ts
@@ -8,7 +8,7 @@ test.describe('Tooltip', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'deprecated-components-tooltip--default',
+            id: 'deprecated-components-tooltipv1--default',
             globals: {
               colorScheme: theme,
             },
@@ -21,7 +21,7 @@ test.describe('Tooltip', () => {
 
         test('axe @aat', async ({page}) => {
           await visit(page, {
-            id: 'deprecated-components-tooltip--default',
+            id: 'deprecated-components-tooltipv1--default',
             globals: {
               colorScheme: theme,
             },

--- a/packages/react/src/Tooltip/Tooltip.features.stories.tsx
+++ b/packages/react/src/Tooltip/Tooltip.features.stories.tsx
@@ -8,7 +8,7 @@ import {SearchIcon} from '@primer/octicons-react'
 /* Tooltip v1 */
 
 export default {
-  title: 'Deprecated/Components/TooltipV1/Features',
+  title: 'Deprecated/Components/Tooltip/Features',
   component: Tooltip,
 
   decorators: [

--- a/packages/react/src/Tooltip/Tooltip.features.stories.tsx
+++ b/packages/react/src/Tooltip/Tooltip.features.stories.tsx
@@ -8,7 +8,7 @@ import {SearchIcon} from '@primer/octicons-react'
 /* Tooltip v1 */
 
 export default {
-  title: 'Components/Tooltip/Features',
+  title: 'Deprecated/Components/TooltipV1/Features',
   component: Tooltip,
 
   decorators: [

--- a/packages/react/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/Tooltip/Tooltip.stories.tsx
@@ -7,7 +7,7 @@ import Tooltip from './Tooltip'
 /* Tooltip v1 */
 
 export default {
-  title: 'Components/Tooltip',
+  title: 'Depreacted/Components/Tooltip',
   component: Tooltip,
 
   decorators: [

--- a/packages/react/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/Tooltip/Tooltip.stories.tsx
@@ -7,7 +7,7 @@ import Tooltip from './Tooltip'
 /* Tooltip v1 */
 
 export default {
-  title: 'Deprecated/Components/TooltipV1',
+  title: 'Deprecated/Components/Tooltip',
   component: Tooltip,
 
   decorators: [

--- a/packages/react/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/Tooltip/Tooltip.stories.tsx
@@ -7,7 +7,7 @@ import Tooltip from './Tooltip'
 /* Tooltip v1 */
 
 export default {
-  title: 'Depreacted/Components/Tooltip',
+  title: 'Deprecated/Components/TooltipV1',
   component: Tooltip,
 
   decorators: [


### PR DESCRIPTION
To keep things less confusing for consumers / users of Storybook, starting the deprecation cycle for tooltipV1 by removing it from the main components area of Storybook.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

`Moved Components/Tooltip` -> `Deprecated/Components/TooltipV1`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [X] None; if selected, include a brief description as to why

### Testing & Reviewing
Tests are still operating. E2E is updated.

### Merge checklist

- [X] Added/updated tests
- [X] Added/updated documentation
- [X] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
