### PR TITLE
feat(BaseStyles): Fix Typography and Common props when CSS modules feature flag is enabled

### DIFF
--- a/.changeset/polite-books-sneeze.md
+++ b/.changeset/polite-books-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Fix Typography and Common props for BaseStyles when CSS modules feature flag is enabled

--- a/packages/react/src/BaseStyles.dev.stories.tsx
+++ b/packages/react/src/BaseStyles.dev.stories.tsx
@@ -1,6 +1,5 @@
 import {BaseStyles} from '.'
 import type {Meta} from '@storybook/react'
-import React from 'react'
 import type {ComponentProps} from './utils/types'
 
 export default {
@@ -8,4 +7,4 @@ export default {
   component: BaseStyles,
 } as Meta<ComponentProps<typeof BaseStyles>>
 
-export const Default = () => <BaseStyles>Hello</BaseStyles>
+export const Default = () => 'Hello'

--- a/packages/react/src/BaseStyles.tsx
+++ b/packages/react/src/BaseStyles.tsx
@@ -47,6 +47,7 @@ export type BaseStylesProps = PropsWithChildren & {
   as?: React.ComponentType<any> | keyof JSX.IntrinsicElements
   className?: string
   style?: CSSProperties
+  color?: string // Fixes `color` ts-error
 } & SystemTypographyProps &
   SystemCommonProps &
   SxProp

--- a/packages/react/src/BaseStyles.tsx
+++ b/packages/react/src/BaseStyles.tsx
@@ -1,12 +1,14 @@
-import React from 'react'
+import React, {type CSSProperties, type PropsWithChildren} from 'react'
 import {clsx} from 'clsx'
 import styled, {createGlobalStyle} from 'styled-components'
-import type {ComponentProps} from './utils/types'
 import type {SystemCommonProps, SystemTypographyProps} from './constants'
 import {COMMON, TYPOGRAPHY} from './constants'
 import {useTheme} from './ThemeProvider'
 import {useFeatureFlag} from './FeatureFlags'
-import {toggleStyledComponent} from './internal/utils/toggleStyledComponent'
+import Box from './Box'
+import type {SxProp} from './sx'
+import {includesSystemProps} from './utils/includeSystemProps'
+
 import classes from './BaseStyles.module.css'
 
 // load polyfill for :focus-visible
@@ -35,45 +37,106 @@ const GlobalStyle = createGlobalStyle<{colorScheme?: 'light' | 'dark'}>`
   }
 `
 
-const Base = toggleStyledComponent(
-  CSS_MODULES_FEATURE_FLAG,
-  'div',
-  styled.div<SystemTypographyProps & SystemCommonProps>`
-    ${TYPOGRAPHY};
-    ${COMMON};
-  `,
-)
+const StyledDiv = styled.div<SystemTypographyProps & SystemCommonProps>`
+  ${TYPOGRAPHY};
+  ${COMMON};
+`
 
-export type BaseStylesProps = ComponentProps<typeof Base>
+export type BaseStylesProps = PropsWithChildren & {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  as?: React.ComponentType<any> | keyof JSX.IntrinsicElements
+  className?: string
+  style?: CSSProperties
+  color?: string // Fixes `color` ts error
+} & SystemTypographyProps &
+  SystemCommonProps &
+  SxProp
 
 function BaseStyles(props: BaseStylesProps) {
-  const {children, color = 'fg.default', fontFamily = 'normal', lineHeight = 'default', className, ...rest} = props
+  const {
+    children,
+    color = 'var(--fgColor-default)',
+    fontFamily = 'normal',
+    lineHeight = 'default',
+    className,
+    as: Component = 'div',
+    ...rest
+  } = props
 
   const {colorScheme, dayScheme, nightScheme} = useTheme()
   const enabled = useFeatureFlag(CSS_MODULES_FEATURE_FLAG)
 
-  const stylingProps = enabled ? {className: clsx(classes.BaseStyles, className)} : {className}
+  if (enabled) {
+    const newClassName = clsx(classes.BaseStyles, className)
 
-  /**
-   * We need to map valid primer/react color modes onto valid color modes for primer/primitives
-   * valid color modes for primer/primitives: auto | light | dark
-   * valid color modes for primer/primer: auto | day | night | light | dark
-   */
+    // If props includes TYPOGRAPHY or COMMON props, pass them to the Box component
+    if (includesSystemProps(props)) {
+      return (
+        // @ts-ignore shh
+        <Box
+          as={Component}
+          className={newClassName}
+          color={color}
+          fontFamily={fontFamily}
+          lineHeight={lineHeight}
+          data-portal-root
+          /**
+           * We need to map valid primer/react color modes onto valid color modes for primer/primitives
+           * valid color modes for primer/primitives: auto | light | dark
+           * valid color modes for primer/primer: auto | day | night | light | dark
+           */
+          data-color-mode={colorScheme?.includes('dark') ? 'dark' : 'light'}
+          data-light-theme={dayScheme}
+          data-dark-theme={nightScheme}
+          {...rest}
+        >
+          {children}
+        </Box>
+      )
+    }
+
+    return (
+      <Component
+        className={newClassName}
+        color={color}
+        fontFamily={fontFamily}
+        lineHeight={lineHeight}
+        data-portal-root
+        /**
+         * We need to map valid primer/react color modes onto valid color modes for primer/primitives
+         * valid color modes for primer/primitives: auto | light | dark
+         * valid color modes for primer/primer: auto | day | night | light | dark
+         */
+        data-color-mode={colorScheme?.includes('dark') ? 'dark' : 'light'}
+        data-light-theme={dayScheme}
+        data-dark-theme={nightScheme}
+        {...rest}
+      >
+        {children}
+      </Component>
+    )
+  }
+
   return (
-    <Base
-      {...rest}
-      {...stylingProps}
+    <StyledDiv
+      className={className}
       color={color}
       fontFamily={fontFamily}
       lineHeight={lineHeight}
       data-portal-root
+      /**
+       * We need to map valid primer/react color modes onto valid color modes for primer/primitives
+       * valid color modes for primer/primitives: auto | light | dark
+       * valid color modes for primer/primer: auto | day | night | light | dark
+       */
       data-color-mode={colorScheme?.includes('dark') ? 'dark' : 'light'}
       data-light-theme={dayScheme}
       data-dark-theme={nightScheme}
+      {...rest}
     >
-      {!enabled && <GlobalStyle colorScheme={colorScheme?.includes('dark') ? 'dark' : 'light'} />}
+      <GlobalStyle colorScheme={colorScheme?.includes('dark') ? 'dark' : 'light'} />
       {children}
-    </Base>
+    </StyledDiv>
   )
 }
 

--- a/packages/react/src/BaseStyles.tsx
+++ b/packages/react/src/BaseStyles.tsx
@@ -7,7 +7,7 @@ import {useTheme} from './ThemeProvider'
 import {useFeatureFlag} from './FeatureFlags'
 import Box from './Box'
 import type {SxProp} from './sx'
-import {includesSystemProps} from './utils/includeSystemProps'
+import {includesSystemProps, getTypographyAndCommonProps} from './utils/includeSystemProps'
 
 import classes from './BaseStyles.module.css'
 
@@ -47,7 +47,6 @@ export type BaseStylesProps = PropsWithChildren & {
   as?: React.ComponentType<any> | keyof JSX.IntrinsicElements
   className?: string
   style?: CSSProperties
-  color?: string // Fixes `color` ts error
 } & SystemTypographyProps &
   SystemCommonProps &
   SxProp
@@ -71,6 +70,7 @@ function BaseStyles(props: BaseStylesProps) {
 
     // If props includes TYPOGRAPHY or COMMON props, pass them to the Box component
     if (includesSystemProps(props)) {
+      const systemProps = getTypographyAndCommonProps(props)
       return (
         // @ts-ignore shh
         <Box
@@ -88,6 +88,7 @@ function BaseStyles(props: BaseStylesProps) {
           data-color-mode={colorScheme?.includes('dark') ? 'dark' : 'light'}
           data-light-theme={dayScheme}
           data-dark-theme={nightScheme}
+          style={systemProps}
           {...rest}
         >
           {children}

--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -8,8 +8,9 @@ import sx from '../sx'
 import {useFeatureFlag} from '../FeatureFlags'
 import Box from '../Box'
 import {useRefObjectAsForwardedRef} from '../hooks'
-import classes from './Text.module.css'
 import type {ComponentProps} from '../utils/types'
+import {includesSystemProps} from '../utils/includeSystemProps'
+import classes from './Text.module.css'
 
 type StyledTextProps = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -57,19 +58,6 @@ const StyledText = styled.span<StyledTextProps>`
 
   ${sx};
 `
-
-const COMMON_PROP_NAMES = new Set(Object.keys(COMMON))
-const TYPOGRAPHY_PROP_NAMES = new Set(Object.keys(TYPOGRAPHY))
-
-const includesSystemProps = (props: StyledTextProps) => {
-  if (props.sx) {
-    return true
-  }
-
-  return Object.keys(props).some(prop => {
-    return TYPOGRAPHY_PROP_NAMES.has(prop) || COMMON_PROP_NAMES.has(prop)
-  })
-}
 
 const Text = forwardRef(({as: Component = 'span', className, size, weight, ...props}, forwardedRef) => {
   const enabled = useFeatureFlag('primer_react_css_modules_ga')

--- a/packages/react/src/__tests__/BaseStyles.test.tsx
+++ b/packages/react/src/__tests__/BaseStyles.test.tsx
@@ -33,7 +33,7 @@ describe('BaseStyles', () => {
 
   it('respects system props', () => {
     const {container} = render(
-      <BaseStyles display="contents" whiteSpace="pre-wrap">
+      <BaseStyles display="contents" whiteSpace="pre-wrap" mr="2">
         Hello
       </BaseStyles>,
     )
@@ -41,6 +41,7 @@ describe('BaseStyles', () => {
     expect(container.children[0]).toHaveStyle({
       display: 'contents',
       'white-space': 'pre-wrap',
+      'margin-right': '8px',
     })
   })
 

--- a/packages/react/src/__tests__/BaseStyles.test.tsx
+++ b/packages/react/src/__tests__/BaseStyles.test.tsx
@@ -16,7 +16,7 @@ describe('BaseStyles', () => {
   })
 
   it('has default styles', () => {
-    const {container} = render(<BaseStyles></BaseStyles>)
+    const {container} = render(<BaseStyles>Hello</BaseStyles>)
     expect(container).toMatchSnapshot()
   })
 
@@ -27,8 +27,21 @@ describe('BaseStyles', () => {
       lineHeight: '3.5',
     }
 
-    const {container} = render(<BaseStyles {...styles}></BaseStyles>)
+    const {container} = render(<BaseStyles {...styles}>Hello</BaseStyles>)
     expect(container.children[0]).toHaveStyle({color: '#f00', 'font-family': 'Arial', 'line-height': '3.5'})
+  })
+
+  it('respects system props', () => {
+    const {container} = render(
+      <BaseStyles display="contents" whiteSpace="pre-wrap">
+        Hello
+      </BaseStyles>,
+    )
+
+    expect(container.children[0]).toHaveStyle({
+      display: 'contents',
+      'white-space': 'pre-wrap',
+    })
   })
 
   it('accepts className and style props', () => {
@@ -38,7 +51,7 @@ describe('BaseStyles', () => {
       sx: {},
     }
 
-    const {container} = render(<BaseStyles {...styles}></BaseStyles>)
+    const {container} = render(<BaseStyles {...styles}>Hello</BaseStyles>)
     expect(container.children[0]).toHaveClass('test-classname')
     expect(container.children[0]).toHaveStyle({margin: '10px'})
   })

--- a/packages/react/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`AnchoredOverlay should render consistently when open 1`] = `
 .c0 {
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   line-height: 1.5;
-  color: var(--fgColor-default,var(--color-fg-default,#1F2328));
+  color: var(--fgColor-default);
 }
 
 .c1 {
@@ -38,7 +38,7 @@ exports[`AnchoredOverlay should render consistently when open 1`] = `
 <div>
   <div
     class="c0"
-    color="fg.default"
+    color="var(--fgColor-default)"
     data-color-mode="light"
     data-dark-theme="dark"
     data-light-theme="light"

--- a/packages/react/src/__tests__/__snapshots__/BaseStyles.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/BaseStyles.test.tsx.snap
@@ -4,16 +4,18 @@ exports[`BaseStyles has default styles 1`] = `
 .c0 {
   font-family: normal;
   line-height: default;
-  color: fg.default;
+  color: var(--fgColor-default);
 }
 
 <div>
   <div
     class="c0"
-    color="fg.default"
+    color="var(--fgColor-default)"
     data-color-mode="light"
     data-portal-root="true"
     font-family="normal"
-  />
+  >
+    Hello
+  </div>
 </div>
 `;

--- a/packages/react/src/utils/includeSystemProps.ts
+++ b/packages/react/src/utils/includeSystemProps.ts
@@ -1,0 +1,17 @@
+import {COMMON, TYPOGRAPHY} from '../constants'
+import type {SxProp} from '../sx'
+
+const COMMON_PROP_NAMES = new Set(Object.keys(COMMON))
+const TYPOGRAPHY_PROP_NAMES = new Set(Object.keys(TYPOGRAPHY))
+
+const includesSystemProps = (props: SxProp) => {
+  if (props.sx) {
+    return true
+  }
+
+  return Object.keys(props).some(prop => {
+    return TYPOGRAPHY_PROP_NAMES.has(prop) || COMMON_PROP_NAMES.has(prop)
+  })
+}
+
+export {includesSystemProps}

--- a/packages/react/src/utils/includeSystemProps.ts
+++ b/packages/react/src/utils/includeSystemProps.ts
@@ -1,4 +1,4 @@
-import {COMMON, TYPOGRAPHY} from '../constants'
+import {COMMON, TYPOGRAPHY, type SystemCommonProps, type SystemTypographyProps} from '../constants'
 import type {SxProp} from '../sx'
 
 const COMMON_PROP_NAMES = new Set(Object.keys(COMMON))
@@ -14,4 +14,18 @@ const includesSystemProps = (props: SxProp) => {
   })
 }
 
-export {includesSystemProps}
+type TypographyAndCommonProp = SystemTypographyProps & SystemCommonProps
+
+const getTypographyAndCommonProps = (props: TypographyAndCommonProp): TypographyAndCommonProp => {
+  let typographyAndCommonProps = {} as TypographyAndCommonProp
+  for (const prop of Object.keys(props)) {
+    if (TYPOGRAPHY_PROP_NAMES.has(prop) || COMMON_PROP_NAMES.has(prop)) {
+      const p = prop as keyof TypographyAndCommonProp
+      typographyAndCommonProps = {...typographyAndCommonProps, [p]: props[p]}
+    }
+  }
+
+  return typographyAndCommonProps
+}
+
+export {includesSystemProps, getTypographyAndCommonProps}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Related to [slack (hubbers only)](https://github.slack.com/archives/C07QUP8G909/p1734116004316449)

The issue reported was the inability to scroll on the project's settings page when the CSS modules feature flag was enabled. This was due to a missing `display: "contents"` styling from a prop passed to `BaseStyles`. This PR is ensure the props passed to BaseStyles are correctly styled when ff is enabled.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Created `includesSystemProps` util from `Text` to be reused in `BaseStyles`
- Created `getTypographyAndCommonProps` to return an object of the typography and common props
- Added test for system props in BaseStyles

#### Changed

<!-- List of things changed in this PR -->

- [Based on prior art in Text component](https://github.com/primer/react/blob/main/packages/react/src/Text/Text.tsx#L81), I removed `toggleStyledComponent` and updated the component to check for system props passed through
#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
