### PR TITLE
Move Text component feature flag from primer_react_css_modules_staff to primer_react_css_modules_ga

### DIFF
--- a/.changeset/long-pans-travel.md
+++ b/.changeset/long-pans-travel.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Move Text component feature flag from primer_react_css_modules_staff to primer_react_css_modules_ga

--- a/e2e/components/Text.test.ts
+++ b/e2e/components/Text.test.ts
@@ -46,7 +46,7 @@ test.describe('Text', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_staff: true,
+              primer_react_css_modules_ga: true,
             },
           },
         })
@@ -60,7 +60,7 @@ test.describe('Text', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_staff: false,
+              primer_react_css_modules_ga: false,
             },
           },
         })
@@ -74,7 +74,7 @@ test.describe('Text', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_staff: true,
+              primer_react_css_modules_ga: true,
             },
           },
         })
@@ -86,7 +86,7 @@ test.describe('Text', () => {
           id: story.id,
           globals: {
             featureFlags: {
-              primer_react_css_modules_staff: false,
+              primer_react_css_modules_ga: false,
             },
           },
         })

--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -59,7 +59,7 @@ const StyledText = styled.span<StyledTextProps>`
 `
 
 const Text = forwardRef(({as: Component = 'span', className, size, weight, ...props}, forwardedRef) => {
-  const enabled = useFeatureFlag('primer_react_css_modules_staff')
+  const enabled = useFeatureFlag('primer_react_css_modules_ga')
 
   const innerRef = React.useRef<HTMLElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, innerRef)


### PR DESCRIPTION
### Changelog

#### Changed

Move Text component feature flag from primer_react_css_modules_staff to primer_react_css_modules_ga

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
