### PR TITLE
docs: update dynamic button examples to use AriaAlert

### DIFF
--- a/packages/react/src/Banner/Banner.docs.json
+++ b/packages/react/src/Banner/Banner.docs.json
@@ -4,50 +4,6 @@
   "status": "alpha",
   "a11yReviewed": true,
   "importPath": "@primer/react/experimental",
-  "stories": [
-    {
-      "id": "experimental-components-banner--default"
-    },
-    {
-      "id": "experimental-components-banner-features--critical"
-    },
-    {
-      "id": "experimental-components-banner-features--info"
-    },
-    {
-      "id": "experimental-components-banner-features--success"
-    },
-    {
-      "id": "experimental-components-banner-features--upsell"
-    },
-    {
-      "id": "experimental-components-banner-features--warning"
-    },
-    {
-      "id": "experimental-components-banner-features--dismiss"
-    },
-    {
-      "id": "experimental-components-banner-features--dismiss-with-actions"
-    },
-    {
-      "id": "experimental-components-banner-features--with-hidden-title"
-    },
-    {
-      "id": "experimental-components-banner-features--with-hidden-title-and-actions"
-    },
-    {
-      "id": "experimental-components-banner-features--dismissible-with-hidden-title-and-actions"
-    },
-    {
-      "id": "experimental-components-banner-features--dismissible-with-hidden-title-and-secondary-action"
-    },
-    {
-      "id": "experimental-components-banner-features--with-actions"
-    },
-    {
-      "id": "experimental-components-banner-features--custom-icon"
-    }
-  ],
   "props": [
     {
       "name": "aria-label",

--- a/packages/react/src/Banner/Banner.docs.json
+++ b/packages/react/src/Banner/Banner.docs.json
@@ -4,6 +4,7 @@
   "status": "alpha",
   "a11yReviewed": true,
   "importPath": "@primer/react/experimental",
+  "stories": [],
   "props": [
     {
       "name": "aria-label",

--- a/packages/react/src/Banner/Banner.docs.json
+++ b/packages/react/src/Banner/Banner.docs.json
@@ -4,7 +4,53 @@
   "status": "alpha",
   "a11yReviewed": true,
   "importPath": "@primer/react/experimental",
-  "stories": [],
+  "stories": [
+    {
+      "id": "experimental-components-banner--default"
+    },
+    {
+      "id": "experimental-components-banner-features--critical"
+    },
+    {
+      "id": "experimental-components-banner-features--info"
+    },
+    {
+      "id": "experimental-components-banner-features--success"
+    },
+    {
+      "id": "experimental-components-banner-features--upsell"
+    },
+    {
+      "id": "experimental-components-banner-features--warning"
+    },
+    {
+      "id": "experimental-components-banner-features--dismiss"
+    },
+    {
+      "id": "experimental-components-banner-features--dismiss-with-actions"
+    },
+    {
+      "id": "experimental-components-banner-features--with-hidden-title"
+    },
+    {
+      "id": "experimental-components-banner-features--with-hidden-title-and-actions"
+    },
+    {
+      "id": "experimental-components-banner-features--dismissible-with-hidden-title-and-actions"
+    },
+    {
+      "id": "experimental-components-banner-features--dismissible-with-hidden-title-and-secondary-action"
+    },
+    {
+      "id": "experimental-components-banner-features--with-actions"
+    },
+    {
+      "id": "experimental-components-banner-features--custom-icon"
+    },
+    {
+      "id": "experimental-components-banner-examples--with-announcement"
+    }
+  ],
   "props": [
     {
       "name": "aria-label",

--- a/packages/react/src/Banner/Banner.examples.stories.tsx
+++ b/packages/react/src/Banner/Banner.examples.stories.tsx
@@ -46,7 +46,7 @@ export const WithUserAction = () => {
   )
 }
 
-export const WithDynamicContent = () => {
+export const WithAnnouncement = () => {
   type Choice = 'one' | 'two' | 'three'
   const messages: Map<Choice, string> = new Map([
     ['one', 'This is a message for choice one'],

--- a/packages/react/src/Banner/Banner.examples.stories.tsx
+++ b/packages/react/src/Banner/Banner.examples.stories.tsx
@@ -2,7 +2,10 @@ import {Banner} from '../Banner'
 import {action} from '@storybook/addon-actions'
 import Link from '../Link'
 import type {Meta} from '@storybook/react'
-import {AriaAlert} from '../live-region'
+import {AriaAlert, AriaStatus} from '../live-region'
+import FormControl from '../FormControl'
+import RadioGroup from '../RadioGroup'
+import Radio from '../Radio'
 import {Button} from '../Button'
 import React from 'react'
 import {useFocus} from '../internal/hooks/useFocus'
@@ -39,6 +42,49 @@ export const WithUserAction = () => {
       >
         Update profile
       </Button>
+    </>
+  )
+}
+
+export const WithDynamicContent = () => {
+  type Choice = 'one' | 'two' | 'three'
+  const messages: Map<Choice, string> = new Map([
+    ['one', 'This is a message for choice one'],
+    ['two', 'This is a message for choice two'],
+    ['three', 'This is a message for choice three'],
+  ])
+  const [selected, setSelected] = React.useState<Choice>('one')
+
+  return (
+    <>
+      <Banner
+        title="Info"
+        description={<AriaStatus>{messages.get(selected)}</AriaStatus>}
+        onDismiss={action('onDismiss')}
+        primaryAction={<Banner.PrimaryAction>Button</Banner.PrimaryAction>}
+        secondaryAction={<Banner.SecondaryAction>Button</Banner.SecondaryAction>}
+      />
+      <RadioGroup
+        sx={{marginTop: 4}}
+        name="options"
+        onChange={selected => {
+          setSelected(selected as Choice)
+        }}
+      >
+        <RadioGroup.Label>Choices</RadioGroup.Label>
+        <FormControl>
+          <Radio value="one" defaultChecked />
+          <FormControl.Label>Choice one</FormControl.Label>
+        </FormControl>
+        <FormControl>
+          <Radio value="two" />
+          <FormControl.Label>Choice two</FormControl.Label>
+        </FormControl>
+        <FormControl>
+          <Radio value="three" />
+          <FormControl.Label>Choice three</FormControl.Label>
+        </FormControl>
+      </RadioGroup>
     </>
   )
 }

--- a/packages/react/src/Banner/Banner.examples.stories.tsx
+++ b/packages/react/src/Banner/Banner.examples.stories.tsx
@@ -2,10 +2,7 @@ import {Banner} from '../Banner'
 import {action} from '@storybook/addon-actions'
 import Link from '../Link'
 import type {Meta} from '@storybook/react'
-import {AriaAlert, AriaStatus} from '../live-region'
-import FormControl from '../FormControl'
-import RadioGroup from '../RadioGroup'
-import Radio from '../Radio'
+import {AriaAlert} from '../live-region'
 import {Button} from '../Button'
 import React from 'react'
 import {useFocus} from '../internal/hooks/useFocus'
@@ -42,49 +39,6 @@ export const WithUserAction = () => {
       >
         Update profile
       </Button>
-    </>
-  )
-}
-
-export const WithDynamicContent = () => {
-  type Choice = 'one' | 'two' | 'three'
-  const messages: Map<Choice, string> = new Map([
-    ['one', 'This is a message for choice one'],
-    ['two', 'This is a message for choice two'],
-    ['three', 'This is a message for choice three'],
-  ])
-  const [selected, setSelected] = React.useState<Choice>('one')
-
-  return (
-    <>
-      <Banner
-        title="Info"
-        description={<AriaStatus>{messages.get(selected)}</AriaStatus>}
-        onDismiss={action('onDismiss')}
-        primaryAction={<Banner.PrimaryAction>Button</Banner.PrimaryAction>}
-        secondaryAction={<Banner.SecondaryAction>Button</Banner.SecondaryAction>}
-      />
-      <RadioGroup
-        sx={{marginTop: 4}}
-        name="options"
-        onChange={selected => {
-          setSelected(selected as Choice)
-        }}
-      >
-        <RadioGroup.Label>Choices</RadioGroup.Label>
-        <FormControl>
-          <Radio value="one" defaultChecked />
-          <FormControl.Label>Choice one</FormControl.Label>
-        </FormControl>
-        <FormControl>
-          <Radio value="two" />
-          <FormControl.Label>Choice two</FormControl.Label>
-        </FormControl>
-        <FormControl>
-          <Radio value="three" />
-          <FormControl.Label>Choice three</FormControl.Label>
-        </FormControl>
-      </RadioGroup>
     </>
   )
 }

--- a/packages/react/src/Banner/Banner.features.stories.tsx
+++ b/packages/react/src/Banner/Banner.features.stories.tsx
@@ -4,6 +4,10 @@ import {action} from '@storybook/addon-actions'
 import type {Meta} from '@storybook/react'
 import {Banner} from '../Banner'
 import Link from '../Link'
+import FormControl from '../FormControl'
+import RadioGroup from '../RadioGroup'
+import Radio from '../Radio'
+import {AriaStatus} from '../live-region'
 
 const meta = {
   title: 'Experimental/Components/Banner/Features',
@@ -256,5 +260,48 @@ export const CustomIcon = () => {
       onDismiss={action('onDismiss')}
       variant="upsell"
     />
+  )
+}
+
+export const WithAnnouncement = () => {
+  type Choice = 'one' | 'two' | 'three'
+  const messages: Map<Choice, string> = new Map([
+    ['one', 'This is a message for choice one'],
+    ['two', 'This is a message for choice two'],
+    ['three', 'This is a message for choice three'],
+  ])
+  const [selected, setSelected] = React.useState<Choice>('one')
+
+  return (
+    <>
+      <Banner
+        title="Info"
+        description={<AriaStatus>{messages.get(selected)}</AriaStatus>}
+        onDismiss={action('onDismiss')}
+        primaryAction={<Banner.PrimaryAction>Button</Banner.PrimaryAction>}
+        secondaryAction={<Banner.SecondaryAction>Button</Banner.SecondaryAction>}
+      />
+      <RadioGroup
+        sx={{marginTop: 4}}
+        name="options"
+        onChange={selected => {
+          setSelected(selected as Choice)
+        }}
+      >
+        <RadioGroup.Label>Choices</RadioGroup.Label>
+        <FormControl>
+          <Radio value="one" defaultChecked />
+          <FormControl.Label>Choice one</FormControl.Label>
+        </FormControl>
+        <FormControl>
+          <Radio value="two" />
+          <FormControl.Label>Choice two</FormControl.Label>
+        </FormControl>
+        <FormControl>
+          <Radio value="three" />
+          <FormControl.Label>Choice three</FormControl.Label>
+        </FormControl>
+      </RadioGroup>
+    </>
   )
 }

--- a/packages/react/src/Banner/Banner.features.stories.tsx
+++ b/packages/react/src/Banner/Banner.features.stories.tsx
@@ -4,10 +4,6 @@ import {action} from '@storybook/addon-actions'
 import type {Meta} from '@storybook/react'
 import {Banner} from '../Banner'
 import Link from '../Link'
-import FormControl from '../FormControl'
-import RadioGroup from '../RadioGroup'
-import Radio from '../Radio'
-import {AriaStatus} from '../live-region'
 
 const meta = {
   title: 'Experimental/Components/Banner/Features',
@@ -260,48 +256,5 @@ export const CustomIcon = () => {
       onDismiss={action('onDismiss')}
       variant="upsell"
     />
-  )
-}
-
-export const WithAnnouncement = () => {
-  type Choice = 'one' | 'two' | 'three'
-  const messages: Map<Choice, string> = new Map([
-    ['one', 'This is a message for choice one'],
-    ['two', 'This is a message for choice two'],
-    ['three', 'This is a message for choice three'],
-  ])
-  const [selected, setSelected] = React.useState<Choice>('one')
-
-  return (
-    <>
-      <Banner
-        title="Info"
-        description={<AriaStatus>{messages.get(selected)}</AriaStatus>}
-        onDismiss={action('onDismiss')}
-        primaryAction={<Banner.PrimaryAction>Button</Banner.PrimaryAction>}
-        secondaryAction={<Banner.SecondaryAction>Button</Banner.SecondaryAction>}
-      />
-      <RadioGroup
-        sx={{marginTop: 4}}
-        name="options"
-        onChange={selected => {
-          setSelected(selected as Choice)
-        }}
-      >
-        <RadioGroup.Label>Choices</RadioGroup.Label>
-        <FormControl>
-          <Radio value="one" defaultChecked />
-          <FormControl.Label>Choice one</FormControl.Label>
-        </FormControl>
-        <FormControl>
-          <Radio value="two" />
-          <FormControl.Label>Choice two</FormControl.Label>
-        </FormControl>
-        <FormControl>
-          <Radio value="three" />
-          <FormControl.Label>Choice three</FormControl.Label>
-        </FormControl>
-      </RadioGroup>
-    </>
   )
 }

--- a/packages/react/src/Button/Button.examples.stories.tsx
+++ b/packages/react/src/Button/Button.examples.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta} from '@storybook/react'
 import {Button} from '.'
 import {DownloadIcon} from '@primer/octicons-react'
 import {Banner} from '../experimental'
-import {AriaStatus} from '../live-region'
+import {AriaStatus, AriaAlert} from '../live-region'
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Button/Examples',
@@ -69,7 +69,11 @@ export const LoadingStatusAnnouncementError = () => {
 
   return (
     <>
-      {!loading && error ? <Banner title="Export failed" variant="critical" /> : null}
+      {!loading && error ? (
+        <AriaAlert>
+          <Banner title="Export failed" variant="critical" />
+        </AriaAlert>
+      ) : null}
 
       <Button loading={loading} leadingVisual={DownloadIcon} onClick={onClick('error')}>
         Export (error)


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/accessibility-audits/issues/10017

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

* Added `AriaAlert` to ensure dynamic banner content is announced.
* Move and rename announcement banner example to improve discoverability. I was looking for guidance on how to do announcements for React banner. From [the main Primer Banner page](https://primer.style/components/banner/react/alpha#examples), no storybook examples are available for announcements. After going directly to the storybook page, I found a relevant example. I think that renaming this and moving it to the `features` folder will help improve discoverability for this common usecase.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
