### PR TITLE
TooltipV2: Use [disabled] selector to check for disabled elements

### DIFF
--- a/.changeset/flat-avocados-cheer.md
+++ b/.changeset/flat-avocados-cheer.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Utilizes `[disabled]` selector instead of `:disabled` in `TooltipV2` to address a false positive

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -171,7 +171,7 @@ const positionToDirection: Record<string, TooltipDirection> = {
 // The list is from GitHub's custom-axe-rules https://github.com/github/github/blob/master/app/assets/modules/github/axe-custom-rules.ts#L3
 const interactiveElements = [
   'a[href]',
-  'button:not(:disabled)',
+  'button:not([disabled])',
   'summary',
   'select',
   'input:not([type=hidden])',

--- a/packages/react/src/TooltipV2/__tests__/Tooltip.test.tsx
+++ b/packages/react/src/TooltipV2/__tests__/Tooltip.test.tsx
@@ -109,4 +109,31 @@ describe('Tooltip', () => {
     const triggerEL = getByRole('button')
     expect(triggerEL.getAttribute('aria-describedby')).toContain('custom-tooltip-id')
   })
+  it('should throw an error if the trigger element is disabled', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation()
+    expect(() => {
+      HTMLRender(
+        <Tooltip text="Tooltip text" direction="n">
+          <Button disabled>Delete</Button>
+        </Tooltip>,
+      )
+    }).toThrow(
+      'The `Tooltip` component expects a single React element that contains interactive content. Consider using a `<button>` or equivalent interactive element instead.',
+    )
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+  it('should not throw an error when the trigger element is a button in a fieldset', () => {
+    const {getByRole} = HTMLRender(
+      <fieldset>
+        <legend>Legend</legend>
+        <Tooltip text="Tooltip text">
+          <button>Button Text</button>
+        </Tooltip>
+      </fieldset>,
+    )
+
+    const triggerEL = getByRole('button')
+    expect(triggerEL).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

A bug in Jest was causing a false positive when using `:disabled`, this is now fixed by using `[disabled]` instead.

Context for the false positive: https://github.com/dperini/nwsapi/pull/125

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->

* Uses `[disabled]` instead of `:disabled`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
