### PR TITLE
Bug Fix for Text component and styled system arguments

### DIFF
--- a/.changeset/wet-apples-hide.md
+++ b/.changeset/wet-apples-hide.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Correctly pass styled system typography and common props to the `Box` component in the `Text` component when the CSS modules feature flag is enabled.

--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -63,7 +63,7 @@ const TYPOGRAPHY_PROP_NAMES = new Set(Object.keys(TYPOGRAPHY))
 
 const includesSystemProps = (props: StyledTextProps) => {
   if (props.sx) {
-    return true;
+    return true
   }
 
   return Object.keys(props).some(prop => {

--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -58,14 +58,21 @@ const StyledText = styled.span<StyledTextProps>`
   ${sx};
 `
 
+const includesSystemProps = (props: StyledTextProps) => {
+  return (
+    props.sx ||
+    Object.keys(props).some(prop => Object.keys(TYPOGRAPHY).includes(prop) || Object.keys(COMMON).includes(prop))
+  )
+}
+
 const Text = forwardRef(({as: Component = 'span', className, size, weight, ...props}, forwardedRef) => {
   const enabled = useFeatureFlag('primer_react_css_modules_ga')
 
   const innerRef = React.useRef<HTMLElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, innerRef)
-
   if (enabled) {
-    if (props.sx) {
+    // If props includes TYPOGRAPHY or COMMON props, pass them to the Box component
+    if (includesSystemProps(props)) {
       return (
         // @ts-ignore shh
         <Box
@@ -81,7 +88,6 @@ const Text = forwardRef(({as: Component = 'span', className, size, weight, ...pr
     }
 
     return (
-      // @ts-ignore shh
       <Component
         className={clsx(className, classes.Text)}
         data-size={size}
@@ -94,7 +100,6 @@ const Text = forwardRef(({as: Component = 'span', className, size, weight, ...pr
   }
 
   return (
-    // @ts-ignore shh
     <StyledText
       as={Component}
       className={className}

--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -58,17 +58,17 @@ const StyledText = styled.span<StyledTextProps>`
   ${sx};
 `
 
-const COMMON_PROP_NAMES = new Set(Object.keys(COMMON));
-const TYPOGRAPHY_PROP_NAMES = new Set(Object.keys(TYPOGRAPHY));
+const COMMON_PROP_NAMES = new Set(Object.keys(COMMON))
+const TYPOGRAPHY_PROP_NAMES = new Set(Object.keys(TYPOGRAPHY))
 
 const includesSystemProps = (props: StyledTextProps) => {
   if (props.sx) {
     return true;
   }
-  
-  return Object.keys(props).some((prop) => {
-    return TYPOGRAPHY_PROP_NAMES.has(prop) ?? COMMON_PROP_NAMES.has(prop)
-  });
+
+  return Object.keys(props).some(prop => {
+    return TYPOGRAPHY_PROP_NAMES.has(prop) || COMMON_PROP_NAMES.has(prop)
+  })
 }
 
 const Text = forwardRef(({as: Component = 'span', className, size, weight, ...props}, forwardedRef) => {

--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -58,11 +58,17 @@ const StyledText = styled.span<StyledTextProps>`
   ${sx};
 `
 
+const COMMON_PROP_NAMES = new Set(Object.keys(COMMON));
+const TYPOGRAPHY_PROP_NAMES = new Set(Object.keys(TYPOGRAPHY));
+
 const includesSystemProps = (props: StyledTextProps) => {
-  return (
-    props.sx ||
-    Object.keys(props).some(prop => Object.keys(TYPOGRAPHY).includes(prop) || Object.keys(COMMON).includes(prop))
-  )
+  if (props.sx) {
+    return true;
+  }
+  
+  return Object.keys(props).some((prop) => {
+    return TYPOGRAPHY_PROP_NAMES.has(prop) ?? COMMON_PROP_NAMES.has(prop)
+  });
 }
 
 const Text = forwardRef(({as: Component = 'span', className, size, weight, ...props}, forwardedRef) => {


### PR DESCRIPTION
This was discovered in #5070. The `Text` component wasn't doing anything with styled system typography or common props. This PR adds logic to ensure that these props are correctly passed to the `Box` component when the `Text` component is used with the CSS modules feature flag enabled.

You can observe the bug by visiting the SegmentedControl storybook example with [flag off](https://primer-fe2b40caf3-13348165.drafts.github.io/storybook/iframe.html?args=&globals=&id=components-segmentedcontrol-features--associated-with-a-label-and-caption) vs [flag on](https://primer-fe2b40caf3-13348165.drafts.github.io/storybook/iframe.html?args=&globals=featureFlags.primer_react_css_modules_team:!true;featureFlags.primer_react_css_modules_staff:!true;featureFlags.primer_react_css_modules_ga:!true&id=components-segmentedcontrol-features--associated-with-a-label-and-caption).

### Changelog

#### Changed

Correctly pass styled system typography and common props to the `Box` component in the `Text` component when the CSS modules feature flag is enabled.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
