### PR TITLE
docs(storybook): add react plugin for fast refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1708,11 +1708,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.24.1",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.24.7.tgz",
+      "integrity": "sha512-fOPQYbGSgH0HUp4UJO4sMBFjY6DuWq+2i8rixyUMb3CdGixs/gccURvYOAhajBdKDoGajFr3mUq5rH3phtkGzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -9836,15 +9838,17 @@
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.2.1",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.1.tgz",
+      "integrity": "sha512-m/V2syj5CuVnaxcUJOQRel/Wr31FFXRFlnOoq1TVtkCxsY5veGMTEmpWHndrhB2U8ScHtCQB1e+4hWYExQc6Lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.23.5",
-        "@babel/plugin-transform-react-jsx-self": "^7.23.3",
-        "@babel/plugin-transform-react-jsx-source": "^7.23.3",
+        "@babel/core": "^7.24.5",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.5",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.1",
         "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.14.0"
+        "react-refresh": "^0.14.2"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -26871,7 +26875,9 @@
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.14.0",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -34214,6 +34220,7 @@
         "@types/react-test-renderer": "18.3.0",
         "@types/semver": "7.5.8",
         "@types/styled-components": "^5.1.26",
+        "@vitejs/plugin-react": "4.3.1",
         "ajv": "8.16.0",
         "axe-core": "4.9.1",
         "babel-core": "7.0.0-bridge.0",

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -1,5 +1,6 @@
 import {createRequire} from 'node:module'
 import path from 'node:path'
+import react from '@vitejs/plugin-react'
 import postcssPresetPrimer from 'postcss-preset-primer'
 import type {StorybookConfig} from '@storybook/react-vite'
 
@@ -48,12 +49,14 @@ const config: StorybookConfig = {
       },
     }
 
+    config.plugins = [...(config.plugins ?? []), react()]
+
     return config
   },
 }
 
 export default config
 
-function getAbsolutePath(value) {
+function getAbsolutePath(value: string) {
   return path.dirname(require.resolve(path.join(value, 'package.json')))
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -163,6 +163,7 @@
     "@types/react-test-renderer": "18.3.0",
     "@types/semver": "7.5.8",
     "@types/styled-components": "^5.1.26",
+    "@vitejs/plugin-react": "^4.3.1",
     "ajv": "8.16.0",
     "axe-core": "4.9.1",
     "babel-core": "7.0.0-bridge.0",


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

With the change, it seems like Fast Refresh is not enabled by default in React Vite 🤔 This PR adds the react plugin to enable this (and get Fast Refresh for styles too)

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update storybook to have Fast Refresh for React components

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to our internal storybook and will not impact the public API 

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- [ ] Pull down the PR, install dependencies, and very that making a change does not reload the page 👀 