### PR TITLE
ActionMenu: Remove `eslint` disable from `ActionMenu` story

### DIFF
--- a/packages/react/src/ActionMenu/ActionMenu.examples.stories.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.examples.stories.tsx
@@ -235,22 +235,22 @@ export const ShortcutMenu = () => {
 
 export const ContextMenu = () => {
   const ListItemWithContextMenu = ({children}: {children: string}) => {
-    const handleContextMenu: React.MouseEventHandler<HTMLLIElement> = event => {
+    const handleContextMenu: React.MouseEventHandler<HTMLElement> = event => {
       event.preventDefault()
       setOpen(true)
     }
 
     const [open, setOpen] = React.useState(false)
-    const triggerRef = React.useRef<HTMLLIElement>(null)
+    const triggerRef = React.useRef<HTMLButtonElement>(null)
 
     return (
-      // We need to add an aria-label for improving support for more assistive technologies. For example: VoiceOver might not detect the `name` without `aria-label`
-      // Since this has a custom context menu, it's ok to add a tabIndex
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-      <li ref={triggerRef} onContextMenu={handleContextMenu} tabIndex={0} aria-label={children}>
-        {children}
+      <li onContextMenu={handleContextMenu}>
         <ActionMenu open={open} onOpenChange={setOpen} anchorRef={triggerRef}>
-          <ActionMenu.Button sx={{visibility: 'hidden', height: 0}}>Anchor</ActionMenu.Button>
+          <ActionMenu.Anchor>
+            <Button ref={triggerRef} variant="invisible" onClick={handleContextMenu}>
+              {children}
+            </Button>
+          </ActionMenu.Anchor>
           <ActionMenu.Overlay>
             <ActionList>
               <ActionList.Item>


### PR DESCRIPTION
Removes eslint disable and makes story keyboard accessible.

<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Resolves lint disable in https://github.com/github/primer/issues/3726.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->

* Makes `ActionMenu` story keyboard accessible

#### Removed

<!-- List of things removed in this PR -->

* Removes `eslint` disable

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
