### PR TITLE
TextInput: Add `autoComplete` to Storybook/docs

### DIFF
--- a/packages/react/src/TextInput/TextInput.docs.json
+++ b/packages/react/src/TextInput/TextInput.docs.json
@@ -10,8 +10,14 @@
       "name": "aria-label",
       "type": "string",
       "defaultValue": "",
-      "description": "Allows input to be accessible."
+      "description": "Gives the input an accessible name."
     },
+    {
+      "name": "autoComplete",
+      "type": "string",
+      "defaultValue": "",
+      "description": "Allows input to autofill based on value given."
+    }
     {
       "name": "block",
       "type": "boolean",

--- a/packages/react/src/TextInput/TextInput.docs.json
+++ b/packages/react/src/TextInput/TextInput.docs.json
@@ -17,7 +17,7 @@
       "type": "string",
       "defaultValue": "",
       "description": "Allows input to autofill based on value given."
-    }
+    },
     {
       "name": "block",
       "type": "boolean",

--- a/packages/react/src/TextInput/TextInput.features.stories.tsx
+++ b/packages/react/src/TextInput/TextInput.features.stories.tsx
@@ -294,3 +294,16 @@ WithLoadingIndicator.parameters = {
     exclude: [...textInputExcludedControlKeys, 'loaderPosition', ...Object.keys(formControlArgTypes), 'children'],
   },
 }
+
+export const WithAutocompleteAttribute = () => (
+  <Box as="form">
+    <FormControl>
+      <FormControl.Label>First name</FormControl.Label>
+      <TextInput autoComplete="given-name" />
+    </FormControl>
+    <FormControl>
+      <FormControl.Label>Last name</FormControl.Label>
+      <TextInput autoComplete="family-name" />
+    </FormControl>
+  </Box>
+)


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3394

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Utilizing the `autocomplete` attribute is tied to [WCAG SC 1.3.5](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html), and is essential for inputs that can be mapped to a valid autocomplete value. This PR adds a story and documentation for the `autoComplete` prop in the TextInput component to better surface this attribute. More context at https://github.com/primer/design/pull/867.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

* Adds `autocomplete` attribute to docs
* Add specific story for `autoComplete` prop in `TextInput`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
