### PR TITLE
fix(Text): update type cast to match styled-component type

### DIFF
--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -1,5 +1,5 @@
 import cx from 'clsx'
-import styled from 'styled-components'
+import styled, {type StyledComponent} from 'styled-components'
 import React, {forwardRef} from 'react'
 import type {SystemCommonProps, SystemTypographyProps} from '../constants'
 import {COMMON, TYPOGRAPHY} from '../constants'
@@ -10,7 +10,6 @@ import Box from '../Box'
 import {useRefObjectAsForwardedRef} from '../hooks'
 import classes from './Text.module.css'
 import type {ComponentProps} from '../utils/types'
-import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 
 type StyledTextProps = {
   size?: 'large' | 'medium' | 'small'
@@ -104,7 +103,7 @@ const Text = forwardRef(({as: Component = 'span', className, size, weight, ...pr
       ref={innerRef}
     />
   )
-}) as PolymorphicForwardRefComponent<'span', StyledTextProps>
+}) as StyledComponent<'span', any, StyledTextProps, never>
 
 Text.displayName = 'Text'
 

--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -12,6 +12,8 @@ import classes from './Text.module.css'
 import type {ComponentProps} from '../utils/types'
 
 type StyledTextProps = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  as?: React.ComponentType<any> | keyof JSX.IntrinsicElements
   size?: 'large' | 'medium' | 'small'
   weight?: 'light' | 'normal' | 'medium' | 'semibold'
 } & SystemTypographyProps &
@@ -103,6 +105,7 @@ const Text = forwardRef(({as: Component = 'span', className, size, weight, ...pr
       ref={innerRef}
     />
   )
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }) as StyledComponent<'span', any, StyledTextProps, never>
 
 Text.displayName = 'Text'


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update the types for our Text component to match downstream expectations by using `StyledComponent`. This helps to address an issue blocking the current release

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update type cast for `Text` from `PolymorphicForwardRef` to `StyledComponent`

#### Removed

<!-- List of things removed in this PR -->
