### PR TITLE
fix(Pagination): a11y improvements

### DIFF
--- a/packages/react/src/Pagination/Pagination.tsx
+++ b/packages/react/src/Pagination/Pagination.tsx
@@ -76,14 +76,11 @@ const Page = styled.a`
 
   &[aria-disabled],
   &[aria-disabled]:hover {
-    color: ${get('colors.primer.fg.disabled')}; // check
-    cursor: default;
-    background-color: transparent;
-    border-color: transparent;
-    font-size: inherit;
-    font-family: inherit;
-    padding-top: inherit;
-    padding-bottom: inherit;
+    margin: 0 2px;
+
+    &:first-child {
+      margin-right: 6px;
+    }
   }
 
   &[aria-disabled],

--- a/packages/react/src/Pagination/model.tsx
+++ b/packages/react/src/Pagination/model.tsx
@@ -148,13 +148,14 @@ export function buildComponentData(
       key = 'page-prev'
       content = 'Previous'
       if (page.disabled) {
-        Object.assign(props, {as: 'button', 'aria-disabled': 'true'})
+        Object.assign(props, {'aria-disabled': 'true'})
       } else {
         Object.assign(props, {
           rel: 'prev',
           href: hrefBuilder(page.num),
           'aria-label': 'Previous Page',
           onClick,
+          role: 'link',
         })
       }
       break
@@ -163,13 +164,14 @@ export function buildComponentData(
       key = 'page-next'
       content = 'Next'
       if (page.disabled) {
-        Object.assign(props, {as: 'button', 'aria-disabled': 'true'})
+        Object.assign(props, {'aria-disabled': 'true'})
       } else {
         Object.assign(props, {
           rel: 'next',
           href: hrefBuilder(page.num),
           'aria-label': 'Next Page',
           onClick,
+          role: 'link',
         })
       }
       break
@@ -185,6 +187,7 @@ export function buildComponentData(
         'aria-label': `Page ${page.num}${page.precedesBreak ? '...' : ''}`,
         onClick,
         'aria-current': page.selected ? 'page' : undefined,
+        role: 'link',
       })
       break
     }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #https://github.com/github/primer/issues/3395

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Makes the Previous/Next controls in `Pagination` non-focusable by rendering them as `a`s instead of `button`. Also adds `role="link" to all `<a/>'s in the component.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->
- Margin styles for disabled Next/Previous control to account for disparity between `button` borders and `a`s

#### Changed

<!-- List of things changed in this PR -->
- Render Next/Previous controls as `a` instead of `button` to make them non-focusable
- Adds `role="link"` to all `<a>`'s (Next, Previous and page numbers) in the component to improve accessibility

#### Removed

<!-- List of things removed in this PR -->
- Removes styles added for button on https://github.com/primer/react/pull/3277

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
