### PR TITLE
fix(Button): do not render main spinner if there is a count when loading

### DIFF
--- a/packages/react/src/Button/ButtonBase.tsx
+++ b/packages/react/src/Button/ButtonBase.tsx
@@ -141,6 +141,7 @@ const ButtonBase = forwardRef(
                       !LeadingVisual &&
                       !TrailingVisual &&
                       !TrailingAction &&
+                      count === undefined &&
                       renderModuleVisual(Spinner, loading, 'loadingSpinner', false)
                   }
                   {
@@ -258,6 +259,7 @@ const ButtonBase = forwardRef(
                     !LeadingVisual &&
                     !TrailingVisual &&
                     !TrailingAction &&
+                    count === undefined &&
                     renderModuleVisual(Spinner, loading, 'loadingSpinner', false)
                 }
                 {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/5600

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->
A button count loads its own spinner. Currently, the button is rendering two loading spinners when a count is introduced. This PR fixes the issue by not rendering the main spinner when there is a count.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->
- Add condition to not show main spinner in button when there is a count.


### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
