### PR TITLE
chore(deps): update typescript to 5.7.2

### DIFF
--- a/examples/app-router/package.json
+++ b/examples/app-router/package.json
@@ -15,7 +15,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "styled-components": "5.x",
-    "typescript": "^5.6.3"
+    "typescript": "^5.7.2"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "14.1.0",

--- a/examples/codesandbox/package.json
+++ b/examples/codesandbox/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.7",
     "styled-components": "5.x",
-    "typescript": "^5.6.3",
+    "typescript": "^5.7.2",
     "vite": "^5.2.14"
   }
 }

--- a/examples/theming/package.json
+++ b/examples/theming/package.json
@@ -17,7 +17,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "styled-components": "5.x",
-    "typescript": "^5.6.3"
+    "typescript": "^5.7.2"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "rimraf": "5.0.5",
         "size-limit": "11.1.5",
         "stylelint": "16.9.0",
-        "typescript": "5.6.3"
+        "typescript": "^5.7.2"
       },
       "engines": {
         "node": ">=12",
@@ -67,7 +67,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "styled-components": "5.x",
-        "typescript": "^5.6.3"
+        "typescript": "^5.7.2"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "14.1.0",
@@ -91,7 +91,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.7",
         "styled-components": "5.x",
-        "typescript": "^5.6.3",
+        "typescript": "^5.7.2",
         "vite": "^5.2.14"
       }
     },
@@ -131,7 +131,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "styled-components": "5.x",
-        "typescript": "^5.6.3"
+        "typescript": "^5.7.2"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "14.1.0",
@@ -28714,9 +28714,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -30301,7 +30301,7 @@
         "postcss": "^8.4.41",
         "postcss-custom-properties-fallback": "^1.0.2",
         "postcss-mixins": "^11.0.1",
-        "typescript": "^5.6.3"
+        "typescript": "^5.7.2"
       },
       "peerDependencies": {
         "postcss": "^8.4.41"
@@ -30569,7 +30569,7 @@
         "terser": "5.36.0",
         "ts-toolbelt": "9.6.0",
         "tsx": "4.7.0",
-        "typescript": "^5.6.3",
+        "typescript": "^5.7.2",
         "typescript-plugin-css-modules": "5.1.0",
         "unist-util-find": "3.0.0",
         "unist-util-find-before": "4.0.0",
@@ -30895,7 +30895,8 @@
         "postcss-modules": "^6.0.0",
         "rimraf": "^5.0.7",
         "rollup-plugin-esbuild": "^6.1.1",
-        "rollup-plugin-typescript2": "^0.36.0"
+        "rollup-plugin-typescript2": "^0.36.0",
+        "typescript": "^5.7.2"
       },
       "peerDependencies": {
         "postcss": "^8.4.38",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "rimraf": "5.0.5",
     "size-limit": "11.1.5",
     "stylelint": "16.9.0",
-    "typescript": "5.6.3"
+    "typescript": "^5.7.2"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.9.6"

--- a/packages/postcss-preset-primer/package.json
+++ b/packages/postcss-preset-primer/package.json
@@ -29,6 +29,6 @@
     "postcss": "^8.4.41",
     "postcss-custom-properties-fallback": "^1.0.2",
     "postcss-mixins": "^11.0.1",
-    "typescript": "^5.6.3"
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -201,7 +201,7 @@
     "terser": "5.36.0",
     "ts-toolbelt": "9.6.0",
     "tsx": "4.7.0",
-    "typescript": "^5.6.3",
+    "typescript": "^5.7.2",
     "typescript-plugin-css-modules": "5.1.0",
     "unist-util-find": "3.0.0",
     "unist-util-find-before": "4.0.0",

--- a/packages/rollup-plugin-import-css/package.json
+++ b/packages/rollup-plugin-import-css/package.json
@@ -25,7 +25,8 @@
     "postcss-modules": "^6.0.0",
     "rimraf": "^5.0.7",
     "rollup-plugin-esbuild": "^6.1.1",
-    "rollup-plugin-typescript2": "^0.36.0"
+    "rollup-plugin-typescript2": "^0.36.0",
+    "typescript": "^5.7.2"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update TypeScript dependencies to 5.7.2. This will include updates from their [5.7 release](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/).

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update typescript to 5.7.2

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to our internal typescript version and does not impact the public API for consumers.