### PR TITLE
ci: update hash generation for package

### DIFF
--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -49,7 +49,12 @@ jobs:
 
           pkg_json_path=packages/react/package.json
           version=$(jq -r .version $pkg_json_path)
-          echo "$( jq ".version = \"$(echo $version)-rc.$(git rev-parse --short HEAD)\"" $pkg_json_path )" > $pkg_json_path
+
+          # Update how the version is generated in these prereleases. By
+          # default, -rc. is included in versions when `pre.json` is present.
+          # Add this back in when we exit the v37 release
+          # TODO: remove in v37
+          echo "$( jq ".version = \"$(echo $version).$(git rev-parse --short HEAD)\"" $pkg_json_path )" > $pkg_json_path
           npx changeset publish --tag next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update how our "next" versions get formatted now that the `-rc` prefix is already included in our prerelease.

This will now format release candidates to be: `37.0.0-rc.0.<hash>`

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update hash in release candidate workflow

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None

This is a change to our release candidates and will not impact the public API
