### PR TITLE
chore(CounterLabel): Move CounterLabel css modules feature flag to staff

### DIFF
--- a/.changeset/wise-llamas-exist.md
+++ b/.changeset/wise-llamas-exist.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Move CounterLabel css modules feature flag to staff

--- a/packages/react/src/CounterLabel/CounterLabel.tsx
+++ b/packages/react/src/CounterLabel/CounterLabel.tsx
@@ -20,7 +20,7 @@ export type CounterLabelProps = React.PropsWithChildren<
 
 const CounterLabel = forwardRef<HTMLSpanElement, CounterLabelProps>(
   ({scheme = 'secondary', sx = defaultSxProp, className, children, ...rest}, forwardedRef) => {
-    const enabled = useFeatureFlag('primer_react_css_modules_team')
+    const enabled = useFeatureFlag('primer_react_css_modules_staff')
     const label = <VisuallyHidden>&nbsp;({children})</VisuallyHidden>
     const counterProps = {
       ref: forwardedRef,


### PR DESCRIPTION
### Changelog

#### Changed

Move CounterLabel css modules feature flag to staff

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
