### PR TITLE
Moving Heading feature flag from staff ship to team ship

### DIFF
--- a/e2e/components/Heading.test.ts
+++ b/e2e/components/Heading.test.ts
@@ -28,7 +28,7 @@ test.describe('Heading', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_staff: true,
+              primer_react_css_modules_ga: true,
             },
           },
         })
@@ -51,7 +51,7 @@ test.describe('Heading', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_staff: true,
+              primer_react_css_modules_ga: true,
             },
           },
         })

--- a/packages/react/src/Heading/Heading.tsx
+++ b/packages/react/src/Heading/Heading.tsx
@@ -37,7 +37,7 @@ const StyledHeading = styled.h2<StyledHeadingProps>`
 `
 
 const Heading = forwardRef(({as: Component = 'h2', className, variant, ...props}, forwardedRef) => {
-  const enabled = useFeatureFlag('primer_react_css_modules_staff')
+  const enabled = useFeatureFlag('primer_react_css_modules_ga')
   const innerRef = React.useRef<HTMLHeadingElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, innerRef)
 

--- a/packages/react/src/Heading/__tests__/Heading.test.tsx
+++ b/packages/react/src/Heading/__tests__/Heading.test.tsx
@@ -142,12 +142,12 @@ describe('Heading', () => {
     ).toHaveStyleRule('font-style', 'italic')
   })
 
-  describe('with primer_react_css_modules_staff enabled', () => {
+  describe('with primer_react_css_modules_ga enabled', () => {
     it('should only include css modules class', () => {
       HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
+            primer_react_css_modules_ga: true,
           }}
         >
           <Heading>test</Heading>
@@ -163,7 +163,7 @@ describe('Heading', () => {
       const {container} = HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
+            primer_react_css_modules_ga: true,
           }}
         >
           <Heading className="test">test</Heading>
@@ -176,7 +176,7 @@ describe('Heading', () => {
       HTMLRender(
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
+            primer_react_css_modules_ga: true,
           }}
         >
           <Heading


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/3716

### Changelog

#### Changed

The feature flag for Heading changed from `primer_react_css_modules_staff` to `primer_react_css_modules_ga`

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why
