### PR TITLE
bugfix(Stack): Fix typo in custom media variable used in Stack component

### DIFF
--- a/.changeset/chilled-nails-juggle.md
+++ b/.changeset/chilled-nails-juggle.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+bugfix(Stack): Fix typo in custom media variable used in Stack component

--- a/packages/react/src/Stack/Stack.module.css
+++ b/packages/react/src/Stack/Stack.module.css
@@ -113,7 +113,7 @@
     flex-wrap: nowrap;
   }
 
-  @media (--veiwportRange-regular) {
+  @media (--viewportRange-regular) {
     &[data-padding-regular='none'] {
       padding: 0;
     }
@@ -301,7 +301,7 @@
     flex-grow: 1;
   }
 
-  @media (--veiwportRange-regular) {
+  @media (--viewportRange-regular) {
     &[data-grow-regular='true'] {
       flex-grow: 1;
     }

--- a/packages/react/src/Stack/Stack.tsx
+++ b/packages/react/src/Stack/Stack.tsx
@@ -126,7 +126,7 @@ const StyledStack = toggleStyledComponent(
       flex-wrap: nowrap;
     }
 
-    // @custom-media --veiwportRange-regular
+    // @custom-media --viewportRange-regular
     @media (min-width: 48rem) {
       &[data-padding-regular='none'] {
         padding: 0;
@@ -406,7 +406,7 @@ const StyledStackItem = toggleStyledComponent(
       flex-grow: 1;
     }
 
-    // @custom-media --veiwportRange-regular
+    // @custom-media --viewportRange-regular
     @media (min-width: 48rem) {
       &[data-grow-regular='true'] {
         flex-grow: 1;


### PR DESCRIPTION
This fixes an issue brought up https://github.slack.com/archives/C01L618AEP9/p1733943072984009

The variable I was using for the custom media was a typo and wasn't compiling into the actual value.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

Fix typo in custom media variable used in Stack component

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
