### PR TITLE
fix(CounterLabel): update styles to work with sx overrides

### DIFF
--- a/.changeset/spicy-pants-breathe.md
+++ b/.changeset/spicy-pants-breathe.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Update CSS styles for CounterLabel to allow overrides for color, background color

--- a/packages/react/src/CounterLabel/CounterLabel.module.css
+++ b/packages/react/src/CounterLabel/CounterLabel.module.css
@@ -9,17 +9,17 @@
   /* stylelint-disable-next-line primer/borders */
   border-radius: 20px;
 
-  &[data-scheme='primary'] {
+  &:where([data-scheme='primary']) {
     color: var(--fgColor-onEmphasis);
     background-color: var(--bgColor-neutral-emphasis);
   }
 
-  &[data-scheme='secondary'] {
+  &:where([data-scheme='secondary']) {
     color: var(--fgColor-default);
     background-color: var(--bgColor-neutral-muted);
   }
 
-  &:empty {
+  &:where(:empty) {
     display: none;
   }
 }

--- a/packages/react/src/CounterLabel/CounterLabel.tsx
+++ b/packages/react/src/CounterLabel/CounterLabel.tsx
@@ -70,21 +70,24 @@ const StyledCounterLabel = styled.span`
   border-radius: 20px;
   border: var(--borderWidth-thin, max(1px, 0.0625rem)) solid var(--counter-borderColor, var(--color-counter-border));
 
-  &[data-scheme='primary'] {
+  &:where([data-scheme='primary']) {
     background-color: ${get('colors.neutral.emphasis')};
     color: ${get('colors.fg.onEmphasis')};
   }
 
-  &[data-scheme='secondary'] {
+  &:where([data-scheme='secondary']) {
     background-color: ${get('colors.neutral.muted')};
     color: ${get('colors.fg.default')};
   }
 
-  &:empty {
+  &:where(:empty) {
     display: none;
   }
 
-  ${sx}
+  /* Place the sx prop styles after previously inserted styles so that it will win out in specificity */
+  & {
+    ${sx}
+  }
 `
 
 CounterLabel.displayName = 'CounterLabel'

--- a/packages/react/src/CounterLabel/__snapshots__/CounterLabel.test.tsx.snap
+++ b/packages/react/src/CounterLabel/__snapshots__/CounterLabel.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`CounterLabel renders with secondary scheme when no "scheme" prop is pro
   border: var(--borderWidth-thin,max(1px,0.0625rem)) solid var(--counter-borderColor,var(--color-counter-border));
 }
 
-.c0:empty {
+.c0:where(:empty) {
   display: none;
 }
 
@@ -64,7 +64,7 @@ exports[`CounterLabel respects the primary "scheme" prop 1`] = `
   border: var(--borderWidth-thin,max(1px,0.0625rem)) solid var(--counter-borderColor,var(--color-counter-border));
 }
 
-.c0:empty {
+.c0:where(:empty) {
   display: none;
 }
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Context https://github.slack.com/archives/C01L618AEP9/p1728656511278919

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Update the styles of `CounterLabel` to work with overrides for color, background color, etc.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Check out the storybook locally
- Update the default story for CounterLabel to use `sx` with overrides for color and background color
- Confirm that the colors match what was given in the override and are not overridden due to specificity