### PR TITLE
refactor(eslint): add lint rule for clsx

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -149,6 +149,11 @@ module.exports = {
                 message:
                   'Please use the `useIsomorphicLayoutEffect` hook from `src/hooks/useIsomorphicLayoutEffect.ts` instead',
               },
+              {
+                name: 'clsx',
+                importNames: ['default'],
+                message: 'Use the named import instead: `import {clsx} from "clsx"`',
+              },
             ],
             patterns: [
               {

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -3,7 +3,7 @@ import React, {useEffect} from 'react'
 import {ThemeProvider, BaseStyles, theme} from '../src'
 import {FeatureFlags} from '../src/FeatureFlags'
 import {DefaultFeatureFlags} from '../src/FeatureFlags/DefaultFeatureFlags'
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 
 import './storybook.css'
 import './primitives-v8.css'

--- a/packages/react/src/AvatarStack/AvatarStack.tsx
+++ b/packages/react/src/AvatarStack/AvatarStack.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import React from 'react'
 import styled from 'styled-components'
 import {get} from '../constants'

--- a/packages/react/src/Banner/Banner.tsx
+++ b/packages/react/src/Banner/Banner.tsx
@@ -1,4 +1,4 @@
-import cx from 'clsx'
+import {clsx} from 'clsx'
 import React, {useEffect} from 'react'
 import styled from 'styled-components'
 import {AlertIcon, InfoIcon, StopIcon, CheckCircleIcon, XIcon} from '@primer/octicons-react'
@@ -372,7 +372,7 @@ export type BannerTitleProps<As extends HeadingElement> = {
 export function BannerTitle<As extends HeadingElement>(props: BannerTitleProps<As>) {
   const {as: Heading = 'h2', className, children, ...rest} = props
   return (
-    <Heading {...rest} className={cx('BannerTitle', className)} data-banner-title="">
+    <Heading {...rest} className={clsx('BannerTitle', className)} data-banner-title="">
       {children}
     </Heading>
   )
@@ -382,7 +382,7 @@ export type BannerDescriptionProps = React.ComponentPropsWithoutRef<'div'>
 
 export function BannerDescription({children, className, ...rest}: BannerDescriptionProps) {
   return (
-    <div {...rest} className={cx('BannerDescription', className)}>
+    <div {...rest} className={clsx('BannerDescription', className)}>
       {children}
     </div>
   )
@@ -412,7 +412,7 @@ export type BannerPrimaryActionProps = Omit<React.ComponentPropsWithoutRef<typeo
 
 export function BannerPrimaryAction({children, className, ...rest}: BannerPrimaryActionProps) {
   return (
-    <Button className={cx('BannerPrimaryAction', className)} variant="default" {...rest}>
+    <Button className={clsx('BannerPrimaryAction', className)} variant="default" {...rest}>
       {children}
     </Button>
   )
@@ -422,7 +422,7 @@ export type BannerSecondaryActionProps = Omit<React.ComponentPropsWithoutRef<typ
 
 export function BannerSecondaryAction({children, className, ...rest}: BannerSecondaryActionProps) {
   return (
-    <Button className={cx('BannerPrimaryAction', className)} variant="link" {...rest}>
+    <Button className={clsx('BannerPrimaryAction', className)} variant="link" {...rest}>
       {children}
     </Button>
   )

--- a/packages/react/src/Blankslate/Blankslate.tsx
+++ b/packages/react/src/Blankslate/Blankslate.tsx
@@ -1,4 +1,4 @@
-import cx from 'clsx'
+import {clsx} from 'clsx'
 import React from 'react'
 import Box from '../Box'
 import {Button} from '../Button'
@@ -135,7 +135,7 @@ function Blankslate({border, children, narrow, spacious, className}: BlankslateP
     return (
       <div className={classes.Container}>
         <div
-          className={cx(classes.Blankslate, className)}
+          className={clsx(classes.Blankslate, className)}
           data-border={border}
           data-narrow={narrow}
           data-spacious={spacious}
@@ -154,7 +154,12 @@ function Blankslate({border, children, narrow, spacious, className}: BlankslateP
       */}
       <style type="text/css" dangerouslySetInnerHTML={{__html: BlankslateContainerQuery}} />
       <StyledBlankslate>
-        <div className={cx('Blankslate', className)} data-border={border} data-narrow={narrow} data-spacious={spacious}>
+        <div
+          className={clsx('Blankslate', className)}
+          data-border={border}
+          data-narrow={narrow}
+          data-spacious={spacious}
+        >
           {children}
         </div>
       </StyledBlankslate>
@@ -168,7 +173,7 @@ function Visual({children}: VisualProps) {
   const enabled = useFeatureFlag('primer_react_css_modules_staff')
   return (
     <span
-      className={cx('Blankslate-Visual', {
+      className={clsx('Blankslate-Visual', {
         [classes.Visual]: enabled,
       })}
     >
@@ -185,11 +190,11 @@ function Heading({as: Component = 'h2', children}: HeadingProps) {
   const enabled = useFeatureFlag('primer_react_css_modules_staff')
 
   if (enabled) {
-    return <Component className={cx('Blankslate-Heading', classes.Heading)}>{children}</Component>
+    return <Component className={clsx('Blankslate-Heading', classes.Heading)}>{children}</Component>
   }
 
   return (
-    <Box as={Component} className={cx('Blankslate-Heading')}>
+    <Box as={Component} className={clsx('Blankslate-Heading')}>
       {children}
     </Box>
   )
@@ -201,7 +206,7 @@ function Description({children}: DescriptionProps) {
   const enabled = useFeatureFlag('primer_react_css_modules_staff')
   return (
     <p
-      className={cx('Blankslate-Description', {
+      className={clsx('Blankslate-Description', {
         [classes.Description]: enabled,
       })}
     >
@@ -218,7 +223,7 @@ function PrimaryAction({children, href}: PrimaryActionProps) {
   const enabled = useFeatureFlag('primer_react_css_modules_staff')
   return (
     <div
-      className={cx('Blankslate-Action', {
+      className={clsx('Blankslate-Action', {
         [classes.Action]: enabled,
       })}
     >
@@ -237,7 +242,7 @@ function SecondaryAction({children, href}: SecondaryActionProps) {
   const enabled = useFeatureFlag('primer_react_css_modules_staff')
   return (
     <div
-      className={cx('Blankslate-Action', {
+      className={clsx('Blankslate-Action', {
         [classes.Action]: enabled,
       })}
     >

--- a/packages/react/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react/src/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import type {To} from 'history'
 import React from 'react'
 import styled from 'styled-components'

--- a/packages/react/src/DataTable/Table.tsx
+++ b/packages/react/src/DataTable/Table.tsx
@@ -1,5 +1,5 @@
 import {SortAscIcon, SortDescIcon} from '@primer/octicons-react'
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import React from 'react'
 import styled from 'styled-components'
 import Box from '../Box'

--- a/packages/react/src/Heading/Heading.tsx
+++ b/packages/react/src/Heading/Heading.tsx
@@ -1,4 +1,4 @@
-import cx from 'clsx'
+import {clsx} from 'clsx'
 import React, {forwardRef, useEffect} from 'react'
 import styled from 'styled-components'
 import {get} from '../constants'
@@ -62,7 +62,7 @@ const Heading = forwardRef(({as: Component = 'h2', className, variant, ...props}
       return (
         <Box
           as={Component}
-          className={cx(className, classes.Heading)}
+          className={clsx(className, classes.Heading)}
           data-variant={variant}
           {...props}
           // @ts-ignore shh
@@ -70,7 +70,7 @@ const Heading = forwardRef(({as: Component = 'h2', className, variant, ...props}
         />
       )
     }
-    return <Component className={cx(className, classes.Heading)} data-variant={variant} {...props} ref={innerRef} />
+    return <Component className={clsx(className, classes.Heading)} data-variant={variant} {...props} ref={innerRef} />
   }
 
   return (

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -1,4 +1,4 @@
-import cx from 'clsx'
+import {clsx} from 'clsx'
 import React, {forwardRef, useEffect} from 'react'
 import styled from 'styled-components'
 import {system} from 'styled-system'
@@ -96,7 +96,7 @@ const Link = forwardRef(({as: Component = 'a', className, ...props}, forwardedRe
       return (
         <Box
           as={Component}
-          className={cx(className, classes.Link)}
+          className={clsx(className, classes.Link)}
           data-muted={props.muted}
           data-inline={props.inline}
           data-underline={props.underline}
@@ -109,7 +109,7 @@ const Link = forwardRef(({as: Component = 'a', className, ...props}, forwardedRe
 
     return (
       <Component
-        className={cx(className, classes.Link)}
+        className={clsx(className, classes.Link)}
         data-muted={props.muted}
         data-inline={props.inline}
         data-underline={props.underline}

--- a/packages/react/src/Popover/Popover.tsx
+++ b/packages/react/src/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import styled from 'styled-components'
 import {get} from '../constants'
 import type {SxProp} from '../sx'

--- a/packages/react/src/SideNav.tsx
+++ b/packages/react/src/SideNav.tsx
@@ -7,7 +7,7 @@ import Box from './Box'
 import type {ComponentProps} from './utils/types'
 import Link from './Link'
 import React from 'react'
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import type {SxProp} from './sx'
 import sx from './sx'
 

--- a/packages/react/src/SubNav/SubNav.tsx
+++ b/packages/react/src/SubNav/SubNav.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import type {To} from 'history'
 import React from 'react'
 import styled from 'styled-components'

--- a/packages/react/src/TabNav/TabNav.tsx
+++ b/packages/react/src/TabNav/TabNav.tsx
@@ -1,5 +1,5 @@
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import type {To} from 'history'
 import React, {useRef, useState} from 'react'
 import styled from 'styled-components'

--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -1,4 +1,4 @@
-import cx from 'clsx'
+import {clsx} from 'clsx'
 import styled from 'styled-components'
 import React, {forwardRef} from 'react'
 import type {SystemCommonProps, SystemTypographyProps} from '../constants'
@@ -69,7 +69,7 @@ const Text = forwardRef(({as: Component = 'span', className, size, weight, ...pr
         // @ts-ignore shh
         <Box
           as={Component}
-          className={cx(className, classes.Text)}
+          className={clsx(className, classes.Text)}
           data-size={size}
           data-weight={weight}
           {...props}
@@ -82,7 +82,7 @@ const Text = forwardRef(({as: Component = 'span', className, size, weight, ...pr
     return (
       // @ts-ignore shh
       <Component
-        className={cx(className, classes.Text)}
+        className={clsx(className, classes.Text)}
         data-size={size}
         data-weight={weight}
         {...props}

--- a/packages/react/src/TextInput/TextInput.tsx
+++ b/packages/react/src/TextInput/TextInput.tsx
@@ -2,7 +2,7 @@ import type {MouseEventHandler} from 'react'
 import React, {useCallback, useState} from 'react'
 import {isValidElementType} from 'react-is'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 
 import TextInputInnerVisualSlot from '../internal/components/TextInputInnerVisualSlot'
 import {useProvidedRefOrCreate} from '../hooks'

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import React from 'react'
 import styled, {css} from 'styled-components'
 import Box from '../Box'

--- a/packages/react/src/Tooltip/Tooltip.tsx
+++ b/packages/react/src/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import React, {useMemo} from 'react'
 import styled from 'styled-components'
 import {get} from '../constants'

--- a/packages/react/src/TreeView/TreeView.tsx
+++ b/packages/react/src/TreeView/TreeView.tsx
@@ -4,7 +4,7 @@ import {
   FileDirectoryFillIcon,
   FileDirectoryOpenFillIcon,
 } from '@primer/octicons-react'
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import React, {useCallback, useEffect} from 'react'
 import styled from 'styled-components'
 import {ConfirmationDialog} from '../ConfirmationDialog/ConfirmationDialog'

--- a/packages/react/src/deprecated/UnderlineNav/UnderlineNav.tsx
+++ b/packages/react/src/deprecated/UnderlineNav/UnderlineNav.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import type {To} from 'history'
 import React from 'react'
 import styled from 'styled-components'

--- a/packages/react/src/drafts/CSSComponent/index.tsx
+++ b/packages/react/src/drafts/CSSComponent/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 import classNames from './component.module.css'
 
 export const Component: React.FC<React.HTMLProps<HTMLDivElement>> = ({className, ...props}) => {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This mirrors a change over in github/github to enforce consistent importing of `clsx`. This changes matches the pattern found upstream.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update the `no-restricted-imports` rule to enforce named exports from `clsx`
- Update files that used default imports from `clsx`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This change does not impact the public API of our components