### PR TITLE
workflow: Check for integration result comment

### DIFF
--- a/.github/workflows/check-for-integration-result-comment.yml
+++ b/.github/workflows/check-for-integration-result-comment.yml
@@ -1,4 +1,4 @@
-name: Check for integration result
+name: Check for integration result comment
 
 on:
   issue_comment:
@@ -7,7 +7,7 @@ on:
       
 jobs:
   # note: this workflow always passes, it does not fail when integration tests are failing
-  check-for-integration-result:
+  check-for-integration-result-comment:
     if: github.event.issue.pull_request
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-for-integration-result-comment.yml
+++ b/.github/workflows/check-for-integration-result-comment.yml
@@ -3,7 +3,6 @@ name: Check for integration result comment
 on:
   issue_comment:
     types: [created, edited]
-  pull_request: # for debugging
       
 jobs:
   # note: this workflow always passes, it does not fail when integration tests are failing

--- a/.github/workflows/check-for-integration-result-comment.yml
+++ b/.github/workflows/check-for-integration-result-comment.yml
@@ -3,7 +3,7 @@ name: Check for integration result comment
 on:
   issue_comment:
     types: [created, edited]
-      
+
 jobs:
   # note: this workflow always passes, it does not fail when integration tests are failing
   check-for-integration-result-comment:
@@ -22,20 +22,20 @@ jobs:
               failing: 'integration-tests: failing',
               passing: 'integration-tests: passing'
             };
-            
+
             const issue = {
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo
             };
-            
+
             const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue(issue);
             const existingIntegrationLabels = currentLabels
               .map(label => label.name)
               .filter(label => label.startsWith('integration-tests:'));
-            
+
             if (existingIntegrationLabels.includes(INTEGRATION_LABEL_NAMES.skipped)) return;
-            
+
             const result = await github.rest.issues.listComments(issue);
             const integrationComments = result.data.filter(
               comment =>
@@ -46,17 +46,17 @@ jobs:
               console.log('Integration comment with test-result not found');
               return; // CI should pass if there's nothing to do
             }
-            
+
             const latestComment = integrationComments.pop();
             console.log(latestComment.body);
 
             // based on comment message in github/github: https://github.com/github/github/blob/fe7fe9072fd913ec04255ce7403ae764e6c33d5f/.github/workflows/github-ci.yml#L664-L692
             const pass = latestComment.body.includes('🟢');
             console.log({ pass });
-            
+
             const newIntegrationLabel = pass ? INTEGRATION_LABEL_NAMES.passing : INTEGRATION_LABEL_NAMES.failing;
             console.log({existingIntegrationLabels, newIntegrationLabel})
-            
+
             Object.values(INTEGRATION_LABEL_NAMES).map(async (name) => {
               if (name === newIntegrationLabel) {
                 if (existingIntegrationLabels.includes(name)); // already added, nothing to do here

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -11,8 +11,6 @@ jobs:
     # if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - name: debug event
-        run: echo ${{ toJson(github) }}
       - name: Get integration result comment
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: debug event
-        run: 'echo ${{ github.event }}'
+        run: 'echo ${{ toJson(github.event) }}'
       - name: Get integration result comment
         uses: actions/github-script@v7
         with:
@@ -24,7 +24,7 @@ jobs:
               repo: context.repo.repo
             });
             console.log(result)
-            const integrationComments = result.data.filter(c => c.user.login == 'primer-integration[bot]' && c.body.includes('test-result))
+            const integrationComments = result.data.filter(c => c.user.login == 'primer-integration[bot]' && c.body.includes('test-result'))
             console.log(integrationComments)
 
             const latestComment = integrationComments.sort(c => c.createdAt)[0]

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -3,7 +3,7 @@ name: Check for integration result
 on:
   issue_comment:
     types: [created, edited, deleted]
-  push: # for debugging
+  pull_request: # for debugging
       
 jobs:
   # fetch comments, if integration-test comment is present, use that to label pass or fail. remove in-progress.

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -32,17 +32,24 @@ jobs:
             const latestComment = integrationComments.pop()
             console.log(latestComment.body)
             const pass = latestComment.body.includes(':green-circle:')
+            console.log({pass})
 
+            // reset integration-tests labels before applying the latest label again
             try {
-              // reset before applying labels again
-              await github.rest.issues.removeLabel({
-                ...issue,
-                name: ['integration-tests: recommended', 'integration-tests: passing', 'integration-tests: failing'],
-              })
+              await github.rest.issues.removeLabel({...issue, name: 'integration-tests: recommended'})
             } catch (error) {
-              // fails if label is not applied
-              console.log(error) 
-            } 
+              console.log(error.data.message) 
+            }
+            try {
+              await github.rest.issues.removeLabel({...issue, name: 'integration-tests: passing'})
+            } catch (error) {
+              console.log(error.data.message) 
+            }
+            try {
+              await github.rest.issues.removeLabel({...issue, name: 'integration-tests: failing'})
+            } catch (error) {
+              console.log(error.data.message) 
+            }
             
             await github.rest.issues.addLabels({
               ...issue,

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   # note: this workflow always passes, it does not fail when integration tests are failing
   check-for-integration-result:
-    # if: ${{ github.event.issue.pull_request }}
+    if: github.event.issue.pull_request
     runs-on: ubuntu-latest
     steps:
       - name: Get integration result comment

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -6,7 +6,7 @@ on:
   pull_request: # for debugging
       
 jobs:
-  # fetch comments, if integration-test comment is present, use that to label pass or fail. remove in-progress.
+  # note: this workflow always passes, it does not fail when integration tests are failing
   check-for-integration-result:
     # if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
@@ -16,51 +16,53 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const INTEGRATION_LABEL_NAMES = {
+              // synced with https://github.com/primer/react/labels?q=integration-tests
+              skipped: 'integration-tests: skipped manually',
+              recommended: 'integration-tests: recommended',
+              failing: 'integration-tests: failing',
+              passing: 'integration-tests: passing'
+            };
+            
             const issue = {
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo
-            }
-          
+            };
+            
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue(issue);
+            const integrationLabels = currentLabels
+              .map(label => label.name)
+              .filter(label => label.startsWith('integration-tests:'));
+            
+            if (integrationLabels.includes(INTEGRATION_LABEL_NAMES.skipped)) return;
+            
             const result = await github.rest.issues.listComments(issue);
-            const integrationComments = result.data.filter(c => c.user.login == 'primer-integration[bot]' && c.body.includes('<!-- test-result'))
+            const integrationComments = result.data.filter(
+              comment =>
+                comment.user.login == 'primer-integration[bot]' &&
+                comment.body.includes('<!-- test-result')
+            );
             if (integrationComments.length === 0) {
-              console.log('Integration comment with test-result not found')
-              return // nothing to do here
-            }
-
-            const latestComment = integrationComments.pop()
-            console.log(latestComment.body)
-            const pass = latestComment.body.includes('🟢')
-            console.log({pass})
-
-            const existingLabels = await github.rest.issues.listLabelsOnIssue({...issue})
-            console.log(existingLabels)
-            const integrationLabels = existingLabels.filter(label => label.name.startsWith('integration-tests:'))
-            console.log(integrationLabels)
-
-            // reset integration-tests labels before applying the latest label again
-            // todo: only try to remove these when they are present
-            try {
-              await github.rest.issues.removeLabel({...issue, name: 'integration-tests: recommended'})
-            } catch (error) {
-              console.log(error.response.status, error.response.url)
-            }
-            try {
-              await github.rest.issues.removeLabel({...issue, name: 'integration-tests: passing'})
-            } catch (error) {
-              console.log(error.response.status, error.response.url)
-            }
-            try {
-              await github.rest.issues.removeLabel({...issue, name: 'integration-tests: failing'})
-            } catch (error) {
-              console.log(error.response.status, error.response.url)
+              console.log('Integration comment with test-result not found');
+              return; // CI should pass if there's nothing to do
             }
             
-            await github.rest.issues.addLabels({
-              ...issue,
-              labels: [pass ? 'integration-tests: passing' : 'integration-tests: failing'],
-            })
+            const latestComment = integrationComments.pop();
+            console.log(latestComment.body);
 
+            // based on comment message in github/github: https://github.com/github/github/blob/fe7fe9072fd913ec04255ce7403ae764e6c33d5f/.github/workflows/github-ci.yml#L664-L692
+            const pass = latestComment.body.includes('🟢');
+            console.log({ pass });
             
+            const newIntegrationLabel = pass ? INTEGRATION_LABEL_NAMES.passing : INTEGRATION_LABEL_NAMES.failing;
             
+            INTEGRATION_LABEL_NAMES.map(async (name) => {
+              if (name === newIntegrationLabel) {
+                if (integrationLabels.includes(name)); // already added, nothing to do here
+                else await github.rest.issues.addLabels({...issue, labels: [newIntegrationLabel]});
+              } else if (integrationLabels.includes(name)) {
+                // remove outdated labels
+                await github.rest.issues.removeLabel({ ...issue, name });
+              }
+            });

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -21,8 +21,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             });
-            console.log(result)
-            const integrationComments = result.data.filter(c => c.user.login == 'primer-integration[bot]' && c.body.includes('test-result'))
+            const integrationComments = result.data.filter(c => c.user.login == 'primer-integration[bot]') // && c.body.includes('test-result'))
             console.log(integrationComments)
 
             const latestComment = integrationComments.sort(c => c.createdAt)[0]

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -24,11 +24,14 @@ jobs:
           
             const result = await github.rest.issues.listComments(issue);
             const integrationComments = result.data.filter(c => c.user.login == 'primer-integration[bot]' && c.body.includes('<!-- test-result'))
-            console.log(integrationComments)
-            if (integrationComments.length === 0) return
+            if (integrationComments.length === 0) {
+              console.log('Integration comment with test-result not found')
+              return
+            }
 
             const latestComment = integrationComments.pop()
-            const pass = latestComment.includes(':green-circle:')
+            console.log(latestComment.body)
+            const pass = latestComment.body.includes(':green-circle:')
             
             await github.rest.issues.addLabels({
               ...issue,

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -43,7 +43,7 @@ jobs:
                 ...issue,
                 name: ['integration-tests: recommended'],
               })
-            } catch (erorr) {
+            } catch (error) {
               console.log(error) // no need to fail
             } 
             

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -57,7 +57,7 @@ jobs:
             
             const newIntegrationLabel = pass ? INTEGRATION_LABEL_NAMES.passing : INTEGRATION_LABEL_NAMES.failing;
             
-            INTEGRATION_LABEL_NAMES.map(async (name) => {
+            Object.values(INTEGRATION_LABEL_NAMES).map(async (name) => {
               if (name === newIntegrationLabel) {
                 if (integrationLabels.includes(name)); // already added, nothing to do here
                 else await github.rest.issues.addLabels({...issue, labels: [newIntegrationLabel]});

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -2,7 +2,7 @@ name: Check for integration result
 
 on:
   issue_comment:
-    types: [created, edited, deleted]
+    types: [created, edited]
   pull_request: # for debugging
       
 jobs:
@@ -32,18 +32,22 @@ jobs:
             const latestComment = integrationComments.pop()
             console.log(latestComment.body)
             const pass = latestComment.body.includes(':green-circle:')
+
+            try {
+              // reset before applying labels again
+              await github.rest.issues.removeLabel({
+                ...issue,
+                name: ['integration-tests: recommended', 'integration-tests: passing', 'integration-tests: failing'],
+              })
+            } catch (error) {
+              // fails if label is not applied
+              console.log(error) 
+            } 
             
             await github.rest.issues.addLabels({
               ...issue,
               labels: [pass ? 'integration-tests: passing' : 'integration-tests: failing'],
             })
 
-            try {
-              await github.rest.issues.removeLabel({
-                ...issue,
-                name: ['integration-tests: recommended'],
-              })
-            } catch (error) {
-              console.log(error) // no need to fail
-            } 
+            
             

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: debug event
-        run: 'echo ${{ toJson(github.event) }}'
+        run: echo ${{ toJson(github) }}
       - name: Get integration result comment
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -3,7 +3,7 @@ name: Check for integration result
 on:
   issue_comment:
     types: [created, edited, deleted]
-  workflow_dispatch: # for debugging
+  push: # for debugging
       
 jobs:
   # fetch comments, if integration-test comment is present, use that to label pass or fail. remove in-progress.

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -3,6 +3,7 @@ name: Check for integration result
 on:
   issue_comment:
     types: [created, edited, deleted]
+  workflow_dispatch: # for debugging
       
 jobs:
   # fetch comments, if integration-test comment is present, use that to label pass or fail. remove in-progress.

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -31,11 +31,11 @@ jobs:
             };
             
             const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue(issue);
-            const integrationLabels = currentLabels
+            const existingIntegrationLabels = currentLabels
               .map(label => label.name)
               .filter(label => label.startsWith('integration-tests:'));
             
-            if (integrationLabels.includes(INTEGRATION_LABEL_NAMES.skipped)) return;
+            if (existingIntegrationLabels.includes(INTEGRATION_LABEL_NAMES.skipped)) return;
             
             const result = await github.rest.issues.listComments(issue);
             const integrationComments = result.data.filter(
@@ -56,13 +56,13 @@ jobs:
             console.log({ pass });
             
             const newIntegrationLabel = pass ? INTEGRATION_LABEL_NAMES.passing : INTEGRATION_LABEL_NAMES.failing;
-            console.log({newIntegrationLabel})
+            console.log({existingIntegrationLabels, newIntegrationLabel})
             
             Object.values(INTEGRATION_LABEL_NAMES).map(async (name) => {
               if (name === newIntegrationLabel) {
-                if (integrationLabels.includes(name)); // already added, nothing to do here
+                if (existingIntegrationLabels.includes(name)); // already added, nothing to do here
                 else await github.rest.issues.addLabels({...issue, labels: [newIntegrationLabel]});
-              } else if (integrationLabels.includes(name)) {
+              } else if (existingIntegrationLabels.includes(name)) {
                 // remove outdated labels
                 await github.rest.issues.removeLabel({ ...issue, name });
               }

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -8,9 +8,11 @@ on:
 jobs:
   # fetch comments, if integration-test comment is present, use that to label pass or fail. remove in-progress.
   check-for-integration-result:
-    if: ${{ github.event.issue.pull_request }}
+    # if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
+      - name: debug event
+        run: 'echo ${{ github.event }}'
       - name: Get integration result comment
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -38,17 +38,17 @@ jobs:
             try {
               await github.rest.issues.removeLabel({...issue, name: 'integration-tests: recommended'})
             } catch (error) {
-              console.log(error.data) 
+              console.log(error.response.status, error.response.url)
             }
             try {
               await github.rest.issues.removeLabel({...issue, name: 'integration-tests: passing'})
             } catch (error) {
-              console.log(error.data) 
+              console.log(error.response.status, error.response.url)
             }
             try {
               await github.rest.issues.removeLabel({...issue, name: 'integration-tests: failing'})
             } catch (error) {
-              console.log(error.data) 
+              console.log(error.response.status, error.response.url)
             }
             
             await github.rest.issues.addLabels({

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -1,0 +1,30 @@
+name: Check for integration result
+
+on:
+  issue_comment:
+    types: [created, edited, deleted]
+      
+jobs:
+  # fetch comments, if integration-test comment is present, use that to label pass or fail. remove in-progress.
+  check-for-integration-result:
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get integration result comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const result = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            console.log(result)
+            const integrationComments = result.data.filter(c => c.user.login == 'primer-integration[bot]' && c.body.includes('test-result))
+            console.log(integrationComments)
+
+            const latestComment = integrationComments.sort(c => c.createdAt)[0]
+            if (latestComment) {
+              // add label
+            }

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -16,15 +16,27 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const result = await github.rest.issues.listComments({
+            const issue = {
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo
-            });
-            const integrationComments = result.data.filter(c => c.user.login == 'primer-integration[bot]') // && c.body.includes('test-result'))
-            console.log(integrationComments)
-
-            const latestComment = integrationComments.sort(c => c.createdAt)[0]
-            if (latestComment) {
-              // add label
             }
+          
+            const result = await github.rest.issues.listComments(issue);
+            const integrationComments = result.data.filter(c => c.user.login == 'primer-integration[bot]' && c.body.includes('<!-- test-result'))
+            console.log(integrationComments)
+            if (integrationComments.length === 0) return
+
+            const latestComment = integrationComments.pop()
+            const pass = latestComment.includes(':green-circle:')
+            
+            await github.rest.issues.addLabels({
+              ...issue,
+              labels: [pass ? 'integration-tests: passing' : 'integration-tests: failing'],
+            })
+
+            await github.rest.issues.removeLabel({
+              ...issue,
+              name: ['integration-tests: recommended'],
+            })
+            

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -31,24 +31,24 @@ jobs:
 
             const latestComment = integrationComments.pop()
             console.log(latestComment.body)
-            const pass = latestComment.body.includes(':green-circle:')
+            const pass = latestComment.body.includes('🟢')
             console.log({pass})
 
             // reset integration-tests labels before applying the latest label again
             try {
               await github.rest.issues.removeLabel({...issue, name: 'integration-tests: recommended'})
             } catch (error) {
-              console.log(error.data.message) 
+              console.log(error.data) 
             }
             try {
               await github.rest.issues.removeLabel({...issue, name: 'integration-tests: passing'})
             } catch (error) {
-              console.log(error.data.message) 
+              console.log(error.data) 
             }
             try {
               await github.rest.issues.removeLabel({...issue, name: 'integration-tests: failing'})
             } catch (error) {
-              console.log(error.data.message) 
+              console.log(error.data) 
             }
             
             await github.rest.issues.addLabels({

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -26,7 +26,7 @@ jobs:
             const integrationComments = result.data.filter(c => c.user.login == 'primer-integration[bot]' && c.body.includes('<!-- test-result'))
             if (integrationComments.length === 0) {
               console.log('Integration comment with test-result not found')
-              return
+              return // nothing to do here
             }
 
             const latestComment = integrationComments.pop()
@@ -34,7 +34,13 @@ jobs:
             const pass = latestComment.body.includes('🟢')
             console.log({pass})
 
+            const existingLabels = await github.rest.issues.listLabelsOnIssue({...issue})
+            console.log(existingLabels)
+            const integrationLabels = existingLabels.filter(label => label.name.startsWith('integration-tests:'))
+            console.log(integrationLabels)
+
             // reset integration-tests labels before applying the latest label again
+            // todo: only try to remove these when they are present
             try {
               await github.rest.issues.removeLabel({...issue, name: 'integration-tests: recommended'})
             } catch (error) {

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -38,8 +38,12 @@ jobs:
               labels: [pass ? 'integration-tests: passing' : 'integration-tests: failing'],
             })
 
-            await github.rest.issues.removeLabel({
-              ...issue,
-              name: ['integration-tests: recommended'],
-            })
+            try {
+              await github.rest.issues.removeLabel({
+                ...issue,
+                name: ['integration-tests: recommended'],
+              })
+            } catch (erorr) {
+              console.log(error) // no need to fail
+            } 
             

--- a/.github/workflows/check-for-integration-result.yml
+++ b/.github/workflows/check-for-integration-result.yml
@@ -56,6 +56,7 @@ jobs:
             console.log({ pass });
             
             const newIntegrationLabel = pass ? INTEGRATION_LABEL_NAMES.passing : INTEGRATION_LABEL_NAMES.failing;
+            console.log({newIntegrationLabel})
             
             Object.values(INTEGRATION_LABEL_NAMES).map(async (name) => {
               if (name === newIntegrationLabel) {


### PR DESCRIPTION
Add workflow to look at the integration-tests comment on pull requests and update labels. 

- This workflow is trigged on issue_comment: [created, edited]
- It checks if there is a comment [from integration tests workflow in github/github](https://github.com/github/github/blob/fe7fe9072fd913ec04255ce7403ae764e6c33d5f/.github/workflows/github-ci.yml#L664-L692)
- Based on the message format (🟢 or 🔴), it will add `integration-tests: passing` or `integration-tests: failing` label
- We can, in the future, choose to fail CI if the comment from integration-tests says failing. Don't want to do that just yet though

Example:

<img width="770" alt="comment on PR with text:  github-actions bot added integration-tests: passing and removed integration-tests: recommended labels 17 minutes ago" src="https://github.com/user-attachments/assets/dc61dbe2-bec5-40bd-b6a8-d7660da5d79f">


### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why