### PR TITLE
bugFix:(IconButton) Set the min-width of IconButton to unset

### DIFF
--- a/.changeset/dull-beans-dance.md
+++ b/.changeset/dull-beans-dance.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Set the `min-width` of `IconButton` to `unset` to resolve layout issues.

--- a/packages/react/src/Button/ButtonBase.module.css
+++ b/packages/react/src/Button/ButtonBase.module.css
@@ -71,7 +71,7 @@
   &:where(.IconButton) {
     display: inline-grid;
     width: var(--control-medium-size);
-    min-width: var(--control-medium-size);
+    min-width: unset;
     /* stylelint-disable-next-line primer/spacing */
     padding: unset;
     place-content: center;


### PR DESCRIPTION
This bug was found as part of #5070 and manifested in production as some bugs in the Sub-issues drag-n-drop buttons.

You can see the problem this change is trying to fix in the updated Storybook examples for the ActionBar with the [flag off](https://primer-fe2b40caf3-13348165.drafts.github.io/storybook/iframe.html?args=&globals=&id=experimental-components-actionbar--comment-box) vs [staff flag on](https://primer-fe2b40caf3-13348165.drafts.github.io/storybook/iframe.html?args=&globals=featureFlags.primer_react_css_modules_staff:!true&id=experimental-components-actionbar--comment-box).

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

Set the `min-width` of `IconButton` to `unset` to resolve layout issues.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
