### PR TITLE
Add gap to progressbar with multiple sections

### DIFF
--- a/.changeset/stale-pets-tan.md
+++ b/.changeset/stale-pets-tan.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Adding default gap between sections for progressbars with more than one section

--- a/.changeset/stale-pets-tan.md
+++ b/.changeset/stale-pets-tan.md
@@ -2,4 +2,4 @@
 '@primer/react': patch
 ---
 
-Adding default gap between sections for progressbars with more than one section
+ProgressBar: Adding default gap between sections for progressbars with more than one section

--- a/packages/react/src/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/react/src/ProgressBar/ProgressBar.stories.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import type {Meta, StoryFn} from '@storybook/react'
-import {ProgressBar} from '..'
+import type {Meta} from '@storybook/react'
+import {ProgressBar, type ProgressBarProps} from '..'
+
+const sectionColors = ['success.emphasis', 'done.emphasis', 'severe.emphasis', 'danger.emphasis', 'attention.emphasis']
 
 export default {
   title: 'Components/ProgressBar',
@@ -9,15 +11,26 @@ export default {
 
 export const Default = () => <ProgressBar aria-label="Upload test.png" />
 
-export const Playground: StoryFn<typeof ProgressBar> = args => (
-  <ProgressBar {...args} sx={args.inline ? {width: '100px'} : {}} aria-label="Upload test.png" />
-)
+export const Playground = ({sections, ...args}: ProgressBarProps & {sections: number}) => {
+  if (sections === 1) {
+    return <ProgressBar {...args} sx={args.inline ? {width: '100px'} : {}} aria-label="Upload test.png" />
+  } else {
+    return (
+      <ProgressBar aria-label="Upload test.png">
+        {[...Array(sections).keys()].map(i => (
+          <ProgressBar.Item key={i} progress={100 / sections} sx={{bg: sectionColors[i]}} />
+        ))}
+      </ProgressBar>
+    )
+  }
+}
 
 Playground.args = {
   progress: 66,
   barSize: 'default',
   inline: false,
   bg: 'success.emphasis',
+  sections: 1,
 }
 
 Playground.argTypes = {
@@ -35,6 +48,14 @@ Playground.argTypes = {
   inline: {
     control: {
       type: 'boolean',
+    },
+  },
+  sections: {
+    control: {
+      type: 'number',
+      min: 1,
+      max: 5,
+      step: 1,
     },
   },
 }

--- a/packages/react/src/ProgressBar/ProgressBar.tsx
+++ b/packages/react/src/ProgressBar/ProgressBar.tsx
@@ -52,7 +52,7 @@ const ProgressContainer = styled.span<StyledProgressContainerProps>`
   background-color: ${get('colors.border.default')};
   border-radius: ${get('radii.1')};
   height: ${props => sizeMap[props.barSize || 'default']};
-
+  gap: '2px';
   ${width}
   ${sx};
 `

--- a/packages/react/src/ProgressBar/ProgressBar.tsx
+++ b/packages/react/src/ProgressBar/ProgressBar.tsx
@@ -52,7 +52,7 @@ const ProgressContainer = styled.span<StyledProgressContainerProps>`
   background-color: ${get('colors.border.default')};
   border-radius: ${get('radii.1')};
   height: ${props => sizeMap[props.barSize || 'default']};
-  gap: '2px';
+  gap: 2px;
   ${width}
   ${sx};
 `

--- a/packages/react/src/__tests__/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/ProgressBar.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ProgressBar respects the "progress" prop 1`] = `
   background-color: var(--borderColor-default,var(--color-border-default,#d0d7de));
   border-radius: 3px;
   height: 8px;
-  gap: '2px';
+  gap: 2px;
 }
 
 @media (prefers-reduced-motion:no-preference) {

--- a/packages/react/src/__tests__/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/ProgressBar.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`ProgressBar respects the "progress" prop 1`] = `
   background-color: var(--borderColor-default,var(--color-border-default,#d0d7de));
   border-radius: 3px;
   height: 8px;
+  gap: '2px';
 }
 
 @media (prefers-reduced-motion:no-preference) {


### PR DESCRIPTION
This bug was mentioned in [slack](https://github.slack.com/archives/CSGAVNZ19/p1726702236854379) and is apparent when looking at the [docs](https://primer.style/components/progress-bar).

**Expected**
When a progressbar has multiple sections, a 2px gap is shown between them.

**Current behavior**
When a progressbar has multiple sections, a **no gap** is shown between them. making them sometimes very hard to distinguish.

![without gap](https://github.com/user-attachments/assets/75a9b80d-0e66-405b-82b5-7478a4c269b0)

### Changelog
- added a 2opx gap when the Progressbar component has children.

| Before | After |
|--------|--------|
| ![before without gap](https://github.com/user-attachments/assets/75a9b80d-0e66-405b-82b5-7478a4c269b0) | ![after with gap](https://github.com/user-attachments/assets/dba2994c-5ac8-4589-9a90-1fefb2b80011) |

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

- added `sections` control to the playground story to allow users to check the difference.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
