### PR TITLE
Refactor Link, Blankslate, Heading to use :where css

### DIFF
--- a/.changeset/early-lions-vanish.md
+++ b/.changeset/early-lions-vanish.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Refactor Link, Blankslate, Heading to use :where css

--- a/packages/react/src/Blankslate/Blankslate.module.css
+++ b/packages/react/src/Blankslate/Blankslate.module.css
@@ -11,17 +11,17 @@
   /* stylelint-disable-next-line primer/spacing */
   padding: var(--blankslate-outer-padding-block) var(--blankslate-outer-padding-inline);
 
-  &[data-spacious='true'] {
+  &:where([data-spacious='true']) {
     --blankslate-outer-padding-block: var(--base-size-80);
     --blankslate-outer-padding-inline: var(--base-size-40);
   }
 
-  &[data-border='true'] {
+  &:where([data-border='true']) {
     border: var(--borderWidth-thin) solid var(--borderColor-default);
     border-radius: var(--borderRadius-medium);
   }
 
-  &[data-narrow='true'] {
+  &:where([data-narrow='true']) {
     max-width: 485px;
     margin: 0 auto;
   }
@@ -63,7 +63,7 @@
     --blankslate-outer-padding-block: var(--base-size-20);
     --blankslate-outer-padding-inline: var(--base-size-20);
 
-    &[data-spacious='true'] {
+    &:where([data-spacious='true']) {
       --blankslate-outer-padding-block: var(--base-size-44);
       --blankslate-outer-padding-inline: var(--base-size-28);
     }

--- a/packages/react/src/Heading/Heading.module.css
+++ b/packages/react/src/Heading/Heading.module.css
@@ -3,15 +3,15 @@
   font-size: var(--text-title-size-large);
   font-weight: var(--base-text-weight-semibold);
 
-  &[data-variant='large'] {
+  &:where([data-variant='large']) {
     font: var(--text-title-shorthand-large);
   }
 
-  &[data-variant='medium'] {
+  &:where([data-variant='medium']) {
     font: var(--text-title-shorthand-medium);
   }
 
-  &[data-variant='small'] {
+  &:where([data-variant='small']) {
     font: var(--text-title-shorthand-small);
   }
 }

--- a/packages/react/src/Link/Link.module.css
+++ b/packages/react/src/Link/Link.module.css
@@ -20,16 +20,16 @@
   }
 
   /* Deprecated: but need to support backwards compatibility */
-  &[data-underline='true'],
+  &:where([data-underline='true']),
   /*
     Inline links (inside a text block), however, should have underline based on accessibility setting set in data-attribute
     Note: setting underline={false} does not override this
   */
-  [data-a11y-link-underlines='true'] &[data-inline='true'] {
+  [data-a11y-link-underlines='true'] &:where([data-inline='true']) {
     text-decoration: underline;
   }
 
-  &[data-muted='true'] {
+  &:where([data-muted='true']) {
     color: var(--fgColor-muted);
 
     &:hover {


### PR DESCRIPTION
This refactors some css in `Link, Blankslate, Heading` to use :where selectors for better specificity. This is in alignment with CSS guidelines we're drafting.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
