### PR TITLE
feat(rollup-plugin): enable sourcemap output for css modules

### DIFF
--- a/.changeset/thirty-tips-bow.md
+++ b/.changeset/thirty-tips-bow.md
@@ -1,0 +1,6 @@
+---
+'rollup-plugin-import-css': minor
+'@primer/react': minor
+---
+
+Add support for sourcemaps for emitted CSS files

--- a/.changeset/thirty-tips-bow.md
+++ b/.changeset/thirty-tips-bow.md
@@ -1,5 +1,4 @@
 ---
-'rollup-plugin-import-css': minor
 '@primer/react': minor
 ---
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Thought it would be nice to have sourcemaps work all the way through to production so I updated our rollup plugin to emit sourcemaps 👀 

Sourcemaps are generated as files that are siblings to generated `*.css` files. The `sourceMappingURL` should be only a name pointing to the `*.css.map` file of the same name in the same directory as the generated `*.css` file.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add support for sourcemaps to our rollup plugin

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- [ ] Run build
- [ ] Verify that CSS generated as expected (blankslate is a good example)
- [ ] Verify that sourcemap generated as expected
- [ ] Verify that the `sourceMappingURL` between CSS and sourcemap is correct

Alternatively, you can use the `app router` example to test out that sourcemaps are generated correctly