### PR TITLE
Docs(TooltipV2): dialog trigger story: accessibility improvements

### DIFF
--- a/packages/react/src/TooltipV2/Tooltip.examples.stories.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.examples.stories.tsx
@@ -161,7 +161,7 @@ export const DialogTrigger = () => {
   return (
     <>
       <Tooltip text="Ready to merge">
-        <IconButton ref={buttonRef} onClick={() => setIsOpen(!isOpen)} icon={CheckIcon} aria-label="Ready to merge" />
+        <IconButton ref={buttonRef} onClick={() => setIsOpen(!isOpen)} icon={CheckIcon} aria-label="Merge" />
       </Tooltip>
       {isOpen && (
         <Dialog

--- a/packages/react/src/TooltipV2/Tooltip.examples.stories.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.examples.stories.tsx
@@ -161,7 +161,7 @@ export const DialogTrigger = () => {
   return (
     <>
       <Tooltip text="Ready to merge">
-        <IconButton ref={buttonRef} onClick={() => setIsOpen(!isOpen)} icon={CheckIcon} aria-label="Check mark" />
+        <IconButton ref={buttonRef} onClick={() => setIsOpen(!isOpen)} icon={CheckIcon} aria-label="Ready to merge" />
       </Tooltip>
       {isOpen && (
         <Dialog
@@ -170,7 +170,7 @@ export const DialogTrigger = () => {
           footerButtons={[
             {buttonType: 'default', content: 'Open Second Dialog', onClick: openSecondDialog},
             {buttonType: 'danger', content: 'Delete the universe', onClick: onDialogClose},
-            {buttonType: 'primary', content: 'Proceed', onClick: openSecondDialog, autoFocus: true},
+            {buttonType: 'primary', content: 'Proceed', onClick: openSecondDialog},
           ]}
         >
           The icon button that triggers the dialog, takes the focus back when the dialog is closed however the the


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3584

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Adds minor accessibility improvements to TooltipV2 Dialog Trigger story by adding a more descriptive aria-label to trigger button and fixing focus order.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->
- Updates trigger icon aria-label to be more descriptive in TooltipV2's `Dialog Trigger` story.
- Removes `autofocus` on TooltipV2's `Dialog Trigger` story to mimic Dialog's stories' focus order functionality.


#### Changed

<!-- List of things changed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

storybook only update

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
