### PR TITLE
SelectPanel: Prepare for non-anchored variants

### DIFF
--- a/.changeset/fluffy-days-brake.md
+++ b/.changeset/fluffy-days-brake.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+SelectPanel: (Implementation detail, should have no changes for users) Replace AnchoredOverlay with Overlay and useAnchoredPosition

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -184,14 +184,6 @@ export function SelectPanel({
   // TODO: anchor should be called button because it's not an anchor anymore
   const anchor = renderMenuAnchor ? renderMenuAnchor(anchorProps) : null
 
-  /** Focus trap */
-  useFocusTrap({
-    containerRef: overlayRef,
-    disabled: !open || !position,
-    returnFocusRef: anchorRef,
-    initialFocusRef: inputRef,
-  })
-
   const itemsToRender = useMemo(() => {
     return items.map(item => {
       const isItemSelected = isMultiSelectVariant(selected) ? doesItemsIncludeItem(selected, item) : selected === item
@@ -226,6 +218,14 @@ export function SelectPanel({
       } as ItemProps
     })
   }, [onClose, onSelectedChange, items, selected])
+
+  /** Focus trap */
+  useFocusTrap({
+    containerRef: overlayRef,
+    disabled: !open || !position,
+    initialFocusRef: inputRef,
+    returnFocusRef: anchorRef,
+  })
 
   const extendedTextInputProps: Partial<TextInputProps> = useMemo(() => {
     return {

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -176,9 +176,9 @@ export function SelectPanel({
 
   const anchorProps = {
     ref: anchorRef,
-    onClick: onAnchorClick,
     'aria-haspopup': true,
     'aria-expanded': open,
+    onClick: onAnchorClick,
     onKeyDown: onAnchorKeyDown,
   }
   // TODO: anchor should be called button because it's not an anchor anymore

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -17,7 +17,6 @@ import {useId} from '../hooks/useId'
 import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
 import {LiveRegion, LiveRegionOutlet, Message} from '../internal/components/LiveRegion'
 import {useFeatureFlag} from '../FeatureFlags'
-
 import {useFocusTrap} from '../hooks/useFocusTrap'
 
 interface SelectPanelSingleSelection {
@@ -239,81 +238,82 @@ export function SelectPanel({
 
   const usingModernActionList = useFeatureFlag('primer_react_select_panel_with_modern_action_list')
 
+  if (!open) return <>{anchor}</>
+
   return (
     <LiveRegion>
       {anchor}
-      {open && (
-        <Overlay
-          role="dialog"
-          aria-labelledby={titleId}
-          aria-describedby={subtitle ? subtitleId : undefined}
-          ref={overlayRef}
-          returnFocusRef={anchorRef}
-          onEscape={() => onClose('escape')}
-          onClickOutside={() => onClose('click-outside')}
-          ignoreClickRefs={
-            /* this is required so that clicking the button while the panel is open does not re-open the panel */
-            [anchorRef]
-          }
-          {...position}
-          {...overlayProps}
-        >
-          <LiveRegionOutlet />
-          {usingModernActionList ? null : (
-            <Message
-              value={
-                filterValue === ''
-                  ? 'Showing all items'
-                  : items.length <= 0
-                    ? 'No matching items'
-                    : `${items.length} matching ${items.length === 1 ? 'item' : 'items'}`
-              }
-            />
-          )}
-          <Box sx={{display: 'flex', flexDirection: 'column', height: 'inherit', maxHeight: 'inherit'}}>
-            <Box sx={{pt: 2, px: 3}}>
-              <Heading as="h1" id={titleId} sx={{fontSize: 1}}>
-                {title}
-              </Heading>
-              {subtitle ? (
-                <Box id={subtitleId} sx={{fontSize: 0, color: 'fg.muted'}}>
-                  {subtitle}
-                </Box>
-              ) : null}
-            </Box>
-            <FilteredActionList
-              filterValue={filterValue}
-              onFilterChange={onFilterChange}
-              placeholderText={placeholderText}
-              {...listProps}
-              role="listbox"
-              // browsers give aria-labelledby precedence over aria-label so we need to make sure
-              // we don't accidentally override props.aria-label
-              aria-labelledby={listProps['aria-label'] ? undefined : titleId}
-              aria-multiselectable={isMultiSelectVariant(selected) ? 'true' : 'false'}
-              selectionVariant={isMultiSelectVariant(selected) ? 'multiple' : 'single'}
-              items={itemsToRender}
-              textInputProps={extendedTextInputProps}
-              inputRef={inputRef}
-              // inheriting height and maxHeight ensures that the FilteredActionList is never taller
-              // than the Overlay (which would break scrolling the items)
-              sx={{...sx, height: 'inherit', maxHeight: 'inherit'}}
-            />
-            {footer && (
-              <Box
-                sx={{
-                  display: 'flex',
-                  borderTop: '1px solid',
-                  borderColor: 'border.default',
-                  padding: 2,
-                }}
-              >
-                {footer}
+
+      <Overlay
+        role="dialog"
+        aria-labelledby={titleId}
+        aria-describedby={subtitle ? subtitleId : undefined}
+        ref={overlayRef}
+        returnFocusRef={anchorRef}
+        onEscape={() => onClose('escape')}
+        onClickOutside={() => onClose('click-outside')}
+        ignoreClickRefs={
+          /* this is required so that clicking the button while the panel is open does not re-open the panel */
+          [anchorRef]
+        }
+        {...position}
+        {...overlayProps}
+      >
+        <LiveRegionOutlet />
+        {usingModernActionList ? null : (
+          <Message
+            value={
+              filterValue === ''
+                ? 'Showing all items'
+                : items.length <= 0
+                  ? 'No matching items'
+                  : `${items.length} matching ${items.length === 1 ? 'item' : 'items'}`
+            }
+          />
+        )}
+        <Box sx={{display: 'flex', flexDirection: 'column', height: 'inherit', maxHeight: 'inherit'}}>
+          <Box sx={{pt: 2, px: 3}}>
+            <Heading as="h1" id={titleId} sx={{fontSize: 1}}>
+              {title}
+            </Heading>
+            {subtitle ? (
+              <Box id={subtitleId} sx={{fontSize: 0, color: 'fg.muted'}}>
+                {subtitle}
               </Box>
-            )}
+            ) : null}
           </Box>
-        </Overlay>
-      )}
+          <FilteredActionList
+            filterValue={filterValue}
+            onFilterChange={onFilterChange}
+            placeholderText={placeholderText}
+            {...listProps}
+            role="listbox"
+            // browsers give aria-labelledby precedence over aria-label so we need to make sure
+            // we don't accidentally override props.aria-label
+            aria-labelledby={listProps['aria-label'] ? undefined : titleId}
+            aria-multiselectable={isMultiSelectVariant(selected) ? 'true' : 'false'}
+            selectionVariant={isMultiSelectVariant(selected) ? 'multiple' : 'single'}
+            items={itemsToRender}
+            textInputProps={extendedTextInputProps}
+            inputRef={inputRef}
+            // inheriting height and maxHeight ensures that the FilteredActionList is never taller
+            // than the Overlay (which would break scrolling the items)
+            sx={{...sx, height: 'inherit', maxHeight: 'inherit'}}
+          />
+          {footer && (
+            <Box
+              sx={{
+                display: 'flex',
+                borderTop: '1px solid',
+                borderColor: 'border.default',
+                padding: 2,
+              }}
+            >
+              {footer}
+            </Box>
+          )}
+        </Box>
+      </Overlay>
     </LiveRegion>
   )
 }


### PR DESCRIPTION
- Based on https://github.com/primer/react/pull/5170

Replace AnchoredOverlay with Overlay + useAnchoredPosition to prepare for variants that would skip anchored position


need to check
- [x] are integration tests passing?
- [x] are the props okay? (were some props going to anchoredoverlay that need to be re-routed)
- [x] are the types okay? (same as props)
- [x] is the rendered dom the same?
   - button is missing tabIndex="0" and id, both of these are okay, as we don't need to do this forwarding anymore
   - check if data-has-active-descendant is still correct, it is
- [x] is the rendered a11y tree the same
- [x] check if footer focus works


### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
