### PR TITLE
Header: add overflow

### DIFF
--- a/.changeset/moody-rivers-impress.md
+++ b/.changeset/moody-rivers-impress.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Header: Add overflow when there are a lot of items

--- a/packages/react/src/Header/Header.features.stories.tsx
+++ b/packages/react/src/Header/Header.features.stories.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import type {Meta} from '@storybook/react'
 
 import Header from './Header'
+import Avatar from '../Avatar'
+import Octicon from '../Octicon'
+import {MarkGithubIcon} from '@primer/octicons-react'
 
 export default {
   title: 'Components/Header/Features',
@@ -26,6 +29,30 @@ export const WithLinks = () => (
     </Header.Item>
     <Header.Item>
       <Header.Link href="#">Team</Header.Link>
+    </Header.Item>
+  </Header>
+)
+
+export const WithManyItems = () => (
+  <Header>
+    <Header.Item>
+      <Header.Link href="#" sx={{fontSize: 2}}>
+        <Octicon icon={MarkGithubIcon} size={32} sx={{mr: 2}} />
+        <span>GitHub</span>
+      </Header.Link>
+    </Header.Item>
+    <Header.Item>Item</Header.Item>
+    <Header.Item>Item</Header.Item>
+    <Header.Item>Item</Header.Item>
+    <Header.Item>Item</Header.Item>
+    <Header.Item>Item</Header.Item>
+    <Header.Item>Item</Header.Item>
+    <Header.Item>Item</Header.Item>
+    <Header.Item>Item</Header.Item>
+    <Header.Item>Item</Header.Item>
+    <Header.Item>Item</Header.Item>
+    <Header.Item sx={{mr: 0}}>
+      <Avatar src="https://github.com/octocat.png" size={20} square alt="@octocat" />
     </Header.Item>
   </Header>
 )

--- a/packages/react/src/Header/Header.tsx
+++ b/packages/react/src/Header/Header.tsx
@@ -19,6 +19,7 @@ const Header = styled.header<StyledHeaderProps>`
   background-color: ${get('colors.header.bg')};
   align-items: center;
   flex-wrap: nowrap;
+  overflow: auto;
 
   ${sx};
 `


### PR DESCRIPTION
- Fixes https://github.com/github/primer/issues/3391

> We recommend rethinking how this component's CSS is implemented. While it currently focuses primarily on making sure items are vertically aligned, it does not account for cases where the content is wider than the viewport. This may require further design consideration (for instance, forcing content to break to a new line whenever there is insufficient space).




| Before | After |
|--------|--------|
| When there a lot of items, the Header makes the page grow wider and adds a scrollbar | When there are a lot of items, the Header becomes scrollable without making the page wider | 
| ![When there a lot of items, the Header makes the page grow wider and adds a scrollbar](https://github.com/user-attachments/assets/421d54ed-3c05-4c69-9f7b-da4db642de78) | ![When there are a lot of items, the Header becomes scrollable without making the page wider](https://github.com/user-attachments/assets/b17727eb-bf34-4afb-ba85-02c57f1b18b9)

Note: This is a bit of a silly fix because it's not common at all to have a scrollable Header. 

However, this component however is an outdated pattern that is barely used: [6 instances in dotcom](https://musical-adventure-wlr3n3k.pages.github.io/?name=%22Header%22&entrypoint=%40primer%2Freact&repo=github%2Fgithub) out of 0 are as it's intended usage as a navigation header. [5 in other places](https://musical-adventure-wlr3n3k.pages.github.io/?name=%22Header%22&entrypoint=%40primer%2Freact&repo=-github%2Fgithub). We have alternatives like [UnderlineNav](https://primer.style/components/underline-nav) that are recommended.


So this feels like a safe change to make to pass an accessibility review without getting into a rabbit hole about correct usage or deprecation in this PR




