### PR TITLE
refactor: update project to use react-compiler eslint rule and babel plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'plugin:import/typescript',
     'plugin:ssr-friendly/recommended',
   ],
+  plugins: ['eslint-plugin-react-compiler'],
   settings: {
     react: {
       version: 'detect',
@@ -165,6 +166,7 @@ module.exports = {
             ],
           },
         ],
+        'react-compiler/react-compiler': 'error',
       },
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-plugin-prettier": "5.0.0",
         "eslint-plugin-primer-react": "5.4.0",
         "eslint-plugin-react": "7.32.2",
+        "eslint-plugin-react-compiler": "19.0.0-beta-63b359f-20241101",
         "eslint-plugin-react-hooks": "4.6.0",
         "eslint-plugin-ssr-friendly": "1.3.0",
         "eslint-plugin-storybook": "0.8.0",
@@ -62,7 +63,7 @@
       "name": "example-app-router",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "37.0.1",
+        "@primer/react": "37.1.0",
         "next": "^14.2.10",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -81,7 +82,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "37.0.1",
+        "@primer/react": "37.1.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
@@ -99,7 +100,7 @@
       "name": "example-consumer-test",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "37.0.1",
+        "@primer/react": "37.1.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.2.19",
         "@types/styled-components": "^5.1.11",
@@ -125,7 +126,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.9.0",
-        "@primer/react": "37.0.1",
+        "@primer/react": "37.1.0",
         "clsx": "^1.2.1",
         "next": "^14.2.10",
         "react": "^18.3.1",
@@ -617,14 +618,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -799,6 +804,24 @@
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-methods": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2302,12 +2325,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.6",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -10265,6 +10289,16 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/babel-plugin-react-compiler": {
+      "version": "19.0.0-beta-63b359f-20241101",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.0.0-beta-63b359f-20241101.tgz",
+      "integrity": "sha512-qrmTHJP3O2kGbtL7kuySX3Lmk+5/4ZR1rHr8QhKa0GzKbmpAUGrTeWOg0NCI5t+QUfKKizxIO1+t0HsZW9x4vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.19.0"
+      }
+    },
     "node_modules/babel-plugin-styled-components": {
       "version": "2.1.4",
       "license": "MIT",
@@ -13848,6 +13882,43 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/eslint-plugin-react-compiler": {
+      "version": "19.0.0-beta-63b359f-20241101",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-63b359f-20241101.tgz",
+      "integrity": "sha512-b7edYKziu3EFUh9I2UirMnzlKT/80TS1i9pHHp5Rssv5HG74wPtxxdU13BN42hNFj2/Wnq4ToPjMVyuIFO5dhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/plugin-proposal-private-methods": "^7.18.6",
+        "hermes-parser": "^0.20.1",
+        "zod": "^3.22.4",
+        "zod-validation-error": "^3.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7"
+      }
+    },
+    "node_modules/eslint-plugin-react-compiler/node_modules/@babel/parser": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "4.6.0",
       "dev": true,
@@ -15870,6 +15941,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
+      "integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
+      "integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.20.1"
       }
     },
     "node_modules/history": {
@@ -24343,6 +24431,15 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/react-compiler-runtime": {
+      "version": "19.0.0-beta-63b359f-20241101",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-63b359f-20241101.tgz",
+      "integrity": "sha512-XxxpP4gqvvn2TQLWFTTqCKcbNFNJhsj+1tT2IFTiR0e13yTm1EF+qm4JSSsaSq++QZ+bIYh2exXsCN3fthd7VA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dnd": {
       "version": "14.0.4",
       "dev": true,
@@ -27813,13 +27910,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "dev": true,
@@ -30068,7 +30158,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "37.0.1",
+      "version": "37.1.0",
       "license": "MIT",
       "dependencies": {
         "@github/relative-time-element": "^4.4.3",
@@ -30094,6 +30184,7 @@
         "hsluv": "1.0.1",
         "lodash.isempty": "^4.4.0",
         "lodash.isobject": "^3.0.2",
+        "react-compiler-runtime": "19.0.0-beta-63b359f-20241101",
         "react-intersection-observer": "^9.4.3",
         "react-is": "^18.2.0",
         "styled-system": "^5.1.5"
@@ -30151,6 +30242,7 @@
         "babel-plugin-dev-expression": "0.2.3",
         "babel-plugin-macros": "3.1.0",
         "babel-plugin-open-source": "1.3.4",
+        "babel-plugin-react-compiler": "19.0.0-beta-63b359f-20241101",
         "babel-plugin-styled-components": "2.1.4",
         "babel-plugin-transform-replace-expressions": "0.2.0",
         "babel-polyfill": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-prettier": "5.0.0",
     "eslint-plugin-primer-react": "5.4.0",
     "eslint-plugin-react": "7.32.2",
+    "eslint-plugin-react-compiler": "19.0.0-beta-63b359f-20241101",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-ssr-friendly": "1.3.0",
     "eslint-plugin-storybook": "0.8.0",
@@ -93,5 +94,6 @@
       "webpack": false,
       "running": false
     }
-  ]
+  ],
+  "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee"
 }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,5 @@
       "webpack": false,
       "running": false
     }
-  ],
-  "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee"
+  ]
 }

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -49,7 +49,21 @@ const config: StorybookConfig = {
       },
     }
 
-    config.plugins = [...(config.plugins ?? []), react()]
+    config.plugins = [
+      ...(config.plugins ?? []),
+      react({
+        babel: {
+          plugins: [
+            [
+              'babel-plugin-react-compiler',
+              {
+                target: '18',
+              },
+            ],
+          ],
+        },
+      }),
+    ]
 
     return config
   },

--- a/packages/react/babel.config.js
+++ b/packages/react/babel.config.js
@@ -1,11 +1,16 @@
 const defines = require('./babel-defines')
 
+const ReactCompilerConfig = {
+  target: '18',
+}
+
 function replacementPlugin(env) {
   return ['babel-plugin-transform-replace-expressions', {replace: defines[env]}]
 }
 
 const sharedPlugins = [
   'macros',
+  ['babel-plugin-react-compiler', ReactCompilerConfig],
   'dev-expression',
   'add-react-displayname',
   'babel-plugin-styled-components',

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -101,6 +101,7 @@
     "hsluv": "1.0.1",
     "lodash.isempty": "^4.4.0",
     "lodash.isobject": "^3.0.2",
+    "react-compiler-runtime": "19.0.0-beta-63b359f-20241101",
     "react-intersection-observer": "^9.4.3",
     "react-is": "^18.2.0",
     "styled-system": "^5.1.5"
@@ -158,6 +159,7 @@
     "babel-plugin-dev-expression": "0.2.3",
     "babel-plugin-macros": "3.1.0",
     "babel-plugin-open-source": "1.3.4",
+    "babel-plugin-react-compiler": "19.0.0-beta-63b359f-20241101",
     "babel-plugin-styled-components": "2.1.4",
     "babel-plugin-transform-replace-expressions": "0.2.0",
     "babel-polyfill": "6.26.0",

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -83,6 +83,12 @@ const baseConfig = {
       ],
       plugins: [
         'macros',
+        [
+          'babel-plugin-react-compiler',
+          {
+            target: '18',
+          },
+        ],
         'add-react-displayname',
         'dev-expression',
         'babel-plugin-styled-components',

--- a/packages/react/src/ActionList/ActionList.examples.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.examples.stories.tsx
@@ -52,6 +52,7 @@ const NextJSLikeLink = forwardRef(
       ref,
       href,
     }
+    // eslint-disable-next-line react-compiler/react-compiler
     return <>{React.isValidElement(child) ? React.cloneElement(child, childProps) : null}</>
   },
 )

--- a/packages/react/src/ActionList/ActionList.features.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.features.stories.tsx
@@ -616,21 +616,21 @@ export const ConditionalChildren = () => {
   )
 }
 
+const SideEffectDescription = () => {
+  const [seconds, setSeconds] = React.useState(0)
+
+  React.useEffect(() => {
+    const fn = () => setSeconds(s => s + 1)
+    const interval = window.setInterval(fn, 1000)
+    return () => window.clearInterval(interval)
+  }, [])
+
+  return <>{seconds} seconds passed</>
+}
+
 export const ChildWithSideEffects = () => {
   const user = users[0]
   const [selected, setSelected] = React.useState(true)
-
-  const SideEffectDescription = () => {
-    const [seconds, setSeconds] = React.useState(0)
-
-    React.useEffect(() => {
-      const fn = () => setSeconds(s => s + 1)
-      const interval = window.setInterval(fn, 1000)
-      return () => window.clearInterval(interval)
-    }, [])
-
-    return <>{seconds} seconds passed</>
-  }
 
   return (
     <ActionList selectionVariant="multiple" role="listbox" aria-label="Assignees">

--- a/packages/react/src/ActionMenu/ActionMenu.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.tsx
@@ -110,6 +110,7 @@ const Menu: React.FC<React.PropsWithChildren<ActionMenuProps>> = ({
       // tooltip trigger
       const anchorChildren = child.props.children
       if (anchorChildren.type === MenuButton) {
+        // eslint-disable-next-line react-compiler/react-compiler
         renderAnchor = anchorProps => {
           // We need to attach the anchor props to the tooltip trigger (ActionMenu.Button's grandchild) not the tooltip itself.
           const triggerButton = React.cloneElement(
@@ -206,6 +207,7 @@ const Anchor = React.forwardRef<HTMLElement, ActionMenuAnchorProps>(({children: 
 
   return (
     <ActionListContainerContext.Provider value={thisActionListContext}>
+      {/* eslint-disable-next-line react-compiler/react-compiler */}
       {React.cloneElement(child, {
         ...anchorProps,
         ref: anchorRef,

--- a/packages/react/src/Autocomplete/AutocompleteInput.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteInput.tsx
@@ -153,6 +153,7 @@ const AutocompleteInput = React.forwardRef(
       }
 
       // calling this useEffect when `highlightRemainingText` changes breaks backspace functionality
+      // eslint-disable-next-line react-compiler/react-compiler
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [autocompleteSuggestion, inputValue, inputRef, isMenuDirectlyActivated])
 

--- a/packages/react/src/Autocomplete/AutocompleteMenu.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteMenu.tsx
@@ -271,6 +271,7 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
       },
       activeDescendantFocus: inputRef,
       onActiveDescendantChanged: (current, _previous, directlyActivated) => {
+        // eslint-disable-next-line react-compiler/react-compiler
         activeDescendantRef.current = current || null
         if (current) {
           const selectedItem = allItemsToRenderRef.current.find(item => {

--- a/packages/react/src/Banner/Banner.tsx
+++ b/packages/react/src/Banner/Banner.tsx
@@ -116,6 +116,7 @@ export const Banner = React.forwardRef<HTMLElement, BannerProps>(function Banner
 
   if (__DEV__) {
     // This hook is called consistently depending on the environment
+    // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       if (title) {

--- a/packages/react/src/Button/ButtonBase.tsx
+++ b/packages/react/src/Button/ButtonBase.tsx
@@ -91,6 +91,7 @@ const ButtonBase = forwardRef(
        * this is safe, and ensures the entire effect is kept out of prod builds
        * shaving precious bytes from the output, and avoiding mounting a noop effect
        */
+      // eslint-disable-next-line react-compiler/react-compiler
       // eslint-disable-next-line react-hooks/rules-of-hooks
       React.useEffect(() => {
         if (

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -187,6 +187,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
 
     useLayoutEffect(() => {
       if (checkboxRef.current) {
+        // eslint-disable-next-line react-compiler/react-compiler
         checkboxRef.current.indeterminate = indeterminate || false
       }
     }, [indeterminate, checked, checkboxRef])

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -421,6 +421,7 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
   const autoFocusedFooterButtonRef = useRef<HTMLButtonElement>(null)
   for (const footerButton of footerButtons) {
     if (footerButton.autoFocus) {
+      // eslint-disable-next-line react-compiler/react-compiler
       footerButton.ref = autoFocusedFooterButtonRef
     }
   }

--- a/packages/react/src/FilteredActionList/useAnnouncements.tsx
+++ b/packages/react/src/FilteredActionList/useAnnouncements.tsx
@@ -13,6 +13,7 @@ const useFirstRender = () => {
   useEffect(() => {
     firstRender.current = false
   }, [])
+  // eslint-disable-next-line react-compiler/react-compiler
   return firstRender.current
 }
 

--- a/packages/react/src/Heading/Heading.tsx
+++ b/packages/react/src/Heading/Heading.tsx
@@ -23,6 +23,7 @@ const Heading = forwardRef(({as: Component = 'h2', className, variant, ...props}
      * this is safe, and ensures the entire effect is kept out of prod builds
      * shaving precious bytes from the output, and avoiding mounting a noop effect
      */
+    // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       if (innerRef.current && !(innerRef.current instanceof HTMLHeadingElement)) {

--- a/packages/react/src/LabelGroup/LabelGroup.tsx
+++ b/packages/react/src/LabelGroup/LabelGroup.tsx
@@ -187,7 +187,8 @@ const LabelGroup: React.FC<React.PropsWithChildren<LabelGroupProps>> = ({
   // and save on reflows caused by measuring DOM nodes.
   const overlayWidth =
     hiddenItemIds.length && overflowStyle === 'overlay'
-      ? getOverlayWidth(buttonClientRect, containerRef, overlayPaddingPx)
+      ? // eslint-disable-next-line react-compiler/react-compiler
+        getOverlayWidth(buttonClientRect, containerRef, overlayPaddingPx)
       : undefined
 
   const expandButtonRef: React.RefCallback<HTMLButtonElement> = React.useCallback(

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -28,6 +28,7 @@ const Link = forwardRef(({as: Component = 'a', className, inline, underline, ...
      * this is safe, and ensures the entire effect is kept out of prod builds
      * shaving precious bytes from the output, and avoiding mounting a noop effect
      */
+    // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       if (

--- a/packages/react/src/NavList/NavList.stories.tsx
+++ b/packages/react/src/NavList/NavList.stories.tsx
@@ -131,6 +131,7 @@ const NextJSLikeLink = React.forwardRef<HTMLAnchorElement, NextJSLinkProps>(
       ref,
       href,
     }
+    // eslint-disable-next-line react-compiler/react-compiler
     return <>{React.isValidElement(child) ? React.cloneElement(child, childProps) : null}</>
   },
 )

--- a/packages/react/src/NavList/NavList.test.tsx
+++ b/packages/react/src/NavList/NavList.test.tsx
@@ -25,6 +25,7 @@ const NextJSLikeLink = React.forwardRef<HTMLAnchorElement, NextJSLinkProps>(
       ref,
       href,
     }
+    // eslint-disable-next-line react-compiler/react-compiler
     return <>{React.isValidElement(child) ? React.cloneElement(child, childProps) : null}</>
   },
 )

--- a/packages/react/src/Portal/Portal.tsx
+++ b/packages/react/src/Portal/Portal.tsx
@@ -97,6 +97,7 @@ export const Portal: React.FC<React.PropsWithChildren<PortalProps>> = ({
     return () => {
       parentElement.removeChild(element)
     }
+    // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [element])
 

--- a/packages/react/src/ThemeProvider.tsx
+++ b/packages/react/src/ThemeProvider.tsx
@@ -71,6 +71,7 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>
   const [dayScheme, setDayScheme] = useSyncedState(props.dayScheme ?? fallbackDayScheme ?? defaultDayScheme)
   const [nightScheme, setNightScheme] = useSyncedState(props.nightScheme ?? fallbackNightScheme ?? defaultNightScheme)
   const systemColorMode = useSystemColorMode()
+  // eslint-disable-next-line react-compiler/react-compiler
   const resolvedColorMode = resolvedColorModePassthrough.current || resolveColorMode(colorMode, systemColorMode)
   const colorScheme = chooseColorScheme(resolvedColorMode, dayScheme, nightScheme)
   const {resolvedTheme, resolvedColorScheme} = React.useMemo(

--- a/packages/react/src/Token/_RemoveTokenButton.tsx
+++ b/packages/react/src/Token/_RemoveTokenButton.tsx
@@ -87,12 +87,12 @@ const StyledTokenButton = styled.span<TokenButtonProps & SxProp>`
 
 const RemoveTokenButton: React.FC<React.PropsWithChildren<ComponentProps<typeof StyledTokenButton>>> = ({
   'aria-label': ariaLabel,
+  // `children` is not included in the output of this component
+  children: _children,
   isParentInteractive,
   size = defaultTokenSize,
   ...rest
 }) => {
-  delete rest.children
-
   return (
     <StyledTokenButton
       as={isParentInteractive ? 'span' : 'button'}

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -323,6 +323,7 @@ export const Tooltip = React.forwardRef(
       <TooltipContext.Provider value={value}>
         <>
           {React.isValidElement(child) &&
+            // eslint-disable-next-line react-compiler/react-compiler
             React.cloneElement(child as React.ReactElement<TriggerPropsType>, {
               ref: triggerRef,
               // If it is a type description, we use tooltip to describe the trigger

--- a/packages/react/src/TreeView/TreeView.tsx
+++ b/packages/react/src/TreeView/TreeView.tsx
@@ -711,6 +711,7 @@ function usePreviousValue<T>(value: T): T {
     ref.current = value
   }, [value])
 
+  // eslint-disable-next-line react-compiler/react-compiler
   return ref.current
 }
 

--- a/packages/react/src/UnderlineNav/UnderlineNav.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNav.tsx
@@ -185,6 +185,7 @@ export const UnderlineNav = forwardRef(
 
     if (__DEV__) {
       // Practically, this is not a conditional hook, it is just making sure this hook runs only on DEV not PROD.
+      // eslint-disable-next-line react-compiler/react-compiler
       // eslint-disable-next-line react-hooks/rules-of-hooks
       useEffect(() => {
         // Address illegal state where there are multiple items that have `aria-current='page'` attribute

--- a/packages/react/src/deprecated/utils/create-slots.tsx
+++ b/packages/react/src/deprecated/utils/create-slots.tsx
@@ -76,6 +76,7 @@ const createSlots = <SlotNames extends string>(slotNames: SlotNames[]) => {
      * Slots uses a render prop API so abstract the
      * implementation detail of using a context provider.
      */
+    // eslint-disable-next-line react-compiler/react-compiler
     const slots = slotsRef.current
 
     return (

--- a/packages/react/src/experimental/SelectPanel2/SelectPanel.tsx
+++ b/packages/react/src/experimental/SelectPanel2/SelectPanel.tsx
@@ -118,6 +118,7 @@ const Panel: React.FC<SelectPanelProps> = ({
 
   const contents = React.Children.map(props.children, child => {
     if (React.isValidElement(child) && child.type === SelectPanelButton) {
+      // eslint-disable-next-line react-compiler/react-compiler
       Anchor = React.cloneElement(child, {
         // @ts-ignore TODO
         ref: anchorRef,
@@ -363,6 +364,7 @@ const SelectPanelButton = React.forwardRef<HTMLButtonElement, ButtonProps>((prop
     return (
       <Button
         ref={anchorRef}
+        // eslint-disable-next-line react-compiler/react-compiler
         aria-label={`${(anchorRef as MutableRefObject<HTMLButtonElement>).current.textContent}, ${labelText}`}
         {...inputProps}
       />

--- a/packages/react/src/hooks/useAnchoredPosition.ts
+++ b/packages/react/src/hooks/useAnchoredPosition.ts
@@ -39,6 +39,7 @@ export function useAnchoredPosition(
         setPosition(undefined)
       }
     },
+    // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [floatingElementRef, anchorElementRef, ...dependencies],
   )

--- a/packages/react/src/hooks/useControllableState.ts
+++ b/packages/react/src/hooks/useControllableState.ts
@@ -100,6 +100,7 @@ export function useControllableState<T>({
     }
   }, [name, value])
 
+  // eslint-disable-next-line react-compiler/react-compiler
   if (controlled.current === true) {
     return [value as T, setState]
   }

--- a/packages/react/src/hooks/useFocusTrap.ts
+++ b/packages/react/src/hooks/useFocusTrap.ts
@@ -82,6 +82,7 @@ export function useFocusTrap(
         }
       }
     },
+    // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [containerRef, initialFocusRef, disabled, ...dependencies],
   )

--- a/packages/react/src/hooks/useFocusZone.ts
+++ b/packages/react/src/hooks/useFocusZone.ts
@@ -59,6 +59,7 @@ export function useFocusZone(
         }
       }
     },
+    // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [disabled, ...dependencies],
   )

--- a/packages/react/src/hooks/useMenuInitialFocus.ts
+++ b/packages/react/src/hooks/useMenuInitialFocus.ts
@@ -71,6 +71,7 @@ export const useMenuInitialFocus = (
     },
     // we don't want containerRef in dependencies
     // because re-renders to containerRef while it's open should not fire initialMenuFocus
+    // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [open, openingGesture, anchorRef],
   )

--- a/packages/react/src/hooks/useOnEscapePress.ts
+++ b/packages/react/src/hooks/useOnEscapePress.ts
@@ -54,6 +54,7 @@ export const useOnEscapePress = (
   onEscape: (e: KeyboardEvent) => void,
   callbackDependencies: React.DependencyList = [onEscape],
 ): void => {
+  // eslint-disable-next-line react-compiler/react-compiler
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const escapeCallback = useCallback(onEscape, callbackDependencies)
 

--- a/packages/react/src/hooks/useRenderForcingRef.ts
+++ b/packages/react/src/hooks/useRenderForcingRef.ts
@@ -10,7 +10,10 @@ import {useCallback, useRef, useState} from 'react'
 export function useRenderForcingRef<TRef>(value?: TRef) {
   const [refCurrent, setRefCurrent] = useState<TRef | null>(value || null)
   const ref = useRef<TRef>(null) as MutableRefObject<TRef | null>
-  ref.current = refCurrent
+
+  if (ref.current === null) {
+    ref.current = refCurrent
+  }
 
   const setRef = useCallback(
     (newRef: TRef | null) => {

--- a/packages/react/src/hooks/useSafeTimeout.ts
+++ b/packages/react/src/hooks/useSafeTimeout.ts
@@ -27,6 +27,7 @@ export default function useSafeTimeout(): {safeSetTimeout: SetTimeout; safeClear
 
   useEffect(() => {
     return () => {
+      // eslint-disable-next-line react-compiler/react-compiler
       // eslint-disable-next-line react-hooks/exhaustive-deps
       for (const id of timers.current) {
         clearTimeout(id)

--- a/packages/react/src/hooks/useScrollFlash.ts
+++ b/packages/react/src/hooks/useScrollFlash.ts
@@ -16,6 +16,7 @@ export default function useScrollFlash(scrollContainerRef: React.RefObject<HTMLE
 
     const altScroll = currentScroll < Math.min(1, maxScroll) ? currentScroll + 1 : currentScroll - 1
 
+    // eslint-disable-next-line react-compiler/react-compiler
     scrollContainer.scrollTop = altScroll
     scrollContainer.scrollTop = currentScroll
   }, [scrollContainerRef])

--- a/packages/react/src/internal/hooks/useMergedRefs.ts
+++ b/packages/react/src/internal/hooks/useMergedRefs.ts
@@ -11,6 +11,7 @@ export function useMergedRefs<T>(
         ref.current = instance
       }
     }
+    // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, refs)
 }

--- a/packages/react/src/stories/deprecated/ActionList.stories.tsx
+++ b/packages/react/src/stories/deprecated/ActionList.stories.tsx
@@ -383,6 +383,7 @@ const NextJSLikeLink = forwardRef(
       ref,
       href,
     }
+    // eslint-disable-next-line react-compiler/react-compiler
     return <>{React.isValidElement(child) ? React.cloneElement(child, childProps) : null}</>
   },
 )


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update `@primer/react` to make use of the `react-compiler` eslint rule and babel plugin. This change will automatically memoize components that the compiler can detect that follow the rules of hooks. This change will show up in the React devtools with a tag by each component ✨ 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Note that these tools are current in **beta** and as such we need to make sure tests don't fail locally and upstream before merging this in.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add eslint-plugin for react compiler
- Update failing code to disable the react-compiler rules
- Update babel config for local development and rollup to compile with react compiler

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release
