### PR TITLE
chore(Token): Add VRT to prep for CSS Module migration

### DIFF
--- a/e2e/components/Token.test.ts
+++ b/e2e/components/Token.test.ts
@@ -14,37 +14,35 @@ const stories = [
 ]
 
 test.describe('Token', () => {
-  test.describe('Default', () => {
-    for (const story of stories) {
-      test.describe(story.title, () => {
-        for (const theme of themes) {
-          test.describe(theme, () => {
-            test('default @vrt', async ({page}) => {
-              await visit(page, {
-                id: 'components-token--default',
-                globals: {
-                  colorScheme: theme,
-                },
-              })
-
-              // Default state
-              expect(await page.screenshot()).toMatchSnapshot(`Token.Default.${theme}.png`)
+  for (const story of stories) {
+    test.describe(story.title, () => {
+      for (const theme of themes) {
+        test.describe(theme, () => {
+          test('default @vrt', async ({page}) => {
+            await visit(page, {
+              id: story.id,
+              globals: {
+                colorScheme: theme,
+              },
             })
 
-            test('axe @aat', async ({page}) => {
-              await visit(page, {
-                id: 'components-token--default',
-                globals: {
-                  colorScheme: theme,
-                },
-              })
-              await expect(page).toHaveNoViolations()
-            })
+            // Default state
+            expect(await page.screenshot()).toMatchSnapshot(`Token.Default.${theme}.png`)
           })
-        }
-      })
-    }
-  })
+
+          test('axe @aat', async ({page}) => {
+            await visit(page, {
+              id: 'components-token--default',
+              globals: {
+                colorScheme: theme,
+              },
+            })
+            await expect(page).toHaveNoViolations()
+          })
+        })
+      }
+    })
+  }
 
   test.describe('Small Token', () => {
     for (const theme of themes) {

--- a/e2e/components/Token.test.ts
+++ b/e2e/components/Token.test.ts
@@ -2,31 +2,46 @@ import {test, expect} from '@playwright/test'
 import {visit} from '../test-helpers/storybook'
 import {themes} from '../test-helpers/themes'
 
+const stories = [
+  {
+    title: 'Default',
+    id: 'components-token--default',
+  },
+  {
+    title: 'Dev Default',
+    id: 'components-token-dev--dev-default',
+  },
+]
+
 test.describe('Token', () => {
   test.describe('Default', () => {
-    for (const theme of themes) {
-      test.describe(theme, () => {
-        test('default @vrt', async ({page}) => {
-          await visit(page, {
-            id: 'components-token--default',
-            globals: {
-              colorScheme: theme,
-            },
-          })
+    for (const story of stories) {
+      test.describe(story.title, () => {
+        for (const theme of themes) {
+          test.describe(theme, () => {
+            test('default @vrt', async ({page}) => {
+              await visit(page, {
+                id: 'components-token--default',
+                globals: {
+                  colorScheme: theme,
+                },
+              })
 
-          // Default state
-          expect(await page.screenshot()).toMatchSnapshot(`Token.Default.${theme}.png`)
-        })
+              // Default state
+              expect(await page.screenshot()).toMatchSnapshot(`Token.Default.${theme}.png`)
+            })
 
-        test('axe @aat', async ({page}) => {
-          await visit(page, {
-            id: 'components-token--default',
-            globals: {
-              colorScheme: theme,
-            },
+            test('axe @aat', async ({page}) => {
+              await visit(page, {
+                id: 'components-token--default',
+                globals: {
+                  colorScheme: theme,
+                },
+              })
+              await expect(page).toHaveNoViolations()
+            })
           })
-          await expect(page).toHaveNoViolations()
-        })
+        }
       })
     }
   })

--- a/packages/react/src/Token/Token.dev.stories.tsx
+++ b/packages/react/src/Token/Token.dev.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import type {Meta} from '@storybook/react'
+import Token from './Token'
+
+export default {
+  title: 'Components/Token/Dev',
+  component: Token,
+} as Meta<typeof Token>
+
+export const DevDefault = () => <Token text="token" sx={{color: 'red'}} style={{border: '2px solid blue'}} />


### PR DESCRIPTION
Related To: https://github.com/github/primer/issues/4367

Add vrt snapshots for the `Token` component to prep for CSS Module migration.