### PR TITLE
chore: add package version numbers

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -4,6 +4,8 @@
   "initialVersions": {
     "docs": "1.0.0",
     "codesandbox": "0.0.0",
+    "example-app-router": "0.0.0",
+    "example-consumer-test": "0.0.0",
     "example-nextjs": "0.0.0",
     "@primer/react": "36.27.0",
     "rollup-plugin-import-css": "0.0.0"

--- a/examples/app-router/package.json
+++ b/examples/app-router/package.json
@@ -1,5 +1,6 @@
 {
   "name": "example-app-router",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .next",

--- a/examples/consumer-test/package.json
+++ b/examples/consumer-test/package.json
@@ -1,5 +1,6 @@
 {
   "name": "example-consumer-test",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "check": "tsc --noEmit"


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

It seems like there is a bug in changesets that will fail in prerelease mode if there is no version available for a private workspace. This PR adds explicit version numbers to each workspace to prevent this from occurring.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add explicit version numbers to internal workspaces

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to internal private packages
