### PR TITLE
fix: ActionList.LinkItem duplicate classes

### DIFF
--- a/.changeset/little-shrimps-hug.md
+++ b/.changeset/little-shrimps-hug.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+fix(ActionList): remove className from menuItemProps to prevent duplicate className bug

--- a/packages/react/src/ActionList/Item.tsx
+++ b/packages/react/src/ActionList/Item.tsx
@@ -335,7 +335,6 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       ...(includeSelectionAttribute && {[itemSelectionAttribute]: selected}),
       role: itemRole,
       id: itemId,
-      className,
     }
 
     const containerProps = _PrivateItemWrapper


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Part of https://github.com/github/primer/issues/4570

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Fixes an issue where `className` was being duplicated in `LinkItem` on both the wrapper `li` (correct) and the inner `a` tag (incorrect). 

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

<!-- List of things removed in this PR -->
- Removes `className` from `menuItemProps` in `ActionList.Item`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [x] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
