### PR TITLE
SegmentedControl: Add context to `ariaLabel` prop

### DIFF
--- a/.changeset/curvy-goats-sell.md
+++ b/.changeset/curvy-goats-sell.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Include current selected menu item in accessible name when using an `aria-label` in `SegmentedControl`

--- a/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
@@ -320,6 +320,21 @@ describe('SegmentedControl', () => {
     expect(spy).toHaveBeenCalledTimes(2)
     spy.mockRestore()
   })
+
+  it('should include the visual text if the user specifies an aria-label', () => {
+    const {getByLabelText} = render(
+      <SegmentedControl aria-label="File view" variant={{narrow: 'dropdown'}}>
+        {segmentData.map(({label}, index) => (
+          <SegmentedControl.Button selected={index === 2} key={label}>
+            {label}
+          </SegmentedControl.Button>
+        ))}
+      </SegmentedControl>,
+    )
+
+    const menuButton = getByLabelText('Blame, File view')
+    expect(menuButton).toBeInTheDocument()
+  })
 })
 
 // TODO: uncomment these tests after we fix a11y for the Tooltip component

--- a/packages/react/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.tsx
@@ -115,7 +115,10 @@ const Root: React.FC<React.PropsWithChildren<SegmentedControlProps>> = ({
           The aria-label is only provided as a backup when the designer or engineer neglects to show a label for the SegmentedControl.
           The best thing to do is to have a visual label who's id is referenced using the `aria-labelledby` prop.
         */}
-        <ActionMenu.Button aria-label={ariaLabel} leadingVisual={getChildIcon(selectedChild)}>
+        <ActionMenu.Button
+          aria-label={ariaLabel && `${getChildText(selectedChild)}, ${ariaLabel}`}
+          leadingVisual={getChildIcon(selectedChild)}
+        >
           {getChildText(selectedChild)}
         </ActionMenu.Button>
         <ActionMenu.Overlay aria-labelledby={ariaLabelledby}>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3497

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

* Updates accessible name of `SegmentedControl` menu button to contain the visual text, and provided `aria-label`. 

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
