### PR TITLE
[Accessibility][Storybook] Add an aria-label to the TextInput's calendar icon in the storybook loading example

### DIFF
--- a/packages/react/src/TextInput/TextInput.features.stories.tsx
+++ b/packages/react/src/TextInput/TextInput.features.stories.tsx
@@ -189,6 +189,8 @@ export const WithTooltipDirection = () => {
   )
 }
 
+const Calendar = () => <CalendarIcon aria-label="Calendar" />
+
 export const WithLoadingIndicator = (args: FormControlArgs<TextInputProps>) => {
   return (
     <Box as="form">
@@ -219,19 +221,19 @@ export const WithLoadingIndicator = (args: FormControlArgs<TextInputProps>) => {
       <Box mb={2}>
         <FormControl>
           <FormControl.Label>Default label</FormControl.Label>
-          <TextInput leadingVisual={CalendarIcon} {...args} value="auto" />
+          <TextInput leadingVisual={Calendar} {...args} value="auto" />
         </FormControl>
       </Box>
       <Box mb={2}>
         <FormControl>
           <FormControl.Label>Default label</FormControl.Label>
-          <TextInput leadingVisual={CalendarIcon} {...args} loaderPosition="leading" value="leading" />
+          <TextInput leadingVisual={Calendar} {...args} loaderPosition="leading" value="leading" />
         </FormControl>
       </Box>
       <Box mb={5}>
         <FormControl>
           <FormControl.Label>Default label</FormControl.Label>
-          <TextInput leadingVisual={CalendarIcon} {...args} loaderPosition="trailing" value="trailing" />
+          <TextInput leadingVisual={Calendar} {...args} loaderPosition="trailing" value="trailing" />
         </FormControl>
       </Box>
 
@@ -240,19 +242,19 @@ export const WithLoadingIndicator = (args: FormControlArgs<TextInputProps>) => {
         <Box mb={2}>
           <FormControl>
             <FormControl.Label>Default label</FormControl.Label>
-            <TextInput trailingVisual={CalendarIcon} {...args} value="auto" />
+            <TextInput trailingVisual={Calendar} {...args} value="auto" />
           </FormControl>
         </Box>
         <Box mb={2}>
           <FormControl>
             <FormControl.Label>Default label</FormControl.Label>
-            <TextInput trailingVisual={CalendarIcon} {...args} loaderPosition="leading" value="leading" />
+            <TextInput trailingVisual={Calendar} {...args} loaderPosition="leading" value="leading" />
           </FormControl>
         </Box>
         <Box mb={5}>
           <FormControl>
             <FormControl.Label>Default label</FormControl.Label>
-            <TextInput trailingVisual={CalendarIcon} {...args} loaderPosition="trailing" value="trailing" />
+            <TextInput trailingVisual={Calendar} {...args} loaderPosition="trailing" value="trailing" />
           </FormControl>
         </Box>
       </FormControl>
@@ -262,15 +264,15 @@ export const WithLoadingIndicator = (args: FormControlArgs<TextInputProps>) => {
       <Box mb={2}>
         <FormControl>
           <FormControl.Label>Default label</FormControl.Label>
-          <TextInput size="small" leadingVisual={CalendarIcon} trailingVisual={CalendarIcon} {...args} value="auto" />
+          <TextInput size="small" leadingVisual={Calendar} trailingVisual={Calendar} {...args} value="auto" />
         </FormControl>
       </Box>
       <Box mb={2}>
         <FormControl>
           <FormControl.Label>Default label</FormControl.Label>
           <TextInput
-            leadingVisual={CalendarIcon}
-            trailingVisual={CalendarIcon}
+            leadingVisual={Calendar}
+            trailingVisual={Calendar}
             {...args}
             loaderPosition="leading"
             value="leading"
@@ -282,8 +284,8 @@ export const WithLoadingIndicator = (args: FormControlArgs<TextInputProps>) => {
           <FormControl.Label>Default label</FormControl.Label>
           <TextInput
             size="large"
-            leadingVisual={CalendarIcon}
-            trailingVisual={CalendarIcon}
+            leadingVisual={Calendar}
+            trailingVisual={Calendar}
             {...args}
             loaderPosition="trailing"
             value="trailing"


### PR DESCRIPTION
The TextInput loading Indicator stories included an icon without an aria-label. This PR aims to improve the accessibility of the TextInput loading Indicator stories by adding an aria-label to the calendar icon.

Closes #

https://github.com/github/accessibility-audits/issues/10139

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [X] None; if selected, include a brief description as to why

Improved documentation.

### Testing & Reviewing

Tested on a screen reader.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [X] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [X] Tested in Chrome
- [ ] Tested in Firefox
- [X] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
