### PR TITLE
fix(useFormControlForwardedProps): do not pass through validationStatus

### DIFF
--- a/.changeset/kind-kiwis-crash.md
+++ b/.changeset/kind-kiwis-crash.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+fix(useFormControlForwardedProps): do not pass through validationStatus

--- a/packages/react/src/FormControl/_FormControlContext.tsx
+++ b/packages/react/src/FormControl/_FormControlContext.tsx
@@ -17,7 +17,7 @@ export function useFormControlContext(): FormControlContext {
   return useContext(FormControlContext) ?? {}
 }
 
-interface FormControlForwardedProps extends Omit<FormControlContext, 'captionId' | 'validationMessageId'> {
+interface FormControlForwardedProps extends Pick<FormControlProps, 'disabled' | 'id' | 'required'> {
   ['aria-describedby']?: string
 }
 
@@ -29,22 +29,14 @@ interface FormControlForwardedProps extends Omit<FormControlContext, 'captionId'
  * @param externalProps The external props passed to this component. If provided, these props will be merged with the
  * `FormControl` props, with external props taking priority.
  */
-export function useFormControlForwardedProps<P>(externalProps: P): P & FormControlForwardedProps
-/**
- * Make any component compatible with `FormControl`'s automatic wiring up of accessibility attributes & validation by
- * reading the props from this hook and handling them / assigning them to the underlying form control. If used outside
- * of `FormControl`, this hook has no effect.
- */
-export function useFormControlForwardedProps(): FormControlForwardedProps
-export function useFormControlForwardedProps(externalProps: FormControlForwardedProps = {}) {
+export function useFormControlForwardedProps<P>(externalProps: P): P & FormControlForwardedProps {
   const context = useContext(FormControlContext)
-  if (!context) return externalProps
+  if (!context) return externalProps as P & FormControlForwardedProps
 
   return {
     disabled: context.disabled,
     id: context.id,
     required: context.required,
-    validationStatus: context.validationStatus,
     ['aria-describedby']: [context.validationMessageId, context.captionId].filter(Boolean).join(' ') || undefined,
     ...externalProps,
   }

--- a/packages/react/src/__tests__/FormControl.test.tsx
+++ b/packages/react/src/__tests__/FormControl.test.tsx
@@ -458,7 +458,7 @@ describe('FormControl', () => {
 describe('useFormControlForwardedProps', () => {
   describe('when used outside FormControl', () => {
     test('returns empty object when no props object passed', () => {
-      const result = renderHook(() => useFormControlForwardedProps())
+      const result = renderHook(() => useFormControlForwardedProps({}))
       expect(result.result.current).toEqual({})
     })
 
@@ -472,7 +472,7 @@ describe('useFormControlForwardedProps', () => {
   test('provides context value when no props object is passed', () => {
     const id = 'test-id'
 
-    const {result} = renderHook(() => useFormControlForwardedProps(), {
+    const {result} = renderHook(() => useFormControlForwardedProps({}), {
       wrapper: ({children}: {children: React.ReactNode}) => (
         <FormControl id={id} disabled required>
           <FormControl.Label>Label</FormControl.Label>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->


<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->
- Update type and remove `validationStatus` from `useFormControlForwardedProps` since it is not a valid aria attribute

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
