### PR TITLE
Move the Blankslate css modules feature flag to ga

### DIFF
--- a/.changeset/six-owls-walk.md
+++ b/.changeset/six-owls-walk.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Move the Blankslate css modules feature flag to primer_react_css_modules_ga

--- a/e2e/components/Blankslate.test.ts
+++ b/e2e/components/Blankslate.test.ts
@@ -52,7 +52,7 @@ test.describe('Blankslate', () => {
               globals: {
                 colorScheme: theme,
                 featureFlags: {
-                  primer_react_css_modules_staff: true,
+                  primer_react_css_modules_ga: true,
                 },
               },
             })
@@ -67,7 +67,7 @@ test.describe('Blankslate', () => {
               globals: {
                 colorScheme: theme,
                 featureFlags: {
-                  primer_react_css_modules_staff: false,
+                  primer_react_css_modules_ga: false,
                 },
               },
             })
@@ -82,7 +82,7 @@ test.describe('Blankslate', () => {
               globals: {
                 colorScheme: theme,
                 featureFlags: {
-                  primer_react_css_modules_staff: true,
+                  primer_react_css_modules_ga: true,
                 },
               },
             })
@@ -108,7 +108,7 @@ test.describe('Blankslate', () => {
               id: story.id,
               globals: {
                 featureFlags: {
-                  primer_react_css_modules_staff: true,
+                  primer_react_css_modules_ga: true,
                 },
               },
             })
@@ -126,7 +126,7 @@ test.describe('Blankslate', () => {
               id: story.id,
               globals: {
                 featureFlags: {
-                  primer_react_css_modules_staff: false,
+                  primer_react_css_modules_ga: false,
                 },
               },
             })

--- a/packages/react/src/Blankslate/Blankslate.tsx
+++ b/packages/react/src/Blankslate/Blankslate.tsx
@@ -129,7 +129,7 @@ const BlankslateContainerQuery = `
 `
 
 function Blankslate({border, children, narrow, spacious, className}: BlankslateProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules_staff')
+  const enabled = useFeatureFlag('primer_react_css_modules_ga')
 
   if (enabled) {
     return (
@@ -170,7 +170,7 @@ function Blankslate({border, children, narrow, spacious, className}: BlankslateP
 export type VisualProps = React.PropsWithChildren
 
 function Visual({children}: VisualProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules_staff')
+  const enabled = useFeatureFlag('primer_react_css_modules_ga')
   return (
     <span
       className={clsx('Blankslate-Visual', {
@@ -187,7 +187,7 @@ export type HeadingProps = React.PropsWithChildren<{
 }>
 
 function Heading({as: Component = 'h2', children}: HeadingProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules_staff')
+  const enabled = useFeatureFlag('primer_react_css_modules_ga')
 
   if (enabled) {
     return <Component className={clsx('Blankslate-Heading', classes.Heading)}>{children}</Component>
@@ -203,7 +203,7 @@ function Heading({as: Component = 'h2', children}: HeadingProps) {
 export type DescriptionProps = React.PropsWithChildren
 
 function Description({children}: DescriptionProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules_staff')
+  const enabled = useFeatureFlag('primer_react_css_modules_ga')
   return (
     <p
       className={clsx('Blankslate-Description', {
@@ -220,7 +220,7 @@ export type PrimaryActionProps = React.PropsWithChildren<{
 }>
 
 function PrimaryAction({children, href}: PrimaryActionProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules_staff')
+  const enabled = useFeatureFlag('primer_react_css_modules_ga')
   return (
     <div
       className={clsx('Blankslate-Action', {
@@ -239,7 +239,7 @@ export type SecondaryActionProps = React.PropsWithChildren<{
 }>
 
 function SecondaryAction({children, href}: SecondaryActionProps) {
-  const enabled = useFeatureFlag('primer_react_css_modules_staff')
+  const enabled = useFeatureFlag('primer_react_css_modules_ga')
   return (
     <div
       className={clsx('Blankslate-Action', {


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/3696

The Blankslate component has been staff shipped for 4 weeks now. This PR promotes it to ga

### Changelog

#### Changed

Changes the `Blankslate` component feature flag to `primer_react_css_modules_ga` feature flag.

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why
