### PR TITLE
AvatarStack: Adds back empty space in `AvatarStack`

### DIFF
--- a/packages/react/src/AvatarStack/AvatarStack.tsx
+++ b/packages/react/src/AvatarStack/AvatarStack.tsx
@@ -314,6 +314,7 @@ const AvatarStack = ({
         tabIndex={!hasInteractiveChildren && !disableExpand ? 0 : undefined}
         ref={stackContainer}
       >
+        {' '}
         {transformChildren(children)}
       </Box>
     </AvatarStackWrapper>

--- a/packages/react/src/__tests__/__snapshots__/AvatarStack.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/AvatarStack.test.tsx.snap
@@ -188,6 +188,7 @@ exports[`Avatar respects alignRight props 1`] = `
     className="pc-AvatarStackBody"
     tabIndex={0}
   >
+     
     <img
       alt=""
       className="pc-AvatarItem"


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Adds back [empty space in `AvatarStack`](https://github.com/primer/react/pull/5134/files#diff-ac2e0985e490c18144511027fdb167638b99b5f051fe11cb0c3de3d80b33c94bL282), as some tests expect it. We can come back and remove it later once reliance in some Dotcom tests are gone.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

* Adds back empty space in `AvatarStack`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [x] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
