### PR TITLE
Revert "SelectPanel: Prepare for non-anchored variants"

### DIFF
--- a/.changeset/fluffy-days-brake.md
+++ b/.changeset/fluffy-days-brake.md
@@ -1,5 +1,0 @@
----
-"@primer/react": patch
----
-
-SelectPanel: (Implementation detail, should have no changes for users) Replace AnchoredOverlay with Overlay and useAnchoredPosition


### PR DESCRIPTION
- Reverts primer/react#5230
- Turns out it had integration issues, which I introduced by adding more commits after running integration tests 🤦 That's totally on me