### PR TITLE
feat: add keybindingDescription exploration

### DIFF
--- a/packages/react/src/Button/ButtonBase.tsx
+++ b/packages/react/src/Button/ButtonBase.tsx
@@ -196,11 +196,11 @@ const ButtonBase = forwardRef(
               </>
             )}
           </Box>
-          {loading && (
+          {loading ? (
             <VisuallyHidden>
               <AriaStatus id={loadingAnnouncementID}>{loadingAnnouncement}</AriaStatus>
             </VisuallyHidden>
-          )}
+          ) : null}
         </ConditionalWrapper>
       )
     }
@@ -228,7 +228,7 @@ const ButtonBase = forwardRef(
           data-variant={variant}
           data-label-wrap={labelWrap}
           data-has-count={count !== undefined ? true : undefined}
-          aria-describedby={[loadingAnnouncementID, ariaDescribedBy]
+          aria-describedby={[loading && loadingAnnouncementID, ariaDescribedBy]
             .filter(descriptionID => Boolean(descriptionID))
             .join(' ')}
           // aria-labelledby is needed because the accessible name becomes unset when the button is in a loading state.

--- a/packages/react/src/Button/IconButton.features.stories.tsx
+++ b/packages/react/src/Button/IconButton.features.stories.tsx
@@ -91,7 +91,10 @@ export const KeybindingHintOnDescription = () => (
     aria-label="Notifications"
     description="You have unread notifications"
     keybindingHint="G+N"
+    keybindingDescription="G, N"
   />
 )
 
-export const KeybindingHint = () => <IconButton icon={BoldIcon} aria-label="Bold" keybindingHint="Mod+B" />
+export const KeybindingHint = () => (
+  <IconButton icon={BoldIcon} aria-label="Bold" keybindingHint="Mod+B" keybindingDescription="Command, B" />
+)

--- a/packages/react/src/Button/IconButton.tsx
+++ b/packages/react/src/Button/IconButton.tsx
@@ -22,6 +22,7 @@ const IconButton = forwardRef(
       unsafeDisableTooltip = false,
       keyshortcuts,
       keybindingHint,
+      keybindingDescription,
       className,
       ...props
     },
@@ -67,6 +68,7 @@ const IconButton = forwardRef(
           type={description ? undefined : 'label'}
           direction={tooltipDirection}
           keybindingHint={keybindingHint ?? keyshortcuts}
+          keybindingDescription={keybindingDescription}
         >
           <ButtonBase
             icon={Icon}

--- a/packages/react/src/Button/types.ts
+++ b/packages/react/src/Button/types.ts
@@ -97,6 +97,7 @@ export type IconButtonProps = ButtonA11yProps & {
   /** @deprecated Use `keybindingHint` instead. */
   keyshortcuts?: string
   keybindingHint?: string
+  keybindingDescription?: string
 } & Omit<ButtonBaseProps, 'aria-label' | 'aria-labelledby'>
 
 // adopted from React.AnchorHTMLAttributes

--- a/packages/react/src/KeybindingHint/props.ts
+++ b/packages/react/src/KeybindingHint/props.ts
@@ -3,6 +3,8 @@ export type KeybindingHintFormat = 'condensed' | 'full'
 export type KeybindingHintVariant = 'normal' | 'onEmphasis' | 'onPrimary'
 
 export interface KeybindingHintProps {
+  description?: string
+
   /**
    * The keys involved in this keybinding. These should be the full names of the keys as would
    * be returned by `KeyboardEvent.key` (e.g. "Control", "Shift", "ArrowUp", "a", etc.).


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

@ericwbailey observed that in IconButton's that use a tooltip and a keybinding hint that the computed label was including extra information. This seems due to the fact that we're constructing the keybinding hint using `aria-hidden` but this is not respected when `aria-labelledby` or `aria-describedby` is used.

This PR is an exploration into what it would look like to add a way to provide an appropriate description through `keybindingDescription` but it would be worth seeing if we can make this work with `KeybindingHint` directly.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add conditional to when the loading describedby is provided in `ButtonBase`
- Update Tooltip so that only the inner context is pointed to by `aria-labelledby` or `aria-describedby`
- Add `keybindingDescription` to see what this would look like to provide an appropriate description for the keybindingHint

#### Removed

<!-- List of things removed in this PR -->
