### PR TITLE
chore(deps): update eslint-plugin-playwright to 2.x

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -200,8 +200,14 @@ module.exports = {
       parserOptions: {
         project: 'tsconfig.json',
       },
-      extends: ['plugin:playwright/jest-playwright'],
-      rules: {},
+      extends: ['plugin:playwright/recommended'],
+      rules: {
+        'playwright/expect-expect': 'off',
+        'playwright/no-conditional-expect': 'off',
+        'playwright/no-conditional-in-test': 'off',
+        'playwright/no-wait-for-selector': 'off',
+        'playwright/valid-title': 'off',
+      },
     },
 
     // rules which apply only to Markdown

--- a/e2e/components/DataTable.test.ts
+++ b/e2e/components/DataTable.test.ts
@@ -180,7 +180,7 @@ test.describe('DataTable', () => {
 
       await expect(region).toBeVisible()
       await expect(tabIndex).toHaveAttribute('tabindex', '0')
-      await expect(labelledby).toHaveAttribute('aria-labelledby', headingId)
+      await expect(labelledby).toHaveAttribute('aria-labelledby', headingId!)
 
       await expect(table).toBeVisible()
       expect(labelledby).toBe(headingId)

--- a/e2e/components/DataTable.test.ts
+++ b/e2e/components/DataTable.test.ts
@@ -175,12 +175,12 @@ test.describe('DataTable', () => {
       const region = page.getByRole('region')
       const table = region.getByRole('table')
 
-      const tabIndex = await region.getAttribute('tabindex')
-      const labelledby = await region.getAttribute('aria-labelledby')
+      const tabIndex = region
+      const labelledby = region
 
       await expect(region).toBeVisible()
-      expect(tabIndex).toBe('0')
-      expect(labelledby).toBe(headingId)
+      await expect(tabIndex).toHaveAttribute('tabindex', '0')
+      await expect(labelledby).toHaveAttribute('aria-labelledby', headingId)
 
       await expect(table).toBeVisible()
       expect(labelledby).toBe(headingId)

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-jest": "28.8.3",
         "eslint-plugin-jsx-a11y": "6.7.1",
         "eslint-plugin-mdx": "3.1.5",
-        "eslint-plugin-playwright": "0.15.1",
+        "eslint-plugin-playwright": "^2.1.0",
         "eslint-plugin-prettier": "5.0.0",
         "eslint-plugin-primer-react": "5.4.0",
         "eslint-plugin-react": "7.32.2",
@@ -13881,17 +13881,51 @@
       }
     },
     "node_modules/eslint-plugin-playwright": {
-      "version": "0.15.1",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.1.0.tgz",
+      "integrity": "sha512-wMbHOehofSB1cBdzz2CLaCYaKNLeTQ0YnOW+7AHa281TJqlpEJUBgTHbRUYOUxiXphfWwOyTPvgr6vvEmArbSA==",
       "dev": true,
       "license": "MIT",
-      "peerDependencies": {
-        "eslint": ">=7",
-        "eslint-plugin-jest": ">=25"
+      "workspaces": [
+        "examples"
+      ],
+      "dependencies": {
+        "globals": "^13.23.0"
       },
-      "peerDependenciesMeta": {
-        "eslint-plugin-jest": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=16.6.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/eslint-plugin-playwright/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-playwright/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-jest": "28.8.3",
     "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-mdx": "3.1.5",
-    "eslint-plugin-playwright": "0.15.1",
+    "eslint-plugin-playwright": "^2.1.0",
     "eslint-plugin-prettier": "5.0.0",
     "eslint-plugin-primer-react": "5.4.0",
     "eslint-plugin-react": "7.32.2",


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Have been taking a look at our eslint config to start moving over to v9 and noticed this plugin was behind a couple major versions 👀 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `eslint-plugin-playwright` to 2.x
- Update our eslint config to disable new recommended rules that don't apply to how we author tests
- Apply autofix from running eslint on test files

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is an internal change to our eslint config.