### PR TITLE
feat: add components.json to export conditions

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,8 @@
     "./test-helpers": {
       "import": "./lib-esm/test-helpers.js",
       "require": "./lib/test-helpers.js"
-    }
+    },
+    "./generated/components.json": "./generated/components.json"
   },
   "typings": "lib/index.d.ts",
   "sideEffects": [


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update our export conditions for `@primer/react` to include support for `generated/components.json`

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add support for importing `@primer/react/generated/components.json`

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release
