### PR TITLE
refactor(FormControl): update FormControl to use CSS Modules behind flag

### DIFF
--- a/.changeset/gentle-stingrays-search.md
+++ b/.changeset/gentle-stingrays-search.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Update FormControl to use CSS Modules behind feature flag

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
       "name": "example-app-router",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "37.9.1",
+        "@primer/react": "37.10.0",
         "next": "^14.2.15",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -82,7 +82,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "37.9.1",
+        "@primer/react": "37.10.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
@@ -101,7 +101,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.14.0",
-        "@primer/react": "37.9.1",
+        "@primer/react": "37.10.0",
         "clsx": "^1.2.1",
         "next": "^14.2.15",
         "react": "^18.3.1",
@@ -29864,7 +29864,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "37.9.1",
+      "version": "37.10.0",
       "license": "MIT",
       "dependencies": {
         "@github/relative-time-element": "^4.4.3",

--- a/packages/react/src/FormControl/FormControl.module.css
+++ b/packages/react/src/FormControl/FormControl.module.css
@@ -1,0 +1,57 @@
+.ControlHorizontalLayout {
+  display: flex;
+
+  &:where([data-has-leading-visual]) {
+    align-items: center;
+  }
+}
+
+.ControlVerticalLayout {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  & > *:not(label) + * {
+    margin-top: var(--base-size-4);
+  }
+
+  &[data-has-label] > * + * {
+    margin-top: var(--base-size-4);
+  }
+}
+
+.ControlChoiceInputs > input {
+  margin-right: 0;
+  margin-left: 0;
+}
+
+.LabelContainer {
+  > * {
+    /* stylelint-disable-next-line primer/spacing */
+    padding-left: var(--stack-gap-condensed);
+  }
+
+  > label {
+    font-weight: var(--base-text-weight-normal);
+  }
+}
+
+.LeadingVisual {
+  margin-left: var(--base-size-8);
+  color: var(--fgColor-muted);
+
+  &:where([data-disabled]) {
+    color: var(--control-fgColor-disabled);
+  }
+
+  > * {
+    min-width: var(--text-body-size-large);
+    min-height: var(--text-body-size-large);
+    fill: currentColor;
+  }
+
+  > *:where([data-has-caption]) {
+    min-width: var(--base-size-24);
+    min-height: var(--base-size-24);
+  }
+}

--- a/packages/react/src/FormControl/FormControlCaption.module.css
+++ b/packages/react/src/FormControl/FormControlCaption.module.css
@@ -1,0 +1,9 @@
+.Caption {
+  display: block;
+  font-size: var(--text-body-size-small);
+  color: var(--fgColor-muted);
+
+  &:where([data-control-disabled]) {
+    color: var(--control-fgColor-disabled);
+  }
+}

--- a/packages/react/src/FormControl/FormControlCaption.tsx
+++ b/packages/react/src/FormControl/FormControlCaption.tsx
@@ -1,22 +1,14 @@
+import {clsx} from 'clsx'
 import React from 'react'
-import type {SxProp} from '../sx'
-import {useFormControlContext} from './_FormControlContext'
-import Text from '../Text'
 import styled from 'styled-components'
-import {get} from '../constants'
+import {cssModulesFlag} from './feature-flags'
+import {useFeatureFlag} from '../FeatureFlags'
+import Text from '../Text'
 import sx from '../sx'
-
-const StyledCaption = styled(Text)`
-  color: var(--fgColor-muted);
-  display: block;
-  font-size: ${get('fontSizes.0')};
-
-  &:where([data-control-disabled]) {
-    color: var(--control-fgColor-disabled);
-  }
-
-  ${sx}
-`
+import type {SxProp} from '../sx'
+import classes from './FormControlCaption.module.css'
+import {useFormControlContext} from './_FormControlContext'
+import {toggleStyledComponent} from '../internal/utils/toggleStyledComponent'
 
 type FormControlCaptionProps = React.PropsWithChildren<
   {
@@ -25,12 +17,36 @@ type FormControlCaptionProps = React.PropsWithChildren<
 >
 
 function FormControlCaption({id, children, sx}: FormControlCaptionProps) {
+  const enabled = useFeatureFlag(cssModulesFlag)
   const {captionId, disabled} = useFormControlContext()
   return (
-    <StyledCaption id={id ?? captionId} data-control-disabled={disabled ? '' : undefined} sx={sx}>
+    <StyledCaption
+      id={id ?? captionId}
+      className={clsx({
+        [classes.Caption]: enabled,
+      })}
+      data-control-disabled={disabled ? '' : undefined}
+      sx={sx}
+    >
       {children}
     </StyledCaption>
   )
 }
+
+const StyledCaption = toggleStyledComponent(
+  cssModulesFlag,
+  Text,
+  styled(Text)`
+    color: var(--fgColor-muted);
+    display: block;
+    font-size: var(--text-body-size-small);
+
+    &:where([data-control-disabled]) {
+      color: var(--control-fgColor-disabled);
+    }
+
+    ${sx}
+  `,
+)
 
 export {FormControlCaption}

--- a/packages/react/src/FormControl/__tests__/FormControl.test.tsx
+++ b/packages/react/src/FormControl/__tests__/FormControl.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {render} from '@testing-library/react'
-import {renderHook} from '@testing-library/react-hooks'
 import axe from 'axe-core'
 import {
   Autocomplete,
@@ -12,8 +11,7 @@ import {
   Textarea,
   TextInput,
   TextInputWithTokens,
-  useFormControlForwardedProps,
-} from '..'
+} from '../..'
 import {MarkGithubIcon} from '@primer/octicons-react'
 
 const LABEL_TEXT = 'Form control'
@@ -452,55 +450,5 @@ describe('FormControl', () => {
       const results = await axe.run(container)
       expect(results).toHaveNoViolations()
     })
-  })
-})
-
-describe('useFormControlForwardedProps', () => {
-  describe('when used outside FormControl', () => {
-    test('returns empty object when no props object passed', () => {
-      const result = renderHook(() => useFormControlForwardedProps({}))
-      expect(result.result.current).toEqual({})
-    })
-
-    test('returns passed props object instance when passed', () => {
-      const props = {id: 'test-id'}
-      const result = renderHook(() => useFormControlForwardedProps(props))
-      expect(result.result.current).toBe(props)
-    })
-  })
-
-  test('provides context value when no props object is passed', () => {
-    const id = 'test-id'
-
-    const {result} = renderHook(() => useFormControlForwardedProps({}), {
-      wrapper: ({children}: {children: React.ReactNode}) => (
-        <FormControl id={id} disabled required>
-          <FormControl.Label>Label</FormControl.Label>
-          {children}
-        </FormControl>
-      ),
-    })
-
-    expect(result.current.disabled).toBe(true)
-    expect(result.current.id).toBe(id)
-    expect(result.current.required).toBe(true)
-  })
-
-  test('merges with props object, overriding to prioritize props when conflicting', () => {
-    const props = {id: 'override-id', xyz: 'someValue'}
-
-    const {result} = renderHook(() => useFormControlForwardedProps(props), {
-      wrapper: ({children}: {children: React.ReactNode}) => (
-        <FormControl id="form-control-id" disabled>
-          <FormControl.Label>Label</FormControl.Label>
-          {children}
-        </FormControl>
-      ),
-    })
-
-    expect(result.current.disabled).toBe(true)
-    expect(result.current.id).toBe(props.id)
-    expect(result.current.required).toBeFalsy()
-    expect(result.current.xyz).toBe(props.xyz)
   })
 })

--- a/packages/react/src/FormControl/__tests__/useFormControlForwardedProps.test.tsx
+++ b/packages/react/src/FormControl/__tests__/useFormControlForwardedProps.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import {renderHook} from '@testing-library/react-hooks'
+import FormControl, {useFormControlForwardedProps} from '../../FormControl'
+
+describe('useFormControlForwardedProps', () => {
+  describe('when used outside FormControl', () => {
+    test('returns empty object when no props object passed', () => {
+      const result = renderHook(() => useFormControlForwardedProps({}))
+      expect(result.result.current).toEqual({})
+    })
+
+    test('returns passed props object instance when passed', () => {
+      const props = {id: 'test-id'}
+      const result = renderHook(() => useFormControlForwardedProps(props))
+      expect(result.result.current).toBe(props)
+    })
+  })
+
+  test('provides context value when no props object is passed', () => {
+    const id = 'test-id'
+
+    const {result} = renderHook(() => useFormControlForwardedProps({}), {
+      wrapper: ({children}: {children: React.ReactNode}) => (
+        <FormControl id={id} disabled required>
+          <FormControl.Label>Label</FormControl.Label>
+          {children}
+        </FormControl>
+      ),
+    })
+
+    expect(result.current.disabled).toBe(true)
+    expect(result.current.id).toBe(id)
+    expect(result.current.required).toBe(true)
+  })
+
+  test('merges with props object, overriding to prioritize props when conflicting', () => {
+    const props = {id: 'override-id', xyz: 'someValue'}
+
+    const {result} = renderHook(() => useFormControlForwardedProps(props), {
+      wrapper: ({children}: {children: React.ReactNode}) => (
+        <FormControl id="form-control-id" disabled>
+          <FormControl.Label>Label</FormControl.Label>
+          {children}
+        </FormControl>
+      ),
+    })
+
+    expect(result.current.disabled).toBe(true)
+    expect(result.current.id).toBe(props.id)
+    expect(result.current.required).toBeFalsy()
+    expect(result.current.xyz).toBe(props.xyz)
+  })
+})

--- a/packages/react/src/FormControl/feature-flags.ts
+++ b/packages/react/src/FormControl/feature-flags.ts
@@ -1,0 +1,1 @@
+export const cssModulesFlag = 'primer_react_css_modules_team'

--- a/packages/react/src/internal/components/InputLabel.module.css
+++ b/packages/react/src/internal/components/InputLabel.module.css
@@ -1,0 +1,32 @@
+.Label {
+  display: block;
+  font-size: var(--text-body-size-medium);
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+  cursor: pointer;
+  align-self: flex-start;
+
+  &:where([data-control-disabled]) {
+    color: var(--control-fgColor-disabled);
+    cursor: not-allowed;
+  }
+
+  &:where([data-visually-hidden]) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    /* stylelint-disable-next-line primer/spacing */
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+    clip-path: inset(50%);
+  }
+}
+
+.RequiredText {
+  display: flex;
+  column-gap: var(--base-size-4);
+}

--- a/packages/react/src/internal/components/InputLabel.module.css
+++ b/packages/react/src/internal/components/InputLabel.module.css
@@ -7,7 +7,7 @@
   align-self: flex-start;
 
   &:where([data-control-disabled]) {
-    color: var(--control-fgColor-disabled);
+    color: var(--fgColor-muted);
     cursor: not-allowed;
   }
 

--- a/packages/react/src/internal/components/InputLabel.tsx
+++ b/packages/react/src/internal/components/InputLabel.tsx
@@ -1,7 +1,10 @@
+import {clsx} from 'clsx'
 import React from 'react'
 import styled from 'styled-components'
-import {get} from '../../constants'
 import sx, {type SxProp} from '../../sx'
+import {cssModulesFlag} from '../../FormControl/feature-flags'
+import {useFeatureFlag} from '../../FeatureFlags'
+import classes from './InputLabel.module.css'
 
 type BaseProps = SxProp & {
   disabled?: boolean
@@ -39,6 +42,7 @@ function InputLabel({
   className,
   ...props
 }: Props) {
+  const enabled = useFeatureFlag(cssModulesFlag)
   return (
     <StyledLabel
       as={as}
@@ -46,12 +50,18 @@ function InputLabel({
       data-visually-hidden={visuallyHidden ? '' : undefined}
       htmlFor={htmlFor}
       id={id}
-      className={className}
+      className={clsx(className, {
+        [classes.Label]: enabled,
+      })}
       sx={sx}
       {...props}
     >
       {required || requiredText ? (
-        <StyledRequiredText>
+        <StyledRequiredText
+          className={clsx({
+            [classes.RequiredText]: enabled,
+          })}
+        >
           <span>{children}</span>
           <span aria-hidden={requiredIndicator ? undefined : true}>{requiredText ?? '*'}</span>
         </StyledRequiredText>
@@ -62,18 +72,13 @@ function InputLabel({
   )
 }
 
-const StyledRequiredText = styled.span`
-  display: flex;
-  column-gap: ${get('space.1')};
-`
-
 const StyledLabel = styled.label`
   align-self: flex-start;
   display: block;
   color: var(--fgColor-default);
   cursor: pointer;
   font-weight: 600;
-  font-size: ${get('fontSizes.1')};
+  font-size: var(--text-body-size-medium);
 
   &:where([data-control-disabled]) {
     color: var(--fgColor-muted);
@@ -94,6 +99,11 @@ const StyledLabel = styled.label`
   }
 
   ${sx}
+`
+
+const StyledRequiredText = styled.span`
+  display: flex;
+  column-gap: var(--base-size-4);
 `
 
 export {InputLabel}

--- a/packages/react/src/internal/components/InputLabel.tsx
+++ b/packages/react/src/internal/components/InputLabel.tsx
@@ -5,6 +5,7 @@ import sx, {type SxProp} from '../../sx'
 import {cssModulesFlag} from '../../FormControl/feature-flags'
 import {useFeatureFlag} from '../../FeatureFlags'
 import classes from './InputLabel.module.css'
+import {toggleStyledComponent} from '../utils/toggleStyledComponent'
 
 type BaseProps = SxProp & {
   disabled?: boolean
@@ -72,38 +73,46 @@ function InputLabel({
   )
 }
 
-const StyledLabel = styled.label`
-  align-self: flex-start;
-  display: block;
-  color: var(--fgColor-default);
-  cursor: pointer;
-  font-weight: 600;
-  font-size: var(--text-body-size-medium);
+const StyledLabel = toggleStyledComponent(
+  cssModulesFlag,
+  'label',
+  styled.label`
+    align-self: flex-start;
+    display: block;
+    color: var(--fgColor-default);
+    cursor: pointer;
+    font-weight: 600;
+    font-size: var(--text-body-size-medium);
 
-  &:where([data-control-disabled]) {
-    color: var(--fgColor-muted);
-    cursor: not-allowed;
-  }
+    &:where([data-control-disabled]) {
+      color: var(--fgColor-muted);
+      cursor: not-allowed;
+    }
 
-  &:where([data-visually-hidden]) {
-    border: 0;
-    clip: rect(0 0 0 0);
-    clip-path: inset(50%);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
+    &:where([data-visually-hidden]) {
+      border: 0;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      height: 1px;
+      margin: -1px;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
+    }
 
-  ${sx}
-`
+    ${sx}
+  `,
+)
 
-const StyledRequiredText = styled.span`
-  display: flex;
-  column-gap: var(--base-size-4);
-`
+const StyledRequiredText = toggleStyledComponent(
+  cssModulesFlag,
+  'span',
+  styled.span`
+    display: flex;
+    column-gap: var(--base-size-4);
+  `,
+)
 
 export {InputLabel}

--- a/packages/react/src/internal/components/InputValidation.module.css
+++ b/packages/react/src/internal/components/InputValidation.module.css
@@ -1,0 +1,32 @@
+.InputValidation {
+  display: flex;
+  font-size: var(--text-body-size-small);
+  font-weight: var(--base-text-weight-semibold);
+  /* stylelint-disable-next-line primer/colors */
+  color: var(--inputValidation-fgColor);
+
+  & :where(a) {
+    color: currentColor;
+    text-decoration: underline;
+  }
+
+  &:where([data-validation-status='success']) {
+    --inputValidation-fgColor: var(--fgColor-success);
+  }
+
+  &:where([data-validation-status='error']) {
+    --inputValidation-fgColor: var(--fgColor-danger);
+  }
+}
+
+.ValidationIcon {
+  align-items: center;
+  display: flex;
+  margin-inline-end: var(--base-size-4);
+  min-height: var(--inputValidation-iconSize);
+}
+
+.ValidationText {
+  /* stylelint-disable-next-line primer/typography */
+  line-height: var(--inputValidation-lineHeight);
+}

--- a/packages/react/src/internal/components/InputValidation.tsx
+++ b/packages/react/src/internal/components/InputValidation.tsx
@@ -1,12 +1,15 @@
 import type {IconProps} from '@primer/octicons-react'
 import {AlertFillIcon, CheckCircleFillIcon} from '@primer/octicons-react'
+import {clsx} from 'clsx'
 import React from 'react'
-import Text from '../../Text'
-import type {SxProp} from '../../sx'
-import type {FormValidationStatus} from '../../utils/types/FormValidationStatus'
 import styled from 'styled-components'
-import {get} from '../../constants'
+import Text from '../../Text'
 import sx from '../../sx'
+import type {SxProp} from '../../sx'
+import {cssModulesFlag} from '../../FormControl/feature-flags'
+import type {FormValidationStatus} from '../../utils/types/FormValidationStatus'
+import {useFeatureFlag} from '../../FeatureFlags'
+import classes from './InputValidation.module.css'
 
 type Props = {
   id: string
@@ -22,6 +25,7 @@ const validationIconMap: Record<
 }
 
 const InputValidation: React.FC<React.PropsWithChildren<Props>> = ({children, id, validationStatus, sx}) => {
+  const enabled = useFeatureFlag(cssModulesFlag)
   const IconComponent = validationStatus ? validationIconMap[validationStatus] : undefined
 
   // TODO: use `text-caption-lineHeight` token as a custom property when it's available
@@ -31,10 +35,19 @@ const InputValidation: React.FC<React.PropsWithChildren<Props>> = ({children, id
   const iconBoxMinHeight = iconSize * captionLineHeight
 
   return (
-    <StyledInputValidation data-validation-status={validationStatus} sx={sx}>
+    <StyledInputValidation
+      className={clsx({
+        [classes.InputValidation]: enabled,
+      })}
+      data-validation-status={validationStatus}
+      sx={sx}
+    >
       {IconComponent ? (
         <StyledValidationIcon
           aria-hidden="true"
+          className={clsx({
+            [classes.ValidationIcon]: enabled,
+          })}
           style={
             {
               '--inputValidation-iconSize': iconBoxMinHeight,
@@ -44,7 +57,13 @@ const InputValidation: React.FC<React.PropsWithChildren<Props>> = ({children, id
           <IconComponent size={iconSize} fill="currentColor" />
         </StyledValidationIcon>
       ) : null}
-      <StyledValidationText id={id} style={{'--inputValidation-lineHeight': captionLineHeight} as React.CSSProperties}>
+      <StyledValidationText
+        id={id}
+        className={clsx({
+          [classes.ValidationText]: enabled,
+        })}
+        style={{'--inputValidation-lineHeight': captionLineHeight} as React.CSSProperties}
+      >
         {children}
       </StyledValidationText>
     </StyledInputValidation>
@@ -54,7 +73,7 @@ const InputValidation: React.FC<React.PropsWithChildren<Props>> = ({children, id
 const StyledInputValidation = styled(Text)`
   color: var(--inputValidation-fgColor);
   display: flex;
-  font-size: ${get('fontSizes.0')};
+  font-size: var(--text-body-size-small);
   font-weight: 600;
 
   & :where(a) {
@@ -63,11 +82,11 @@ const StyledInputValidation = styled(Text)`
   }
 
   &:where([data-validation-status='success']) {
-    --inputValidation-fgColor: ${get('colors.success.fg')};
+    --inputValidation-fgColor: var(--fgColor-success);
   }
 
   &:where([data-validation-status='error']) {
-    --inputValidation-fgColor: ${get('colors.danger.fg')};
+    --inputValidation-fgColor: var(--fgColor-danger);
   }
 
   ${sx}
@@ -76,7 +95,7 @@ const StyledInputValidation = styled(Text)`
 const StyledValidationIcon = styled.span`
   align-items: center;
   display: flex;
-  margin-inline-end: ${get('space.1')};
+  margin-inline-end: var(--base-size-4);
   min-height: var(--inputValidation-iconSize);
 `
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

- Closes https://github.com/github/primer/issues/3812
- Reverts primer/react#5494

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update FormControl and shared internal components to use form control behind feature flag

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release
