### PR TITLE
bug(ActionList.Description): Add missing title prop to block variant

### DIFF
--- a/.changeset/fresh-snails-agree.md
+++ b/.changeset/fresh-snails-agree.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Add missing title prop to block variant of `ActionList.Description`

--- a/packages/react/src/ActionList/Description.tsx
+++ b/packages/react/src/ActionList/Description.tsx
@@ -49,6 +49,7 @@ export const Description: React.FC<React.PropsWithChildren<ActionListDescription
       id={variant === 'block' ? blockDescriptionId : inlineDescriptionId}
       className={className}
       data-component="ActionList.Description"
+      title={props.children as string}
     >
       {props.children}
     </Box>


### PR DESCRIPTION
Found a small missing title prop that was causing integration test failures for an [unrelated PR](https://github.com/primer/react/pull/5271) 