### PR TITLE
refactor(ButtonBase): To use CSS modules behind the feature flag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,13 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[postcss]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.stylelint": "explicit"
+    }
+  },
   "json.schemas": [
     {
       "fileMatch": ["*.docs.json"],

--- a/packages/react/src/Button/Button.dev.stories.tsx
+++ b/packages/react/src/Button/Button.dev.stories.tsx
@@ -33,7 +33,6 @@ export const InvisibleVariants = () => {
 }
 
 export const TestSxProp = () => {
-  const count = 4
   return (
     <div style={{display: 'flex', flexDirection: 'row', gap: '1rem'}}>
       <Button
@@ -87,9 +86,6 @@ export const TestSxProp = () => {
       </Button>
       <Button size="small" block variant="invisible" sx={{width: 320}}>
         Overriden Block
-      </Button>
-      <Button sx={{fontSize: 32}} count={count}>
-        Watch
       </Button>
     </div>
   )

--- a/packages/react/src/Button/ButtonBase.module.css
+++ b/packages/react/src/Button/ButtonBase.module.css
@@ -1,0 +1,500 @@
+/* Base styles */
+.ButtonBase {
+  display: flex;
+  min-width: max-content;
+  height: var(--control-medium-size);
+  /* stylelint-disable-next-line primer/spacing */
+  padding: 0 var(--control-medium-paddingInline-normal);
+  font-family: inherit;
+  font-size: var(--text-body-size-medium);
+  font-weight: var(--base-text-weight-medium);
+  color: var(--button-default-fgColor-rest);
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  user-select: none;
+  background-color: transparent;
+  border: var(--borderWidth-thin) solid;
+  border-color: var(--button-default-borderColor-rest);
+  border-radius: var(--borderRadius-medium);
+  transition: var(--duration-fast) var(--easing-easeInOut);
+  transition-property: color, fill, background-color, border-color;
+  appearance: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--base-size-8);
+
+  &:hover {
+    transition-duration: var(--duration-fast);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--focus-outlineColor);
+    outline-offset: 0;
+    box-shadow: none;
+  }
+
+  &:active {
+    transition: none;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    box-shadow: none;
+
+    & .Visual > :not(.CounterLabel) {
+      color: inherit;
+    }
+
+    & .CounterLabel {
+      color: inherit;
+    }
+  }
+
+  @media (forced-colors: active) {
+    &:focus {
+      outline: solid 1px transparent;
+    }
+  }
+}
+
+/* LinkButton */
+
+.ButtonBase[href] {
+  display: inline-flex;
+
+  &:hover {
+    text-decoration: none;
+  }
+}
+
+/* IconButton */
+
+.ButtonBase:where(.IconButton) {
+  display: inline-grid;
+  width: var(--control-medium-size);
+  min-width: unset;
+  /* stylelint-disable-next-line primer/spacing */
+  padding: unset;
+  place-content: center;
+
+  &:where([data-size='small']) {
+    width: var(--control-small-size);
+  }
+
+  &:where([data-size='large']) {
+    width: var(--control-large-size);
+  }
+}
+
+/* Visuals */
+.Visual {
+  display: flex;
+  pointer-events: none;
+}
+
+.Visual:not(.loadingSpinner) {
+  color: var(--fgColor-muted);
+}
+
+.ConditionalWrapper {
+  display: block;
+}
+
+/* Button layout */
+
+.ButtonContent {
+  flex: 1 0 auto;
+  display: grid;
+  grid-template-areas: 'leadingVisual text trailingVisual';
+  grid-template-columns: min-content minmax(0, auto) min-content;
+  align-items: center;
+  align-content: center;
+}
+
+.ButtonBase [data-component='leadingVisual'] {
+  grid-area: leadingVisual;
+}
+
+.Label {
+  line-height: calc(20 / 14); /* temporary until we use Text component with --text-body-lineHeight-medium */
+  white-space: nowrap;
+  grid-area: text;
+}
+
+.ButtonBase [data-component='trailingVisual'] {
+  grid-area: trailingVisual;
+}
+
+.ButtonBase [data-component='trailingAction'] {
+  margin-right: calc(var(--base-size-4) * -1);
+}
+
+.ButtonBase [data-component='buttonContent'] > :not(:last-child) {
+  margin-right: var(--base-size-8);
+}
+
+/* Props */
+
+/* Content alignment */
+
+.ButtonContent:where([data-align='center']) {
+  justify-content: center;
+}
+
+.ButtonContent:where([data-align='start']) {
+  justify-content: flex-start;
+}
+
+/* Size */
+
+.ButtonBase:where([data-size='small']) {
+  height: var(--control-small-size);
+  /* stylelint-disable-next-line primer/spacing */
+  padding: 0 var(--control-small-paddingInline-condensed);
+  gap: var(--control-small-gap);
+  font-size: var(--text-body-size-small);
+
+  & .ButtonContent > :not(:last-child) {
+    /* stylelint-disable-next-line primer/spacing */
+    margin-right: var(--control-small-gap);
+  }
+
+  & .Label {
+    line-height: calc(20 / 12); /* temporary until we use Text component with --text-body-lineHeight-small */
+  }
+}
+
+.ButtonBase:where([data-size='large']) {
+  height: var(--control-large-size);
+  /* stylelint-disable-next-line primer/spacing */
+  padding: 0 var(--control-large-paddingInline-spacious);
+  gap: var(--control-large-gap);
+
+  & .ButtonContent > :not(:last-child) {
+    /* stylelint-disable-next-line primer/spacing */
+    margin-right: var(--control-large-gap);
+  }
+}
+
+/* Full width */
+
+.ButtonBase:where([data-block='block']) {
+  width: 100%;
+}
+
+/* Wrap label text */
+
+.ButtonBase:where([data-label-wrap='true']) {
+  min-width: fit-content;
+  height: unset;
+  min-height: var(--control-medium-size);
+
+  & .ButtonContent {
+    flex: 1 1 auto;
+    align-self: stretch;
+    /* stylelint-disable-next-line primer/spacing */
+    padding-block: calc(var(--control-medium-paddingBlock) - var(--base-size-2));
+  }
+
+  & .Label {
+    word-break: break-word;
+    white-space: unset;
+  }
+
+  &:where([data-size='small']) {
+    height: unset;
+    min-height: var(--control-small-size);
+
+    & .ButtonContent {
+      /* stylelint-disable-next-line primer/spacing */
+      padding-block: calc(var(--control-small-paddingBlock) - var(--base-size-2));
+    }
+  }
+
+  &:where([data-size='large']) {
+    height: unset;
+    min-height: var(--control-large-size);
+    /* stylelint-disable-next-line primer/spacing */
+    padding-inline: var(--control-large-paddingInline-spacious);
+
+    & .ButtonContent {
+      /* stylelint-disable-next-line primer/spacing */
+      padding-block: calc(var(--control-large-paddingBlock) - var(--base-size-2));
+    }
+  }
+}
+
+/* Loading */
+
+/* only hide label if there's no leading/trailing visuals
+* move spinner to label spot if not leading/trailing visuals
+*/
+
+.ButtonBase:where([data-loading='true']) {
+  &
+    .loadingSpinner:not(
+      [data-component='leadingVisual'],
+      [data-component='trailingVisual'],
+      [data-component='trailingAction']
+    ) {
+    grid-area: text;
+    margin-right: 0 !important;
+    place-self: center;
+
+    & + .Label {
+      visibility: hidden;
+    }
+  }
+}
+
+/* Variants */
+
+/* Default Variant */
+
+.ButtonBase:where([data-variant='default']) {
+  color: var(--button-default-fgColor-rest);
+  background-color: var(--button-default-bgColor-rest);
+  box-shadow: var(--button-default-shadow-resting);
+
+  &:hover {
+    background-color: var(--button-default-bgColor-hover);
+    border-color: var(--button-default-borderColor-hover);
+  }
+
+  &:active {
+    background-color: var(--button-default-bgColor-active);
+    border-color: var(--button-default-borderColor-active);
+  }
+
+  &:disabled {
+    color: var(--control-fgColor-disabled);
+    background-color: var(--button-default-bgColor-disabled);
+    border-color: var(--button-default-borderColor-disabled);
+    box-shadow: none;
+  }
+
+  &[aria-expanded='true'] {
+    background-color: var(--button-default-bgColor-active);
+    border-color: var(--button-default-borderColor-active);
+  }
+
+  & .CounterLabel {
+    background-color: var(--buttonCounter-default-bgColor-rest);
+  }
+
+  &:where(.IconButton) {
+    color: var(--fgColor-muted);
+  }
+}
+
+/* Primary Variant */
+
+.ButtonBase:where([data-variant='primary']) {
+  color: var(--button-primary-fgColor-rest);
+  background-color: var(--button-primary-bgColor-rest);
+  border-color: var(--button-primary-borderColor-rest);
+  box-shadow: var(--shadow-resting-small);
+
+  &:hover {
+    background-color: var(--button-primary-bgColor-hover);
+    border-color: var(--button-primary-borderColor-hover);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--focus-outlineColor);
+    outline-offset: -2px;
+    box-shadow: inset 0 0 0 3px var(--fgColor-onEmphasis);
+  }
+
+  &:active {
+    background-color: var(--button-primary-bgColor-active);
+    box-shadow: var(--button-primary-shadow-selected);
+  }
+
+  &:disabled {
+    color: var(--button-primary-fgColor-disabled);
+    background-color: var(--button-primary-bgColor-disabled);
+    border-color: var(--button-primary-borderColor-disabled);
+    box-shadow: none;
+  }
+
+  &[aria-expanded='true'] {
+    background-color: var(--button-primary-bgColor-active);
+    box-shadow: var(--button-primary-shadow-selected);
+  }
+
+  & .CounterLabel {
+    /* color: inherit; */
+    color: var(--button-primary-fgColor-rest);
+    background-color: var(--buttonCounter-primary-bgColor-rest);
+  }
+
+  /* temporarily using the fgColor to match legacy and reduce visual changes- will eventually be iconColor */
+  & .Visual > :not(.CounterLabel) {
+    color: var(--button-primary-fgColor-rest);
+  }
+}
+
+/* Danger Variant */
+
+.ButtonBase:where([data-variant='danger']) {
+  color: var(--button-danger-fgColor-rest);
+  background-color: var(--button-danger-bgColor-rest);
+  box-shadow: var(--button-default-shadow-resting);
+
+  &:hover {
+    color: var(--button-danger-fgColor-hover);
+    background-color: var(--button-danger-bgColor-hover);
+    border-color: var(--button-danger-borderColor-hover);
+    box-shadow: var(--shadow-resting-small);
+
+    & .CounterLabel {
+      color: var(--buttonCounter-danger-fgColor-hover);
+      background-color: var(--buttonCounter-danger-bgColor-hover);
+    }
+
+    & .Visual > :not(.CounterLabel) {
+      color: var(--button-danger-iconColor-hover);
+    }
+  }
+
+  &:active {
+    color: var(--button-danger-fgColor-active);
+    background-color: var(--button-danger-bgColor-active);
+    border-color: var(--button-danger-borderColor-active);
+    box-shadow: var(--button-danger-shadow-selected);
+
+    & .CounterLabel {
+      color: var(--buttonCounter-danger-fgColor-hover);
+      background-color: var(--buttonCounter-danger-bgColor-hover);
+    }
+  }
+
+  &:disabled {
+    color: var(--button-danger-fgColor-disabled);
+    background-color: var(--button-danger-bgColor-disabled);
+    border-color: var(--button-default-borderColor-disabled);
+    box-shadow: none;
+
+    .CounterLabel {
+      color: var(--buttonCounter-danger-fgColor-disabled);
+      background-color: var(--buttonCounter-danger-bgColor-disabled);
+    }
+  }
+
+  &[aria-expanded='true'] {
+    color: var(--button-danger-fgColor-active);
+    background-color: var(--button-danger-bgColor-active);
+    border-color: var(--button-danger-borderColor-active);
+    box-shadow: var(--button-danger-shadow-selected);
+  }
+
+  & .CounterLabel {
+    color: var(--buttonCounter-danger-fgColor-rest);
+    background-color: var(--buttonCounter-danger-bgColor-rest);
+  }
+
+  & .Visual > :not(.CounterLabel) {
+    color: var(--button-danger-iconColor-rest);
+  }
+}
+
+/* Invisible Variant */
+
+.ButtonBase:where([data-variant='invisible']) {
+  color: var(--button-default-fgColor-rest);
+  border-color: transparent;
+  box-shadow: none;
+
+  &:hover {
+    background-color: var(--button-invisible-bgColor-hover);
+
+    & .Visual > :not(.CounterLabel) {
+      color: var(--button-invisible-iconColor-hover);
+    }
+  }
+
+  &:active {
+    background-color: var(--button-invisible-bgColor-active);
+
+    & .Visual > :not(.CounterLabel) {
+      color: var(--button-invisible-iconColor-hover);
+    }
+  }
+
+  &:disabled {
+    color: var(--button-invisible-fgColor-disabled);
+    background-color: var(--button-invisible-bgColor-disabled);
+    border-color: var(--button-invisible-borderColor-disabled);
+    box-shadow: none;
+  }
+
+  &[aria-expanded='true'] {
+    background-color: var(--button-invisible-bgColor-active);
+  }
+
+  & .Visual > :not(.CounterLabel) {
+    color: var(--button-invisible-iconColor-rest);
+  }
+
+  & .CounterLabel {
+    /* color: inherit; */
+    background-color: var(--buttonCounter-invisible-bgColor-rest);
+  }
+}
+
+/* Link variant */
+
+.ButtonBase:where([data-variant='link']) {
+  display: inline-block;
+  min-width: fit-content;
+  height: unset;
+  padding: 0;
+  font-size: inherit;
+  color: var(--fgColor-link);
+  text-align: left;
+  border: unset;
+
+  &:hover:not(:disabled, [data-inactive]) {
+    text-decoration: underline;
+  }
+
+  &:focus-visible,
+  &:focus {
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    color: var(--control-fgColor-disabled);
+    background-color: transparent;
+    border-color: transparent;
+  }
+
+  & .Label {
+    white-space: unset;
+  }
+
+  &:where([data-inactive]) {
+    color: var(--button-inactive-fgColor);
+    background: transparent !important;
+  }
+}
+
+/* Inactive */
+
+.ButtonBase:where([data-inactive]),
+.ButtonBase:where([data-inactive]):hover {
+  color: var(--button-inactive-fgColor);
+  cursor: auto;
+  background-color: var(--button-inactive-bgColor);
+  border-color: var(--button-inactive-bgColor);
+
+  & .Visual > :not(.CounterLabel) {
+    color: inherit;
+  }
+
+  & .CounterLabel {
+    color: inherit;
+  }
+}

--- a/packages/react/src/Button/ButtonBase.tsx
+++ b/packages/react/src/Button/ButtonBase.tsx
@@ -16,6 +16,9 @@ import CounterLabel from '../CounterLabel'
 import {useId} from '../hooks'
 import {ConditionalWrapper} from '../internal/components/ConditionalWrapper'
 import {AriaStatus} from '../live-region'
+import {clsx} from 'clsx'
+import classes from './ButtonBase.module.css'
+import {useFeatureFlag} from '../FeatureFlags'
 
 const iconWrapStyles = {
   display: 'flex',
@@ -26,6 +29,15 @@ const renderVisual = (Visual: React.ElementType, loading: boolean, visualName: s
   <Box as="span" data-component={visualName} sx={{...iconWrapStyles}}>
     {loading ? <Spinner size="small" /> : <Visual />}
   </Box>
+)
+
+const renderModuleVisual = (Visual: React.ElementType, loading: boolean, visualName: string, counterLabel: boolean) => (
+  <span
+    data-component={visualName}
+    className={clsx(!counterLabel && classes.Visual, loading ? classes.loadingSpinner : '')}
+  >
+    {loading ? <Spinner size="small" /> : <Visual />}
+  </span>
 )
 
 const ButtonBase = forwardRef(
@@ -48,9 +60,11 @@ const ButtonBase = forwardRef(
       inactive,
       onClick,
       labelWrap,
+      className,
       ...rest
     } = props
 
+    const enabled = useFeatureFlag('primer_react_css_modules_team')
     const innerRef = React.useRef<HTMLButtonElement>(null)
     useRefObjectAsForwardedRef(forwardedRef, innerRef)
 
@@ -84,6 +98,239 @@ const ButtonBase = forwardRef(
       }, [innerRef])
     }
 
+    if (enabled) {
+      if (sxProp !== defaultSxProp) {
+        return (
+          <ConditionalWrapper
+            // If anything is passsed to `loading`, we need the wrapper:
+            // If we just checked for `loading` as a boolean, the wrapper wouldn't be rendered
+            // when `loading` is `false`.
+            // Then, the component re-renders in a way that the button will lose focus when switching between loading states.
+            if={typeof loading !== 'undefined'}
+            className={block ? classes.ConditionalWrapper : undefined}
+            data-loading-wrapper
+          >
+            <Box
+              as={Component}
+              sx={sxStyles}
+              aria-disabled={loading ? true : undefined}
+              {...rest}
+              ref={innerRef}
+              className={clsx(classes.ButtonBase, className)}
+              data-block={block ? 'block' : null}
+              data-inactive={inactive ? true : undefined}
+              data-loading={Boolean(loading)}
+              data-no-visuals={!LeadingVisual && !TrailingVisual && !TrailingAction ? true : undefined}
+              data-size={size}
+              data-variant={variant}
+              data-label-wrap={labelWrap}
+              aria-describedby={[loadingAnnouncementID, ariaDescribedBy]
+                .filter(descriptionID => Boolean(descriptionID))
+                .join(' ')}
+              // aria-labelledby is needed because the accessible name becomes unset when the button is in a loading state.
+              // We only set it when the button is in a loading state because it will supercede the aria-label when the screen
+              // reader announces the button name.
+              aria-labelledby={
+                loading
+                  ? [`${uuid}-label`, ariaLabelledBy].filter(labelID => Boolean(labelID)).join(' ')
+                  : ariaLabelledBy
+              }
+              id={id}
+              onClick={loading ? undefined : onClick}
+            >
+              {Icon ? (
+                loading ? (
+                  <Spinner size="small" />
+                ) : (
+                  <Icon />
+                )
+              ) : (
+                <>
+                  <Box
+                    as="span"
+                    data-component="buttonContent"
+                    sx={getAlignContentSize(alignContent)}
+                    className={classes.ButtonContent}
+                  >
+                    {
+                      /* If there are no leading/trailing visuals/actions to replace with a loading spinner,
+                     render a loading spiner in place of the button content. */
+                      loading &&
+                        !LeadingVisual &&
+                        !TrailingVisual &&
+                        !TrailingAction &&
+                        renderModuleVisual(Spinner, loading, 'loadingSpinner', false)
+                    }
+                    {
+                      /* Render a leading visual unless the button is in a loading state.
+                     Then replace the leading visual with a loading spinner. */
+                      LeadingVisual && renderModuleVisual(LeadingVisual, Boolean(loading), 'leadingVisual', false)
+                    }
+                    {children && (
+                      <span data-component="text" className={classes.Label} id={loading ? `${uuid}-label` : undefined}>
+                        {children}
+                      </span>
+                    )}
+                    {
+                      /* If there is a count, render a counter label unless there is a trailing visual.
+                     Then render the counter label as a trailing visual.
+                     Replace the counter label or the trailing visual with a loading spinner if:
+                     - the button is in a loading state
+                     - there is no leading visual to replace with a loading spinner
+                  */
+                      count !== undefined && !TrailingVisual
+                        ? renderModuleVisual(
+                            () => (
+                              <CounterLabel className={classes.CounterLabel} data-component="ButtonCounter">
+                                {count}
+                              </CounterLabel>
+                            ),
+                            Boolean(loading) && !LeadingVisual,
+                            'trailingVisual',
+                            true,
+                          )
+                        : TrailingVisual
+                        ? renderModuleVisual(
+                            TrailingVisual,
+                            Boolean(loading) && !LeadingVisual,
+                            'trailingVisual',
+                            false,
+                          )
+                        : null
+                    }
+                  </Box>
+                  {
+                    /* If there is a trailing action, render it unless the button is in a loading state
+                   and there is no leading or trailing visual to replace with a loading spinner. */
+                    TrailingAction &&
+                      renderModuleVisual(
+                        TrailingAction,
+                        Boolean(loading) && !LeadingVisual && !TrailingVisual,
+                        'trailingAction',
+                        false,
+                      )
+                  }
+                </>
+              )}
+            </Box>
+            {loading && (
+              <VisuallyHidden>
+                <AriaStatus id={loadingAnnouncementID}>{loadingAnnouncement}</AriaStatus>
+              </VisuallyHidden>
+            )}
+          </ConditionalWrapper>
+        )
+      }
+      return (
+        <ConditionalWrapper
+          // If anything is passsed to `loading`, we need the wrapper:
+          // If we just checked for `loading` as a boolean, the wrapper wouldn't be rendered
+          // when `loading` is `false`.
+          // Then, the component re-renders in a way that the button will lose focus when switching between loading states.
+          if={typeof loading !== 'undefined'}
+          className={block ? classes.ConditionalWrapper : undefined}
+          data-loading-wrapper
+        >
+          <Component
+            aria-disabled={loading ? true : undefined}
+            {...rest}
+            // @ts-ignore temporary disable as we migrate to css modules, until we remove PolymorphicForwardRefComponent
+            ref={innerRef}
+            className={clsx(classes.ButtonBase, className)}
+            data-block={block ? 'block' : null}
+            data-inactive={inactive ? true : undefined}
+            data-loading={Boolean(loading)}
+            data-no-visuals={!LeadingVisual && !TrailingVisual && !TrailingAction ? true : undefined}
+            data-size={size}
+            data-variant={variant}
+            data-label-wrap={labelWrap}
+            aria-describedby={[loadingAnnouncementID, ariaDescribedBy]
+              .filter(descriptionID => Boolean(descriptionID))
+              .join(' ')}
+            // aria-labelledby is needed because the accessible name becomes unset when the button is in a loading state.
+            // We only set it when the button is in a loading state because it will supercede the aria-label when the screen
+            // reader announces the button name.
+            aria-labelledby={
+              loading ? [`${uuid}-label`, ariaLabelledBy].filter(labelID => Boolean(labelID)).join(' ') : ariaLabelledBy
+            }
+            id={id}
+            // @ts-ignore temporary disable as we migrate to css modules, until we remove PolymorphicForwardRefComponent
+            onClick={loading ? undefined : onClick}
+          >
+            {Icon ? (
+              loading ? (
+                <Spinner size="small" />
+              ) : (
+                <Icon />
+              )
+            ) : (
+              <>
+                <span data-component="buttonContent" data-align={alignContent} className={classes.ButtonContent}>
+                  {
+                    /* If there are no leading/trailing visuals/actions to replace with a loading spinner,
+                     render a loading spiner in place of the button content. */
+                    loading &&
+                      !LeadingVisual &&
+                      !TrailingVisual &&
+                      !TrailingAction &&
+                      renderModuleVisual(Spinner, loading, 'loadingSpinner', false)
+                  }
+                  {
+                    /* Render a leading visual unless the button is in a loading state.
+                     Then replace the leading visual with a loading spinner. */
+                    LeadingVisual && renderModuleVisual(LeadingVisual, Boolean(loading), 'leadingVisual', false)
+                  }
+                  {children && (
+                    <span data-component="text" className={classes.Label} id={loading ? `${uuid}-label` : undefined}>
+                      {children}
+                    </span>
+                  )}
+                  {
+                    /* If there is a count, render a counter label unless there is a trailing visual.
+                     Then render the counter label as a trailing visual.
+                     Replace the counter label or the trailing visual with a loading spinner if:
+                     - the button is in a loading state
+                     - there is no leading visual to replace with a loading spinner
+                  */
+                    count !== undefined && !TrailingVisual
+                      ? renderModuleVisual(
+                          () => (
+                            <CounterLabel className={classes.CounterLabel} data-component="ButtonCounter">
+                              {count}
+                            </CounterLabel>
+                          ),
+                          Boolean(loading) && !LeadingVisual,
+                          'trailingVisual',
+                          true,
+                        )
+                      : TrailingVisual
+                      ? renderModuleVisual(TrailingVisual, Boolean(loading) && !LeadingVisual, 'trailingVisual', false)
+                      : null
+                  }
+                </span>
+                {
+                  /* If there is a trailing action, render it unless the button is in a loading state
+                   and there is no leading or trailing visual to replace with a loading spinner. */
+                  TrailingAction &&
+                    renderModuleVisual(
+                      TrailingAction,
+                      Boolean(loading) && !LeadingVisual && !TrailingVisual,
+                      'trailingAction',
+                      false,
+                    )
+                }
+              </>
+            )}
+          </Component>
+          {loading && (
+            <VisuallyHidden>
+              <AriaStatus id={loadingAnnouncementID}>{loadingAnnouncement}</AriaStatus>
+            </VisuallyHidden>
+          )}
+        </ConditionalWrapper>
+      )
+    }
+
     return (
       <ConditionalWrapper
         // If anything is passsed to `loading`, we need the wrapper:
@@ -100,6 +347,7 @@ const ButtonBase = forwardRef(
           aria-disabled={loading ? true : undefined}
           {...rest}
           ref={innerRef}
+          className={className}
           data-block={block ? 'block' : null}
           data-inactive={inactive ? true : undefined}
           data-loading={Boolean(loading)}

--- a/packages/react/src/Button/IconButton.tsx
+++ b/packages/react/src/Button/IconButton.tsx
@@ -6,6 +6,7 @@ import {defaultSxProp} from '../utils/defaultSxProp'
 import {generateCustomSxProp} from './Button'
 import {TooltipContext, Tooltip} from '../TooltipV2/Tooltip'
 import {TooltipContext as TooltipContextV1} from '../Tooltip/Tooltip'
+import classes from './ButtonBase.module.css'
 
 const IconButton = forwardRef(
   (
@@ -43,6 +44,7 @@ const IconButton = forwardRef(
       return (
         <ButtonBase
           icon={Icon}
+          className={classes.IconButton}
           data-component="IconButton"
           sx={sxStyles}
           type="button"
@@ -66,6 +68,7 @@ const IconButton = forwardRef(
         >
           <ButtonBase
             icon={Icon}
+            className={classes.IconButton}
             data-component="IconButton"
             sx={sxStyles}
             type="button"

--- a/packages/react/src/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`Button respects block prop 1`] = `
 
 .c0 [data-component="text"] {
   grid-area: text;
-  line-height: calc(20/14);
+  line-height: calc(20 / 14);
   white-space: nowrap;
 }
 
@@ -537,7 +537,7 @@ exports[`Button respects the alignContent prop 1`] = `
 
 .c0 [data-component="text"] {
   grid-area: text;
-  line-height: calc(20/14);
+  line-height: calc(20 / 14);
   white-space: nowrap;
 }
 
@@ -852,7 +852,7 @@ exports[`Button respects the large size prop 1`] = `
 
 .c0 [data-component="text"] {
   grid-area: text;
-  line-height: calc(20/14);
+  line-height: calc(20 / 14);
   white-space: nowrap;
 }
 
@@ -1168,7 +1168,7 @@ exports[`Button respects the small size prop 1`] = `
 
 .c0 [data-component="text"] {
   grid-area: text;
-  line-height: calc(20/14);
+  line-height: calc(20 / 14);
   white-space: nowrap;
 }
 
@@ -1486,7 +1486,7 @@ exports[`Button styles danger button appropriately 1`] = `
 
 .c0 [data-component="text"] {
   grid-area: text;
-  line-height: calc(20/14);
+  line-height: calc(20 / 14);
   white-space: nowrap;
 }
 
@@ -1803,7 +1803,7 @@ exports[`Button styles invisible button appropriately 1`] = `
 
 .c0 [data-component="text"] {
   grid-area: text;
-  line-height: calc(20/14);
+  line-height: calc(20 / 14);
   white-space: nowrap;
 }
 
@@ -2127,7 +2127,7 @@ exports[`Button styles primary button appropriately 1`] = `
 
 .c0 [data-component="text"] {
   grid-area: text;
-  line-height: calc(20/14);
+  line-height: calc(20 / 14);
   white-space: nowrap;
 }
 

--- a/packages/react/src/Button/styles.ts
+++ b/packages/react/src/Button/styles.ts
@@ -382,7 +382,7 @@ export const getButtonStyles = (theme?: Theme) => {
     },
     '[data-component="text"]': {
       gridArea: 'text',
-      lineHeight: 'calc(20/14)',
+      lineHeight: 'calc(20 / 14)',
       whiteSpace: 'nowrap',
     },
     '[data-component="trailingVisual"]': {

--- a/packages/react/src/CounterLabel/CounterLabel.tsx
+++ b/packages/react/src/CounterLabel/CounterLabel.tsx
@@ -9,15 +9,17 @@ import {defaultSxProp} from '../utils/defaultSxProp'
 export type CounterLabelProps = React.PropsWithChildren<
   HTMLAttributes<HTMLSpanElement> & {
     scheme?: 'primary' | 'secondary'
+    className?: string
   } & SxProp
 >
 
 const CounterLabel = forwardRef<HTMLSpanElement, CounterLabelProps>(
-  ({scheme = 'secondary', sx = defaultSxProp, children, ...props}, forwardedRef) => {
+  ({scheme = 'secondary', sx = defaultSxProp, children, className, ...props}, forwardedRef) => {
     return (
       <>
         <Box
           aria-hidden="true"
+          className={className}
           sx={merge<BetterSystemStyleObject>(
             {
               display: 'inline-block',

--- a/packages/react/src/Heading/Heading.tsx
+++ b/packages/react/src/Heading/Heading.tsx
@@ -65,7 +65,7 @@ const Heading = forwardRef(({as: Component = 'h2', className, variant, ...props}
           className={clsx(className, classes.Heading)}
           data-variant={variant}
           {...props}
-          // @ts-ignore shh
+          // @ts-ignore temporary disable as we migrate to css modules, until we remove PolymorphicForwardRefComponent
           ref={innerRef}
         />
       )
@@ -80,7 +80,7 @@ const Heading = forwardRef(({as: Component = 'h2', className, variant, ...props}
       data-variant={variant}
       sx={sx}
       {...props}
-      // @ts-ignore shh
+      // @ts-ignore temporary disable as we migrate to css modules, until we remove PolymorphicForwardRefComponent
       ref={innerRef}
     />
   )

--- a/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1884,7 +1884,7 @@ exports[`TextInput renders trailingAction icon button 1`] = `
 
 .c4 [data-component="text"] {
   grid-area: text;
-  line-height: calc(20/14);
+  line-height: calc(20 / 14);
   white-space: nowrap;
 }
 
@@ -2238,7 +2238,7 @@ exports[`TextInput renders trailingAction icon button 1`] = `
     <button
       aria-describedby=":ro:-loading-announcement"
       aria-labelledby=":rn:"
-      className="c4"
+      className="c4 IconButton"
       data-block={null}
       data-component="IconButton"
       data-loading={false}
@@ -2515,7 +2515,7 @@ exports[`TextInput renders trailingAction text button 1`] = `
 
 .c4 [data-component="text"] {
   grid-area: text;
-  line-height: calc(20/14);
+  line-height: calc(20 / 14);
   white-space: nowrap;
 }
 
@@ -3007,7 +3007,7 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
 
 .c4 [data-component="text"] {
   grid-area: text;
-  line-height: calc(20/14);
+  line-height: calc(20 / 14);
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/3815

### Changelog

#### Changed

- The ButtonBase component uses CSS modules behind the flag

### Rollout strategy

- Minor release

### Testing & Reviewing

Snapshots should match with flag on/off

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
