### PR TITLE
Adding a workflow for scanning component files for stats

### DIFF
--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -27,10 +27,9 @@ jobs:
         id: release-info
         with:
           script: |
-            var glob = require("glob")
+            const glob = require("glob")
 
-            glob("packages/react/src/**/*.tsx", {
-              ignore: "packages/react/src/__tests__"
-            }, function (er, files) {
-              console.log(files)
+            const files = await glob("packages/react/src/**/*.tsx", {
+              ignore: "packages/react/src/__tests__/**"
             })
+            console.log(files)

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -24,12 +24,35 @@ jobs:
         run: npm ci
 
       - uses: actions/github-script@v7
-        id: release-info
+        id: file-counts
         with:
           script: |
-            const glob = require("glob")
-
-            const files = await glob("packages/react/src/**/*.tsx", {
-              ignore: "packages/react/src/__tests__/**"
+            const files = await fg.glob('packages/react/src/**/*.tsx', {
+              ignore: [
+                '**/__tests__/**',
+                '**/_*.tsx',
+                '**/*.figma.tsx',
+                '**/*.stories.tsx',
+                '**/*.test.tsx',
+                '**/hooks/**',
+                '**/index.tsx',
+                '**/utils/**',
+              ],
             })
-            console.log(files)
+
+            const metrics = []
+
+            for (const file of files) {
+              const content = fs.readFileSync(file, 'utf8')
+              const matched = content.match(/.`$([^`]*)^`$/gm)
+              if (matched) {
+                const count = matched.join('\n').split('\n').length
+                metrics.push(
+                  `- type: "count"\n  name: "primer.react.styled-system.count"\n  value: ${count}\n  tags:\n    - "path:${file}"`,
+                )
+              }
+            }
+
+            core.setOutput('metrics', metrics.join('\n'))
+
+      - run: echo "${{ steps.file-counts.outputs.metrics }}"

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -27,6 +27,8 @@ jobs:
         id: file-counts
         with:
           script: |
+            const fg = require('fast-glob')
+            const fs = require('fs')
             const files = await fg.glob('packages/react/src/**/*.tsx', {
               ignore: [
                 '**/__tests__/**',

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -1,0 +1,39 @@
+name: 'Code Scan'
+
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  codescan:
+    name: Scan the repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm i -g npm@^10.5.1
+      - name: Install dependencies
+        run: npm ci
+
+      - uses: actions/github-script@v7
+        id: release-info
+        with:
+          script: |
+            var glob = require("glob")
+
+            // options is optional
+            glob("packages/react/src/**/*.tsx", {ignore:"__tests__"}, function (er, files) {
+              // files is an array of filenames.
+              // If the `nonull` option is set, and nothing
+              // was found, then files is ["**/*.js"]
+              // er is an error object or null.
+              console.log(files)
+            })

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -1,7 +1,6 @@
 name: 'Code Scan'
 
 on:
-  push:
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -29,13 +29,14 @@ jobs:
           script: |
             const fg = require('fast-glob')
             const fs = require('fs')
-            const files = await fg.glob('packages/react/src/**/*.tsx', {
+            const files = await fg.glob(['packages/react/src/**/*.tsx', 'packages/react/src/**/*.module.css'], {
               ignore: [
                 '**/__tests__/**',
                 '**/_*.tsx',
                 '**/*.figma.tsx',
                 '**/*.stories.tsx',
                 '**/*.test.tsx',
+                '**/CSSComponent/**',
                 '**/hooks/**',
                 '**/index.tsx',
                 '**/utils/**',
@@ -46,15 +47,26 @@ jobs:
 
             for (const file of files) {
               const content = fs.readFileSync(file, 'utf8')
-              const matched = content.match(/.`$([^`]*)^`$/gm)
-              if (matched) {
-                const count = matched.join('\n').split('\n').length
+              if (file.endsWith('.tsx')) {
+                const matched = content.match(/.`$([^`]*)^`$/gm)
+                if (matched) {
+                  const count = matched.join('\n').split('\n').length
+                  metrics.push(
+                    `- type: "count"\n  name: "primer.react.styled-system.count"\n  value: ${count}\n  tags:\n    - "path:${file}"`,
+                  )
+                }
+              } else {
+                const count = content.split('\n').length
                 metrics.push(
-                  `- type: "count"\n  name: "primer.react.styled-system.count"\n  value: ${count}\n  tags:\n    - "path:${file}"`,
+                  `- type: "count"\n  name: "primer.react.css-module.count"\n  value: ${count}\n  tags:\n    - "path:${file}"`,
                 )
               }
             }
 
             core.setOutput('metrics', metrics.join('\n'))
 
-      - run: echo "${{ steps.file-counts.outputs.metrics }}"
+      - name: Build count
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.datadog_api_key }}
+          metrics: ${{ steps.file-counts.outputs.metrics }}

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -28,6 +28,7 @@ jobs:
           script: |
             const fg = require('fast-glob')
             const fs = require('fs')
+            const path = require('path')
             const files = await fg.glob(['packages/react/src/**/*.tsx', 'packages/react/src/**/*.module.css'], {
               ignore: [
                 '**/__tests__/**',
@@ -46,18 +47,19 @@ jobs:
 
             for (const file of files) {
               const content = fs.readFileSync(file, 'utf8')
+              const name = path.parse(file).name.replace('.module', '')
               if (file.endsWith('.tsx')) {
                 const matched = content.match(/.`$([^`]*)^`$/gm)
                 if (matched) {
                   const count = matched.join('\n').split('\n').length
                   metrics.push(
-                    `- type: "count"\n  name: "primer.react.styled-system.count"\n  value: ${count}\n  tags:\n    - "path:${file}"`,
+                    `- type: "count"\n  name: "primer.react.styled-system.count"\n  value: ${count}\n  tags:\n    - "path:${file}"\n    - "component:${name}"`,
                   )
                 }
               } else {
                 const count = content.split('\n').length
                 metrics.push(
-                  `- type: "count"\n  name: "primer.react.css-module.count"\n  value: ${count}\n  tags:\n    - "path:${file}"`,
+                  `- type: "count"\n  name: "primer.react.css-module.count"\n  value: ${count}\n  tags:\n    - "path:${file}"\n    - "component:${name}"`,
                 )
               }
             }

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -29,11 +29,8 @@ jobs:
           script: |
             var glob = require("glob")
 
-            // options is optional
-            glob("packages/react/src/**/*.tsx", {ignore:"packages/react/src/__tests__"}, function (er, files) {
-              // files is an array of filenames.
-              // If the `nonull` option is set, and nothing
-              // was found, then files is ["**/*.js"]
-              // er is an error object or null.
+            glob("packages/react/src/**/*.tsx", {
+              ignore: "packages/react/src/__tests__"
+            }, function (er, files) {
               console.log(files)
             })

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -2,7 +2,7 @@ name: 'Code Scan'
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 * * * *'
 
 jobs:
   codescan:

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -30,7 +30,7 @@ jobs:
             var glob = require("glob")
 
             // options is optional
-            glob("packages/react/src/**/*.tsx", {ignore:"__tests__"}, function (er, files) {
+            glob("packages/react/src/**/*.tsx", {ignore:"packages/react/src/__tests__"}, function (er, files) {
               // files is an array of filenames.
               // If the `nonull` option is set, and nothing
               // was found, then files is ["**/*.js"]


### PR DESCRIPTION
This adds a scan workflow that runs independently every hour to count the number of lines of CSS and Styled System code in the components. This is in support of https://github.com/github/primer/issues/3159

![image](https://github.com/user-attachments/assets/4844d37a-9592-4956-87a0-57f0edb43c55)