### PR TITLE
Add `className` prop support to `<Textarea>`

### DIFF
--- a/.changeset/wicked-ties-walk.md
+++ b/.changeset/wicked-ties-walk.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Add `className` prop support to `<Textarea>` component

--- a/packages/react/src/Textarea/Textarea.docs.json
+++ b/packages/react/src/Textarea/Textarea.docs.json
@@ -60,6 +60,12 @@
     {
       "name": "sx",
       "type": "SystemStyleObject"
+    },
+    {
+      "name": "className",
+      "type": "string | undefined",
+      "defaultValue": "",
+      "description": "CSS string"
     }
   ],
   "subcomponents": []

--- a/packages/react/src/Textarea/Textarea.tsx
+++ b/packages/react/src/Textarea/Textarea.tsx
@@ -31,6 +31,10 @@ export type TextareaProps = {
    * apply a high contrast color to background
    */
   contrast?: boolean
+  /**
+   * The className to apply to the wrapper element
+   */
+  className?: string
 } & TextareaHTMLAttributes<HTMLTextAreaElement> &
   SxProp
 
@@ -79,6 +83,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       resize = DEFAULT_TEXTAREA_RESIZE,
       block,
       contrast,
+      className,
       ...rest
     }: TextareaProps,
     ref,
@@ -90,6 +95,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         disabled={disabled}
         block={block}
         contrast={contrast}
+        className={className}
       >
         <StyledTextarea
           value={value}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Related to: https://github.com/github/collaboration-workflows-flex/issues/1145

### Changelog

#### New

Added `className` prop to the `Textarea` component for CSS Module support.

#### Changed


#### Removed


### Rollout strategy

- [x] Minor release

