### PR TITLE
feat(Banner): add support for custom icons when variant="upsell"

### DIFF
--- a/.changeset/twelve-tables-leave.md
+++ b/.changeset/twelve-tables-leave.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Add support for custom icons when a Banner is variant="upsell"

--- a/packages/react/src/Banner/Banner.docs.json
+++ b/packages/react/src/Banner/Banner.docs.json
@@ -18,13 +18,13 @@
     },
     {
       "name": "hideTitle",
-       "type": "boolean",
+      "type": "boolean",
       "description": "Whether to hide the title visually."
     },
     {
       "name": "icon",
       "type": "React.ReactNode",
-      "description": "Provide an icon for the banner"
+      "description": "Provide a custom icon for the Banner. This is only available when `variant` is `info` or `upsell`"
     },
     {
       "name": "onDismiss",

--- a/packages/react/src/Banner/Banner.features.stories.tsx
+++ b/packages/react/src/Banner/Banner.features.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import {CopilotIcon} from '@primer/octicons-react'
 import {action} from '@storybook/addon-actions'
 import type {Meta} from '@storybook/react'
 import {Banner} from '../Banner'
@@ -199,6 +200,18 @@ export const WithActions = () => {
       primaryAction={<Banner.PrimaryAction>Button</Banner.PrimaryAction>}
       secondaryAction={<Banner.SecondaryAction>Button</Banner.SecondaryAction>}
       variant="warning"
+    />
+  )
+}
+
+export const CustomIcon = () => {
+  return (
+    <Banner
+      title="Upsell"
+      description="An example banner with a custom icon"
+      icon={<CopilotIcon />}
+      onDismiss={action('onDismiss')}
+      variant="upsell"
     />
   )
 }

--- a/packages/react/src/Banner/Banner.test.tsx
+++ b/packages/react/src/Banner/Banner.test.tsx
@@ -160,40 +160,20 @@ describe('Banner', () => {
     expect(container.firstChild).toHaveAttribute('data-testid', 'test')
   })
 
-  it('should support a custom icon only for info variants', () => {
+  it('should support a custom icon for info and upsell variants', () => {
     const CustomIcon = jest.fn(() => <svg data-testid="icon" aria-hidden="true" />)
     const {rerender} = render(
       <Banner title="test" description="test-description" variant="info" icon={<CustomIcon />} />,
     )
     expect(screen.getByTestId('icon')).toBeInTheDocument()
 
-    rerender(<Banner title="test" description="test-description" variant="critical" icon={<CustomIcon />} />)
-    expect(screen.queryByTestId('icon')).toBe(null)
-
-    rerender(<Banner title="test" description="test-description" variant="success" icon={<CustomIcon />} />)
-    expect(screen.queryByTestId('icon')).toBe(null)
-
     rerender(<Banner title="test" description="test-description" variant="upsell" icon={<CustomIcon />} />)
-    expect(screen.queryByTestId('icon')).toBe(null)
-
-    rerender(<Banner title="test" description="test-description" variant="warning" icon={<CustomIcon />} />)
-    expect(screen.queryByTestId('icon')).toBe(null)
-  })
-
-  it('should support a custom icon only for upsell variants', () => {
-    const CustomIcon = jest.fn(() => <svg data-testid="icon" aria-hidden="true" />)
-    const {rerender} = render(
-      <Banner title="test" description="test-description" variant="upsell" icon={<CustomIcon />} />,
-    )
     expect(screen.getByTestId('icon')).toBeInTheDocument()
 
     rerender(<Banner title="test" description="test-description" variant="critical" icon={<CustomIcon />} />)
     expect(screen.queryByTestId('icon')).toBe(null)
 
     rerender(<Banner title="test" description="test-description" variant="success" icon={<CustomIcon />} />)
-    expect(screen.queryByTestId('icon')).toBe(null)
-
-    rerender(<Banner title="test" description="test-description" variant="upsell" icon={<CustomIcon />} />)
     expect(screen.queryByTestId('icon')).toBe(null)
 
     rerender(<Banner title="test" description="test-description" variant="warning" icon={<CustomIcon />} />)

--- a/packages/react/src/Banner/Banner.test.tsx
+++ b/packages/react/src/Banner/Banner.test.tsx
@@ -180,6 +180,26 @@ describe('Banner', () => {
     expect(screen.queryByTestId('icon')).toBe(null)
   })
 
+  it('should support a custom icon only for upsell variants', () => {
+    const CustomIcon = jest.fn(() => <svg data-testid="icon" aria-hidden="true" />)
+    const {rerender} = render(
+      <Banner title="test" description="test-description" variant="upsell" icon={<CustomIcon />} />,
+    )
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+
+    rerender(<Banner title="test" description="test-description" variant="critical" icon={<CustomIcon />} />)
+    expect(screen.queryByTestId('icon')).toBe(null)
+
+    rerender(<Banner title="test" description="test-description" variant="success" icon={<CustomIcon />} />)
+    expect(screen.queryByTestId('icon')).toBe(null)
+
+    rerender(<Banner title="test" description="test-description" variant="upsell" icon={<CustomIcon />} />)
+    expect(screen.queryByTestId('icon')).toBe(null)
+
+    rerender(<Banner title="test" description="test-description" variant="warning" icon={<CustomIcon />} />)
+    expect(screen.queryByTestId('icon')).toBe(null)
+  })
+
   describe('Banner.Title', () => {
     it('should render as a h2 element by default', () => {
       render(

--- a/packages/react/src/Banner/Banner.tsx
+++ b/packages/react/src/Banner/Banner.tsx
@@ -99,6 +99,7 @@ export const Banner = React.forwardRef<HTMLElement, BannerProps>(function Banner
   const hasActions = primaryAction || secondaryAction
   const bannerRef = React.useRef<HTMLElement>(null)
   const ref = useMergedRefs(forwardRef, bannerRef)
+  const supportsCustomIcon = variant === 'info' || variant === 'upsell'
 
   if (__DEV__) {
     // This hook is called consistently depending on the environment
@@ -134,7 +135,7 @@ export const Banner = React.forwardRef<HTMLElement, BannerProps>(function Banner
       ref={ref}
     >
       <style>{BannerContainerQuery}</style>
-      <div className="BannerIcon">{icon && variant === 'info' ? icon : iconForVariant[variant]}</div>
+      <div className="BannerIcon">{icon && supportsCustomIcon ? icon : iconForVariant[variant]}</div>
       <div className="BannerContainer">
         <div className="BannerContent">
           {title ? (

--- a/packages/react/src/Banner/Banner.tsx
+++ b/packages/react/src/Banner/Banner.tsx
@@ -28,8 +28,7 @@ export type BannerProps = React.ComponentPropsWithoutRef<'section'> & {
   hideTitle?: boolean
 
   /**
-   * Provide an icon for the banner.
-   * Note: Only `variant="info"` banners should use custom icons
+   * Provide a custom icon for the Banner. This is only available when `variant` is `info` or `upsell`
    */
   icon?: React.ReactNode
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3784

Update Banner to support customizing icons with both `info` and `upsell`

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add support for custom icons when Banner variant="upsell"

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release
