### PR TITLE
chore(project): update lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:components.json": "npm run build:components.json -w @primer/react",
     "lint": "eslint '**/*.{js,ts,tsx,md,mdx}' --max-warnings=0",
     "lint:css": "stylelint '**/*.css' --max-warnings=0",
-    "lint:css:fix": "stylelint --fix '**/*.css'",
+    "lint:css:fix": "npm run lint:css -- --fix",
     "lint:fix": "npm run lint -- --fix",
     "lint:md": "markdownlint-cli2 \"**/*.{md,mdx}\" \"!.github\" \"!.changeset\" \"!**/node_modules/**\" \"!**/CHANGELOG.md\"",
     "test": "jest",
@@ -98,7 +98,13 @@
     }
   ],
   "lint-staged": {
-    "**/*.{js,ts,tsx,md,mdx}": "npm run lint"
-  },
-  "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c"
+    "**/*.{js,ts,tsx,md,mdx}": [
+      "prettier --cache --write",
+      "eslint --cache --max-warnings=0 --fix"
+    ],
+    "**/*.css": [
+      "prettier --cache --write",
+      "stylelint --report-needless-disables --report-invalid-scope-disables --allow-empty-input"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     ],
     "**/*.css": [
       "prettier --cache --write",
-      "stylelint --report-needless-disables --report-invalid-scope-disables --allow-empty-input"
+      "stylelint --report-needless-disables --report-invalid-scope-disables --allow-empty-input --fix"
     ]
   }
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Noticed now that husky is running on the project and that it was using the `npm run lint` task which can take a while when committing 😅 

This PR updates it to use what are (hopefully) different commands that only check on the files being committed and autofixes them.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `lint-staged` config in `package.json` to include checks for ts/css files that use prettier and eslint/stylelint

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->


- [x] None; if selected, include a brief description as to why
