### PR TITLE
bugFix: When the feature flag is enabled and sx prop is passed in use, Box

### DIFF
--- a/.changeset/plenty-books-agree.md
+++ b/.changeset/plenty-books-agree.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+fix for `toggleStyledComponent` utility, When the feature flag is enabled and sx prop is passed in use, Box

--- a/packages/react/src/internal/utils/__tests__/toggleStyledComponent.test.tsx
+++ b/packages/react/src/internal/utils/__tests__/toggleStyledComponent.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import {render} from '@testing-library/react'
+import {FeatureFlags} from '../../../FeatureFlags'
+import {toggleStyledComponent} from '../toggleStyledComponent'
+import styled from 'styled-components'
+
+describe('toggleStyledComponent', () => {
+  test('renders the `as` prop when flag is enabled', () => {
+    const TestComponent = toggleStyledComponent('testFeatureFlag', () => <div />)
+    const {container} = render(
+      <FeatureFlags flags={{testFeatureFlag: true}}>
+        <TestComponent as="button" />
+      </FeatureFlags>,
+    )
+    expect(container.firstChild).toBeInstanceOf(HTMLButtonElement)
+  })
+
+  test('renders a div as fallback when flag is enabled and no `as` prop is provided', () => {
+    const TestComponent = toggleStyledComponent('testFeatureFlag', () => <div />)
+    const {container} = render(
+      <FeatureFlags flags={{testFeatureFlag: true}}>
+        <TestComponent />
+      </FeatureFlags>,
+    )
+    expect(container.firstChild).toBeInstanceOf(HTMLDivElement)
+  })
+
+  test('renders Box with `as` if `sx` is provided and flag is enabled', () => {
+    const TestComponent = toggleStyledComponent('testFeatureFlag', () => styled.div``)
+    const {container} = render(
+      <FeatureFlags flags={{testFeatureFlag: true}}>
+        <TestComponent sx={{color: 'red'}} />
+      </FeatureFlags>,
+    )
+
+    expect(container.firstChild).toHaveStyle('color: red')
+  })
+
+  test('renders styled component when flag is disabled', () => {
+    const StyledComponent = toggleStyledComponent('testFeatureFlag', styled.div.attrs({['data-styled']: true})``)
+    const {container} = render(
+      <FeatureFlags flags={{testFeatureFlag: false}}>
+        <StyledComponent />
+      </FeatureFlags>,
+    )
+    expect(container.firstChild).toHaveAttribute('data-styled')
+  })
+})

--- a/packages/react/src/internal/utils/__tests__/toggleStyledComponent.test.tsx
+++ b/packages/react/src/internal/utils/__tests__/toggleStyledComponent.test.tsx
@@ -29,10 +29,11 @@ describe('toggleStyledComponent', () => {
     const TestComponent = toggleStyledComponent('testFeatureFlag', () => styled.div``)
     const {container} = render(
       <FeatureFlags flags={{testFeatureFlag: true}}>
-        <TestComponent sx={{color: 'red'}} />
+        <TestComponent as="button" sx={{color: 'red'}} />
       </FeatureFlags>,
     )
 
+    expect(container.firstChild).toBeInstanceOf(HTMLButtonElement)
     expect(container.firstChild).toHaveStyle('color: red')
   })
 

--- a/packages/react/src/internal/utils/toggleStyledComponent.tsx
+++ b/packages/react/src/internal/utils/toggleStyledComponent.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 import {useFeatureFlag} from '../../FeatureFlags'
+import Box from '../../Box'
+import {defaultSxProp} from '../../utils/defaultSxProp'
 
 type CSSModulesProps = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   as?: string | React.ComponentType<any>
+  sx?: React.CSSProperties
 }
 
 /**
@@ -18,12 +21,18 @@ type CSSModulesProps = {
  * is disabled
  */
 export function toggleStyledComponent<T, P extends CSSModulesProps>(flag: string, Component: React.ComponentType<P>) {
-  const Wrapper = React.forwardRef<T, P>(function Wrapper({as: BaseComponent = 'div', ...rest}, ref) {
+  const Wrapper = React.forwardRef<T, P>(function Wrapper(
+    {as: BaseComponent = 'div', sx: sxProp = defaultSxProp, ...rest},
+    ref,
+  ) {
     const enabled = useFeatureFlag(flag)
     if (enabled) {
+      if (sxProp !== defaultSxProp) {
+        return <Box as={BaseComponent} {...rest} sx={sxProp} ref={ref} />
+      }
       return <BaseComponent {...rest} ref={ref} />
     }
-    return <Component as={BaseComponent} {...(rest as P)} ref={ref} />
+    return <Component as={BaseComponent} {...(rest as P)} sx={sxProp} ref={ref} />
   })
 
   return Wrapper


### PR DESCRIPTION
Fixes an issue when the flag is enabled and an sx prop is passed in, we want to still process the sx.

### Changelog

#### Changed

When the feature flag is enabled and sx prop is passed in use the Box component

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
