### PR TITLE
TreeView: Add accessible names to `LeadingVisual`

### DIFF
--- a/packages/react/src/TreeView/TreeView.features.stories.tsx
+++ b/packages/react/src/TreeView/TreeView.features.stories.tsx
@@ -999,7 +999,7 @@ export const LeadingAction: StoryFn = () => {
         <TreeView.LeadingAction>
           <IconButton icon={GrabberIcon} aria-label="Reorder item 1" variant="invisible" />
         </TreeView.LeadingAction>
-        <TreeView.LeadingVisual>
+        <TreeView.LeadingVisual label="Issue closed">
           <Octicon icon={IssueClosedIcon} sx={{color: 'done.fg'}} />
         </TreeView.LeadingVisual>
         Item 1
@@ -1008,19 +1008,19 @@ export const LeadingAction: StoryFn = () => {
         <TreeView.LeadingAction>
           <IconButton icon={GrabberIcon} aria-label="Reorder item 2" variant="invisible" />
         </TreeView.LeadingAction>
-        <TreeView.LeadingVisual>
+        <TreeView.LeadingVisual label="Issue opened">
           <Octicon icon={IssueOpenedIcon} sx={{color: 'open.fg'}} />
         </TreeView.LeadingVisual>
         Item 2
         <TreeView.SubTree>
           <TreeView.Item id="item-2-sub-task-1">
-            <TreeView.LeadingVisual>
+            <TreeView.LeadingVisual label="Issue opened">
               <Octicon icon={IssueOpenedIcon} sx={{color: 'open.fg'}} />
             </TreeView.LeadingVisual>
             sub task 1
           </TreeView.Item>
           <TreeView.Item id="item-2-sub-task-2">
-            <TreeView.LeadingVisual>
+            <TreeView.LeadingVisual label="Issue opened">
               <Octicon icon={IssueOpenedIcon} sx={{color: 'open.fg'}} />
             </TreeView.LeadingVisual>
             sub task 2
@@ -1031,7 +1031,7 @@ export const LeadingAction: StoryFn = () => {
         <TreeView.LeadingAction>
           <IconButton icon={GrabberIcon} aria-label="Reorder item 3" variant="invisible" />
         </TreeView.LeadingAction>
-        <TreeView.LeadingVisual>
+        <TreeView.LeadingVisual label="Issue opened">
           <Octicon icon={IssueOpenedIcon} sx={{color: 'open.fg'}} />
         </TreeView.LeadingVisual>
         Item 3

--- a/packages/react/src/TreeView/TreeView.features.stories.tsx
+++ b/packages/react/src/TreeView/TreeView.features.stories.tsx
@@ -960,24 +960,26 @@ export const WithoutIndentation: StoryFn = () => (
           <TreeView.DirectoryIcon />
         </TreeView.LeadingVisual>
         src
-      </TreeView.Item>
-      <TreeView.Item id="src/Avatar.tsx">
-        <TreeView.LeadingVisual>
-          <FileIcon />
-        </TreeView.LeadingVisual>
-        Avatar.tsx
-        <TreeView.TrailingVisual label="Added">
-          <Octicon icon={DiffAddedIcon} color="success.fg" />
-        </TreeView.TrailingVisual>
-      </TreeView.Item>
-      <TreeView.Item id="src/Button.tsx" current>
-        <TreeView.LeadingVisual>
-          <FileIcon />
-        </TreeView.LeadingVisual>
-        Button.tsx
-        <TreeView.TrailingVisual label="Modified">
-          <Octicon icon={DiffModifiedIcon} color="attention.fg" />
-        </TreeView.TrailingVisual>
+        <TreeView.SubTree>
+          <TreeView.Item id="src/Avatar.tsx">
+            <TreeView.LeadingVisual>
+              <FileIcon />
+            </TreeView.LeadingVisual>
+            Avatar.tsx
+            <TreeView.TrailingVisual label="Added">
+              <Octicon icon={DiffAddedIcon} color="success.fg" />
+            </TreeView.TrailingVisual>
+          </TreeView.Item>
+          <TreeView.Item id="src/Button.tsx" current>
+            <TreeView.LeadingVisual>
+              <FileIcon />
+            </TreeView.LeadingVisual>
+            Button.tsx
+            <TreeView.TrailingVisual label="Modified">
+              <Octicon icon={DiffModifiedIcon} color="attention.fg" />
+            </TreeView.TrailingVisual>
+          </TreeView.Item>
+        </TreeView.SubTree>
       </TreeView.Item>
       <TreeView.Item id="package.json">
         <TreeView.LeadingVisual>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3444

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

* Adds accessible names (`aria-label`) to leading visuals in TreeView story
* Adjusts "Without Indentation" story [based on feedback](https://github.com/github/primer/issues/3445#issuecomment-2286622513)

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why **(Storybook specific)**

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
