### PR TITLE
Add support for `aria-disabled` in `Button`

### DIFF
--- a/.changeset/grumpy-hairs-look.md
+++ b/.changeset/grumpy-hairs-look.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Add support for `aria-disabled` in `Button`

--- a/packages/react/src/Button/Button.stories.tsx
+++ b/packages/react/src/Button/Button.stories.tsx
@@ -26,6 +26,11 @@ Playground.argTypes = {
       type: 'boolean',
     },
   },
+  'aria-disabled': {
+    control: {
+      type: 'boolean',
+    },
+  },
   inactive: {
     control: {
       type: 'boolean',
@@ -79,6 +84,7 @@ Playground.args = {
   leadingVisual: null,
   trailingAction: null,
   labelWrap: false,
+  'aria-disabled': false,
 }
 
 export const Default = () => <Button>Default</Button>

--- a/packages/react/src/Button/ButtonBase.module.css
+++ b/packages/react/src/Button/ButtonBase.module.css
@@ -36,7 +36,8 @@
     transition: none;
   }
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled='true'] {
     cursor: not-allowed;
     box-shadow: none;
 
@@ -263,7 +264,8 @@
       border-color: var(--button-default-borderColor-active);
     }
 
-    &:disabled {
+    &:disabled,
+    &[aria-disabled='true'] {
       color: var(--control-fgColor-disabled);
       background-color: var(--button-default-bgColor-disabled);
       border-color: var(--button-default-borderColor-disabled);
@@ -306,7 +308,8 @@
       box-shadow: var(--button-primary-shadow-selected);
     }
 
-    &:disabled {
+    &:disabled,
+    &[aria-disabled='true'] {
       color: var(--button-primary-fgColor-disabled);
       background-color: var(--button-primary-bgColor-disabled);
       border-color: var(--button-primary-borderColor-disabled);
@@ -374,7 +377,8 @@
       }
     }
 
-    &:disabled {
+    &:disabled,
+    &[aria-disabled='true'] {
       color: var(--button-danger-fgColor-disabled);
       background-color: var(--button-danger-bgColor-disabled);
       border-color: var(--button-default-borderColor-disabled);
@@ -423,7 +427,8 @@
       }
     }
 
-    &:disabled {
+    &:disabled,
+    &[aria-disabled='true'] {
       color: var(--button-invisible-fgColor-disabled);
       background-color: var(--button-invisible-bgColor-disabled);
       border-color: var(--button-invisible-borderColor-disabled);
@@ -464,7 +469,8 @@
       outline-offset: 2px;
     }
 
-    &:disabled {
+    &:disabled,
+    &[aria-disabled='true'] {
       color: var(--control-fgColor-disabled);
       background-color: transparent;
       border-color: transparent;

--- a/packages/react/src/Button/ButtonBase.module.css
+++ b/packages/react/src/Button/ButtonBase.module.css
@@ -37,7 +37,7 @@
   }
 
   &:disabled,
-  &[aria-disabled='true'] {
+  &[aria-disabled='true']:not([data-loading='true']) {
     cursor: not-allowed;
     box-shadow: none;
 
@@ -265,7 +265,7 @@
     }
 
     &:disabled,
-    &[aria-disabled='true'] {
+    &[aria-disabled='true']:not([data-loading='true']) {
       color: var(--control-fgColor-disabled);
       background-color: var(--button-default-bgColor-disabled);
       border-color: var(--button-default-borderColor-disabled);
@@ -309,7 +309,7 @@
     }
 
     &:disabled,
-    &[aria-disabled='true'] {
+    &[aria-disabled='true']:not([data-loading='true']) {
       color: var(--button-primary-fgColor-disabled);
       background-color: var(--button-primary-bgColor-disabled);
       border-color: var(--button-primary-borderColor-disabled);
@@ -378,7 +378,7 @@
     }
 
     &:disabled,
-    &[aria-disabled='true'] {
+    &[aria-disabled='true']:not([data-loading='true']) {
       color: var(--button-danger-fgColor-disabled);
       background-color: var(--button-danger-bgColor-disabled);
       border-color: var(--button-default-borderColor-disabled);
@@ -428,7 +428,7 @@
     }
 
     &:disabled,
-    &[aria-disabled='true'] {
+    &[aria-disabled='true']:not([data-loading='true']) {
       color: var(--button-invisible-fgColor-disabled);
       background-color: var(--button-invisible-bgColor-disabled);
       border-color: var(--button-invisible-borderColor-disabled);
@@ -470,7 +470,7 @@
     }
 
     &:disabled,
-    &[aria-disabled='true'] {
+    &[aria-disabled='true']:not([data-loading='true']) {
       color: var(--control-fgColor-disabled);
       background-color: transparent;
       border-color: transparent;


### PR DESCRIPTION
Adds style support for `aria-disabled` on all button variants. Also adds the option to the Playground story.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
