### PR TITLE
chore: exit prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "codesandbox": "0.0.0",


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Exit prerelease mode for v37 🥳 This change will (hopefully) cause our Release Tracking workflow to officially release v37 for Primer React.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update our `pre.json` file to `exit` mode using `npx changeset pre exit`

#### Removed

<!-- List of things removed in this PR -->
