### PR TITLE
Bug fix: `ButtonBase` sx base styles leaking into CSS modules feat flag

### DIFF
--- a/.changeset/chilly-phones-explode.md
+++ b/.changeset/chilly-phones-explode.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Bug fix: `ButtonBase` sx base styles leaking into CSS modules feat flag

--- a/packages/react/src/Button/ButtonBase.tsx
+++ b/packages/react/src/Button/ButtonBase.tsx
@@ -118,7 +118,7 @@ const ButtonBase = forwardRef(
           >
             <Box
               as={Component}
-              sx={sxStyles}
+              sx={sxProp}
               aria-disabled={loading ? true : undefined}
               {...rest}
               ref={innerRef}


### PR DESCRIPTION
Related:

https://github.com/github/primer/issues/4189
https://github.com/github/primer/issues/4190

We've been running into some sx conflicts with Button related components. This should remove the base styles from components using `sx`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
