### PR TITLE
chore: Add defaultAs argument to toggleStyledComponent utility

### DIFF
--- a/packages/react/src/Banner/Banner.tsx
+++ b/packages/react/src/Banner/Banner.tsx
@@ -209,6 +209,7 @@ const StyledBanner = toggleStyledComponent(
    * line-height of `20px` so that means that the height of icons should match
    * that value.
    */
+  'div',
   styled.div`
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;

--- a/packages/react/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.tsx
@@ -10,6 +10,7 @@ import {useFeatureFlag} from '../FeatureFlags'
 
 const StyledButtonGroup = toggleStyledComponent(
   'primer_react_css_modules_team',
+  'div',
   styled.div`
     display: inline-flex;
     vertical-align: middle;

--- a/packages/react/src/internal/utils/__tests__/toggleStyledComponent.test.tsx
+++ b/packages/react/src/internal/utils/__tests__/toggleStyledComponent.test.tsx
@@ -5,8 +5,32 @@ import {toggleStyledComponent} from '../toggleStyledComponent'
 import styled from 'styled-components'
 
 describe('toggleStyledComponent', () => {
+  test('renders the component as `defaultAs` when flag is enabled and no `as` prop is provided', () => {
+    const TestComponent = toggleStyledComponent('testFeatureFlag', 'span', ({as: BaseComponent = 'div'}) => (
+      <BaseComponent />
+    ))
+    const {container} = render(
+      <FeatureFlags flags={{testFeatureFlag: true}}>
+        <TestComponent />
+      </FeatureFlags>,
+    )
+    expect(container.firstChild).toBeInstanceOf(HTMLSpanElement)
+  })
+
+  test('renders the component as `defaultAs` when flag is disabled and no `as` prop is provided', () => {
+    const TestComponent = toggleStyledComponent('testFeatureFlag', 'span', ({as: BaseComponent = 'div'}) => (
+      <BaseComponent />
+    ))
+    const {container} = render(
+      <FeatureFlags flags={{testFeatureFlag: false}}>
+        <TestComponent />
+      </FeatureFlags>,
+    )
+    expect(container.firstChild).toBeInstanceOf(HTMLSpanElement)
+  })
+
   test('renders the `as` prop when flag is enabled', () => {
-    const TestComponent = toggleStyledComponent('testFeatureFlag', () => <div />)
+    const TestComponent = toggleStyledComponent('testFeatureFlag', 'div', () => <div />)
     const {container} = render(
       <FeatureFlags flags={{testFeatureFlag: true}}>
         <TestComponent as="button" />
@@ -16,7 +40,7 @@ describe('toggleStyledComponent', () => {
   })
 
   test('renders a div as fallback when flag is enabled and no `as` prop is provided', () => {
-    const TestComponent = toggleStyledComponent('testFeatureFlag', () => <div />)
+    const TestComponent = toggleStyledComponent('testFeatureFlag', 'div', () => <div />)
     const {container} = render(
       <FeatureFlags flags={{testFeatureFlag: true}}>
         <TestComponent />
@@ -26,7 +50,7 @@ describe('toggleStyledComponent', () => {
   })
 
   test('renders Box with `as` if `sx` is provided and flag is enabled', () => {
-    const TestComponent = toggleStyledComponent('testFeatureFlag', () => styled.div``)
+    const TestComponent = toggleStyledComponent('testFeatureFlag', 'div', () => styled.div``)
     const {container} = render(
       <FeatureFlags flags={{testFeatureFlag: true}}>
         <TestComponent as="button" sx={{color: 'red'}} />
@@ -38,7 +62,7 @@ describe('toggleStyledComponent', () => {
   })
 
   test('renders styled component when flag is disabled', () => {
-    const StyledComponent = toggleStyledComponent('testFeatureFlag', styled.div.attrs({['data-styled']: true})``)
+    const StyledComponent = toggleStyledComponent('testFeatureFlag', 'div', styled.div.attrs({['data-styled']: true})``)
     const {container} = render(
       <FeatureFlags flags={{testFeatureFlag: false}}>
         <StyledComponent />

--- a/packages/react/src/internal/utils/toggleStyledComponent.tsx
+++ b/packages/react/src/internal/utils/toggleStyledComponent.tsx
@@ -38,7 +38,7 @@ export function toggleStyledComponent<T, P extends CSSModulesProps>(
       }
       return <BaseComponent {...rest} ref={ref} />
     }
-    return <Component as={BaseComponent} {...(rest as P)} sx={sxProp} ref={ref} />
+    return <Component as={BaseComponent} {...(rest as unknown as P)} sx={sxProp} ref={ref} />
   })
 
   return Wrapper

--- a/packages/react/src/internal/utils/toggleStyledComponent.tsx
+++ b/packages/react/src/internal/utils/toggleStyledComponent.tsx
@@ -17,12 +17,18 @@ type CSSModulesProps = {
  *
  * @param flag - the feature flag that will control whether or not the provided
  * styled component is used
+ * @param defautlAs - the default component to use when `as` is not provided
  * @param Component - the styled component that will be used if the feature flag
  * is disabled
  */
-export function toggleStyledComponent<T, P extends CSSModulesProps>(flag: string, Component: React.ComponentType<P>) {
+export function toggleStyledComponent<T, P extends CSSModulesProps>(
+  flag: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  defaultAs: string | React.ComponentType<any>,
+  Component: React.ComponentType<P>,
+) {
   const Wrapper = React.forwardRef<T, P>(function Wrapper(
-    {as: BaseComponent = 'div', sx: sxProp = defaultSxProp, ...rest},
+    {as: BaseComponent = defaultAs, sx: sxProp = defaultSxProp, ...rest},
     ref,
   ) {
     const enabled = useFeatureFlag(flag)
@@ -32,7 +38,7 @@ export function toggleStyledComponent<T, P extends CSSModulesProps>(flag: string
       }
       return <BaseComponent {...rest} ref={ref} />
     }
-    return <Component as={BaseComponent} {...(rest as unknown as P)} sx={sxProp} ref={ref} />
+    return <Component as={BaseComponent} {...(rest as P)} sx={sxProp} ref={ref} />
   })
 
   return Wrapper


### PR DESCRIPTION
This adds a `defaultAs` argument to the `toggleStyledComponent` utility. This is because we were defaulting the `BaseComponent` to `'div'` when no `as` prop was provided. This was incorrect sometimes because the styled component was using something like `styled.a`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
