### PR TITLE
Move CSS Module feature flags to lifecycle rules

### DIFF
--- a/e2e/components/Blankslate.test.ts
+++ b/e2e/components/Blankslate.test.ts
@@ -52,7 +52,7 @@ test.describe('Blankslate', () => {
               globals: {
                 colorScheme: theme,
                 featureFlags: {
-                  primer_react_css_modules: true,
+                  primer_react_css_modules_staff: true,
                 },
               },
             })
@@ -67,7 +67,7 @@ test.describe('Blankslate', () => {
               globals: {
                 colorScheme: theme,
                 featureFlags: {
-                  primer_react_css_modules: false,
+                  primer_react_css_modules_staff: false,
                 },
               },
             })
@@ -82,7 +82,7 @@ test.describe('Blankslate', () => {
               globals: {
                 colorScheme: theme,
                 featureFlags: {
-                  primer_react_css_modules: true,
+                  primer_react_css_modules_staff: true,
                 },
               },
             })
@@ -108,7 +108,7 @@ test.describe('Blankslate', () => {
               id: story.id,
               globals: {
                 featureFlags: {
-                  primer_react_css_modules: true,
+                  primer_react_css_modules_staff: true,
                 },
               },
             })
@@ -126,7 +126,7 @@ test.describe('Blankslate', () => {
               id: story.id,
               globals: {
                 featureFlags: {
-                  primer_react_css_modules: false,
+                  primer_react_css_modules_staff: false,
                 },
               },
             })

--- a/e2e/components/Heading.test.ts
+++ b/e2e/components/Heading.test.ts
@@ -28,7 +28,7 @@ test.describe('Heading', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules: true,
+              primer_react_css_modules_heading: true,
             },
           },
         })
@@ -51,7 +51,7 @@ test.describe('Heading', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules: true,
+              primer_react_css_modules_heading: true,
             },
           },
         })

--- a/e2e/components/Heading.test.ts
+++ b/e2e/components/Heading.test.ts
@@ -28,7 +28,7 @@ test.describe('Heading', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_heading: true,
+              primer_react_css_modules_team: true,
             },
           },
         })
@@ -51,7 +51,7 @@ test.describe('Heading', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_heading: true,
+              primer_react_css_modules_team: true,
             },
           },
         })

--- a/e2e/components/Link.test.ts
+++ b/e2e/components/Link.test.ts
@@ -32,7 +32,7 @@ test.describe('Link', () => {
               globals: {
                 colorScheme: theme,
                 featureFlags: {
-                  primer_react_css_modules_link: true,
+                  primer_react_css_modules_team: true,
                 },
               },
             })
@@ -55,7 +55,7 @@ test.describe('Link', () => {
               globals: {
                 colorScheme: theme,
                 featureFlags: {
-                  primer_react_css_modules_link: true,
+                  primer_react_css_modules_team: true,
                 },
               },
             })

--- a/e2e/components/Link.test.ts
+++ b/e2e/components/Link.test.ts
@@ -32,7 +32,7 @@ test.describe('Link', () => {
               globals: {
                 colorScheme: theme,
                 featureFlags: {
-                  primer_react_css_modules: true,
+                  primer_react_css_modules_link: true,
                 },
               },
             })
@@ -55,7 +55,7 @@ test.describe('Link', () => {
               globals: {
                 colorScheme: theme,
                 featureFlags: {
-                  primer_react_css_modules: true,
+                  primer_react_css_modules_link: true,
                 },
               },
             })

--- a/packages/react/src/Blankslate/Blankslate.tsx
+++ b/packages/react/src/Blankslate/Blankslate.tsx
@@ -129,7 +129,7 @@ const BlankslateContainerQuery = `
 `
 
 function Blankslate({border, children, narrow, spacious, className}: BlankslateProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules')
+  const enabled = useFeatureFlag('primer_react_css_modules_staff')
 
   if (enabled) {
     return (
@@ -165,7 +165,7 @@ function Blankslate({border, children, narrow, spacious, className}: BlankslateP
 export type VisualProps = React.PropsWithChildren
 
 function Visual({children}: VisualProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules')
+  const enabled = useFeatureFlag('primer_react_css_modules_staff')
   return (
     <span
       className={cx('Blankslate-Visual', {
@@ -182,7 +182,7 @@ export type HeadingProps = React.PropsWithChildren<{
 }>
 
 function Heading({as: Component = 'h2', children}: HeadingProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules')
+  const enabled = useFeatureFlag('primer_react_css_modules_staff')
 
   if (enabled) {
     return <Component className={cx('Blankslate-Heading', classes.Heading)}>{children}</Component>
@@ -198,7 +198,7 @@ function Heading({as: Component = 'h2', children}: HeadingProps) {
 export type DescriptionProps = React.PropsWithChildren
 
 function Description({children}: DescriptionProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules')
+  const enabled = useFeatureFlag('primer_react_css_modules_staff')
   return (
     <p
       className={cx('Blankslate-Description', {
@@ -215,7 +215,7 @@ export type PrimaryActionProps = React.PropsWithChildren<{
 }>
 
 function PrimaryAction({children, href}: PrimaryActionProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules')
+  const enabled = useFeatureFlag('primer_react_css_modules_staff')
   return (
     <div
       className={cx('Blankslate-Action', {
@@ -234,7 +234,7 @@ export type SecondaryActionProps = React.PropsWithChildren<{
 }>
 
 function SecondaryAction({children, href}: SecondaryActionProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules')
+  const enabled = useFeatureFlag('primer_react_css_modules_staff')
   return (
     <div
       className={cx('Blankslate-Action', {

--- a/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
+++ b/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
@@ -2,7 +2,6 @@ import {FeatureFlagScope} from './FeatureFlagScope'
 
 export const DefaultFeatureFlags = FeatureFlagScope.create({
   primer_react_css_modules_team: false,
-  primer_react_css_modules_team: false,
   primer_react_css_modules_staff: false,
   primer_react_css_modules_ga: false,
   primer_react_action_list_item_as_button: false,

--- a/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
+++ b/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
@@ -1,6 +1,9 @@
 import {FeatureFlagScope} from './FeatureFlagScope'
 
 export const DefaultFeatureFlags = FeatureFlagScope.create({
-  primer_react_css_modules: false,
+  primer_react_css_modules_link: false,
+  primer_react_css_modules_heading: false,
+  primer_react_css_modules_staff: false,
+  primer_react_css_modules_ga: false,
   primer_react_action_list_item_as_button: false,
 })

--- a/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
+++ b/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
@@ -1,8 +1,8 @@
 import {FeatureFlagScope} from './FeatureFlagScope'
 
 export const DefaultFeatureFlags = FeatureFlagScope.create({
-  primer_react_css_modules_link: false,
-  primer_react_css_modules_heading: false,
+  primer_react_css_modules_team: false,
+  primer_react_css_modules_team: false,
   primer_react_css_modules_staff: false,
   primer_react_css_modules_ga: false,
   primer_react_action_list_item_as_button: false,

--- a/packages/react/src/Heading/Heading.tsx
+++ b/packages/react/src/Heading/Heading.tsx
@@ -37,7 +37,7 @@ const StyledHeading = styled.h2<StyledHeadingProps>`
 `
 
 const Heading = forwardRef(({as: Component = 'h2', className, variant, ...props}, forwardedRef) => {
-  const enabled = useFeatureFlag('primer_react_css_modules')
+  const enabled = useFeatureFlag('primer_react_css_modules_heading')
   const innerRef = React.useRef<HTMLHeadingElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, innerRef)
 

--- a/packages/react/src/Heading/Heading.tsx
+++ b/packages/react/src/Heading/Heading.tsx
@@ -37,7 +37,7 @@ const StyledHeading = styled.h2<StyledHeadingProps>`
 `
 
 const Heading = forwardRef(({as: Component = 'h2', className, variant, ...props}, forwardedRef) => {
-  const enabled = useFeatureFlag('primer_react_css_modules_heading')
+  const enabled = useFeatureFlag('primer_react_css_modules_team')
   const innerRef = React.useRef<HTMLHeadingElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, innerRef)
 

--- a/packages/react/src/Heading/__tests__/Heading.test.tsx
+++ b/packages/react/src/Heading/__tests__/Heading.test.tsx
@@ -142,12 +142,12 @@ describe('Heading', () => {
     ).toHaveStyleRule('font-style', 'italic')
   })
 
-  describe('with primer_react_css_modules enabled', () => {
+  describe('with primer_react_css_modules_heading enabled', () => {
     it('should only include css modules class', () => {
       HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules: true,
+            primer_react_css_modules_heading: true,
           }}
         >
           <Heading>test</Heading>
@@ -163,7 +163,7 @@ describe('Heading', () => {
       const {container} = HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules: true,
+            primer_react_css_modules_heading: true,
           }}
         >
           <Heading className="test">test</Heading>
@@ -176,7 +176,7 @@ describe('Heading', () => {
       HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules: true,
+            primer_react_css_modules_heading: true,
           }}
         >
           <Heading

--- a/packages/react/src/Heading/__tests__/Heading.test.tsx
+++ b/packages/react/src/Heading/__tests__/Heading.test.tsx
@@ -142,12 +142,12 @@ describe('Heading', () => {
     ).toHaveStyleRule('font-style', 'italic')
   })
 
-  describe('with primer_react_css_modules_heading enabled', () => {
+  describe('with primer_react_css_modules_team enabled', () => {
     it('should only include css modules class', () => {
       HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules_heading: true,
+            primer_react_css_modules_team: true,
           }}
         >
           <Heading>test</Heading>
@@ -163,7 +163,7 @@ describe('Heading', () => {
       const {container} = HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules_heading: true,
+            primer_react_css_modules_team: true,
           }}
         >
           <Heading className="test">test</Heading>
@@ -176,7 +176,7 @@ describe('Heading', () => {
       HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules_heading: true,
+            primer_react_css_modules_team: true,
           }}
         >
           <Heading

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -62,7 +62,7 @@ const StyledLink = styled.a<StyledLinkProps>`
 `
 
 const Link = forwardRef(({as: Component = 'a', className, ...props}, forwardedRef) => {
-  const enabled = useFeatureFlag('primer_react_css_modules')
+  const enabled = useFeatureFlag('primer_react_css_modules_link')
 
   const innerRef = React.useRef<HTMLAnchorElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, innerRef)

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -62,7 +62,7 @@ const StyledLink = styled.a<StyledLinkProps>`
 `
 
 const Link = forwardRef(({as: Component = 'a', className, ...props}, forwardedRef) => {
-  const enabled = useFeatureFlag('primer_react_css_modules_link')
+  const enabled = useFeatureFlag('primer_react_css_modules_team')
 
   const innerRef = React.useRef<HTMLAnchorElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, innerRef)


### PR DESCRIPTION
This changes the feature flags in the components to use this lifecycle guidance https://github.com/github/primer-engineering/discussions/138

### Changelog

#### Changed

* `Blankslate` is now under `primer_react_css_modules_staff` feature flag.
* `Heading` is now under `primer_react_css_modules_team` feature flag.
* `Link` is now under `primer_react_css_modules_team` feature flag.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
