### PR TITLE
Add className back to TokenBase

### DIFF
--- a/.changeset/dirty-wasps-behave.md
+++ b/.changeset/dirty-wasps-behave.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Add className back to TokenBase

--- a/packages/react/src/Token/AvatarToken.tsx
+++ b/packages/react/src/Token/AvatarToken.tsx
@@ -70,6 +70,7 @@ const AvatarToken = forwardRef(({avatarSrc, id, size = defaultTokenSize, classNa
       sx={{
         paddingLeft: get('space.1'),
       }}
+      className={className}
       {...rest}
       ref={forwardedRef}
     />

--- a/packages/react/src/Token/IssueLabelToken.tsx
+++ b/packages/react/src/Token/IssueLabelToken.tsx
@@ -180,6 +180,7 @@ const IssueLabelToken = forwardRef((props, forwardedRef) => {
       text={text}
       size={size}
       sx={labelStyles}
+      className={className}
       {...(!hasMultipleActionTargets ? interactiveTokenProps : {})}
       {...rest}
       ref={forwardedRef}

--- a/packages/react/src/Token/Token.tsx
+++ b/packages/react/src/Token/Token.tsx
@@ -136,6 +136,7 @@ const Token = forwardRef((props, forwardedRef) => {
       text={text}
       size={size}
       sx={mergedSx}
+      className={className}
       {...(!hasMultipleActionTargets ? interactiveTokenProps : {})}
       {...rest}
       ref={forwardedRef}

--- a/packages/react/src/Token/TokenBase.tsx
+++ b/packages/react/src/Token/TokenBase.tsx
@@ -173,6 +173,7 @@ const TokenBase = React.forwardRef<HTMLButtonElement | HTMLAnchorElement | HTMLS
             onRemove()
           }
         }}
+        className={className}
         id={id?.toString()}
         size={size}
         {...rest}

--- a/packages/react/src/Token/__tests__/Token.test.tsx
+++ b/packages/react/src/Token/__tests__/Token.test.tsx
@@ -77,6 +77,13 @@ const testTokenComponent = (Component: React.ComponentType<React.PropsWithChildr
     expect(onRemoveMock).toHaveBeenCalled()
   })
 
+  it('adds className to rendered component', () => {
+    const {getByText} = HTMLRender(<Component text="token" className="testing-class" />)
+    const domNode = getByText('token')
+
+    expect(domNode.parentElement).toHaveClass('testing-class')
+  })
+
   it('should have no axe violations', async () => {
     const {container} = HTMLRender(<Component text="token" />)
     const results = await axe.run(container)


### PR DESCRIPTION
Prior to https://github.com/primer/react/pull/5271, the `className` in `TokenBase` was part of the `...rest` variables that were spread onto the token base. Now that the `className` is directly referenced as part of the feature-flagged token, we need to directly reference it for the non-feature flagged token.

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Create a `Token` with a class name, that class should be on the resulting rendered token.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
