### PR TITLE
fix: Add :where selector to classes that land on nodes that have a sx prop

### DIFF
--- a/.changeset/blue-stingrays-decide.md
+++ b/.changeset/blue-stingrays-decide.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Add `:where()` selector to classes that land on nodes that have a `sx` prop.

--- a/packages/react/src/Heading/Heading.module.css
+++ b/packages/react/src/Heading/Heading.module.css
@@ -1,4 +1,4 @@
-.Heading {
+:where(.Heading) {
   margin: 0;
   font-size: var(--text-title-size-large);
   font-weight: var(--base-text-weight-semibold);

--- a/packages/react/src/Link/Link.module.css
+++ b/packages/react/src/Link/Link.module.css
@@ -1,4 +1,4 @@
-.Link {
+:where(.Link) {
   color: var(--fgColor-accent);
   text-decoration: none;
 


### PR DESCRIPTION
This addresses a regression found in the last release of PRC https://github.com/github/github/pull/338276#issuecomment-2301557787

The problem is when the component has an `sx=` prop applied to it, the styled-components styles are being overridden by the CSS modules styles. This is because the two classes have equal specificity `0,1,0`. 

The solution here is to add the `:where` selector to the CSS modules classes whenever they might exist on the same dom node as a sx prop. This will give the CSS modules classes a lower specificity `0,0,0` and will prevent the styled-components styles from being overridden.

**Before**

![CleanShot 2024-08-21 at 11 56 45@2x](https://github.com/user-attachments/assets/15ad753e-9bc5-4525-a59d-1ac2209f77f8)

**After**

![CleanShot 2024-08-21 at 11 56 54@2x](https://github.com/user-attachments/assets/37c6f7a9-d90a-4a83-b18e-f7d8fb4338ca)

### Changelog

#### Changed

Add `:where()` selector to classes that land on nodes that have a `sx` prop.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

I'm going to test this locally, then also on a review-lab instance.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
