### PR TITLE
feat(FormControl.Label) add `className` prop 

### DIFF
--- a/.changeset/angry-pants-brush.md
+++ b/.changeset/angry-pants-brush.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Add `className` prop to `FormControl.Label` component

--- a/packages/react/src/FormControl/_FormControlLabel.tsx
+++ b/packages/react/src/FormControl/_FormControlLabel.tsx
@@ -11,11 +11,12 @@ export type Props = {
   requiredText?: string
   requiredIndicator?: boolean
   id?: string
+  className?: string
 } & SxProp
 
 const FormControlLabel: React.FC<
   React.PropsWithChildren<{htmlFor?: string} & React.ComponentProps<typeof InputLabel> & Props>
-> = ({as, children, htmlFor, id, visuallyHidden, requiredIndicator = true, requiredText, sx, ...props}) => {
+> = ({as, children, htmlFor, id, visuallyHidden, requiredIndicator = true, requiredText, sx, className, ...props}) => {
   const {disabled, id: formControlId, required} = useFormControlContext()
 
   /**
@@ -26,6 +27,7 @@ const FormControlLabel: React.FC<
       ? {
           as,
           id,
+          className,
           visuallyHidden,
           required,
           requiredText,
@@ -37,6 +39,7 @@ const FormControlLabel: React.FC<
       : {
           as,
           id,
+          className,
           visuallyHidden,
           htmlFor: htmlFor || formControlId,
           required,

--- a/packages/react/src/internal/components/InputLabel.tsx
+++ b/packages/react/src/internal/components/InputLabel.tsx
@@ -10,6 +10,7 @@ type BaseProps = SxProp & {
   requiredIndicator?: boolean
   visuallyHidden?: boolean
   id?: string
+  className?: string
 }
 
 export type LabelProps = BaseProps & {
@@ -35,6 +36,7 @@ const InputLabel: React.FC<React.PropsWithChildren<Props>> = ({
   visuallyHidden,
   sx,
   as = 'label',
+  className,
   ...props
 }) => {
   return (
@@ -45,6 +47,7 @@ const InputLabel: React.FC<React.PropsWithChildren<Props>> = ({
       }
       htmlFor={htmlFor}
       id={id}
+      className={className}
       sx={{
         fontWeight: 'bold',
         fontSize: 1,


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Related To: https://github.com/github/collaboration-workflows-flex/issues/1143

### Changelog

#### New

Added `className` prop to the `FormControl.Label` component for CSS Module support.

#### Changed


#### Removed


### Rollout strategy

- [x] Minor release
