### PR TITLE
Add `onPrimary` variant to `KeybindingHint`

### DIFF
--- a/.changeset/flat-sheep-look.md
+++ b/.changeset/flat-sheep-look.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Add `onPrimary` `variant` to `KeybindingHint`

--- a/packages/react/src/KeybindingHint/KeybindingHint.examples.stories.tsx
+++ b/packages/react/src/KeybindingHint/KeybindingHint.examples.stories.tsx
@@ -20,7 +20,16 @@ export const PrimaryButton: StoryObj<KeybindingHintProps> = {
       Submit
     </Button>
   ),
-  args: {keys: 'Mod+Enter', variant: 'onEmphasis'},
+  args: {keys: 'Mod+Enter', variant: 'onPrimary'},
+}
+
+export const DangerButton: StoryObj<KeybindingHintProps> = {
+  render: args => (
+    <Button variant="danger" trailingVisual={() => <KeybindingHint {...args} />}>
+      Delete
+    </Button>
+  ),
+  args: {keys: 'Mod+Delete', variant: 'normal'},
 }
 
 export const ActionListExample: StoryObj<KeybindingHintProps> = {

--- a/packages/react/src/KeybindingHint/KeybindingHint.features.stories.tsx
+++ b/packages/react/src/KeybindingHint/KeybindingHint.features.stories.tsx
@@ -22,11 +22,20 @@ export const SequenceFull = {args: {keys: sequence, format: 'full'}}
 
 export const OnEmphasis: StoryObj<KeybindingHintProps> = {
   render: args => (
-    <Box sx={{backgroundColor: 'accent.fg', p: 3}}>
+    <Box sx={{backgroundColor: 'var(--bgColor-black)', p: 3}}>
       <KeybindingHint {...args} />
     </Box>
   ),
   args: {keys: chord, variant: 'onEmphasis'},
+}
+
+export const OnPrimary: StoryObj<KeybindingHintProps> = {
+  render: args => (
+    <Box sx={{backgroundColor: 'var(--button-primary-bgColor-rest)', p: 3}}>
+      <KeybindingHint {...args} />
+    </Box>
+  ),
+  args: {keys: chord, variant: 'onPrimary'},
 }
 
 export const Small = {args: {keys: chord, size: 'small'}}

--- a/packages/react/src/KeybindingHint/components/Chord.tsx
+++ b/packages/react/src/KeybindingHint/components/Chord.tsx
@@ -29,14 +29,20 @@ const splitChord = (chord: string) =>
     .map(k => k.toLowerCase())
     .sort(compareLowercaseKeys)
 
+const backgroundColors = {
+  normal: 'var(--bgColor-transparent)',
+  onEmphasis: 'var(--counter-bgColor-emphasis)',
+  onPrimary: 'var(--button-primary-bgColor-active)',
+}
+
 export const Chord = ({keys, format = 'condensed', variant = 'normal', size = 'normal'}: KeybindingHintProps) => (
   <Text
     sx={{
       display: 'inline-flex',
-      bg: variant === 'onEmphasis' ? 'var(--counter-bgColor-emphasis)' : 'var(--bgColor-transparent)',
-      color: variant === 'onEmphasis' ? 'var(--fgColor-onEmphasis)' : 'var(--fgColor-muted)',
+      bg: backgroundColors[variant],
+      color: variant === 'normal' ? 'var(--fgColor-muted)' : 'var(--fgColor-onEmphasis)',
       border: '1px solid',
-      borderColor: variant === 'onEmphasis' ? 'transparent' : 'var(--borderColor-default)',
+      borderColor: variant === 'normal' ? 'var(--borderColor-default)' : 'transparent',
       borderRadius: size === 'small' ? 1 : 2,
       fontWeight: 'normal',
       fontFamily: 'normal',

--- a/packages/react/src/KeybindingHint/props.ts
+++ b/packages/react/src/KeybindingHint/props.ts
@@ -1,6 +1,6 @@
 export type KeybindingHintFormat = 'condensed' | 'full'
 
-export type KeybindingHintVariant = 'normal' | 'onEmphasis'
+export type KeybindingHintVariant = 'normal' | 'onEmphasis' | 'onPrimary'
 
 export interface KeybindingHintProps {
   /**
@@ -24,7 +24,7 @@ export interface KeybindingHintProps {
    */
   format?: KeybindingHintFormat
   /**
-   * Set to `onEmphasis` for display on emphasis colors.
+   * Set to `onEmphasis` for display on emphasis colors, and `onPrimary` for display on primary buttons.
    */
   variant?: KeybindingHintVariant
   /**


### PR DESCRIPTION
Adds an `onPrimary` variant to `KeybindingHint` to close https://github.com/primer/react/issues/5351 and improve the appearance of primary button hints:

<img width="135" alt="image" src="https://github.com/user-attachments/assets/8e834919-19d8-4777-9850-13ddd3534d80" />

This is a temporary fix until we have a more full-featured design spec for this component, at which point we can implement this in a better manner. I don't really love the `onEmphasis/onPrimary` variant names, but it's consistent with what's there and doesn't break anything.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

Adds an `onPrimary` variant to `KeybindingHint` for use on primary buttons

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
