### PR TITLE
Add changelog.md to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .changeset
+packages/react/CHANGELOG.md
 dist
 lib
 !codemods/lib/**


### PR DESCRIPTION
I went into a silly rabbit hole of CI and come back with this:

- Noticed that CI is failing in https://github.com/primer/react/pull/5234, because `npm run format` found unrelated changes in `CHANGELOG.md`
- This happens because changesets can no longer find our `prettierConfig` from `package.json`, it uses the default prettier config.
- This started happening last week with the upgrade to prettier from 3.0.0 to 3.3.3 https://github.com/primer/react/pull/5180
- This was introduced in prettier 3.1.1 https://github.com/prettier/prettier/pull/15663. Related doc change: https://github.com/prettier/prettier/pull/15910/files
- Until changesets updates their prettier config code, adding `CHANGELOG.md` to `.prettierignore`
- **changesets would still run prettier (default config) on `CHANGELOG.md`, but our format CI job will no longer complain about it**

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, only affects CI

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

