### PR TITLE
fix(PageLayout): Remove unused width value in PageLayout.Pane

### DIFF
--- a/.changeset/forty-doors-visit.md
+++ b/.changeset/forty-doors-visit.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Fix responsive width of PageLayout

--- a/packages/react/src/PageLayout/PageLayout.examples.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.examples.stories.tsx
@@ -61,6 +61,7 @@ export const ParentDetail: StoryFn = () => {
             regular: false,
             wide: false,
           }}
+          aria-label="Side pane"
         >
           <NavList>
             <NavList.Item
@@ -175,6 +176,7 @@ export const ParentDetailBreadcrumb: StoryFn = () => {
             regular: false,
             wide: false,
           }}
+          aria-label="Side pane"
         >
           <NavList>
             <NavList.Item
@@ -275,6 +277,7 @@ export const FilterBottomSheet: StoryFn = () => {
             regular: false,
             wide: false,
           }}
+          aria-label="Side pane"
         >
           <NavList>
             <NavList.Item
@@ -364,6 +367,7 @@ export const FilterActionMenu: StoryFn = () => {
             regular: false,
             wide: false,
           }}
+          aria-label="Side pane"
         >
           <NavList>
             <NavList.Item
@@ -627,6 +631,7 @@ export const FiltersBottomSheetTwoLevels: StoryFn = () => {
             regular: false,
             wide: false,
           }}
+          aria-label="Side pane"
         >
           <NavList>
             <NavList.Item
@@ -1118,6 +1123,7 @@ export const ParentDetailPlusFilters: StoryFn = () => {
             regular: false,
             wide: false,
           }}
+          aria-label="Side pane"
         >
           <NavList>
             <NavList.Item

--- a/packages/react/src/PageLayout/PageLayout.features.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.features.stories.tsx
@@ -58,7 +58,7 @@ export const PullRequestPage = () => (
         this overflows, it should not break to overall page layout!
       </Box>
     </PageLayout.Content>
-    <PageLayout.Pane>
+    <PageLayout.Pane aria-label="Side pane">
       <Box sx={{display: 'flex', flexDirection: 'column', gap: 3}}>
         <Box>
           <Text sx={{fontSize: 0, fontWeight: 'bold', display: 'block', color: 'fg.muted'}}>Assignees</Text>
@@ -310,7 +310,7 @@ export const ResizablePane: StoryFn = () => (
     <PageLayout.Header>
       <Placeholder height={64} label="Header" />
     </PageLayout.Header>
-    <PageLayout.Pane resizable position="start">
+    <PageLayout.Pane resizable position="start" aria-label="Side pane">
       <Placeholder height={320} label="Pane" />
     </PageLayout.Pane>
     <PageLayout.Content>
@@ -329,7 +329,7 @@ export const ScrollContainerWithinPageLayoutPane: StoryFn = () => (
       <PageLayout rowGap="none" columnGap="none" padding="none" containerWidth="full">
         <PageLayout.Pane position="start" padding="normal" divider="line" sticky aria-label="Sticky pane">
           <Box sx={{overflow: 'auto'}}>
-            <PageLayout.Pane padding="normal">
+            <PageLayout.Pane padding="normal" aria-label="Side pane">
               <Placeholder label="Inner scroll container" height={800} />
             </PageLayout.Pane>
           </Box>
@@ -350,7 +350,7 @@ export const CustomPaneWidths: StoryFn = () => (
     <PageLayout.Header>
       <Placeholder height={64} label="Header" />
     </PageLayout.Header>
-    <PageLayout.Pane resizable width={{min: '200px', default: '300px', max: '400px'}}>
+    <PageLayout.Pane resizable width={{min: '200px', default: '300px', max: '400px'}} aria-label="Side pane">
       <Placeholder height={320} label="Pane" />
     </PageLayout.Pane>
     <PageLayout.Content>
@@ -367,7 +367,7 @@ export const WithCustomPaneHeading: StoryFn = () => (
     <PageLayout.Header>
       <Placeholder height={64} label="Header" />
     </PageLayout.Header>
-    <PageLayout.Pane resizable position="start">
+    <PageLayout.Pane resizable position="start" aria-label="Side pane">
       <Heading as="h2" sx={{fontSize: 3}} id="pane-heading">
         Pane Heading
       </Heading>

--- a/packages/react/src/PageLayout/PageLayout.module.css
+++ b/packages/react/src/PageLayout/PageLayout.module.css
@@ -27,6 +27,11 @@ body[data-page-layout-dragging='true'] * {
     --spacing-normal: var(--base-size-24);
   }
 
+/* 
+  small: ['100%', null, '240px', '256px'],
+  medium: ['100%', null, '256px', '296px'],
+  large: ['100%', null, '256px', '320px', '336px'], */
+
   /* Pane Width Values */
   --pane-width-small: 100%;
   --pane-width-medium: 100%;
@@ -46,7 +51,6 @@ body[data-page-layout-dragging='true'] * {
   }
 
   @media screen and (min-width: 1280px) {
-    --pane-width-large: 336px;
     --pane-max-width-diff: 959px;
   }
 

--- a/packages/react/src/PageLayout/PageLayout.tsx
+++ b/packages/react/src/PageLayout/PageLayout.tsx
@@ -764,6 +764,8 @@ const paneWidths = {
 
 const defaultPaneWidth = {small: 256, medium: 296, large: 320}
 
+const overflowProps = {tabIndex: 0, role: 'region'}
+
 const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayoutPaneProps>>(
   (
     {
@@ -998,7 +1000,7 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
         />
         <Box
           ref={paneRef}
-          {...(hasOverflow && {tabIndex: 0, role: 'region'})}
+          {...(hasOverflow ? overflowProps : {})}
           {...labelProp}
           {...(id && {id: paneId})}
           {...paneStylingProps}

--- a/packages/react/src/PageLayout/PageLayout.tsx
+++ b/packages/react/src/PageLayout/PageLayout.tsx
@@ -759,7 +759,7 @@ const panePositions = {
 const paneWidths = {
   small: ['100%', null, '240px', '256px'],
   medium: ['100%', null, '256px', '296px'],
-  large: ['100%', null, '256px', '320px', '336px'],
+  large: ['100%', null, '256px', '320px'],
 }
 
 const defaultPaneWidth = {small: 256, medium: 296, large: 320}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/4532

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

It appears that for responsive array values for `sx`, they only accept arrays of max lengh of 4 and ignore any values after that point. When converting to CSS modules I thought the 5th value would associated to the `1280px` breakpoint, but that was not the case. This removes the 5th value from the array since it's not being used.

Appears that the 

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
