### PR TITLE
Tooltip: Do not export all types publicly in the experimental bundle

### DIFF
--- a/.changeset/eight-avocados-lick.md
+++ b/.changeset/eight-avocados-lick.md
@@ -1,5 +1,5 @@
 ---
-"@primer/react": patch
+"@primer/react": minor
 ---
 
 Tooltip: Do not export all types publicly in the experimental bundle

--- a/.changeset/eight-avocados-lick.md
+++ b/.changeset/eight-avocados-lick.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Tooltip: Do not export all types publicly in the experimental bundle

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -123,7 +123,7 @@ const StyledTooltip = styled.span`
   ${sx};
 `
 
-export type TooltipDirection = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w'
+type TooltipDirection = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w'
 export type TooltipProps = React.PropsWithChildren<
   {
     direction?: TooltipDirection
@@ -133,7 +133,7 @@ export type TooltipProps = React.PropsWithChildren<
     ComponentProps<typeof StyledTooltip>
 >
 
-export type TriggerPropsType = {
+type TriggerPropsType = {
   'aria-describedby'?: string
   'aria-labelledby'?: string
   'aria-label'?: string

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -123,7 +123,7 @@ const StyledTooltip = styled.span`
   ${sx};
 `
 
-type TooltipDirection = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w'
+export type TooltipDirection = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w'
 export type TooltipProps = React.PropsWithChildren<
   {
     direction?: TooltipDirection

--- a/packages/react/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -317,7 +317,6 @@ exports[`@primer/react/experimental should not update exports without a semver c
   "type TitleProps",
   "Tooltip",
   "type TooltipProps",
-  "type TriggerPropsType",
   "UnderlinePanels",
   "type UnderlinePanelsPanelProps",
   "type UnderlinePanelsProps",

--- a/packages/react/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -316,8 +316,6 @@ exports[`@primer/react/experimental should not update exports without a semver c
   "type TableTitleProps",
   "type TitleProps",
   "Tooltip",
-  "TooltipContext",
-  "type TooltipDirection",
   "type TooltipProps",
   "type TriggerPropsType",
   "UnderlinePanels",

--- a/packages/react/src/experimental/index.ts
+++ b/packages/react/src/experimental/index.ts
@@ -52,7 +52,8 @@ export type {
   NavListDividerProps,
 } from '../NavList'
 export * from './SelectPanel2'
-export * from '../TooltipV2'
+export {Tooltip} from '../TooltipV2'
+export type {TooltipProps} from '../TooltipV2'
 export * from '../ActionBar'
 
 export {ScrollableRegion} from '../ScrollableRegion'


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

- We don't need to export `TriggerPropsType` since it is only used in Tooltip component. 

<!-- List of things changed in this PR -->

#### Removed

- Remove `TriggerPropsType`, `TooltipContext`, `TooltipDirection` from the experimental export

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release 
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->


