### PR TITLE
WIP: Select panel custom screen reader announcements

### DIFF
--- a/.changeset/selectpanel-announcements.md
+++ b/.changeset/selectpanel-announcements.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+SelectPanel: Add announcements for screen readers (behind feature flag `primer_react_select_panel_with_modern_action_list`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6724,8 +6724,9 @@
       }
     },
     "node_modules/@primer/live-region-element": {
-      "version": "0.7.0",
-      "license": "MIT",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@primer/live-region-element/-/live-region-element-0.7.1.tgz",
+      "integrity": "sha512-9uQCeBCb3wefz3kJNSo+PECc7T7TNB3k22JUdHY08Zlv9bd1rtsQgpazM5umcbZQrACzGbgufAfdbhGUBXI3jA==",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
@@ -34152,7 +34153,7 @@
         "@lit-labs/react": "1.2.1",
         "@oddbird/popover-polyfill": "^0.3.1",
         "@primer/behaviors": "^1.7.2",
-        "@primer/live-region-element": "^0.7.0",
+        "@primer/live-region-element": "^0.7.1",
         "@primer/octicons-react": "^19.9.0",
         "@primer/primitives": "^9.0.3",
         "@styled-system/css": "^5.1.5",
@@ -34220,7 +34221,7 @@
         "@types/react-test-renderer": "18.3.0",
         "@types/semver": "7.5.8",
         "@types/styled-components": "^5.1.26",
-        "@vitejs/plugin-react": "4.3.1",
+        "@vitejs/plugin-react": "^4.3.1",
         "ajv": "8.16.0",
         "axe-core": "4.9.1",
         "babel-core": "7.0.0-bridge.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -95,7 +95,7 @@
     "@lit-labs/react": "1.2.1",
     "@oddbird/popover-polyfill": "^0.3.1",
     "@primer/behaviors": "^1.7.2",
-    "@primer/live-region-element": "^0.7.0",
+    "@primer/live-region-element": "^0.7.1",
     "@primer/octicons-react": "^19.9.0",
     "@primer/primitives": "^9.0.3",
     "@styled-system/css": "^5.1.5",

--- a/packages/react/src/FilteredActionList/FilteredActionListWithModernActionList.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionListWithModernActionList.tsx
@@ -20,6 +20,7 @@ import type {SxProp} from '../sx'
 
 import {isValidElementType} from 'react-is'
 import type {RenderItemFn} from '../deprecated/ActionList/List'
+import {useAnnouncements} from './useAnnouncements'
 
 const menuScrollMargins: ScrollIntoViewOptions = {startMargin: 0, endMargin: 8}
 
@@ -114,6 +115,7 @@ export function FilteredActionList({
   }, [items])
 
   useScrollFlash(scrollContainerRef)
+  useAnnouncements(items, listContainerRef, inputRef)
 
   function getItemListForEachGroup(groupId: string) {
     const itemsInGroup = []

--- a/packages/react/src/FilteredActionList/useAnnouncements.tsx
+++ b/packages/react/src/FilteredActionList/useAnnouncements.tsx
@@ -1,0 +1,97 @@
+// Announcements for FilteredActionList (and SelectPanel) based
+// on https://github.com/github/multi-select-user-testing
+
+import {announce} from '@primer/live-region-element'
+import {useEffect, useRef} from 'react'
+import type {FilteredActionListProps} from './FilteredActionListEntry'
+
+// we add a delay so that it does not interrupt default screen reader announcement and queues after it
+const delayMs = 500
+
+const useFirstRender = () => {
+  const firstRender = useRef(true)
+  useEffect(() => {
+    firstRender.current = false
+  }, [])
+  return firstRender.current
+}
+
+const getItemWithActiveDescendant = (
+  listRef: React.RefObject<HTMLUListElement>,
+  items: FilteredActionListProps['items'],
+) => {
+  const listElement = listRef.current
+  const activeItemElement = listElement?.querySelector('[data-is-active-descendant]')
+
+  if (!listElement || !activeItemElement?.textContent) return
+
+  const optionElements = listElement.querySelectorAll('[role="option"]')
+
+  const index = Array.from(optionElements).indexOf(activeItemElement)
+  const activeItem = items[index]
+
+  const text = activeItem.text
+  const selected = activeItem.selected
+
+  return {index, text, selected}
+}
+
+export const useAnnouncements = (
+  items: FilteredActionListProps['items'],
+  listContainerRef: React.RefObject<HTMLUListElement>,
+  inputRef: React.RefObject<HTMLInputElement>,
+) => {
+  useEffect(
+    function announceInitialFocus() {
+      const focusHandler = () => {
+        // give @primer/behaviors a moment to apply active-descendant
+        window.requestAnimationFrame(() => {
+          const activeItem = getItemWithActiveDescendant(listContainerRef, items)
+          if (!activeItem) return
+          const {index, text, selected} = activeItem
+
+          const announcementText = [
+            `Focus on filter text box and list of labels`,
+            `Focused item: ${text}`,
+            `${selected ? 'selected' : 'not selected'}`,
+            `${index + 1} of ${items.length}`,
+          ].join(', ')
+          announce(announcementText, {delayMs})
+        })
+      }
+
+      const inputElement = inputRef.current
+      inputElement?.addEventListener('focus', focusHandler)
+      return () => inputElement?.removeEventListener('focus', focusHandler)
+    },
+    [listContainerRef, inputRef, items],
+  )
+
+  const isFirstRender = useFirstRender()
+  useEffect(
+    function announceListUpdates() {
+      if (isFirstRender) return // ignore on first render as announceInitialFocus will also announce
+
+      if (items.length === 0) {
+        announce('No matching items.', {delayMs})
+        return
+      }
+
+      // give @primer/behaviors a moment to update active-descendant
+      window.requestAnimationFrame(() => {
+        const activeItem = getItemWithActiveDescendant(listContainerRef, items)
+        if (!activeItem) return
+        const {index, text, selected} = activeItem
+
+        const announcementText = [
+          `List updated`,
+          `Focused item: ${text}`,
+          `${selected ? 'selected' : 'not selected'}`,
+          `${index} of ${items.length}`,
+        ].join(', ')
+        announce(announcementText, {delayMs})
+      })
+    },
+    [listContainerRef, inputRef, items, isFirstRender],
+  )
+}

--- a/packages/react/src/FilteredActionList/useAnnouncements.tsx
+++ b/packages/react/src/FilteredActionList/useAnnouncements.tsx
@@ -1,7 +1,8 @@
 // Announcements for FilteredActionList (and SelectPanel) based
 // on https://github.com/github/multi-select-user-testing
 
-import {LiveRegionElement, announce} from '@primer/live-region-element'
+import {announce} from '@primer/live-region-element'
+import type {LiveRegionElement} from '@primer/live-region-element'
 import {useEffect, useRef} from 'react'
 import type {FilteredActionListProps} from './FilteredActionListEntry'
 

--- a/packages/react/src/FilteredActionList/useAnnouncements.tsx
+++ b/packages/react/src/FilteredActionList/useAnnouncements.tsx
@@ -87,7 +87,7 @@ export const useAnnouncements = (
           `List updated`,
           `Focused item: ${text}`,
           `${selected ? 'selected' : 'not selected'}`,
-          `${index} of ${items.length}`,
+          `${index + 1} of ${items.length}`,
         ].join(', ')
         announce(announcementText, {delayMs})
       })

--- a/packages/react/src/FilteredActionList/useAnnouncements.tsx
+++ b/packages/react/src/FilteredActionList/useAnnouncements.tsx
@@ -54,7 +54,7 @@ export const useAnnouncements = (
           const {index, text, selected} = activeItem
 
           const announcementText = [
-            `Focus on filter text box and list of labels`,
+            `Focus on filter text box and list of items`,
             `Focused item: ${text}`,
             `${selected ? 'selected' : 'not selected'}`,
             `${index + 1} of ${items.length}`,

--- a/packages/react/src/FilteredActionList/useAnnouncements.tsx
+++ b/packages/react/src/FilteredActionList/useAnnouncements.tsx
@@ -1,7 +1,7 @@
 // Announcements for FilteredActionList (and SelectPanel) based
 // on https://github.com/github/multi-select-user-testing
 
-import {announce} from '@primer/live-region-element'
+import {LiveRegionElement, announce} from '@primer/live-region-element'
 import {useEffect, useRef} from 'react'
 import type {FilteredActionListProps} from './FilteredActionListEntry'
 
@@ -41,6 +41,8 @@ export const useAnnouncements = (
   listContainerRef: React.RefObject<HTMLUListElement>,
   inputRef: React.RefObject<HTMLInputElement>,
 ) => {
+  const liveRegion = document.querySelector('live-region') as LiveRegionElement
+
   useEffect(
     function announceInitialFocus() {
       const focusHandler = () => {
@@ -56,7 +58,7 @@ export const useAnnouncements = (
             `${selected ? 'selected' : 'not selected'}`,
             `${index + 1} of ${items.length}`,
           ].join(', ')
-          announce(announcementText, {delayMs})
+          announce(announcementText, {delayMs, from: liveRegion})
         })
       }
 
@@ -64,13 +66,15 @@ export const useAnnouncements = (
       inputElement?.addEventListener('focus', focusHandler)
       return () => inputElement?.removeEventListener('focus', focusHandler)
     },
-    [listContainerRef, inputRef, items],
+    [listContainerRef, inputRef, items, liveRegion],
   )
 
   const isFirstRender = useFirstRender()
   useEffect(
     function announceListUpdates() {
       if (isFirstRender) return // ignore on first render as announceInitialFocus will also announce
+
+      liveRegion.clear() // clear previous announcements
 
       if (items.length === 0) {
         announce('No matching items.', {delayMs})
@@ -89,9 +93,9 @@ export const useAnnouncements = (
           `${selected ? 'selected' : 'not selected'}`,
           `${index + 1} of ${items.length}`,
         ].join(', ')
-        announce(announcementText, {delayMs})
+        announce(announcementText, {delayMs, from: liveRegion})
       })
     },
-    [listContainerRef, inputRef, items, isFirstRender],
+    [listContainerRef, inputRef, items, isFirstRender, liveRegion],
   )
 }

--- a/packages/react/src/FilteredActionList/useAnnouncements.tsx
+++ b/packages/react/src/FilteredActionList/useAnnouncements.tsx
@@ -2,7 +2,6 @@
 // on https://github.com/github/multi-select-user-testing
 
 import {announce} from '@primer/live-region-element'
-import type {LiveRegionElement} from '@primer/live-region-element'
 import {useEffect, useRef} from 'react'
 import type {FilteredActionListProps} from './FilteredActionListEntry'
 

--- a/packages/react/src/FilteredActionList/useAnnouncements.tsx
+++ b/packages/react/src/FilteredActionList/useAnnouncements.tsx
@@ -42,7 +42,7 @@ export const useAnnouncements = (
   listContainerRef: React.RefObject<HTMLUListElement>,
   inputRef: React.RefObject<HTMLInputElement>,
 ) => {
-  const liveRegion = document.querySelector('live-region') as LiveRegionElement
+  const liveRegion = document.querySelector('live-region')
 
   useEffect(
     function announceInitialFocus() {
@@ -59,7 +59,10 @@ export const useAnnouncements = (
             `${selected ? 'selected' : 'not selected'}`,
             `${index + 1} of ${items.length}`,
           ].join(', ')
-          announce(announcementText, {delayMs, from: liveRegion})
+          announce(announcementText, {
+            delayMs,
+            from: liveRegion ? liveRegion : undefined, // announce will create a liveRegion if it doesn't find one
+          })
         })
       }
 
@@ -75,7 +78,7 @@ export const useAnnouncements = (
     function announceListUpdates() {
       if (isFirstRender) return // ignore on first render as announceInitialFocus will also announce
 
-      liveRegion.clear() // clear previous announcements
+      liveRegion?.clear() // clear previous announcements
 
       if (items.length === 0) {
         announce('No matching items.', {delayMs})
@@ -94,9 +97,13 @@ export const useAnnouncements = (
           `${selected ? 'selected' : 'not selected'}`,
           `${index + 1} of ${items.length}`,
         ].join(', ')
-        announce(announcementText, {delayMs, from: liveRegion})
+
+        announce(announcementText, {
+          delayMs,
+          from: liveRegion ? liveRegion : undefined, // announce will create a liveRegion if it doesn't find one
+        })
       })
     },
-    [listContainerRef, inputRef, items, isFirstRender, liveRegion],
+    [isFirstRender, items, listContainerRef, liveRegion],
   )
 }

--- a/packages/react/src/SelectPanel/SelectPanel.test.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.test.tsx
@@ -398,7 +398,7 @@ for (const useModernActionList of [false, true]) {
           // we wait because announcement is intentionally updated after a timeout to not interrupt user input
           await waitFor(async () => {
             expect(getLiveRegion().getMessage('polite')).toBe(
-              'Focus on filter text box and list of labels, Focused item: item one, not selected, 1 of 3',
+              'Focus on filter text box and list of items, Focused item: item one, not selected, 1 of 3',
             )
           })
         })

--- a/packages/react/src/SelectPanel/SelectPanel.test.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.test.tsx
@@ -1,10 +1,11 @@
-import {render, screen} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
 import React from 'react'
 import {SelectPanel, type SelectPanelProps} from '../SelectPanel'
 import type {ItemInput, GroupedListProps} from '../deprecated/ActionList/List'
 import {userEvent} from '@testing-library/user-event'
 import ThemeProvider from '../ThemeProvider'
 import {FeatureFlags} from '../FeatureFlags'
+import {getLiveRegion} from '../utils/testing'
 
 const renderWithFlag = (children: React.ReactNode, flag: boolean) => {
   return render(
@@ -336,39 +337,39 @@ for (const useModernActionList of [false, true]) {
         })
       })
 
-      describe('filtering', () => {
-        function FilterableSelectPanel() {
-          const [selected, setSelected] = React.useState<SelectPanelProps['items']>([])
-          const [filter, setFilter] = React.useState('')
-          const [open, setOpen] = React.useState(false)
+      function FilterableSelectPanel() {
+        const [selected, setSelected] = React.useState<SelectPanelProps['items']>([])
+        const [filter, setFilter] = React.useState('')
+        const [open, setOpen] = React.useState(false)
 
-          const onSelectedChange = (selected: SelectPanelProps['items']) => {
-            setSelected(selected)
-          }
-
-          return (
-            <ThemeProvider>
-              <SelectPanel
-                title="test title"
-                subtitle="test subtitle"
-                items={items.filter(item => item.text?.includes(filter))}
-                placeholder="Select items"
-                placeholderText="Filter items"
-                selected={selected}
-                onSelectedChange={onSelectedChange}
-                filterValue={filter}
-                onFilterChange={value => {
-                  setFilter(value)
-                }}
-                open={open}
-                onOpenChange={isOpen => {
-                  setOpen(isOpen)
-                }}
-              />
-            </ThemeProvider>
-          )
+        const onSelectedChange = (selected: SelectPanelProps['items']) => {
+          setSelected(selected)
         }
 
+        return (
+          <ThemeProvider>
+            <SelectPanel
+              title="test title"
+              subtitle="test subtitle"
+              items={items.filter(item => item.text?.includes(filter))}
+              placeholder="Select items"
+              placeholderText="Filter items"
+              selected={selected}
+              onSelectedChange={onSelectedChange}
+              filterValue={filter}
+              onFilterChange={value => {
+                setFilter(value)
+              }}
+              open={open}
+              onOpenChange={isOpen => {
+                setOpen(isOpen)
+              }}
+            />
+          </ThemeProvider>
+        )
+      }
+
+      describe('filtering', () => {
         it('should filter the list of items when the user types into the input', async () => {
           const user = userEvent.setup()
 
@@ -381,10 +382,67 @@ for (const useModernActionList of [false, true]) {
           await user.type(document.activeElement!, 'two')
           expect(screen.getAllByRole('option')).toHaveLength(1)
         })
+      })
 
-        it.todo('should announce the number of results')
+      describe('screen reader announcements', () => {
+        // this is only implemented with the feature flag
+        if (!useModernActionList) return
 
-        it.todo('should announce when no results are available')
+        it('should announce initial focused item', async () => {
+          const user = userEvent.setup()
+          renderWithFlag(<FilterableSelectPanel />, useModernActionList)
+
+          await user.click(screen.getByText('Select items'))
+          expect(screen.getByLabelText('Filter items')).toHaveFocus()
+
+          // we wait because announcement is intentionally updated after a timeout to not interrupt user input
+          await waitFor(async () => {
+            expect(getLiveRegion().getMessage('polite')).toBe(
+              'Focus on filter text box and list of labels, Focused item: item one, not selected, 1 of 3',
+            )
+          })
+        })
+
+        it('should announce filtered results', async () => {
+          const user = userEvent.setup()
+          renderWithFlag(<FilterableSelectPanel />, useModernActionList)
+
+          await user.click(screen.getByText('Select items'))
+          await user.type(document.activeElement!, 'o')
+          expect(screen.getAllByRole('option')).toHaveLength(2)
+
+          await waitFor(
+            async () => {
+              expect(getLiveRegion().getMessage('polite')).toBe(
+                'List updated, Focused item: item one, not selected, 1 of 2',
+              )
+            },
+            {timeout: 3000}, // increased timeout because we don't want the test to compare with previous announcement
+          )
+
+          await user.type(document.activeElement!, 'ne') // now: one
+          expect(screen.getAllByRole('option')).toHaveLength(1)
+
+          await waitFor(async () => {
+            expect(getLiveRegion().getMessage('polite')).toBe(
+              'List updated, Focused item: item one, not selected, 1 of 1',
+            )
+          })
+        })
+
+        it('should announce when no results are available', async () => {
+          const user = userEvent.setup()
+          renderWithFlag(<FilterableSelectPanel />, useModernActionList)
+
+          await user.click(screen.getByText('Select items'))
+
+          await user.type(document.activeElement!, 'zero')
+          expect(screen.queryByRole('option')).toBeNull()
+
+          await waitFor(async () => {
+            expect(getLiveRegion().getMessage('polite')).toBe('No matching items.')
+          })
+        })
       })
 
       describe('with footer', () => {

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -17,6 +17,7 @@ import type {FocusZoneHookSettings} from '../hooks/useFocusZone'
 import {useId} from '../hooks/useId'
 import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
 import {LiveRegion, LiveRegionOutlet, Message} from '../internal/components/LiveRegion'
+import {useFeatureFlag} from '../FeatureFlags'
 
 interface SelectPanelSingleSelection {
   selected: ItemInput | undefined
@@ -174,6 +175,8 @@ export function SelectPanel({
     }
   }, [inputLabel, textInputProps])
 
+  const usingModernActionList = useFeatureFlag('primer_react_select_panel_with_modern_action_list')
+
   return (
     <LiveRegion>
       <AnchoredOverlay
@@ -192,15 +195,17 @@ export function SelectPanel({
         focusZoneSettings={focusZoneSettings}
       >
         <LiveRegionOutlet />
-        <Message
-          value={
-            filterValue === ''
-              ? 'Showing all items'
-              : items.length <= 0
-              ? 'No matching items'
-              : `${items.length} matching ${items.length === 1 ? 'item' : 'items'}`
-          }
-        />
+        {usingModernActionList ? null : (
+          <Message
+            value={
+              filterValue === ''
+                ? 'Showing all items'
+                : items.length <= 0
+                ? 'No matching items'
+                : `${items.length} matching ${items.length === 1 ? 'item' : 'items'}`
+            }
+          />
+        )}
         <Box sx={{display: 'flex', flexDirection: 'column', height: 'inherit', maxHeight: 'inherit'}}>
           <Box sx={{pt: 2, px: 3}}>
             <Heading as="h1" id={titleId} sx={{fontSize: 1}}>

--- a/packages/react/src/live-region/__tests__/Announce.test.tsx
+++ b/packages/react/src/live-region/__tests__/Announce.test.tsx
@@ -1,15 +1,7 @@
 import {render, screen} from '@testing-library/react'
 import React from 'react'
-import type {LiveRegionElement} from '@primer/live-region-element'
 import {Announce} from '../Announce'
-
-function getLiveRegion(): LiveRegionElement {
-  const liveRegion = document.querySelector('live-region')
-  if (liveRegion) {
-    return liveRegion as LiveRegionElement
-  }
-  throw new Error('No live-region found')
-}
+import {getLiveRegion} from '../../utils/testing'
 
 describe('Announce', () => {
   beforeEach(() => {

--- a/packages/react/src/live-region/__tests__/AriaAlert.test.tsx
+++ b/packages/react/src/live-region/__tests__/AriaAlert.test.tsx
@@ -1,15 +1,7 @@
 import {render, screen} from '@testing-library/react'
 import React from 'react'
-import type {LiveRegionElement} from '@primer/live-region-element'
 import {AriaAlert} from '../AriaAlert'
-
-function getLiveRegion(): LiveRegionElement {
-  const liveRegion = document.querySelector('live-region')
-  if (liveRegion) {
-    return liveRegion as LiveRegionElement
-  }
-  throw new Error('No live-region found')
-}
+import {getLiveRegion} from '../../utils/testing'
 
 describe('AriaAlert', () => {
   beforeEach(() => {

--- a/packages/react/src/live-region/__tests__/AriaStatus.test.tsx
+++ b/packages/react/src/live-region/__tests__/AriaStatus.test.tsx
@@ -1,16 +1,8 @@
 import {render, screen} from '@testing-library/react'
 import React from 'react'
-import type {LiveRegionElement} from '@primer/live-region-element'
 import {AriaStatus} from '../AriaStatus'
 import {userEvent} from '@testing-library/user-event'
-
-function getLiveRegion(): LiveRegionElement {
-  const liveRegion = document.querySelector('live-region')
-  if (liveRegion) {
-    return liveRegion as LiveRegionElement
-  }
-  throw new Error('No live-region found')
-}
+import {getLiveRegion} from '../../utils/testing'
 
 describe('AriaStatus', () => {
   beforeEach(() => {

--- a/packages/react/src/utils/testing.tsx
+++ b/packages/react/src/utils/testing.tsx
@@ -7,6 +7,7 @@ import axe from 'axe-core'
 import customRules from '@github/axe-github'
 import {ThemeProvider} from '..'
 import {default as defaultTheme} from '../theme'
+import type {LiveRegionElement} from '@primer/live-region-element'
 
 type ComputedStyles = Record<string, string | Record<string, string>>
 
@@ -269,4 +270,12 @@ export function checkStoriesForAxeViolations(name: string, storyDir?: string) {
       expect(results).toHaveNoViolations()
     })
   })
+}
+
+export function getLiveRegion(): LiveRegionElement {
+  const liveRegion = document.querySelector('live-region')
+  if (liveRegion) {
+    return liveRegion as LiveRegionElement
+  }
+  throw new Error('No live-region found')
 }


### PR DESCRIPTION
- Fixes https://github.com/github/primer/issues/3409
- Based on https://github.com/github/multi-select-user-testing
- Only available behind feature flag (`primer_react_select_panel_with_modern_action_list`)


#### Context

Browser + screen reader combinations have different default announcements. We are trying to fill in the gaps, which leads to great results for some combinations but redundant/verbose results for others. See notes below for more information.

We shy away from browser + OS (proxy for screen reader) detection to optimise these results, in order to avoid accidentally doing more harm than good. We are choosing redundancy/verbosity over missing information.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

#### Voiceover on MacOS + Safari

Notes: Safari has the least amount of automated announcements, so our additions fill in the gaps very nicely. 
- 🟢 On first open, Safari (default announcements) tells the user about the structure, Then, we inform the user about focus state. 
- 🟢 On updates to results, Safari announces nothing. We inform user about focused item, selection state and number of items 

| Event | Before | After (with custom announcements) |
|---|---|---|
| recording | <video src="https://github.com/user-attachments/assets/56d58511-5649-4a45-beca-9e3f20b6a130"> | <video src="https://github.com/user-attachments/assets/8309359d-0b80-4671-a80a-cd6840bfae99"> | 
| On panel open | Select labels Filter items, web dialogue, with 6 items, Filter items. Items will be filtered as you type, edit text. <br/><br/> | Select labels Filter items, web dialogue, with 6 items, Filter items. Items will be filtered as you type, edit text. <br/> Focus on filter text box and list of items, Focused item: enhancement, selected, 1 of 7 | 
| type letter "b" | _silence_ | List updated, Focused item: bug, selected, 1 of 3 |
| type letter "l" | _silence_ | List updated, Focused item: blocker, not selected, 1 of 1 |
| type letter "a" (no results) | _silence_ | No matching items. |


#### Voiceover on MacOS + Chrome

Notes: Chrome has more automated announcements than Safari, so our additions could sometimes be seen as noisy or redundant
- 🟡 On first open, Chrome (default announcements) tells the user about the structure without any details + the focused item, selection state and number of items. Then, we inform the user about the focused input AND the focused item, selection state and number of items.
- 🟡 On updates to results, Chrome announces the current selected item, selection state and number of items. We also inform the user about focused item, selection state and number of items 

| Event | Before | After (with custom announcements) |
|---|---|---|
| recording | <video src="https://github.com/user-attachments/assets/24dcff67-b342-4e36-87cd-b0b0a6faba1f"> | <video src="https://github.com/user-attachments/assets/4d19fa23-719e-418e-957f-5dec148aa873"> | 
| On panel open | dialogue, with 6 items enhancement selected, selected, (1 of 7)<br/><br/><br/> | dialogue, with 6 items enhancement selected, selected, (1 of 7) <br/> Focus on filter text box and list of labels, Focused item: enhancement, selected, 1 of 7 |
| type letter "b" | bug selected, selected, (1 of 3) <br/><br/><br/> | bug selected, selected, (1 of 3) <br/> List updated, Focused item: bug, selected, 1 of 3 |
| type letter "l" | blocker not selected, selected, (1 of 1) <br/><br/><br/> | blocker not selected, selected, (1 of 1) <br/> List updated, Focused item: blocker, not selected, 1 of 1 |
| type letter "a" (no results) | bla, Insertion at end of text., Filter items Items will be filtered as you type, edit text <br/><br/><br/> | bla, Insertion at end of text., Filter items Items will be filtered as you type, edit text <br/> No matching items. |

#### NVDA on Windows + Edge/Chrome

Notes: NVDA includes more information about the structure, so our additions could sometimes be seen as noisy or redundant. Chrome has the same exact behavior as Edge.
- 🟡 On first open, Edge/Chrome (default announcements) tells the user about the structure + the focused item and number of items, but not it's selection state. Then, we inform the user about the focused input AND the focused item, selection state and number of items.
- 🟢 On updates to results, Edge/Chrome announces the current selected item but not it's selection state or number of items. We also inform the user about focused item, selection state and number of items 

| Event | Before | After (with custom announcements) |
|---|---|---|
| recording | <video src="https://github.com/user-attachments/assets/734dfb76-f69c-4133-b0b6-7de1fffb6d81"> | <video src="https://github.com/user-attachments/assets/c7a5a285-c5b3-4c10-9f73-05c5790d5c1e"> | 
| On panel open | Select labels dialog. Use labels to organize issues and pull requests. <br/>Select labels list. <br/> enhancement 1 of 7<br/><br/><br/> |  Select labels dialog. Use labels to organize issues and pull requests. <br/> Select labels list. <br/> enhancement 1 of 7 <br/> Focus on filter text box and list of labels, Focused item: enhancement, selected, 1 of 7 |
| type letter "b" | b. bug <br/><br/> | b. bug. <br/> List updated, Focused item: bug, selected, 1 of 3 |
| type letter "l" | l. blocker, not selected<br/><br/> | l. blocker, not selected. <br/> List updated, Focused item: blocker, not selected, 1 of 1 |
| type letter "a" (no results) | a. Filter items edit Items will be filtered as you type, bla<br/><br/> | a. Filter items edit Items will be filtered as you type, bla. <br/> No matching items. |

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
