### PR TITLE
Don't deprecate Box sx prop

### DIFF
--- a/packages/react/src/Box/Box.tsx
+++ b/packages/react/src/Box/Box.tsx
@@ -12,11 +12,13 @@ import type {
   TypographyProps,
 } from 'styled-system'
 import {background, border, color, flexbox, grid, layout, position, shadow, space, typography} from 'styled-system'
-import type {SxProp} from '../sx'
+import type {BetterSystemStyleObject} from '../sx'
 import sx from '../sx'
 import type {ComponentProps} from '../utils/types'
 
-type StyledBoxProps = SpaceProps &
+type StyledBoxProps = {
+  sx?: BetterSystemStyleObject
+} & SpaceProps &
   ColorProps &
   TypographyProps &
   LayoutProps &
@@ -25,8 +27,7 @@ type StyledBoxProps = SpaceProps &
   BackgroundProps &
   BorderProps &
   PositionProps &
-  ShadowProps &
-  SxProp
+  ShadowProps
 
 const Box = styled.div<StyledBoxProps>(
   space,


### PR DESCRIPTION
I missed this in https://github.com/primer/react/pull/5443

We don't want to deprecate `Box`'s use of `sx` prop because it only is used for sx. We will likely follow up with a deprecation pr for Box

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
