### PR TITLE
Try running vrt and aat on 16 core runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         run: npm run build -ws --if-present
 
   vrt-runner:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     strategy:
       fail-fast: false
       matrix:
@@ -180,7 +180,7 @@ jobs:
         run: exit 1
 
   vrt-runner-all-flags:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     strategy:
       fail-fast: false
       matrix:
@@ -258,7 +258,7 @@ jobs:
         run: exit 1
 
   aat-runner:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     strategy:
       fail-fast: false
       matrix:
@@ -332,7 +332,7 @@ jobs:
         run: exit 1
 
   aat-runner-all-flags:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We have `ubuntu-latest-16-cores` in primer, so I thought I'd give changing this a try. The jobs do seem faster, and we have 20 jobs we can run at a time. https://github.com/organizations/primer/settings/actions/github-hosted-runners/3?viewing_from_runner_group=false