### PR TITLE
Popover: Deprecate the caret

### DIFF
--- a/.changeset/tidy-bats-warn.md
+++ b/.changeset/tidy-bats-warn.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Popover: Add note on deprecation of `caret` in v38

--- a/packages/react/src/Popover/Popover.tsx
+++ b/packages/react/src/Popover/Popover.tsx
@@ -20,6 +20,7 @@ type CaretPosition =
   | 'right-top'
 
 type StyledPopoverProps = {
+  /* @deprecated `caret` is deprecated and will be removed in v38. */
   caret?: CaretPosition
   relative?: boolean
   open?: boolean

--- a/packages/react/src/Popover/Popover.tsx
+++ b/packages/react/src/Popover/Popover.tsx
@@ -20,7 +20,9 @@ type CaretPosition =
   | 'right-top'
 
 type StyledPopoverProps = {
-  /* @deprecated `caret` is deprecated and will be removed in v38. */
+  /**
+   * @deprecated `caret` is deprecated and will be removed in v38.
+   */
   caret?: CaretPosition
   relative?: boolean
   open?: boolean


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Prerequisite to https://github.com/primer/react/pull/4978

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

* Add comment on deprecation of `Caret` in v38

<!-- List of things changed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
