### PR TITLE
Workflow: Recommend integration tests again if there are new commits

### DIFF
--- a/.github/workflows/recommend-integration-tests.yml
+++ b/.github/workflows/recommend-integration-tests.yml
@@ -35,20 +35,31 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const result = await github.paginate(github.rest.issues.listComments, {
+            const issue = {
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo
-            });
+            }
+            const comments = await github.paginate(github.rest.issues.listComments, issue);
+            const previousComments = comments.filter(c => c.user.login == 'github-actions[bot]' && c.body.startsWith('<!-- recommend-integration-tests.yml -->'))
 
-            const previousComment = result.filter(c => c.user.login == 'github-actions[bot]' && c.body.startsWith('<!-- recommend-integration-tests.yml -->'))
-            if (!previousComment.length) {
+            if (previousComments.length === 0) {
+              // recommend integration tests
               await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                ...issue,
                 body: '<!-- recommend-integration-tests.yml -->\n\n :wave: Hi, this pull request contains changes to the source code that github/github depends on. If you are GitHub staff, we recommend testing these changes with github/github using the [integration workflow](https://gh.io/testing_primer_at_dotcom). Thanks!'
               })
+            } else {
+              const labels = await github.rest.issues.listLabelsOnIssue(issue)
+              const hasPassingLabel = labels.data.find(label => label.name === 'integration-tests: passing')
+              
+              if (hasPassingLabel) {
+                // recommend running integration tests again as there are new commits that might change the status
+                await github.rest.issues.createComment({
+                  ...issue,
+                  body: '<!-- recommend-integration-tests.yml -->\n\n :wave: Hi, there are new commits since previous integration test. We recommend running the [integration workflow](https://gh.io/testing_primer_at_dotcom) once more, unless you are sure the new changes do not affect github/github. Thanks!'
+                })
+              }
             }
 
       - name: Add label
@@ -57,18 +68,21 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const result = await github.rest.issues.listLabelsOnIssue({
+            const issue = {
               issue_number: context.issue.number,
               owner: context.repo.owner,
-              repo: context.repo.repo,
-            })
-
+              repo: context.repo.repo
+            }
+            const labels = await github.rest.issues.listLabelsOnIssue(issue)
             const integrationLabels = result.data.filter(label => label.name.startsWith('integration-tests'))
+
             if (!integrationLabels.length) {
-              await github.rest.issues.addLabels({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                labels: ['integration-tests: recommended'],
-              })
+              // recommend integration tests
+              await github.rest.issues.addLabels({...issue, labels: ['integration-tests: recommended']})
+            } else {
+              const hasPassingLabel = integrationLabels.find(label => label.name === 'integration-tests: passing')
+              if (hasPassingLabel) {
+                // recommend running integration tests again as there are new commits that might change the status
+                await github.rest.issues.addLabels({...issue, labels: ['integration-tests: recommended']})
+              }
             }

--- a/.github/workflows/recommend-integration-tests.yml
+++ b/.github/workflows/recommend-integration-tests.yml
@@ -29,60 +29,43 @@ jobs:
       - name: Has diff?
         run: echo ${{ steps.source-files.outputs.diff != '' }}
 
-      - name: Get or Create Comment
+      - name: Add label and comment
         if: ${{ steps.source-files.outputs.diff != '' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const INTEGRATION_LABEL_NAMES = {
+              // synced with https://github.com/primer/react/labels?q=integration-tests
+              skipped: 'integration-tests: skipped manually',
+              recommended: 'integration-tests: recommended',
+              failing: 'integration-tests: failing',
+              passing: 'integration-tests: passing'
+            }
+
             const issue = {
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo
             }
-            const comments = await github.paginate(github.rest.issues.listComments, issue);
-            const previousComments = comments.filter(c => c.user.login == 'github-actions[bot]' && c.body.startsWith('<!-- recommend-integration-tests.yml -->'))
 
-            if (previousComments.length === 0) {
+            const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, issue);
+            const integrationLabels = labels.filter(label => label.name.startsWith('integration-tests'))
+            const hasPassingLabel = integrationLabels.find(label => label.name === INTEGRATION_LABEL_NAMES.passing)
+
+            if (integrationLabels.length === 0) {
               // recommend integration tests
+              await github.rest.issues.addLabels({...issue, labels: [INTEGRATION_LABEL_NAMES.recommended]})
               await github.rest.issues.createComment({
                 ...issue,
                 body: '<!-- recommend-integration-tests.yml -->\n\n :wave: Hi, this pull request contains changes to the source code that github/github depends on. If you are GitHub staff, we recommend testing these changes with github/github using the [integration workflow](https://gh.io/testing_primer_at_dotcom). Thanks!'
               })
-            } else {
-              const labels = await github.rest.issues.listLabelsOnIssue(issue)
-              const hasPassingLabel = labels.data.find(label => label.name === 'integration-tests: passing')
-              
-              if (hasPassingLabel) {
-                // recommend running integration tests again as there are new commits that might change the status
-                await github.rest.issues.createComment({
-                  ...issue,
-                  body: '<!-- recommend-integration-tests.yml -->\n\n :wave: Hi, there are new commits since previous integration test. We recommend running the [integration workflow](https://gh.io/testing_primer_at_dotcom) once more, unless you are sure the new changes do not affect github/github. Thanks!'
-                })
-              }
-            }
-
-      - name: Add label
-        if: ${{ steps.source-files.outputs.diff != '' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issue = {
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            }
-            const labels = await github.rest.issues.listLabelsOnIssue(issue)
-            const integrationLabels = result.data.filter(label => label.name.startsWith('integration-tests'))
-
-            if (!integrationLabels.length) {
-              // recommend integration tests
-              await github.rest.issues.addLabels({...issue, labels: ['integration-tests: recommended']})
-            } else {
-              const hasPassingLabel = integrationLabels.find(label => label.name === 'integration-tests: passing')
-              if (hasPassingLabel) {
-                // recommend running integration tests again as there are new commits that might change the status
-                await github.rest.issues.addLabels({...issue, labels: ['integration-tests: recommended']})
-              }
+            } else if (hasPassingLabel) {
+              // recommend running integration tests again as there are new commits that might change the status
+              // note: we don't remove 'integration-tests: passing' label because this is only a suggestion/nudge
+              await github.rest.issues.addLabels({...issue, labels: [INTEGRATION_LABEL_NAMES.recommended]})
+              await github.rest.issues.createComment({
+                ...issue,
+                body: '<!-- recommend-integration-tests.yml -->\n\n :wave: Hi, there are new commits since the last successful integration test. We recommend running the [integration workflow](https://gh.io/testing_primer_at_dotcom) once more, unless you are sure the new changes do not affect github/github. Thanks!'
+              })
             }


### PR DESCRIPTION
- If we think you should run integration tests, this workflow already adds a `integration-tests: recommended` label. 
- After you run integration tests, another workflow [check-for-integration-result-comment.yml](https://github.com/primer/react/blob/main/.github/workflows/check-for-integration-result-comment.yml) checks for integration test results and adds a `integration-tests: passing` label.
- But, if you add more commits to the PR, your integration results might be outdated/invalid now. 

This workflow now suggests you to run integration tests again. It does not remove your `integration-tests: passing`, it only adds `integration-tests: recommended` again.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; workflow only change

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
