### PR TITLE
Move Heading component to staff feature flag

### DIFF
--- a/.changeset/dull-dolphins-bake.md
+++ b/.changeset/dull-dolphins-bake.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Move Heading component to staff feature flag

--- a/e2e/components/Heading.test.ts
+++ b/e2e/components/Heading.test.ts
@@ -28,7 +28,7 @@ test.describe('Heading', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_team: true,
+              primer_react_css_modules_staff: true,
             },
           },
         })
@@ -51,7 +51,7 @@ test.describe('Heading', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_team: true,
+              primer_react_css_modules_staff: true,
             },
           },
         })

--- a/packages/react/src/Heading/Heading.tsx
+++ b/packages/react/src/Heading/Heading.tsx
@@ -37,7 +37,7 @@ const StyledHeading = styled.h2<StyledHeadingProps>`
 `
 
 const Heading = forwardRef(({as: Component = 'h2', className, variant, ...props}, forwardedRef) => {
-  const enabled = useFeatureFlag('primer_react_css_modules_team')
+  const enabled = useFeatureFlag('primer_react_css_modules_staff')
   const innerRef = React.useRef<HTMLHeadingElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, innerRef)
 

--- a/packages/react/src/Heading/__tests__/Heading.test.tsx
+++ b/packages/react/src/Heading/__tests__/Heading.test.tsx
@@ -142,12 +142,12 @@ describe('Heading', () => {
     ).toHaveStyleRule('font-style', 'italic')
   })
 
-  describe('with primer_react_css_modules_team enabled', () => {
+  describe('with primer_react_css_modules_staff enabled', () => {
     it('should only include css modules class', () => {
       HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules_team: true,
+            primer_react_css_modules_staff: true,
           }}
         >
           <Heading>test</Heading>
@@ -163,7 +163,7 @@ describe('Heading', () => {
       const {container} = HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules_team: true,
+            primer_react_css_modules_staff: true,
           }}
         >
           <Heading className="test">test</Heading>
@@ -176,7 +176,7 @@ describe('Heading', () => {
       HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules_team: true,
+            primer_react_css_modules_staff: true,
           }}
         >
           <Heading


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3716

Heading has been team shipped for a week without any issues, promoting to staff ship based on lifecycle. https://github.com/github/primer-engineering/discussions/138

### Changelog

#### Changed

Heading CSS modules behind `primer_react_css_modules_staff` feature flag.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
