### PR TITLE
Patch 37.11.1

### DIFF
--- a/.changeset/sour-snakes-clap.md
+++ b/.changeset/sour-snakes-clap.md
@@ -1,5 +1,0 @@
----
-"@primer/react": patch
----
-
-fix(FormControl): fix spacing in vertical layouts"

--- a/.changeset/sour-snakes-clap.md
+++ b/.changeset/sour-snakes-clap.md
@@ -1,5 +1,5 @@
 ---
-"@primer/react": minor
+"@primer/react": patch
 ---
 
 fix(FormControl): fix spacing in vertical layouts"

--- a/.changeset/sour-snakes-clap.md
+++ b/.changeset/sour-snakes-clap.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+fix(FormControl): fix spacing in vertical layouts"

--- a/examples/app-router/package.json
+++ b/examples/app-router/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@primer/react": "37.11.0",
+    "@primer/react": "37.11.1",
     "next": "^14.2.15",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/examples/codesandbox/package.json
+++ b/examples/codesandbox/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.3.1",
     "@vitejs/plugin-react": "^4.3.3",
-    "@primer/react": "37.11.0",
+    "@primer/react": "37.11.1",
     "eslint": "^8.56.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.7",

--- a/examples/theming/package.json
+++ b/examples/theming/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@primer/octicons-react": "^19.14.0",
-    "@primer/react": "37.11.0",
+    "@primer/react": "37.11.1",
     "clsx": "^1.2.1",
     "next": "^14.2.15",
     "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
       "name": "example-app-router",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "37.10.0",
+        "@primer/react": "37.11.1",
         "next": "^14.2.15",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -82,7 +82,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "37.10.0",
+        "@primer/react": "37.11.1",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
@@ -101,7 +101,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.14.0",
-        "@primer/react": "37.10.0",
+        "@primer/react": "37.11.1",
         "clsx": "^1.2.1",
         "next": "^14.2.15",
         "react": "^18.3.1",
@@ -29976,7 +29976,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "37.10.0",
+      "version": "37.11.1",
       "license": "MIT",
       "dependencies": {
         "@github/relative-time-element": "^4.4.3",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @primer/react
 
+## 37.11.1
+
+### Patch Changes
+
+- [`a12ab59`](https://github.com/primer/react/commit/a12ab599565651cf30233a2cd97357f07cf39cb8) Thanks [@hussam-i-am](https://github.com/hussam-i-am)! - fix(FormControl): fix spacing in vertical layouts"
+
 ## 37.11.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/react",
-  "version": "37.11.0",
+  "version": "37.11.1",
   "description": "An implementation of GitHub's Primer Design System using React",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",

--- a/packages/react/script/build
+++ b/packages/react/script/build
@@ -22,3 +22,6 @@ npx copyfiles --flat ./lib/components.css ./css
 
 # Build components.json file for documentation
 npm run build:components.json
+
+# Build hooks.json file for documentation
+npm run build:hooks.json

--- a/packages/react/src/FormControl/FormControl.tsx
+++ b/packages/react/src/FormControl/FormControl.tsx
@@ -8,6 +8,7 @@ import {SelectPanel} from '../SelectPanel'
 import TextInput from '../TextInput'
 import TextInputWithTokens from '../TextInputWithTokens'
 import Textarea from '../Textarea'
+import Box from '../Box'
 import {CheckboxOrRadioGroupContext} from '../internal/components/CheckboxOrRadioGroup'
 import ValidationAnimationContainer from '../internal/components/ValidationAnimationContainer'
 import {useSlots} from '../hooks/useSlots'
@@ -182,10 +183,17 @@ const FormControl = React.forwardRef<HTMLDivElement, FormControlProps>(
             </StyledLabelContainer>
           </StyledHorizontalLayout>
         ) : (
-          <StyledVerticalLayout
+          <Box
             ref={ref}
             data-has-label={!isLabelHidden ? '' : undefined}
-            sx={sx}
+            display="flex"
+            flexDirection="column"
+            alignItems="flex-start"
+            sx={
+              enabled
+                ? sx
+                : {...(isLabelHidden ? {'> *:not(label) + *': {marginTop: 1}} : {'> * + *': {marginTop: 1}}), ...sx}
+            }
             className={clsx(className, {
               [classes.ControlVerticalLayout]: enabled,
             })}
@@ -214,7 +222,7 @@ const FormControl = React.forwardRef<HTMLDivElement, FormControlProps>(
               <ValidationAnimationContainer show>{slots.validation}</ValidationAnimationContainer>
             ) : null}
             {slots.caption}
-          </StyledVerticalLayout>
+          </Box>
         )}
       </FormControlContextProvider>
     )
@@ -257,26 +265,6 @@ const StyledLabelContainer = toggleStyledComponent(
     > label {
       font-weight: var(--base-text-weight-normal);
     }
-  `,
-)
-
-const StyledVerticalLayout = toggleStyledComponent(
-  cssModulesFlag,
-  'div',
-  styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-
-    & > *:not(label) + * {
-      margin-top: var(--base-size-4);
-    }
-
-    &:where([data-has-label]) > * + * {
-      margin-top: var(--base-size-4);
-    }
-
-    ${sx}
   `,
 )
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

v37.11.0 introduced some visual regressions to FormControl, this pulls [the fix](https://github.com/primer/react/pull/5618) into a new patch release. Also includes https://github.com/primer/react/pull/5607 for convenience

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

#### New

<!-- List of things added in this PR -->
- https://github.com/primer/react/pull/5618
- https://github.com/primer/react/pull/5607
- Update versions to v37.11.1

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
