### PR TITLE
fix(Table): update invalid line-height value

### DIFF
--- a/.changeset/healthy-humans-chew.md
+++ b/.changeset/healthy-humans-chew.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Update line-height value for Table to be a valid calc() expression

--- a/packages/react/src/DataTable/Table.tsx
+++ b/packages/react/src/DataTable/Table.tsx
@@ -31,7 +31,7 @@ const StyledTable = styled.table<React.ComponentPropsWithoutRef<'table'>>`
   display: grid;
   font-size: var(--table-font-size);
   grid-template-columns: var(--grid-template-columns);
-  line-height: calc(20 / var(--table-font-size));
+  line-height: calc(20 / 12);
   width: 100%;
 
   /* Density modes: condensed, normal, spacious */


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/5362
Closes https://github.com/github/primer/issues/4415

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Update an invalid `line-height` value which was dividing a unitless number by a `rem` value.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update the `line-height` specified in `Table` to use unitless values

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
