### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,19 +13,12 @@ updates:
     labels:
       - 'dependencies'
       - 'skip changeset'
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    versioning-strategy: increase
-    labels:
-      - 'dependencies'
-      - 'skip changeset'
     groups:
       storybook:
         patterns:
           - '@storybook/*'
           - 'storybook'
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
Update storybook book to be included in the default `npm` config. This should keep our current behavior (dependabot makes a PR per package) but will now group updates that match the pattern into a storybook group (see: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--:~:text=When%20groups%20is,individual%20pull%20requests.)