### PR TITLE
fix: IconButton dev stories - make target size 24x24 px

### DIFF
--- a/packages/react/src/Button/IconButton.dev.stories.tsx
+++ b/packages/react/src/Button/IconButton.dev.stories.tsx
@@ -7,7 +7,7 @@ export default {
 }
 
 export const CustomSize = () => (
-  <IconButton aria-label="Expand" variant="primary" size="small" icon={ChevronDownIcon} sx={{width: 16, height: 16}} />
+  <IconButton aria-label="Expand" variant="primary" size="small" icon={ChevronDownIcon} sx={{width: 24, height: 24}} />
 )
 
 export const CustomSizeWithMedia = () => {
@@ -17,7 +17,7 @@ export const CustomSizeWithMedia = () => {
       variant="primary"
       size="small"
       icon={ChevronDownIcon}
-      sx={{'@media (min-width: 123px)': {width: 16, height: 16}}}
+      sx={{'@media (min-width: 123px)': {width: 24, height: 24}}}
     />
   )
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #3424 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->
- Update Dev-Only "Custom Size" and "Custom Size With Media" Storybook stories' button size to 24x24 for [a11y compliance](https://www.w3.org/TR/WCAG22/#target-size-minimum)

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

Storybook only change, not relevant to deployed package.

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
