### PR TITLE
Fix dialog background layout shift

### DIFF
--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -475,18 +475,26 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
   )
 
   React.useEffect(() => {
-    const bodyOverflowStyle = document.body.style.overflow || ''
-    // If the body is already set to overflow: hidden, it likely means
+    const {body, documentElement} = document
+    let {scrollTop} = documentElement
+    const bodyOverflowStyle = body.style.overflowY || ''
+
+    // If the body is already set to scroll, it likely means
     // that there is already a modal open. In that case, we should bail
     // so we don't re-enable scroll after the second dialog is closed.
-    if (bodyOverflowStyle === 'hidden') {
+    if (bodyOverflowStyle === 'scroll') {
       return
     }
 
-    document.body.style.overflow = 'hidden'
+    scrollTop = documentElement.scrollTop
+    body.style.top = `-${scrollTop}px`
+    body.style.position = 'fixed'
+    body.style.overflowY = 'scroll'
 
     return () => {
-      document.body.style.overflow = bodyOverflowStyle
+      documentElement.scrollTop = scrollTop
+      body.style.position = 'static'
+      body.style.overflowY = 'auto'
     }
   }, [])
 


### PR DESCRIPTION
Closes https://github.com/github/copilot-productivity/issues/2608

## Background

Original PR: Prevents body scroll when Dialog is open https://github.com/primer/react/pull/3547

This issue is caused by the `overscroll: hidden` behaviour which removes the scrollbar when the dialog is shown.
As you can see, the layout noticeably shifts in the background.

https://github.com/user-attachments/assets/66ae114f-413e-4cb3-9802-56c8a1cd7c9f

I have explored several solutions, each with its own tradeoffs:

1. overscroll-behavior
I tried adding `overscroll-behavior: contain` on the dialog and ::backdrop element but that didn’t seem to work.

2. Always showing the scrollbars
Using `overscroll-gutter: stable` or `overflow-y: scroll` will always show the scrollbar, which leaves a blank strip down the side of the page even when the scrollbar isn’t there, which can look awkward. But this is the most stable solution, likely to work on untested layouts.

https://github.com/user-attachments/assets/17d254ef-23c0-488a-927d-660acb67bda4

3. Compensate for missing scrollbar
Another avenue I tried was to add a padding or margin to the body to compensate for the missing scrollbar ala [Bootstrap](https://github.com/twbs/bootstrap/blob/a5d430d526dcb330b3e0f12aa1321cf948d726f1/js/src/util/scrollbar.js#L37). It works but any fixed position components will still see a jitter as the top/right/bottom/left positioning doesn't respect padding or margin. It could be fixed programmatically by finding all fixed position elements and adding an offset `calc(100vw - 100%)`.

Notice the background layout is unchanged.

https://github.com/user-attachments/assets/58c2fb8a-a061-4b09-98f1-3496aa3b4702

4. Position fixed
Finally I followed the suggestion from [StackOverflow]( https://stackoverflow.com/questions/8701754/how-to-disable-scroll-without-hiding-it).
It kinda works but could likely fail with other layouts.

https://github.com/user-attachments/assets/6ae23685-5152-4ec7-b6ff-257c6dd18389

5. Positioning inside a 100vw width parent
I haven't tried this: https://dev.to/rashidshamloo/preventing-the-layout-shift-caused-by-scrollbars-2flp

6. Leave it
I'm not sure if the solutions listed above is worth the problems they might caused.

References:
https://frontendmasters.com/blog/scroll-locked-dialogs/



### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
