### PR TITLE
ProgressBar: Remove `aria-busy` from `ProgressBar`

### DIFF
--- a/.changeset/sixty-olives-glow.md
+++ b/.changeset/sixty-olives-glow.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Remove `aria-busy` from `ProgressBar` component

--- a/packages/react/src/ProgressBar/ProgressBar.tsx
+++ b/packages/react/src/ProgressBar/ProgressBar.tsx
@@ -82,7 +82,6 @@ export const ProgressBar = forwardRef<HTMLSpanElement, ProgressBarProps>(
       'aria-valuenow': progressAsNumber ? Math.round(progressAsNumber) : undefined,
       'aria-valuemin': 0,
       'aria-valuemax': 100,
-      'aria-busy': progressAsNumber ? progressAsNumber !== 100 : false,
     }
 
     return (

--- a/packages/react/src/__tests__/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/ProgressBar.test.tsx.snap
@@ -34,7 +34,6 @@ exports[`ProgressBar respects the "progress" prop 1`] = `
 }
 
 <span
-  aria-busy={true}
   aria-label="Upload test.png"
   aria-valuemax={100}
   aria-valuemin={0}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3360

It was noted that the usage of `aria-busy` on `role="progressbar"` is unnecessary, as it is intended for a section of the page that is currently being updated, signaling to screen readers that they should wait before announcing the content.

This PR removes the attribute from `ProgressBar`.


<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Removed

<!-- List of things removed in this PR -->

* Removed `aria-busy` from `ProgressBar`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [x] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
