### PR TITLE
Catch tooltip v2 errors in older browsers

### DIFF
--- a/.changeset/grumpy-lamps-behave.md
+++ b/.changeset/grumpy-lamps-behave.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+catch TooltipV2 errors in old browsers as a temp fix for unnecessary Sentry reports

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -198,40 +198,72 @@ export const Tooltip = React.forwardRef(
     const [isPopoverOpen, setIsPopoverOpen] = useState(false)
 
     const openTooltip = () => {
-      if (
-        tooltipElRef.current &&
-        triggerRef.current &&
-        tooltipElRef.current.hasAttribute('popover') &&
-        !tooltipElRef.current.matches(':popover-open')
-      ) {
-        const tooltip = tooltipElRef.current
-        const trigger = triggerRef.current
-        tooltip.showPopover()
-        setIsPopoverOpen(true)
-        /*
-         * TOOLTIP POSITIONING
-         */
-        const settings = {
-          side: directionToPosition[direction].side,
-          align: directionToPosition[direction].align,
+      try {
+        if (
+          tooltipElRef.current &&
+          triggerRef.current &&
+          tooltipElRef.current.hasAttribute('popover') &&
+          !tooltipElRef.current.matches(':popover-open')
+        ) {
+          const tooltip = tooltipElRef.current
+          const trigger = triggerRef.current
+          tooltip.showPopover()
+          setIsPopoverOpen(true)
+          /*
+           * TOOLTIP POSITIONING
+           */
+          const settings = {
+            side: directionToPosition[direction].side,
+            align: directionToPosition[direction].align,
+          }
+          const {top, left, anchorAlign, anchorSide} = getAnchoredPosition(tooltip, trigger, settings)
+          // This is required to make sure the popover is positioned correctly i.e. when there is not enough space on the specified direction, we set a new direction to position the ::after
+          const calculatedDirection = positionToDirection[`${anchorSide}-${anchorAlign}` as string]
+          setCalculatedDirection(calculatedDirection)
+          tooltip.style.top = `${top}px`
+          tooltip.style.left = `${left}px`
         }
-        const {top, left, anchorAlign, anchorSide} = getAnchoredPosition(tooltip, trigger, settings)
-        // This is required to make sure the popover is positioned correctly i.e. when there is not enough space on the specified direction, we set a new direction to position the ::after
-        const calculatedDirection = positionToDirection[`${anchorSide}-${anchorAlign}` as string]
-        setCalculatedDirection(calculatedDirection)
-        tooltip.style.top = `${top}px`
-        tooltip.style.left = `${left}px`
+      } catch (error) {
+        // older browsers don't support the :popover-open selector and will throw, even though we use a polyfill
+        // see https://github.com/github/issues/issues/12468
+        if (
+          error &&
+          typeof error === 'object' &&
+          'message' in error &&
+          typeof error.message === 'string' &&
+          error.message.includes('not a valid selector')
+        ) {
+          // fail silently
+        } else {
+          throw error
+        }
       }
     }
     const closeTooltip = () => {
-      if (
-        tooltipElRef.current &&
-        triggerRef.current &&
-        tooltipElRef.current.hasAttribute('popover') &&
-        tooltipElRef.current.matches(':popover-open')
-      ) {
-        tooltipElRef.current.hidePopover()
-        setIsPopoverOpen(false)
+      try {
+        if (
+          tooltipElRef.current &&
+          triggerRef.current &&
+          tooltipElRef.current.hasAttribute('popover') &&
+          tooltipElRef.current.matches(':popover-open')
+        ) {
+          tooltipElRef.current.hidePopover()
+          setIsPopoverOpen(false)
+        }
+      } catch (error) {
+        // older browsers don't support the :popover-open selector and will throw, even though we use a polyfill
+        // see https://github.com/github/issues/issues/12468
+        if (
+          error &&
+          typeof error === 'object' &&
+          'message' in error &&
+          typeof error.message === 'string' &&
+          error.message.includes('not a valid selector')
+        ) {
+          // fail silently
+        } else {
+          throw error
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

- related to https://github.com/github/issues/issues/12468

Add try..catch to the functions to open and close the tooltip v2 to avoid flooding sentry with errors. This is a short term solution until the Primer team can get to the bottom of why this is happening even though we have a polyfill in place.

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [X] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

Try to use a tooltip v2 with an older browser that doesn't support the tooltip api and check for any js errors. We haven't been able to reliably introduce the error, but we're seeing it happen in production.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [X] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
