### PR TITLE
fix(Treevieew):do not add aria-describedby attribute when empty leading/trailing visual

### DIFF
--- a/.changeset/tender-dodos-walk.md
+++ b/.changeset/tender-dodos-walk.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+fix(Treevieew):do not add aria-describedby attribute when empty leading/trailing visual

--- a/packages/react/src/TreeView/TreeView.test.tsx
+++ b/packages/react/src/TreeView/TreeView.test.tsx
@@ -189,6 +189,19 @@ describe('Markup', () => {
     expect(noDescription).toHaveAccessibleDescription(' ')
   })
 
+  it('should not have aria-describedby when no leading or trailing visual', () => {
+    const {getByLabelText} = renderWithTheme(
+      <TreeView aria-label="Test tree">
+        <TreeView.Item id="item-1">Item 1</TreeView.Item>
+        <TreeView.Item id="item-2">Item 2</TreeView.Item>
+      </TreeView>,
+    )
+
+    const noDescription = getByLabelText(/Item 1/)
+    expect(noDescription).not.toHaveAccessibleDescription()
+    expect(noDescription).not.toHaveAttribute('aria-describedby')
+  })
+
   it('should include `aria-expanded` when a SubTree contains content', async () => {
     const user = userEvent.setup({
       advanceTimers: jest.advanceTimersByTime,

--- a/packages/react/src/TreeView/TreeView.tsx
+++ b/packages/react/src/TreeView/TreeView.tsx
@@ -458,6 +458,11 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
       [onSelect, setIsExpandedWithCache, toggle],
     )
 
+    const ariaDescribedByIds = [
+      slots.leadingVisual ? leadingVisualId : null,
+      slots.trailingVisual ? trailingVisualId : null,
+    ].filter(Boolean)
+
     return (
       <ItemContext.Provider
         value={{
@@ -480,7 +485,7 @@ const Item = React.forwardRef<HTMLElement, TreeViewItemProps>(
           role="treeitem"
           aria-label={ariaLabel}
           aria-labelledby={ariaLabel ? undefined : ariaLabelledby || labelId}
-          aria-describedby={`${leadingVisualId} ${trailingVisualId}`}
+          aria-describedby={ariaDescribedByIds.length ? ariaDescribedByIds.join(' ') : undefined}
           aria-level={level}
           aria-expanded={isSubTreeEmpty ? undefined : isExpanded}
           aria-current={isCurrentItem ? 'true' : undefined}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/4457

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Currently a leadingVisualId and TrailingVisualId are generated and attached to the TreeItem's `aria-describedby` attribute regardless of whether these nodes are supplied to the component or not. This PR refactors the aria-describedby logic in to only add `aria-describedby` when the nodes (for trailing and leading visuals) are actually present, and mark it as undefined otherwise.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->
- Adds test to cover for new behavior

#### Changed

<!-- List of things changed in this PR -->
- `aria-describedby` is only added to TreeItem's when at least one of leading/trailing visual is present and only the present ID(s) is added.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
Load deployed treeview stories and ensure TreeItem's aria-describedby only contains the Id(s) of the present leading/trailing visual in the various stories.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [x] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
