### PR TITLE
SelectPanel: add `role=combobox` to filter input

### DIFF
--- a/.changeset/green-poems-play.md
+++ b/.changeset/green-poems-play.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+SelectPanel: Add `role=combobox` to filter input (behind feature flag `primer_react_select_panel_with_modern_action_list`)

--- a/packages/react/src/FilteredActionList/FilteredActionListWithModernActionList.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionListWithModernActionList.tsx
@@ -138,8 +138,11 @@ export function FilteredActionList({
           onChange={onInputChange}
           onKeyPress={onInputKeyPress}
           placeholder={placeholderText}
-          aria-label={placeholderText}
+          role="combobox"
+          aria-expanded="true"
+          aria-autocomplete="list"
           aria-controls={listId}
+          aria-label={placeholderText}
           aria-describedby={inputDescriptionTextId}
           {...textInputProps}
         />


### PR DESCRIPTION
- Fixes https://github.com/github/primer/issues/3408
- Only available behind feature flag (`primer_react_select_panel_with_modern_action_list`)

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release (behind feature flag)
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

### Testing & Reviewing

tl;dr: The only diff is on Voiceover on MacOS for the screen reader announcement when the panel is opened. (no difference on other browsers or on Windows + NVDA)

```diff
// without combobox:
Select labels. Filter items, web dialogue, with 6 items. Filter items. 
Items will be filtered as you type, edit text

// without combobox:
Select labels. Filter items, web dialogue, with 6 items. Filter items. 
+ Items will be filtered as you type, list box pop-up. Menu pop-up combo box
```

Full details:

#### Voiceover on MacOS (diff on Safari)

| Without combobox | With combobox |
|--------|--------|
| <b>Voiceover on Safari</b> | <b>Voiceover on Safari</b> |
| Select labels. Filter items, web dialogue, with 6 items. Filter items. Items will be filtered as you type, 🟥 edit text | Select labels. Filter items, web dialogue, with 6 items. Filter items. Items will be filtered as you type, 🟩 list box pop-up. Menu pop-up combo box |
| <details><summary>see+listen video</summary><video src="https://github.com/user-attachments/assets/b0a93a06-07bf-4455-9c6b-b40f6952d2ed"><details> | <details><summary>see+listen video</summary><video src="https://github.com/user-attachments/assets/68a006d5-cc55-4210-acad-e1eca0f5fda3"></details> |
| <b>Voiceover on Chrome</b> | <b>Voiceover on Chrome (no difference)</b> |
| dialogue, with 6 items enhancement selected, selected, (1 of 7) | dialogue, with 6 items enhancement selected, selected, (1 of 7) |
| <details><summary>see+listen video</summary><video src="https://github.com/user-attachments/assets/c8750ba7-b7c2-468a-b334-e63498dcb3e8"><details> | <details><summary>see+listen video</summary><video src="https://github.com/user-attachments/assets/87f3f04e-733e-4c59-a883-0974352f38f0"><details> |
| <b>Voiceover on Firefox</b> | <b>Voiceover on Firefox (no difference)</b> |
| enhancement, enhancement, selected, (1 of 7) | enhancement, enhancement, selected, (1 of 7) |
| <details><summary>see+hear video</summary><video src="https://github.com/user-attachments/assets/25b57a48-3cbd-4c1d-9f74-82076fd4bde1"><details> | <details><summary>see+hear video</summary><video src="https://github.com/user-attachments/assets/65f8c084-63da-466b-9ac2-34f2acdc792b"><details> |

#### NVDA on Windows (no difference)

| Without combobox | With combobox |
|--------|--------|
| <b>NVDA on Edge</b> | <b>NVDA on Edge</b> |
| Select labels dialog. Use labels to organize issues and pull requests. Select labels list enhancement 1 of 7 | Select labels dialog. Use labels to organize issues and pull requests. Select labels list enhancement 1 of 7 |
| <details><summary>see+hear video</summary><video src="https://github.com/user-attachments/assets/8c056939-af3c-4777-aec5-25ceebcf8d45"><details> | <details><summary>see+hear video</summary><video src="https://github.com/user-attachments/assets/4c6f6dc3-c4e0-4914-bf68-34f2602e58be"><details> |
| <b>NVDA on Chrome</b> | <b>NVDA on Chrome</b> |
| Select labels dialog. Use labels to organize issues and pull requests. Select labels list enhancement 1 of 7 | Select labels dialog. Use labels to organize issues and pull requests. Select labels list enhancement 1 of 7 | 
| <details><summary>see+hear video</summary><video src="https://github.com/user-attachments/assets/edb16983-b31d-4ca8-8e2e-d806a341c282"><details> | <details><summary>see+hear video</summary><video src="https://github.com/user-attachments/assets/e44f6119-e785-4d29-bbee-7bfabdd00bd6"><details> |

