### PR TITLE
Bug fix IconButton width in style prop not working when feature flag is on

### DIFF
--- a/.changeset/silver-cheetahs-compare.md
+++ b/.changeset/silver-cheetahs-compare.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Bug fix for `IconButton` to respect the `style` prop width when the feature flag is on.

--- a/packages/react/src/Button/ButtonBase.module.css
+++ b/packages/react/src/Button/ButtonBase.module.css
@@ -68,7 +68,7 @@
 
   /* IconButton */
 
-  &:where(.IconButton) {
+  &.IconButton {
     display: inline-grid;
     width: var(--control-medium-size);
     min-width: unset;
@@ -78,12 +78,10 @@
 
     &:where([data-size='small']) {
       width: var(--control-small-size);
-      min-width: var(--control-small-size);
     }
 
     &:where([data-size='large']) {
       width: var(--control-large-size);
-      min-width: var(--control-large-size);
     }
   }
 

--- a/packages/react/src/Button/IconButton.dev.stories.tsx
+++ b/packages/react/src/Button/IconButton.dev.stories.tsx
@@ -1,6 +1,7 @@
-import {ChevronDownIcon} from '@primer/octicons-react'
+import {BoldIcon, ChevronDownIcon} from '@primer/octicons-react'
 import React from 'react'
 import {IconButton} from '.'
+import Box from '../Box'
 
 export default {
   title: 'Components/IconButton/DevOnly',
@@ -24,4 +25,16 @@ export const CustomSizeWithMedia = () => {
 
 export const CustomIconColor = () => (
   <IconButton aria-label="Expand" variant="invisible" size="small" icon={ChevronDownIcon} sx={{color: 'red'}} />
+)
+
+export const CustomSizeWithStyleProp = () => (
+  <Box sx={{border: '1px solid', borderColor: 'border.default', display: 'inline-block'}}>
+    <IconButton
+      icon={BoldIcon}
+      aria-label="Bold"
+      size="large"
+      variant="invisible"
+      style={{width: '20px', height: '28px'}}
+    />
+  </Box>
 )


### PR DESCRIPTION
I saw this weird alignment on https://github.com/github/primer/issues/4028 

![CleanShot 2024-10-08 at 16 30 29@2x](https://github.com/user-attachments/assets/41168429-0748-4407-b96a-6aec3dd53412)

Looking into the issue it seems that when `sx` is used with the `IconButton`, the width defined in the `style` prop was being ignored. This PR fixes that by ensuring the `IconButton` respects the width defined in the `style` prop when the feature flag is enabled.

### Changelog

#### Changed

Bug fix for `IconButton` to respect the `style` prop width when the feature flag is on.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
