### PR TITLE
Bug fix(Avatar): Changed rounded border calculation for the "square" Avatar to better align with existing border styles

### DIFF
--- a/.changeset/large-plants-unite.md
+++ b/.changeset/large-plants-unite.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Bug fix(Avatar): Changed rounded border calculation for the "square" Avatar to better align with existing border styles

--- a/packages/react/src/Avatar/Avatar.module.css
+++ b/packages/react/src/Avatar/Avatar.module.css
@@ -13,7 +13,8 @@
   box-shadow: 0 0 0 1px var(--avatar-borderColor);
 
   &:where([data-square]) {
-    border-radius: var(--borderRadius-medium);
+    /* stylelint-disable-next-line primer/borders */
+    border-radius: clamp(4px, calc(var(--avatarSize-regular) - 24px), var(--borderRadius-medium));
   }
 
   &:where([data-responsive]) {


### PR DESCRIPTION
Fixes an issue I noticed in #5070 where the rounded corners of the "square" Avatar don't match the unflagged version.

You can see the problem this change is trying to fix in the Header storybook example with [flag off](https://primer-fe2b40caf3-13348165.drafts.github.io/storybook/iframe.html?args=&globals=&id=components-header--default) vs with [staff flag](https://primer-fe2b40caf3-13348165.drafts.github.io/storybook/iframe.html?args=&globals=featureFlags.primer_react_css_modules_staff:!true&id=components-header--default).

### Changelog

#### Changed

Changed rounded border calculation for the "square" Avatar to better align with existing border styles

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
