### PR TITLE
bugfix(Spinner): Spinner component size get's large when passing sx and size props

### DIFF
--- a/.changeset/forty-rats-jog.md
+++ b/.changeset/forty-rats-jog.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Spinner component size get's large when passing sx and size props

--- a/.changeset/forty-rats-jog.md
+++ b/.changeset/forty-rats-jog.md
@@ -2,4 +2,4 @@
 "@primer/react": patch
 ---
 
-Spinner component size get's large when passing sx and size props
+Update Spinner component to correctly use the `size` prop when both `sx` and `size` are provided

--- a/packages/react/src/Spinner/Spinner.dev.stories.tsx
+++ b/packages/react/src/Spinner/Spinner.dev.stories.tsx
@@ -7,4 +7,4 @@ export default {
   component: Spinner,
 } as Meta<typeof Spinner>
 
-export const Default = () => <Spinner sx={{border: '1px solid red'}} />
+export const Default = () => <Spinner sx={{border: '1px solid red'}} size={'small'} />

--- a/packages/react/src/Spinner/Spinner.dev.stories.tsx
+++ b/packages/react/src/Spinner/Spinner.dev.stories.tsx
@@ -7,4 +7,4 @@ export default {
   component: Spinner,
 } as Meta<typeof Spinner>
 
-export const Default = () => <Spinner sx={{border: '1px solid red'}} size={'small'} />
+export const Default = () => <Spinner sx={{border: '1px solid red'}} size="small" />

--- a/packages/react/src/Spinner/Spinner.tsx
+++ b/packages/react/src/Spinner/Spinner.tsx
@@ -6,7 +6,6 @@ import type {HTMLDataAttributes} from '../internal/internal-types'
 import {useId} from '../hooks'
 import {useFeatureFlag} from '../FeatureFlags'
 import classes from './Spinner.module.css'
-import Box from '../Box'
 
 const sizeMap = {
   small: '16px',
@@ -87,11 +86,15 @@ const StyledComponentSpinner = styled(Spinner)`
   ${sx}
 `
 
+const StyledBaseSpinner = styled.div`
+  ${sx}
+`
+
 function StyledSpinner({sx, ...props}: SpinnerProps) {
   const enabled = useFeatureFlag('primer_react_css_modules_team')
   if (enabled) {
     if (sx) {
-      return <Box sx={sx} as={Spinner} className={classes.SpinnerAnimation} {...props} />
+      return <StyledBaseSpinner sx={sx} as={Spinner} className={classes.SpinnerAnimation} {...props} />
     }
 
     return <Spinner className={classes.SpinnerAnimation} {...props} />

--- a/packages/react/src/Spinner/Spinner.tsx
+++ b/packages/react/src/Spinner/Spinner.tsx
@@ -6,6 +6,7 @@ import type {HTMLDataAttributes} from '../internal/internal-types'
 import {useId} from '../hooks'
 import {useFeatureFlag} from '../FeatureFlags'
 import classes from './Spinner.module.css'
+import {clsx} from 'clsx'
 
 const sizeMap = {
   small: '16px',
@@ -90,17 +91,17 @@ const StyledBaseSpinner = styled.div`
   ${sx}
 `
 
-function StyledSpinner({sx, ...props}: SpinnerProps) {
+function StyledSpinner({sx, className, ...props}: SpinnerProps) {
   const enabled = useFeatureFlag('primer_react_css_modules_team')
   if (enabled) {
     if (sx) {
-      return <StyledBaseSpinner sx={sx} as={Spinner} className={classes.SpinnerAnimation} {...props} />
+      return <StyledBaseSpinner sx={sx} as={Spinner} className={clsx(className, classes.SpinnerAnimation)} {...props} />
     }
 
-    return <Spinner className={classes.SpinnerAnimation} {...props} />
+    return <Spinner className={clsx(className, classes.SpinnerAnimation)} {...props} />
   }
 
-  return <StyledComponentSpinner sx={sx} {...props} />
+  return <StyledComponentSpinner sx={sx} className={className} {...props} />
 }
 
 StyledSpinner.displayName = 'Spinner'


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/4391

This fixes an issue with the Spinner and CSS modules we discovered this morning. The problem is when `sx=` and `size=` is passed to the Spinner component, we render `<Box as={Spinner} {...props} />` but Box accepts a `size=` prop as well as `Spinner` so `Box` ends up creating some styles thinking that it's meant to render at different breakpoints.

To fix I figured we need to not pass `size` to Box. So to fix it, I ended up removing `Box` and using a `styled.div` component with nothing but `${sx}` inside to render any sx props passed along. 

This fixed the issue. We created a dev story to recreate the issue.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

Spinner component size get's large when passing sx and size props

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
