### PR TITLE
fix(PageHeader): include role and aria-label in top-level element

### DIFF
--- a/.changeset/little-windows-exist.md
+++ b/.changeset/little-windows-exist.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+fix(PageHeader): include role and aria-label in top-level element

--- a/packages/react/src/PageHeader/PageHeader.docs.json
+++ b/packages/react/src/PageHeader/PageHeader.docs.json
@@ -10,7 +10,7 @@
       "name": "aria-label",
       "type": "string | undefined",
       "defaultValue": "",
-      "description": "A unique label for the rendered main landmark"
+      "description": "A unique label for the rendered banner landmark"
     },
     {
       "name": "className",

--- a/packages/react/src/PageHeader/PageHeader.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.stories.tsx
@@ -189,7 +189,7 @@ export default meta
 
 export const Playground: StoryFn = args => (
   <Box sx={{padding: 3}}>
-    <PageHeader>
+    <PageHeader aria-label={args.Title}>
       <PageHeader.TitleArea
         variant={{
           narrow: args['Title.variant'],

--- a/packages/react/src/PageHeader/PageHeader.test.tsx
+++ b/packages/react/src/PageHeader/PageHeader.test.tsx
@@ -198,12 +198,12 @@ describe('PageHeader', () => {
   })
   it('renders custom "aria-label" attribute when explicitly specified', () => {
     const {getByRole} = render(
-      <PageHeader aria-label="custom aria-label">
+      <PageHeader aria-label="Custom aria-label">
         <PageHeader.TitleArea>
           <PageHeader.Title>Title</PageHeader.Title>
         </PageHeader.TitleArea>
       </PageHeader>,
     )
-    expect(getByRole('banner')).toHaveAttribute('aria-label', 'custom aria-label')
+    expect(getByRole('banner')).toHaveAttribute('aria-label', 'Custom aria-label')
   })
 })

--- a/packages/react/src/PageHeader/PageHeader.test.tsx
+++ b/packages/react/src/PageHeader/PageHeader.test.tsx
@@ -161,7 +161,7 @@ describe('PageHeader', () => {
     expect(getByLabelText('Custom')).toBeInTheDocument()
     expect(getByText('Navigation')).toHaveAttribute('aria-label', 'Custom')
   })
-  it('does not renders "aria-label" prop when Navigation is rendered as "div"', () => {
+  it('does not render "aria-label" prop when Navigation is rendered as "div"', () => {
     const {getByText} = render(
       <PageHeader>
         <PageHeader.TitleArea>
@@ -185,5 +185,25 @@ describe('PageHeader', () => {
     expect(consoleSpy).toHaveBeenCalled()
 
     consoleSpy.mockRestore()
+  })
+  it('renders default "aria-label" attribute when not explicitly specified', () => {
+    const {getByRole} = render(
+      <PageHeader>
+        <PageHeader.TitleArea>
+          <PageHeader.Title>Title</PageHeader.Title>
+        </PageHeader.TitleArea>
+      </PageHeader>,
+    )
+    expect(getByRole('banner')).toHaveAttribute('aria-label', 'banner')
+  })
+  it('renders custom "aria-label" attribute when explicitly specified', () => {
+    const {getByRole} = render(
+      <PageHeader aria-label="custom aria-label">
+        <PageHeader.TitleArea>
+          <PageHeader.Title>Title</PageHeader.Title>
+        </PageHeader.TitleArea>
+      </PageHeader>,
+    )
+    expect(getByRole('banner')).toHaveAttribute('aria-label', 'custom aria-label')
   })
 })

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -66,7 +66,7 @@ export type PageHeaderProps = {
 } & SxProp
 
 const Root = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageHeaderProps>>(
-  ({children, className, sx = {}, as = 'div'}, forwardedRef) => {
+  ({children, className, sx = {}, as = 'div', 'aria-label': ariaLabel}, forwardedRef) => {
     const rootStyles = {
       display: 'grid',
       // We have max 5 columns.
@@ -158,7 +158,14 @@ const Root = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageHeader
       [children, rootRef],
     )
     return (
-      <Box ref={rootRef} as={as} className={className} sx={merge<BetterSystemStyleObject>(rootStyles, sx)}>
+      <Box
+        role="banner"
+        ref={rootRef}
+        as={as}
+        className={className}
+        sx={merge<BetterSystemStyleObject>(rootStyles, sx)}
+        aria-label={ariaLabel ?? 'banner'}
+      >
         {children}
       </Box>
     )


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #https://github.com/github/primer/issues/3466

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->
- `PageHeader` tests to assert added functionality

#### Changed

<!-- List of things changed in this PR -->
- Adjust `PageHeader`'s `aria-label` docs description to reference "banner landmark" instead of "main landmark"
- Include `aria-label` prop in `PageHeader` Playground story
- Set `aria-label` attribute in `PageHeader`'s "root" element mapped to the supplied `aria-label` (defaults to "banner")

#### Removed

<!-- List of things removed in this PR -->
N/A

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Check [preview Playground story](https://primer-d606f2367b-13348165.drafts.github.io/storybook/?path=/story/components-pageheader--playground&args=Title:Branches):
    - Notice in the DOM the "banner" role in the top-level `Box` element and the `aria-label` that maps to the `title` prop
    - Change `title` prop in playground and notice the `aria-label` change in the DOM as well
- Check [preview Default story](https://primer-d606f2367b-13348165.drafts.github.io/storybook/?path=/story/components-pageheader--default):
    - Notice in the DOM the "banner" role in the top-level `Box` element and the `aria-label` that defaults to "banner"

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
