### PR TITLE
fix(Link): Do not pass through hoverColor prop in Link

### DIFF
--- a/.changeset/quiet-garlics-compare.md
+++ b/.changeset/quiet-garlics-compare.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Do not pass through hoverColor prop into DOM element

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -17,7 +17,7 @@ type StyledLinkProps = {
   inline?: boolean
 } & SxProp
 
-const Link = forwardRef(({as: Component = 'a', className, inline, underline, ...props}, forwardedRef) => {
+const Link = forwardRef(({as: Component = 'a', className, inline, underline, hoverColor, ...props}, forwardedRef) => {
   const innerRef = React.useRef<HTMLAnchorElement>(null)
   useRefObjectAsForwardedRef(forwardedRef, innerRef)
 
@@ -53,6 +53,7 @@ const Link = forwardRef(({as: Component = 'a', className, inline, underline, ...
         data-muted={props.muted}
         data-inline={inline}
         data-underline={underline}
+        data-hover-color={hoverColor}
         {...props}
         // @ts-ignore shh
         ref={innerRef}
@@ -66,6 +67,7 @@ const Link = forwardRef(({as: Component = 'a', className, inline, underline, ...
       data-muted={props.muted}
       data-inline={inline}
       data-underline={underline}
+      data-hover-color={hoverColor}
       {...props}
       // @ts-ignore shh
       ref={innerRef}

--- a/packages/react/src/Link/__tests__/__snapshots__/Link.test.tsx.snap
+++ b/packages/react/src/Link/__tests__/__snapshots__/Link.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Link passes href down to link element 1`] = `
 exports[`Link respects hoverColor prop 1`] = `
 <a
   className="Link"
-  hoverColor="accent.fg"
+  data-hover-color="accent.fg"
 />
 `;
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Fixes error in [integration tests](https://github.com/github/github/actions/runs/11937592991/job/33274055190?pr=351887):

```
      If the error is expected, test for it explicitly by mocking it out using jest.spyOn(console, 'error').mockImplementation() and test that the warning occurs.
  
      Warning: React does not recognize the `hoverColor` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `hovercolor` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->
- Converts the `hoverColor` prop to a `data-hover-color` attribute in the `Link` component.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
