### PR TITLE
ci: remove continue-on-error from workflows

### DIFF
--- a/.github/workflows/aat-reports.yml
+++ b/.github/workflows/aat-reports.yml
@@ -82,7 +82,6 @@ jobs:
           path: playwright-report
       - name: Check aat-runner job status
         if: ${{ needs.aat-runner.result == 'failure' }}
-        continue-on-error: true
         run: exit 1
 
   aat-runner-all-flags:
@@ -159,5 +158,4 @@ jobs:
           path: playwright-report
       - name: Check aat-runner-all-flags job status
         if: ${{ needs.aat-runner-all-flags.result == 'failure' }}
-        continue-on-error: true
         run: exit 1

--- a/.github/workflows/vrt-reports.yml
+++ b/.github/workflows/vrt-reports.yml
@@ -82,7 +82,6 @@ jobs:
           path: playwright-report
       - name: check vrt-runner job status
         if: ${{ needs.vrt-runner.result == 'failure' }}
-        continue-on-error: true
         run: exit 1
 
   vrt-runner-all-flags:
@@ -159,5 +158,4 @@ jobs:
           path: playwright-report
       - name: check vrt-runner-all-flags job status
         if: ${{ needs.vrt-runner-all-flags.result == 'failure' }}
-        continue-on-error: true
         run: exit 1

--- a/packages/react/src/Button/ButtonBase.module.css
+++ b/packages/react/src/Button/ButtonBase.module.css
@@ -13,8 +13,7 @@
   text-decoration: none;
   cursor: pointer;
   user-select: none;
-  /* background-color: transparent; */
-  background-color: magenta;
+  background-color: transparent;
   border: var(--borderWidth-thin) solid;
   border-color: var(--button-default-borderColor-rest);
   border-radius: var(--borderRadius-medium);

--- a/packages/react/src/Button/ButtonBase.module.css
+++ b/packages/react/src/Button/ButtonBase.module.css
@@ -13,7 +13,8 @@
   text-decoration: none;
   cursor: pointer;
   user-select: none;
-  background-color: transparent;
+  /* background-color: transparent; */
+  background-color: magenta;
   border: var(--borderWidth-thin) solid;
   border-color: var(--button-default-borderColor-rest);
   border-radius: var(--borderRadius-medium);


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Remove `continue-on-error` from jobs so that they no longer report as successful in CI. This should not import how deploy previews generate reports.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Remove `continue-on-error` from report CI jobs

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->


- [x] None; if selected, include a brief description as to why
