### PR TITLE
docs(Octicon): update deprecation notice for Octicon

### DIFF
--- a/packages/react/src/Octicon/Octicon.tsx
+++ b/packages/react/src/Octicon/Octicon.tsx
@@ -13,14 +13,14 @@ const Icon = React.forwardRef((props: StyledOcticonProps, ref: React.Ref<SVGSVGE
 })
 
 /**
- * @deprecated
+ * @deprecated Use the icon component directly from `@primer/octicons-react` instead
  */
 const Octicon = styled(Icon)<SxProp>`
   ${({color, sx: sxProp}) => sx({sx: {color, ...sxProp}})}
 `
 
 /**
- * @deprecated
+ * @deprecated Use the icon component directly from `@primer/octicons-react` instead
  */
 export type OcticonProps = ComponentProps<typeof Octicon>
 export default Octicon


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update the deprecation notice for Octicon to include the relevant suggestion from `@primer/octicons-react`

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- The `@deprecated` JSDoc tag for Octicon now includes instructions to use `@primer/octicons-react`

#### Removed

<!-- List of things removed in this PR -->
