### PR TITLE
ci: update release candidate for pre mode

### DIFF
--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -42,6 +42,11 @@ jobs:
 
       - name: Publish release candidate
         run: |
+          # Remove existing pre.json if one exists. Snapshots are not allowed
+          # in pre-release mode.
+          # TODO: remove in v37
+          rm .changeset/pre.json
+
           pkg_json_path=packages/react/package.json
           version=$(jq -r .version $pkg_json_path)
           echo "$( jq ".version = \"$(echo $version)-rc.$(git rev-parse --short HEAD)\"" $pkg_json_path )" > $pkg_json_path


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update the release candidate workflow to remove the existing `pre.json` file in pre-release mode. This helps to address the failing workflow in our Release Tracking workflows since we want to publish those releases under the `@next` tag.


<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update our release candidate workflow to remove the `pre.json` file before publishing

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to how we publish from Release Tracking PRs and will not impact the public API of our packages.