### PR TITLE
Remove feature-flag and extra @aat

### DIFF
--- a/e2e/components/Axe.test.ts
+++ b/e2e/components/Axe.test.ts
@@ -21,7 +21,7 @@ type Component = {
 
 const {entries} = componentsConfig
 
-test.describe('@aat', () => {
+test.describe('Axe tests', () => {
   for (const [id, entry] of Object.entries(entries as Record<string, Component>)) {
     if (SKIPPED_TESTS.includes(id)) {
       continue
@@ -35,7 +35,7 @@ test.describe('@aat', () => {
     test.describe(id, () => {
       for (const theme of themes) {
         test.describe(theme, () => {
-          test(`${cleanedName} @aat`, async ({page}) => {
+          test(`@aat ${cleanedName}`, async ({page}) => {
             await visit(page, {
               id,
               globals: {

--- a/e2e/components/Axe.test.ts
+++ b/e2e/components/Axe.test.ts
@@ -13,6 +13,7 @@ const SKIPPED_TESTS = [
   'components-treeview-features--contain-intrinsic-size',
   'components-flash-features--with-icon-action-dismiss', // TODO: Remove once color-contrast issues have been resolved
   'components-flash-features--with-icon-and-action', // TODO: Remove once color-contrast issues have been resolved
+  'components-filteredactionlist--default',
 ]
 
 type Component = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26858,7 +26858,7 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/packages/react/src/FilteredActionList/FilteredActionList.stories.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionList.stories.tsx
@@ -4,7 +4,6 @@ import {ThemeProvider} from '..'
 import {FilteredActionList} from '../FilteredActionList'
 import BaseStyles from '../BaseStyles'
 import Box from '../Box'
-import {FeatureFlags} from '../FeatureFlags'
 
 const meta: Meta = {
   title: 'Components/FilteredActionList',
@@ -58,7 +57,7 @@ export function Default(): JSX.Element {
   const filteredItems = items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
 
   return (
-    <FeatureFlags flags={{primer_react_select_panel_with_modern_action_list: true}}>
+    <>
       <h1>Filtered Action List</h1>
       <div>Please select labels that describe your issue:</div>
       <FilteredActionList
@@ -67,6 +66,6 @@ export function Default(): JSX.Element {
         onFilterChange={setFilter}
         sx={{border: '1px solid', padding: '8px'}}
       />
-    </FeatureFlags>
+    </>
   )
 }


### PR DESCRIPTION
I missed two comments on my previous PR (https://github.com/primer/react/pull/5592):
- [Remove extra @aat](https://github.com/primer/react/pull/5592/files#r1937648547)
- [Remove feature flag wrapping FilterActionList and instead skip the story for testing](https://github.com/primer/react/pull/5592/files#r1934362259)


This PR aims to fix them

Closes #

N/A

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [X] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
