### PR TITLE
fix(RelativeTime): bumps relative-time-element version

### DIFF
--- a/.changeset/young-meals-worry.md
+++ b/.changeset/young-meals-worry.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Bumps @github/relative-time-element to v4.4.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -288,7 +288,7 @@
     "examples/app-router": {
       "name": "example-app-router",
       "dependencies": {
-        "@primer/react": "36.26.0",
+        "@primer/react": "36.27.0",
         "next": "^14.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -307,7 +307,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "36.26.0",
+        "@primer/react": "36.27.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
@@ -350,7 +350,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "19.x",
-        "@primer/react": "36.26.0",
+        "@primer/react": "36.27.0",
         "next": "^14.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -4637,8 +4637,9 @@
       "license": "MIT"
     },
     "node_modules/@github/relative-time-element": {
-      "version": "4.4.1",
-      "license": "MIT"
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.4.2.tgz",
+      "integrity": "sha512-wTXunu3hmuGljA5CHaaoUIKV0oI35wno0FKJl2yqKplTRnsCA5bPNj4bDeVIubkuskql6jwionWLlGM1Y6QLaw=="
     },
     "node_modules/@github/tab-container-element": {
       "version": "4.8.0",
@@ -59438,13 +59439,13 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "36.26.0",
+      "version": "36.27.0",
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.1.5",
         "@github/markdown-toolbar-element": "^2.1.0",
         "@github/paste-markdown": "^1.4.0",
-        "@github/relative-time-element": "^4.4.1",
+        "@github/relative-time-element": "^4.4.2",
         "@github/tab-container-element": "^4.8.0",
         "@lit-labs/react": "1.2.1",
         "@oddbird/popover-polyfill": "^0.3.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -88,7 +88,7 @@
     "@github/combobox-nav": "^2.1.5",
     "@github/markdown-toolbar-element": "^2.1.0",
     "@github/paste-markdown": "^1.4.0",
-    "@github/relative-time-element": "^4.4.1",
+    "@github/relative-time-element": "^4.4.2",
     "@github/tab-container-element": "^4.8.0",
     "@lit-labs/react": "1.2.1",
     "@oddbird/popover-polyfill": "^0.3.1",


### PR DESCRIPTION
Update the version of `relative-time-element` to fix the `RelativeTime` component when it is the 31st.

![](https://github.com/user-attachments/assets/e15ffacd-4bd6-4731-98cc-1d58b40e13ba)

### Changelog

#### New

#### Changed

Bumps version of [relative-time-element to v4.4.2](https://github.com/github/relative-time-element/releases/tag/v4.4.2)

> Correctly count month durations relative to the end of longer months by @lilyinstarlight in https://github.com/github/relative-time-element/pull/285

#### Removed


### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

When it's the 31st, see the relative time shown for events more than 31 days and less than 2 months old.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
