### PR TITLE
Update confirmation dialog body to default color

### DIFF
--- a/.changeset/odd-zoos-judge.md
+++ b/.changeset/odd-zoos-judge.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Update confirmation dialog body to default color. Removing the muted color override.

--- a/packages/react/src/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/react/src/ConfirmationDialog/ConfirmationDialog.tsx
@@ -69,7 +69,7 @@ const ConfirmationHeader: React.FC<React.PropsWithChildren<DialogHeaderProps>> =
 const StyledConfirmationBody = styled(Box)`
   font-size: ${get('fontSizes.1')};
   padding: 0 ${get('space.3')} ${get('space.3')} ${get('space.3')};
-  color: ${get('colors.fg.muted')};
+  color: ${get('colors.fg.default')};
   flex-grow: 1;
 `
 const ConfirmationBody: React.FC<React.PropsWithChildren<DialogProps>> = ({children}) => {

--- a/packages/react/src/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/react/src/ConfirmationDialog/ConfirmationDialog.tsx
@@ -69,7 +69,6 @@ const ConfirmationHeader: React.FC<React.PropsWithChildren<DialogHeaderProps>> =
 const StyledConfirmationBody = styled(Box)`
   font-size: ${get('fontSizes.1')};
   padding: 0 ${get('space.3')} ${get('space.3')} ${get('space.3')};
-  color: ${get('colors.fg.default')};
   flex-grow: 1;
 `
 const ConfirmationBody: React.FC<React.PropsWithChildren<DialogProps>> = ({children}) => {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->


In the current implementation of the dialog, the body text is being set to muted purposely. Screenshot below:

<img width="471" alt="screenshot of confirmation dialog with muted text color in body" src="https://github.com/user-attachments/assets/6c3a65c3-78c2-4fd9-9158-0f3968341eab">

However with overriding the body of the text, this affects other components such as putting a `Banner` inside the dialog. This makes the body of the text also muted which is not what we want. Here is an example of how it looks:

<img width="394" alt="screenshot of confirmation dialog with banner inside and the text of the banner also being muted" src="https://github.com/user-attachments/assets/6cd182dc-a615-4f1f-97b1-da94688a6d47">


So I am just removing the set muted text color and just allow the default to happen. Screenshot below:

<img width="430" alt="screenshot of confirmation dialog with default text color in body" src="https://github.com/user-attachments/assets/da918fcf-2a08-41ba-9986-0ddf5cad200b">


<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->
- Body text color of ConfirmationDialog changed from muted to default

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

Just changes the body text from muted to default.

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
