### PR TITLE
refactor(Text): Text component to use CSS modules behind primer_react_css_modules_team feature flag

### DIFF
--- a/.changeset/tidy-clocks-marry.md
+++ b/.changeset/tidy-clocks-marry.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Refactor `Text` to CSS modules behind primer_react_css_modules_team feature flag

--- a/.changeset/tidy-clocks-marry.md
+++ b/.changeset/tidy-clocks-marry.md
@@ -1,5 +1,5 @@
 ---
-"@primer/react": patch
+"@primer/react": minor
 ---
 
 Refactor `Text` to CSS modules behind primer_react_css_modules_team feature flag

--- a/e2e/components/Text.test.ts
+++ b/e2e/components/Text.test.ts
@@ -44,6 +44,25 @@ test.describe('Text', () => {
       test('default @vrt', async ({page}) => {
         await visit(page, {
           id: story.id,
+          globals: {
+            featureFlags: {
+              primer_react_css_modules_team: true,
+            },
+          },
+        })
+
+        // Default state
+        expect(await page.screenshot()).toMatchSnapshot(`Text.${story.title}.png`)
+      })
+
+      test('default (styled-system) @vrt', async ({page}) => {
+        await visit(page, {
+          id: story.id,
+          globals: {
+            featureFlags: {
+              primer_react_css_modules_team: false,
+            },
+          },
         })
 
         // Default state
@@ -53,6 +72,23 @@ test.describe('Text', () => {
       test('axe @aat', async ({page}) => {
         await visit(page, {
           id: story.id,
+          globals: {
+            featureFlags: {
+              primer_react_css_modules_team: true,
+            },
+          },
+        })
+        await expect(page).toHaveNoViolations()
+      })
+
+      test('axe (styled-system) @aat', async ({page}) => {
+        await visit(page, {
+          id: story.id,
+          globals: {
+            featureFlags: {
+              primer_react_css_modules_team: false,
+            },
+          },
         })
         await expect(page).toHaveNoViolations()
       })

--- a/packages/react/src/Text/Text.module.css
+++ b/packages/react/src/Text/Text.module.css
@@ -1,0 +1,32 @@
+.Text {
+  &:where([data-size='small']) {
+    font-size: var(--text-body-size-small);
+    line-height: var(--text-body-lineHeight-small);
+  }
+
+  &:where([data-size='medium']) {
+    font-size: var(--text-body-size-medium);
+    line-height: var(--text-body-lineHeight-medium);
+  }
+
+  &:where([data-size='large']) {
+    font-size: var(--text-body-size-large);
+    line-height: var(--text-body-lineHeight-large);
+  }
+
+  &:where([data-weight='light']) {
+    font-weight: var(--base-text-weight-light);
+  }
+
+  &:where([data-weight='normal']) {
+    font-weight: var(--base-text-weight-normal);
+  }
+
+  &:where([data-weight='medium']) {
+    font-weight: var(--base-text-weight-medium);
+  }
+
+  &:where([data-weight='semibold']) {
+    font-weight: var(--base-text-weight-semibold);
+  }
+}

--- a/packages/react/src/Text/Text.stories.tsx
+++ b/packages/react/src/Text/Text.stories.tsx
@@ -9,19 +9,15 @@ export default {
 
 export const Default = () => <Text>Default Text</Text>
 
-export const Playground: StoryFn<typeof Text> = args => <Text {...args}>{args.text}</Text>
+export const Playground: StoryFn<typeof Text> = args => <Text {...args}>Playground</Text>
 
 Playground.args = {
-  text: 'Playground',
   as: 'span',
   size: 'medium',
   weight: 'normal',
 }
 
 Playground.argTypes = {
-  text: {
-    type: 'string',
-  },
   as: {
     type: 'string',
   },
@@ -32,12 +28,6 @@ Playground.argTypes = {
     },
   },
   ref: {
-    controls: false,
-    table: {
-      disable: true,
-    },
-  },
-  forwardedAs: {
     controls: false,
     table: {
       disable: true,

--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -1,9 +1,16 @@
+import cx from 'clsx'
 import styled from 'styled-components'
+import React, {forwardRef} from 'react'
 import type {SystemCommonProps, SystemTypographyProps} from '../constants'
 import {COMMON, TYPOGRAPHY} from '../constants'
 import type {SxProp} from '../sx'
 import sx from '../sx'
+import {useFeatureFlag} from '../FeatureFlags'
+import Box from '../Box'
+import {useRefObjectAsForwardedRef} from '../hooks'
+import classes from './Text.module.css'
 import type {ComponentProps} from '../utils/types'
+import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 
 type StyledTextProps = {
   size?: 'large' | 'medium' | 'small'
@@ -12,10 +19,7 @@ type StyledTextProps = {
   SystemCommonProps &
   SxProp
 
-const Text = styled.span.attrs<StyledTextProps>(({size, weight}) => ({
-  'data-size': size,
-  'data-weight': weight,
-}))<StyledTextProps>`
+const StyledText = styled.span<StyledTextProps>`
   ${TYPOGRAPHY};
   ${COMMON};
 
@@ -52,5 +56,57 @@ const Text = styled.span.attrs<StyledTextProps>(({size, weight}) => ({
 
   ${sx};
 `
-export type TextProps = ComponentProps<typeof Text>
+
+const Text = forwardRef(({as: Component = 'span', className, size, weight, ...props}, forwardedRef) => {
+  const enabled = useFeatureFlag('primer_react_css_modules_team')
+
+  const innerRef = React.useRef<HTMLElement>(null)
+  useRefObjectAsForwardedRef(forwardedRef, innerRef)
+
+  if (enabled) {
+    if (props.sx) {
+      return (
+        // @ts-ignore shh
+        <Box
+          as={Component}
+          className={cx(className, classes.Text)}
+          data-size={size}
+          data-weight={weight}
+          {...props}
+          // @ts-ignore shh
+          ref={innerRef}
+        />
+      )
+    }
+
+    return (
+      // @ts-ignore shh
+      <Component
+        className={cx(className, classes.Text)}
+        data-size={size}
+        data-weight={weight}
+        {...props}
+        // @ts-ignore shh
+        ref={innerRef}
+      />
+    )
+  }
+
+  return (
+    // @ts-ignore shh
+    <StyledText
+      as={Component}
+      className={className}
+      data-size={size}
+      data-weight={weight}
+      {...props}
+      // @ts-ignore shh
+      ref={innerRef}
+    />
+  )
+}) as PolymorphicForwardRefComponent<'span', StyledTextProps>
+
+Text.displayName = 'Text'
+
+export type TextProps = ComponentProps<typeof StyledText>
 export default Text


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/3785

### Changelog

#### Changed

Refactoring `Text` to use CSS modules behind the primer_react_css_modules_team feature flag.

#### Removed

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

This will be behind the primer_react_css_modules_team feature flag

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
