### PR TITLE
Docs(SplitPageLayout): add PageLayout props to .docs.json

### DIFF
--- a/packages/react/src/SplitPageLayout/SplitPageLayout.docs.json
+++ b/packages/react/src/SplitPageLayout/SplitPageLayout.docs.json
@@ -70,10 +70,20 @@
       "name": "SplitPageLayout.Pane",
       "props": [
         {
+          "name": "aria-label",
+          "type": "string | undefined",
+          "description": "Label for the pane. Required if the pane overflows and doesn't have aria-labelledby."
+        },
+        {
+          "name": "aria-labelledby",
+          "type": "string | undefined",
+          "description": "Id of an element that acts as a label for the pane. Required if the pane overflows and doesn't have aria-label."
+        },
+        {
           "name": "width",
-          "type": "| 'small' | 'medium' | 'large'",
+          "type": "| 'small' | 'medium' | 'large' | { min: string max: string default: string }",
           "defaultValue": "'medium'",
-          "description": "The width of the pane."
+          "description": "The width of the pane. If using custom widths, provide an object with keys 'min', 'max' and 'default'."
         },
         {
           "name": "minWidth",
@@ -116,6 +126,13 @@
           "type": "| 'none' | 'line' | { narrow?: | 'none' | 'line' | 'filled' regular?: | 'none' | 'line' wide?: | 'none' | 'line' }",
           "defaultValue": "'line'",
           "description": ""
+        },
+        {
+          "name": "dividerWhenNarrow",
+          "type": "| 'inherit' | 'none' | 'line' | 'filled'",
+          "defaultValue": "'inherit'",
+          "deprecated": true,
+          "description": "Use the divider prop with a responsive value instead."
         },
         {
           "name": "hidden",

--- a/packages/react/src/SplitPageLayout/SplitPageLayout.docs.json
+++ b/packages/react/src/SplitPageLayout/SplitPageLayout.docs.json
@@ -128,13 +128,6 @@
           "description": ""
         },
         {
-          "name": "dividerWhenNarrow",
-          "type": "| 'inherit' | 'none' | 'line' | 'filled'",
-          "defaultValue": "'inherit'",
-          "deprecated": true,
-          "description": "Use the divider prop with a responsive value instead."
-        },
-        {
           "name": "hidden",
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",

--- a/packages/react/src/SplitPageLayout/SplitPageLayout.features.stories.tsx
+++ b/packages/react/src/SplitPageLayout/SplitPageLayout.features.stories.tsx
@@ -12,7 +12,7 @@ export default {
 
 export const SettingsPage: StoryFn<typeof SplitPageLayout> = () => (
   <SplitPageLayout>
-    <SplitPageLayout.Pane position="start">
+    <SplitPageLayout.Pane position="start" aria-label="Navigation Pane">
       <NavList aria-label="Main navigation">
         <NavList.Item href="#">Profile</NavList.Item>
         <NavList.Item href="#" aria-current="page">

--- a/packages/react/src/SplitPageLayout/SplitPageLayout.stories.tsx
+++ b/packages/react/src/SplitPageLayout/SplitPageLayout.stories.tsx
@@ -390,7 +390,7 @@ export const Default = () => (
     <SplitPageLayout.Header>
       <Placeholder label="Header" height={100} />
     </SplitPageLayout.Header>
-    <SplitPageLayout.Pane position="start">
+    <SplitPageLayout.Pane position="start" aria-label="Pane">
       <Placeholder label="Pane" height={400} />
     </SplitPageLayout.Pane>
     <SplitPageLayout.Content>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/3575

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->
The SplitPageLayout.Pane component is a PageLayout.Pane under the hood and can therefore accept any props that PageLayout.Pane accepts. This PR updates the documentation to reflect some missing props, including `aria-label`, `aria-labelledby`.

This PR also adds `aria-label` to `Pane`s in`SplitPageLayout` stories so that it can be displayed when the content overflows.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->
- Adds `aria-label`, `aria-labelledby` props to `SplitPageLayout.Pane` docs.json file
- Updates type and description of `width` prop in `SplitPageLayout.Pane` docs.json file to more closely match with `PageLayout.Pane` docs
- Adds `aria-label` prop to `Pane`s in `SplitPageLayout` stories

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

Docs only update

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

Navigate to deployed `SplitPageLayout.Pane` story and resize browser so that the pane overflows, verify in the DOM that `aria-label` prop is added, along with tabIndex=0 and role='region'

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
