### PR TITLE
Add dropdown split example to button groups

### DIFF
--- a/packages/react/src/ButtonGroup/ButtonGroup.features.stories.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.features.stories.tsx
@@ -2,7 +2,9 @@ import React, {useState} from 'react'
 import type {Meta} from '@storybook/react'
 import ButtonGroup from './ButtonGroup'
 import {IconButton, Button} from '../Button'
-import {PlusIcon, DashIcon} from '@primer/octicons-react'
+import {PlusIcon, DashIcon, TriangleDownIcon} from '@primer/octicons-react'
+import {ActionMenu} from '../ActionMenu'
+import {ActionList} from '../ActionList'
 
 export default {
   title: 'Components/ButtonGroup/Features',
@@ -32,6 +34,42 @@ export const LoadingButtons = () => {
       </Button>
       <Button onClick={handleClick}>Button 2</Button>
       <Button onClick={handleClick}>Button 3</Button>
+    </ButtonGroup>
+  )
+}
+
+export const DropdownSplit = () => {
+  const actions = ['Action one', 'Action two', 'Action three']
+  const [selectedActionIndex, setSelectedActionIndex] = React.useState<number>(0)
+  const selectedAction = actions[selectedActionIndex]
+  return (
+    <ButtonGroup>
+      <Button
+        onClick={() => {
+          alert(`Activated ${selectedAction}`)
+        }}
+      >
+        {selectedAction}
+      </Button>
+      <ActionMenu>
+        <ActionMenu.Button icon={TriangleDownIcon}>More options</ActionMenu.Button>
+        <ActionMenu.Overlay>
+          <ActionList>
+            {actions.map((action, index) => {
+              return (
+                <ActionList.Item
+                  key={action}
+                  onSelect={() => {
+                    setSelectedActionIndex(index)
+                  }}
+                >
+                  {action}
+                </ActionList.Item>
+              )
+            })}
+          </ActionList>
+        </ActionMenu.Overlay>
+      </ActionMenu>
     </ButtonGroup>
   )
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

We have button group usages that includes a dropdown split button on the docs but we don't have a story in React. A couple of folks (external and internal) asked about it. So I am raising this PR to include a dropdown split example in the ButtonGroup stories. Thanks to @mperrotti sharing the code snippet here: https://github.com/primer/react/issues/5081#issuecomment-2405609157 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

- A new story

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

