### PR TITLE
refactor(react): update build output to use dist dir

### DIFF
--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -1,0 +1,3 @@
+**/__tests__/**
+**/stories/**
+**/*.stories.*

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,37 +6,35 @@
   "module": "lib-esm/index.js",
   "exports": {
     ".": {
-      "import": "./lib-esm/index.js",
-      "require": "./lib/index.js"
+      "import": "./dist/lib-esm/index.js",
+      "require": "./dist/lib/index.js"
     },
     "./experimental": {
-      "import": "./lib-esm/experimental/index.js",
-      "require": "./lib/experimental/index.js"
+      "import": "./dist/lib-esm/experimental/index.js",
+      "require": "./dist/lib/experimental/index.js"
     },
     "./deprecated": {
-      "import": "./lib-esm/deprecated/index.js",
-      "require": "./lib/deprecated/index.js"
+      "import": "./dist/lib-esm/deprecated/index.js",
+      "require": "./dist/lib/deprecated/index.js"
     },
     "./next": {
-      "import": "./lib-esm/next/index.js",
-      "require": "./lib/next/index.js"
+      "import": "./dist/lib-esm/next/index.js",
+      "require": "./dist/lib/next/index.js"
     },
     "./test-helpers": {
-      "import": "./lib-esm/test-helpers.js",
-      "require": "./lib/test-helpers.js"
+      "import": "./dist/lib-esm/test-helpers.js",
+      "require": "./dist/lib/test-helpers.js"
     }
   },
-  "typings": "lib/index.d.ts",
+  "typings": "dist/lib/index.d.ts",
   "sideEffects": [
-    "lib-esm/**/*.css",
-    "lib/**/*.css",
+    "dist/**/*.css",
     "src/**/test-helpers.tsx",
-    "lib-esm/**/test-helpers.js",
-    "lib/**/test-helpers.js"
+    "dist/**/test-helpers.js"
   ],
   "scripts": {
     "build": "./script/build",
-    "clean": "rimraf dist lib lib-esm css",
+    "clean": "rimraf dist lib lib-esm css generated",
     "start": "concurrently npm:start:*",
     "start:storybook": "STORYBOOK=true storybook dev -p 6006",
     "build:storybook": "script/build-storybook",
@@ -55,19 +53,8 @@
     "design-system"
   ],
   "files": [
-    "codemods",
     "dist",
-    "lib",
-    "lib/node_modules",
-    "lib-esm",
-    "css",
-    "index.d.ts",
-    "deprecated/package.json",
-    "experimental/package.json",
-    "!lib/__tests__",
-    "!lib/stories",
-    "!lib-esm/__tests__",
-    "!lib-esm/stories",
+    "dist/lib/node_modules",
     "generated",
     "CHANGELOG.md"
   ],

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -221,7 +221,7 @@ export default [
     external: dependencies.map(createPackageRegex),
     output: {
       interop: 'auto',
-      dir: 'lib-esm',
+      dir: 'dist/lib-esm',
       format: 'esm',
       preserveModules: true,
       preserveModulesRoot: 'src',
@@ -234,7 +234,7 @@ export default [
     external: dependencies.filter(name => !ESM_ONLY.has(name)).map(createPackageRegex),
     output: {
       interop: 'auto',
-      dir: 'lib',
+      dir: 'dist/lib',
       format: 'commonjs',
       preserveModules: true,
       preserveModulesRoot: 'src',

--- a/packages/react/script/build
+++ b/packages/react/script/build
@@ -15,10 +15,7 @@ npx rollup -c
 npx tsc --project tsconfig.build.json
 
 # Copy type declarations
-npx copyfiles -u 1 "./lib/**/*.d.ts" ./lib-esm
-
-# Copy css
-npx copyfiles --flat ./lib/components.css ./css
+npx copyfiles -u 2 "./dist/lib/**/*.d.ts" ./dist/lib-esm
 
 # Build components.json file for documentation
 npm run build:components.json

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "outDir": "dist/lib"
   },
   // NOTE: We exclude Storybook stories and test utilities which import
   // Storybook and its dependencies, because:


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This moves us closer to our end goal for how we want to bundle up `@primer/react` 👀. In this PR, we update our rollup config to emit all package files into the `dist` directory and make the corresponding changes in `package.json` to point to the new location of things.

In the future, we'll likely have this `dist` directory only be exporting ESM files. 

This change will also make it a little easier for us to start to enable tools like `publint` as it's a little easier for us to dual emit types for CJS/ESM (if we want to do that before moving to ESM).

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
