### PR TITLE
Overlay: Add `role="dialog"`, focus trap to `Overlay`

### DIFF
--- a/.changeset/polite-taxis-sin.md
+++ b/.changeset/polite-taxis-sin.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': minor
+---
+
+Overlay: Add `role="dialog"` and `aria-modal="true"` to the `Overlay` component, and implement a focus trap.
+
+

--- a/packages/react/src/Autocomplete/AutocompleteOverlay.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteOverlay.tsx
@@ -53,6 +53,7 @@ function AutocompleteOverlay({
 
   return showMenu ? (
     <Overlay
+      role="none"
       returnFocusRef={inputRef}
       preventFocusOnOpen={true}
       onClickOutside={closeOptionList}

--- a/packages/react/src/Overlay/Overlay.docs.json
+++ b/packages/react/src/Overlay/Overlay.docs.json
@@ -113,6 +113,12 @@
       "description": "If defined, Overlays will be rendered in the named portal. See also `Portal`."
     },
     {
+      "name": "focusTrap",
+      "type": "string",
+      "defaultValue": "true",
+      "description": "Determines if the `Overlay` recieves a focus trap or not"
+    },
+    {
       "name": "sx",
       "type": "SystemStyleObject"
     }

--- a/packages/react/src/Overlay/Overlay.test.tsx
+++ b/packages/react/src/Overlay/Overlay.test.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react'
+import React, {useRef, useState, type AriaRole} from 'react'
 import {Overlay, Box, Text} from '..'
 import {ButtonDanger, Button} from '../deprecated'
 import {render, waitFor, fireEvent} from '@testing-library/react'
@@ -12,8 +12,9 @@ import {NestedOverlays, MemexNestedOverlays, MemexIssueOverlay, PositionedOverla
 type TestComponentSettings = {
   initialFocus?: 'button'
   callback?: () => void
+  role?: AriaRole
 }
-const TestComponent = ({initialFocus, callback}: TestComponentSettings) => {
+const TestComponent = ({initialFocus, callback, role}: TestComponentSettings) => {
   const [isOpen, setIsOpen] = useState(false)
   const buttonRef = useRef<HTMLButtonElement>(null)
   const confirmButtonRef = useRef<HTMLButtonElement>(null)
@@ -39,6 +40,7 @@ const TestComponent = ({initialFocus, callback}: TestComponentSettings) => {
               ignoreClickRefs={[buttonRef]}
               onEscape={closeOverlay}
               onClickOutside={closeOverlay}
+              role={role}
               width="small"
             >
               <Box display="flex" flexDirection="column" p={2}>
@@ -280,5 +282,24 @@ describe('Overlay', () => {
 
     // if stopPropagation worked, mockHandler would not have been called
     expect(mockHandler).toHaveBeenCalledTimes(0)
+  })
+
+  it('should provide `role="dialog"` and `aria-modal="true"`, if role is not provided', async () => {
+    const user = userEvent.setup()
+    const {getByText, getByRole} = render(<TestComponent />)
+
+    await user.click(getByText('open overlay'))
+
+    expect(getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('should not provide `dialog` roles if role is already provided', async () => {
+    const user = userEvent.setup()
+    const {getByText, queryByRole} = render(<TestComponent role="none" />)
+
+    await user.click(getByText('open overlay'))
+
+    expect(queryByRole('dialog')).not.toBeInTheDocument()
+    expect(queryByRole('none')).toBeInTheDocument()
   })
 })

--- a/packages/react/src/Overlay/Overlay.test.tsx
+++ b/packages/react/src/Overlay/Overlay.test.tsx
@@ -1,4 +1,5 @@
-import React, {useRef, useState, type AriaRole} from 'react'
+import React, {useRef, useState} from 'react'
+import type {AriaRole} from '../utils/types'
 import {Overlay, Box, Text} from '..'
 import {ButtonDanger, Button} from '../deprecated'
 import {render, waitFor, fireEvent} from '@testing-library/react'

--- a/packages/react/src/Overlay/Overlay.test.tsx
+++ b/packages/react/src/Overlay/Overlay.test.tsx
@@ -303,4 +303,13 @@ describe('Overlay', () => {
     expect(queryByRole('dialog')).not.toBeInTheDocument()
     expect(queryByRole('none')).toBeInTheDocument()
   })
+
+  it('should add `aria-modal` if `role="dialog"` is present', async () => {
+    const user = userEvent.setup()
+    const {getByText, queryByRole} = render(<TestComponent role="dialog" />)
+
+    await user.click(getByText('open overlay'))
+
+    expect(queryByRole('dialog')).toHaveAttribute('aria-modal')
+  })
 })

--- a/packages/react/src/Overlay/Overlay.tsx
+++ b/packages/react/src/Overlay/Overlay.tsx
@@ -110,6 +110,7 @@ type BaseOverlayProps = {
   portalContainerName?: string
   preventFocusOnOpen?: boolean
   role?: AriaRole
+  focusTrap?: boolean
   children?: React.ReactNode
 }
 
@@ -134,6 +135,7 @@ type OwnOverlayProps = Merge<StyledOverlayProps, BaseOverlayProps>
  * @param bottom Optional. Vertical bottom position of the overlay, relative to its closest positioned ancestor (often its `Portal`).
  * @param position Optional. Sets how an element is positioned in a document. Defaults to `absolute` positioning.
  * @param portalContainerName Optional. The name of the portal container to render the Overlay into.
+ * @param focusTrap Optional. Determines if the `Overlay` recieves a focus trap or not. Defaults to `true`.
  */
 const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
   (
@@ -156,6 +158,7 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
       preventFocusOnOpen,
       position,
       style: styleFromProps = {},
+      focusTrap = true,
       ...rest
     },
     forwardedRef,
@@ -201,8 +204,11 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
     // To be backwards compatible with the old Overlay, we need to set the left prop if x-position is not specified
     const leftPosition: React.CSSProperties = left === undefined && right === undefined ? {left: 0} : {left}
 
-    const {containerRef} = useFocusTrap({
+    const dialog = role && role !== 'dialog' ? true : false
+
+    useFocusTrap({
       containerRef: overlayRef, // only if `role="dialog"`, `aria-modal="true"` is true
+      disabled: !focusTrap || dialog,
     })
 
     return (
@@ -211,6 +217,7 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
           height={height}
           width={width}
           role={role || 'dialog'}
+          aria-modal={dialog ? undefined : 'true'}
           {...rest}
           ref={overlayRef}
           style={

--- a/packages/react/src/Overlay/Overlay.tsx
+++ b/packages/react/src/Overlay/Overlay.tsx
@@ -13,6 +13,7 @@ import {useRefObjectAsForwardedRef} from '../hooks/useRefObjectAsForwardedRef'
 import type {AnchorSide} from '@primer/behaviors'
 import {useTheme} from '../ThemeProvider'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
+import {useFocusTrap} from '../hooks/useFocusTrap'
 
 type StyledOverlayProps = {
   width?: keyof typeof widthMap
@@ -138,7 +139,7 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
   (
     {
       onClickOutside,
-      role = 'none',
+      role,
       initialFocusRef,
       returnFocusRef,
       ignoreClickRefs,
@@ -200,12 +201,16 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
     // To be backwards compatible with the old Overlay, we need to set the left prop if x-position is not specified
     const leftPosition: React.CSSProperties = left === undefined && right === undefined ? {left: 0} : {left}
 
+    const {containerRef} = useFocusTrap({
+      containerRef: overlayRef, // only if `role="dialog"`, `aria-modal="true"` is true
+    })
+
     return (
       <Portal containerName={portalContainerName}>
         <StyledOverlay
           height={height}
           width={width}
-          role={role}
+          role={role || 'dialog'}
           {...rest}
           ref={overlayRef}
           style={

--- a/packages/react/src/Overlay/Overlay.tsx
+++ b/packages/react/src/Overlay/Overlay.tsx
@@ -207,7 +207,7 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
     const dialog = role && role !== 'dialog' ? true : false
 
     useFocusTrap({
-      containerRef: overlayRef, // only if `role="dialog"`, `aria-modal="true"` is true
+      containerRef: overlayRef,
       disabled: !focusTrap || dialog,
     })
 

--- a/packages/react/src/Overlay/Overlay.tsx
+++ b/packages/react/src/Overlay/Overlay.tsx
@@ -204,11 +204,11 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
     // To be backwards compatible with the old Overlay, we need to set the left prop if x-position is not specified
     const leftPosition: React.CSSProperties = left === undefined && right === undefined ? {left: 0} : {left}
 
-    const dialog = role && role !== 'dialog' ? true : false
+    const nonDialog = role && role !== 'dialog' ? true : false
 
     useFocusTrap({
       containerRef: overlayRef,
-      disabled: !focusTrap || dialog,
+      disabled: !focusTrap || nonDialog,
     })
 
     return (
@@ -217,7 +217,7 @@ const Overlay = React.forwardRef<HTMLDivElement, OwnOverlayProps>(
           height={height}
           width={width}
           role={role || 'dialog'}
-          aria-modal={dialog ? undefined : 'true'}
+          aria-modal={nonDialog ? undefined : 'true'}
           {...rest}
           ref={overlayRef}
           style={


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3378

Usages of `Overlay` tend to lean more towards a dialog across GH. This PR aims to define it as a `dialog` in most cases, provided with a focus trap that's toggled via the newly added `focusTrap` prop.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

* Add `role="dialog"` and `aria-modal="true"` to `Overlay` component

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [x] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
