### PR TITLE
feat(react): add useFeatureFlag to experimental entrypoint

### DIFF
--- a/.changeset/silent-fireants-kneel.md
+++ b/.changeset/silent-fireants-kneel.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Add the `useFeatureFlag` hook to `@primer/react/experimental`

--- a/packages/react/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -324,6 +324,7 @@ exports[`@primer/react/experimental should not update exports without a semver c
   "type UnderlinePanelsPanelProps",
   "type UnderlinePanelsProps",
   "type UnderlinePanelsTabProps",
+  "useFeatureFlag",
   "useOverflow",
   "useSlots",
 ]

--- a/packages/react/src/experimental/index.ts
+++ b/packages/react/src/experimental/index.ts
@@ -68,7 +68,7 @@ export {UnderlinePanels} from './UnderlinePanels'
 export type {UnderlinePanelsProps, UnderlinePanelsTabProps, UnderlinePanelsPanelProps} from './UnderlinePanels'
 
 export {SkeletonBox, SkeletonText, SkeletonAvatar} from './Skeleton'
-export {FeatureFlags, DefaultFeatureFlags} from '../FeatureFlags'
+export {FeatureFlags, DefaultFeatureFlags, useFeatureFlag} from '../FeatureFlags'
 export type {FeatureFlagsProps} from '../FeatureFlags'
 
 export {FilteredActionList} from '../FilteredActionList'


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This is a follow-up to removing wildcard entrypoints from Primer React. In the latest version of dotcom, we are seeing usage of `useFeatureFlag` that we are now adding to the experimental entrypoint.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add `useFeatureFlag` to the experimental entrypoint

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release
