### PR TITLE
Move Label component feature flag from primer_react_css_modules_staff to primer_react_css_modules_ga

### DIFF
--- a/.changeset/silent-planes-grab.md
+++ b/.changeset/silent-planes-grab.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Move Label component feature flag from primer_react_css_modules_staff to primer_react_css_modules_ga

--- a/e2e/components/Label.test.ts
+++ b/e2e/components/Label.test.ts
@@ -14,7 +14,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -29,7 +29,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -54,7 +54,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -69,7 +69,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -94,7 +94,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -109,7 +109,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -134,7 +134,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -149,7 +149,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -174,7 +174,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -189,7 +189,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -214,7 +214,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -229,7 +229,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -254,7 +254,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -269,7 +269,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -294,7 +294,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -309,7 +309,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -334,7 +334,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -349,7 +349,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -374,7 +374,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -389,7 +389,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -414,7 +414,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -429,7 +429,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -454,7 +454,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -469,7 +469,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -494,7 +494,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })
@@ -509,7 +509,7 @@ test.describe('Label', () => {
                 globals: {
                   colorScheme: theme,
                   featureFlags: {
-                    primer_react_css_modules_staff: enabled,
+                    primer_react_css_modules_ga: enabled,
                   },
                 },
               })

--- a/packages/react/src/Label/Label.tsx
+++ b/packages/react/src/Label/Label.tsx
@@ -100,7 +100,7 @@ const StyledLabel = styled.span<LabelProps>`
 `
 
 const Label = React.forwardRef(function Label({as, size = 'small', variant = 'default', className, ...rest}, ref) {
-  const enabled = useFeatureFlag('primer_react_css_modules_staff')
+  const enabled = useFeatureFlag('primer_react_css_modules_ga')
   if (enabled) {
     const Component = as || 'span'
     if (rest.sx) {


### PR DESCRIPTION
### Changelog

#### Changed

Move Label component feature flag from primer_react_css_modules_staff to primer_react_css_modules_ga

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
