### PR TITLE
Moving Label and Text to primer_react_css_modules_staff ship feature flag

### DIFF
--- a/.changeset/big-pumas-sit.md
+++ b/.changeset/big-pumas-sit.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+`Text` component CSS module feature flag changed to `primer_react_css_modules_staff`

--- a/.changeset/serious-sheep-love.md
+++ b/.changeset/serious-sheep-love.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+`Label` component CSS module feature flag changed to `primer_react_css_modules_staff`

--- a/e2e/components/Label.test.ts
+++ b/e2e/components/Label.test.ts
@@ -14,7 +14,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -29,7 +29,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -54,7 +54,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -69,7 +69,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -94,7 +94,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -109,7 +109,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -134,7 +134,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -149,7 +149,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -174,7 +174,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -189,7 +189,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -214,7 +214,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -229,7 +229,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -254,7 +254,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -269,7 +269,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -294,7 +294,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -309,7 +309,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -334,7 +334,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -349,7 +349,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -374,7 +374,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -389,7 +389,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -414,7 +414,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -429,7 +429,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -454,7 +454,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -469,7 +469,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -494,7 +494,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })
@@ -509,7 +509,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_team: enabled,
+                    primer_react_css_modules_staff: enabled,
                   },
                 },
               })

--- a/e2e/components/Text.test.ts
+++ b/e2e/components/Text.test.ts
@@ -46,7 +46,7 @@ test.describe('Text', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_team: true,
+              primer_react_css_modules_staff: true,
             },
           },
         })
@@ -60,7 +60,7 @@ test.describe('Text', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_team: false,
+              primer_react_css_modules_staff: false,
             },
           },
         })
@@ -74,7 +74,7 @@ test.describe('Text', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_team: true,
+              primer_react_css_modules_staff: true,
             },
           },
         })
@@ -86,7 +86,7 @@ test.describe('Text', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_team: false,
+              primer_react_css_modules_staff: false,
             },
           },
         })

--- a/packages/react/src/Label/Label.tsx
+++ b/packages/react/src/Label/Label.tsx
@@ -100,7 +100,7 @@ const StyledLabel = styled.span<LabelProps>`
 `
 
 const Label = React.forwardRef(function Label({as, size = 'small', variant = 'default', className, ...rest}, ref) {
-  const enabled = useFeatureFlag('primer_react_css_modules_team')
+  const enabled = useFeatureFlag('primer_react_css_modules_staff')
   if (enabled) {
     const Component = as || 'span'
     if (rest.sx) {

--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -59,7 +59,7 @@ const StyledText = styled.span<StyledTextProps>`
 `
 
 const Text = forwardRef(({as: Component = 'span', className, size, weight, ...props}, forwardedRef) => {
-  const enabled = useFeatureFlag('primer_react_css_modules_team')
+  const enabled = useFeatureFlag('primer_react_css_modules_staff')
 
   const innerRef = React.useRef<HTMLElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, innerRef)


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/3785
Part of https://github.com/github/primer/issues/3914

### Changelog

#### Changed

* `Label` component CSS module feature flag changed to `primer_react_css_modules_staff`
* `Text` component CSS module feature flag changed to `primer_react_css_modules_staff`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why
