### PR TITLE
fix(Blankslate): Don't use Box to render heading when flag is enabled

### DIFF
--- a/.changeset/soft-tips-chew.md
+++ b/.changeset/soft-tips-chew.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+fix(Blankslate): Don't use Box to render heading when flag is enabled

--- a/packages/react/src/Blankslate/Blankslate.tsx
+++ b/packages/react/src/Blankslate/Blankslate.tsx
@@ -174,15 +174,15 @@ export type HeadingProps = React.PropsWithChildren<{
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 }>
 
-function Heading({as = 'h2', children}: HeadingProps) {
+function Heading({as: Component = 'h2', children}: HeadingProps) {
   const enabled = useFeatureFlag('primer_react_css_modules')
+
+  if (enabled) {
+    return <Component className={cx('Blankslate-Heading', classes.Heading)}>{children}</Component>
+  }
+
   return (
-    <Box
-      as={as}
-      className={cx('Blankslate-Heading', {
-        [classes.Heading]: enabled,
-      })}
-    >
+    <Box as={Component} className={cx('Blankslate-Heading')}>
       {children}
     </Box>
   )


### PR DESCRIPTION
I noticed that in `Blankslate` we were still using `<Box` to render the heading when the feature flag was enabled. This was needlessly sending us through the styled components codepath when we didn't need to.

![CleanShot 2024-08-16 at 13 35 15@2x](https://github.com/user-attachments/assets/712c1ae9-ee16-4efb-9a30-e1df9f7a8e50)

### Changelog

#### Changed

Only render the heading with the styled component when the feature flag is disabled.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
