### PR TITLE
feat(storybook): add support for feature flag toggle in toolbar

### DIFF
--- a/packages/react/.storybook/manager.js
+++ b/packages/react/.storybook/manager.js
@@ -1,4 +1,8 @@
 import {addons, types} from '@storybook/addons'
+import {useGlobals} from '@storybook/manager-api'
+import {IconButton, WithTooltip, TooltipLinkList} from '@storybook/components'
+import {BeakerIcon} from '@primer/octicons-react'
+import React from 'react'
 import {Tool, TOOL_ID, ADDON_ID} from './src/accessibility-tool'
 import theme from './theme'
 
@@ -13,5 +17,56 @@ addons.register(ADDON_ID, () => {
     title: 'Show surrounding links',
     match: ({viewMode}) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
     render: Tool,
+  })
+})
+
+const featureFlagList = ['primer_react_action_list_item_as_button', 'primer_react_css_modules']
+
+addons.register('FEATURE_FLAG_ADDON', () => {
+  addons.add('FEATURE_FLAG_ADDON/toolbar', {
+    type: types.TOOL,
+    match: ({tabId, viewMode}) => {
+      return !tabId && viewMode === 'story'
+    },
+    render: () => {
+      const [{featureFlags}, updateGlobals] = useGlobals()
+      const hasFeatureEnabled = Object.values(featureFlags ?? {}).find(value => {
+        return value
+      })
+      return (
+        <WithTooltip
+          placement="top"
+          trigger="click"
+          closeOnOutsideClick
+          tooltip={({onHide}) => {
+            return (
+              <TooltipLinkList
+                links={featureFlagList.map(featureFlag => {
+                  const active = featureFlags?.[featureFlag]
+                  return {
+                    id: featureFlag,
+                    title: active ? `✅ ${featureFlag}` : featureFlag,
+                    active,
+                    onClick: () => {
+                      updateGlobals({
+                        featureFlags: {
+                          ...featureFlags,
+                          [featureFlag]: !active,
+                        },
+                      })
+                      onHide()
+                    },
+                  }
+                })}
+              />
+            )
+          }}
+        >
+          <IconButton active={hasFeatureEnabled} title="Toggle feature flags">
+            <BeakerIcon size={14} />
+          </IconButton>
+        </WithTooltip>
+      )
+    },
   })
 })

--- a/packages/react/.storybook/manager.js
+++ b/packages/react/.storybook/manager.js
@@ -5,6 +5,7 @@ import {BeakerIcon} from '@primer/octicons-react'
 import React from 'react'
 import {Tool, TOOL_ID, ADDON_ID} from './src/accessibility-tool'
 import theme from './theme'
+import {DefaultFeatureFlags} from '../src/FeatureFlags/DefaultFeatureFlags'
 
 addons.setConfig({
   theme,
@@ -20,7 +21,7 @@ addons.register(ADDON_ID, () => {
   })
 })
 
-const featureFlagList = ['primer_react_action_list_item_as_button', 'primer_react_css_modules']
+const featureFlagList = Array.from(DefaultFeatureFlags.flags.keys())
 
 addons.register('FEATURE_FLAG_ADDON', () => {
   addons.add('FEATURE_FLAG_ADDON/toolbar', {

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -183,9 +183,22 @@ export const globalTypes = {
     },
     showSurroundingElements: {},
   },
+  featureFlags: {
+    name: 'Feature flags',
+    description: 'Toggle feature flags',
+    defaultValue: {},
+  },
 }
 
 export const decorators = [
+  (Story, context) => {
+    const {featureFlags} = context.globals
+    return (
+      <FeatureFlags flags={featureFlags}>
+        <Story {...context} />
+      </FeatureFlags>
+    )
+  },
   (Story, context) => {
     const {colorScheme} = context.globals
 

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -2,6 +2,7 @@ import {PrimerBreakpoints} from '../src/utils/layout'
 import React, {useEffect} from 'react'
 import {ThemeProvider, BaseStyles, theme} from '../src'
 import {FeatureFlags} from '../src/FeatureFlags'
+import {DefaultFeatureFlags} from '../src/FeatureFlags/DefaultFeatureFlags'
 import clsx from 'clsx'
 
 import './storybook.css'
@@ -186,7 +187,7 @@ export const globalTypes = {
   featureFlags: {
     name: 'Feature flags',
     description: 'Toggle feature flags',
-    defaultValue: {},
+    defaultValue: Object.fromEntries(DefaultFeatureFlags.flags),
   },
 }
 

--- a/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
+++ b/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
@@ -1,3 +1,6 @@
 import {FeatureFlagScope} from './FeatureFlagScope'
 
-export const DefaultFeatureFlags = FeatureFlagScope.create()
+export const DefaultFeatureFlags = FeatureFlagScope.create({
+  primer_react_css_modules: false,
+  primer_react_action_list_item_as_button: false,
+})


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Add support for toggling feature flags in the storybook toolbar. This helps with local development along with supporting enabling this feature for e2e tests.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add feature flag global value to storybook
- Add feature flag toggle button

#### Changed

<!-- List of things changed in this PR -->

- Add decorator to storybook preview to pass along feature flag global values

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is an internal change to storybook

<img width="397" alt="Screenshot of feature flag dropdown" src="https://github.com/user-attachments/assets/e95cf613-27be-470b-9b12-4e5725ed82af">

