### PR TITLE
Enable color-contrast Axe check for all stories by default

### DIFF
--- a/e2e/components/Button.test.ts
+++ b/e2e/components/Button.test.ts
@@ -557,7 +557,7 @@ test.describe('Button', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'components-button-devonly--invisible-variants',
+            id: 'components-button-dev--invisible-variants',
             globals: {
               colorScheme: theme,
             },
@@ -575,7 +575,7 @@ test.describe('Button', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'components-button-devonly--test-sx-prop',
+            id: 'components-button-dev--test-sx-prop',
             globals: {
               colorScheme: theme,
             },
@@ -632,7 +632,7 @@ test.describe('Button', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'components-button-devonly--disabled-button-variants',
+            id: 'components-button-dev--disabled-button-variants',
             globals: {
               colorScheme: theme,
             },

--- a/e2e/components/ButtonGroup.test.ts
+++ b/e2e/components/ButtonGroup.test.ts
@@ -80,7 +80,7 @@ test.describe('ButtonGroup', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'components-buttongroup-devonly--link-button-with-icon-buttons',
+            id: 'components-buttongroup-dev--link-button-with-icon-buttons',
             globals: {
               colorScheme: theme,
             },
@@ -98,7 +98,7 @@ test.describe('ButtonGroup', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'components-buttongroup-devonly--sx-prop',
+            id: 'components-buttongroup-dev--sx-prop',
             globals: {
               colorScheme: theme,
             },

--- a/e2e/components/IconButton.test.ts
+++ b/e2e/components/IconButton.test.ts
@@ -377,7 +377,7 @@ test.describe('IconButton', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'components-iconbutton-devonly--icon-button-within-flex-container',
+            id: 'components-iconbutton-dev--icon-button-within-flex-container',
             globals: {
               colorScheme: theme,
             },
@@ -389,7 +389,7 @@ test.describe('IconButton', () => {
 
         test('axe @aat', async ({page}) => {
           await visit(page, {
-            id: 'components-iconbutton-devonly--icon-button-within-flex-container',
+            id: 'components-iconbutton-dev--icon-button-within-flex-container',
             globals: {
               colorScheme: theme,
             },

--- a/e2e/components/Link.test.ts
+++ b/e2e/components/Link.test.ts
@@ -55,7 +55,7 @@ test.describe('Link', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'components-link-devonly--inline',
+            id: 'components-link-dev--inline',
             globals: {
               colorScheme: theme,
             },

--- a/e2e/components/NavList.test.ts
+++ b/e2e/components/NavList.test.ts
@@ -26,7 +26,7 @@ test.describe('NavList', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'components-navlist-devonly--with-group-title-and-heading',
+            id: 'components-navlist-dev--with-group-title-and-heading',
             globals: {
               colorScheme: theme,
             },

--- a/e2e/components/PageHeader.test.ts
+++ b/e2e/components/PageHeader.test.ts
@@ -659,7 +659,7 @@ test.describe('PageHeader', () => {
       test.describe(theme, () => {
         test('default @vrt', async ({page}) => {
           await visit(page, {
-            id: 'components-pageheader-devonly--large-variant-with-multiline-title',
+            id: 'components-pageheader-dev--large-variant-with-multiline-title',
             globals: {
               colorScheme: theme,
             },
@@ -671,7 +671,7 @@ test.describe('PageHeader', () => {
 
         test('axe @aat', async ({page}) => {
           await visit(page, {
-            id: 'components-pageheader-devonly--large-variant-with-multiline-title',
+            id: 'components-pageheader-dev--large-variant-with-multiline-title',
             globals: {
               colorScheme: theme,
             },

--- a/e2e/components/SelectPanel.test.ts
+++ b/e2e/components/SelectPanel.test.ts
@@ -73,7 +73,13 @@ test.describe('SelectPanel', () => {
 
     test(`${name} axe @aat ${theme} ${flag}`, async ({page}) => {
       await visit(page, {id: scenario.story.id, globals})
-      await expect(page).toHaveNoViolations()
+      await expect(page).toHaveNoViolations({
+        rules: {
+          'color-contrast': {
+            enabled: false,
+          },
+        },
+      })
     })
   }
 

--- a/e2e/matchers/toHaveNoViolations.ts
+++ b/e2e/matchers/toHaveNoViolations.ts
@@ -37,7 +37,7 @@ expect.extend({
     // get color scheme from globals
 
     const pageUrl = page.url()
-    const isDev = pageUrl.includes('--dev-')
+    const isDev = pageUrl.includes('-dev--')
 
     const globals = new URL(pageUrl).searchParams.get('globals')
     console.log(globals?.split('colorScheme:')[1])

--- a/e2e/matchers/toHaveNoViolations.ts
+++ b/e2e/matchers/toHaveNoViolations.ts
@@ -9,7 +9,6 @@ const COLOR_CONTRAST_SKIP = [
   'experimental-components-hidden-examples--pull-request-page',
   'components-underlinenav-examples--pull-request-page',
   'components-actionmenu-examples--groups-and-descriptions',
-  'components-anchoredoverlay-features--portal-inside-scrolling-element',
   'components-button-features--expanded-button',
   'components-formcontrol-features--with-caption-and-disabled',
   'components-formcontrol-features--with-leading-visual',
@@ -21,7 +20,6 @@ const COLOR_CONTRAST_SKIP = [
   'components-statelabel-features--issue-opened',
   'components-statelabel-features--pull-opened',
   'components-statelabel-features--small',
-  'hooks-usefocuszone--special-situations',
   'deprecated-components-actionlist--complex-list-full-variant-story', // Deprecated component
 ]
 

--- a/e2e/matchers/toHaveNoViolations.ts
+++ b/e2e/matchers/toHaveNoViolations.ts
@@ -16,14 +16,13 @@ const COLOR_CONTRAST_SKIP = [
   'components-pageheader-examples--issues-page',
   'components-pageheader-examples--with-page-layout',
   'components-pagelayout-features--pull-request-page',
-  'components-pagelayout-features--sticky-pane',
   'components-statelabel--default',
   'components-statelabel--playground',
   'components-statelabel-features--issue-opened',
   'components-statelabel-features--pull-opened',
   'components-statelabel-features--small',
   'hooks-usefocuszone--special-situations',
-  'deprecated-components-actionlist--complex-list-full-variant-story',
+  'deprecated-components-actionlist--complex-list-full-variant-story', // Deprecated component
 ]
 
 const defaultOptions = (colorScheme: string, shouldSkip: boolean) => ({
@@ -59,7 +58,7 @@ expect.extend({
 
     const pageUrl = page.url()
     const isDev = pageUrl.includes('-dev--')
-    const idName = pageUrl.split('id=')[0].split('&')[0]
+    const idName = pageUrl.split('id=')[1].split('&')[0]
 
     const shouldSkip = COLOR_CONTRAST_SKIP.includes(idName)
 

--- a/e2e/matchers/toHaveNoViolations.ts
+++ b/e2e/matchers/toHaveNoViolations.ts
@@ -16,7 +16,7 @@ const COLOR_CONTRAST_SKIP = [
   'components-pageheader-examples--with-page-layout',
   'components-pageheader-examples--pull-request-page',
   'experimental-components-hidden-examples--pull-request-page-on-narrow-viewport',
-  'omponents-pageheader-examples--pull-request-page-on-narrow-viewport',
+  'components-pageheader-examples--pull-request-page-on-narrow-viewport',
   'components-pagelayout-features--pull-request-page',
   'components-statelabel--default',
   'components-statelabel--playground',

--- a/e2e/matchers/toHaveNoViolations.ts
+++ b/e2e/matchers/toHaveNoViolations.ts
@@ -16,12 +16,14 @@ const COLOR_CONTRAST_SKIP = [
   'components-pageheader-examples--with-page-layout',
   'components-pageheader-examples--pull-request-page',
   'experimental-components-hidden-examples--pull-request-page-on-narrow-viewport',
+  'omponents-pageheader-examples--pull-request-page-on-narrow-viewport',
   'components-pagelayout-features--pull-request-page',
   'components-statelabel--default',
   'components-statelabel--playground',
   'components-statelabel-features--issue-opened',
   'components-statelabel-features--pull-opened',
   'components-statelabel-features--small',
+  'hooks-usefocuszone--special-situations',
   'deprecated-components-actionlist--complex-list-inset-variant-story', // Deprecated component
   'deprecated-components-actionlist--complex-list-full-variant-story', // Deprecated component
 ]

--- a/e2e/matchers/toHaveNoViolations.ts
+++ b/e2e/matchers/toHaveNoViolations.ts
@@ -5,7 +5,28 @@ import {source} from 'axe-core'
 import path from 'node:path'
 import fs from 'node:fs'
 
-const defaultOptions = (colorScheme: string, isDev: boolean) => ({
+const COLOR_CONTRAST_SKIP = [
+  'experimental-components-hidden-examples--pull-request-page',
+  'components-underlinenav-examples--pull-request-page',
+  'components-actionmenu-examples--groups-and-descriptions',
+  'components-anchoredoverlay-features--portal-inside-scrolling-element',
+  'components-button-features--expanded-button',
+  'components-formcontrol-features--with-caption-and-disabled',
+  'components-formcontrol-features--with-leading-visual',
+  'components-pageheader-examples--issues-page',
+  'components-pageheader-examples--with-page-layout',
+  'components-pagelayout-features--pull-request-page',
+  'components-pagelayout-features--sticky-pane',
+  'components-statelabel--default',
+  'components-statelabel--playground',
+  'components-statelabel-features--issue-opened',
+  'components-statelabel-features--pull-opened',
+  'components-statelabel-features--small',
+  'hooks-usefocuszone--special-situations',
+  'deprecated-components-actionlist--complex-list-full-variant-story',
+]
+
+const defaultOptions = (colorScheme: string, shouldSkip: boolean) => ({
   rules: {
     'document-title': {
       enabled: false,
@@ -27,7 +48,7 @@ const defaultOptions = (colorScheme: string, isDev: boolean) => ({
       enabled: true,
     },
     'color-contrast': {
-      enabled: colorScheme !== 'dark_dimmed' && !isDev,
+      enabled: colorScheme !== 'dark_dimmed' && !shouldSkip,
     },
   },
 })
@@ -38,16 +59,18 @@ expect.extend({
 
     const pageUrl = page.url()
     const isDev = pageUrl.includes('-dev--')
+    const idName = pageUrl.split('id=')[0].split('&')[0]
+
+    const shouldSkip = COLOR_CONTRAST_SKIP.includes(idName)
 
     const globals = new URL(pageUrl).searchParams.get('globals')
-    console.log(globals?.split('colorScheme:')[1])
     const colorScheme = globals?.split('colorScheme:')[1] ?? 'light'
 
     const runConfig = {
-      ...defaultOptions(colorScheme, isDev),
+      ...defaultOptions(colorScheme, isDev || shouldSkip),
       ...options,
       rules: {
-        ...defaultOptions(colorScheme, isDev).rules,
+        ...defaultOptions(colorScheme, isDev || shouldSkip).rules,
         ...options.rules,
       },
     }

--- a/e2e/matchers/toHaveNoViolations.ts
+++ b/e2e/matchers/toHaveNoViolations.ts
@@ -5,7 +5,7 @@ import {source} from 'axe-core'
 import path from 'node:path'
 import fs from 'node:fs'
 
-const defaultOptions = (theme: string) => ({
+const defaultOptions = (colorScheme: string, isDev: boolean) => ({
   rules: {
     'document-title': {
       enabled: false,
@@ -27,7 +27,7 @@ const defaultOptions = (theme: string) => ({
       enabled: true,
     },
     'color-contrast': {
-      enabled: theme !== 'dark_dimmed',
+      enabled: colorScheme !== 'dark_dimmed' && !isDev,
     },
   },
 })
@@ -37,15 +37,17 @@ expect.extend({
     // get color scheme from globals
 
     const pageUrl = page.url()
+    const isDev = pageUrl.includes('--dev-')
 
     const globals = new URL(pageUrl).searchParams.get('globals')
+    console.log(globals?.split('colorScheme:')[1])
     const colorScheme = globals?.split('colorScheme:')[1] ?? 'light'
 
     const runConfig = {
-      ...defaultOptions(colorScheme),
+      ...defaultOptions(colorScheme, isDev),
       ...options,
       rules: {
-        ...defaultOptions(colorScheme).rules,
+        ...defaultOptions(colorScheme, isDev).rules,
         ...options.rules,
       },
     }

--- a/e2e/matchers/toHaveNoViolations.ts
+++ b/e2e/matchers/toHaveNoViolations.ts
@@ -5,7 +5,7 @@ import {source} from 'axe-core'
 import path from 'node:path'
 import fs from 'node:fs'
 
-const defaultOptions = {
+const defaultOptions = (theme: string) => ({
   rules: {
     'document-title': {
       enabled: false,
@@ -27,18 +27,25 @@ const defaultOptions = {
       enabled: true,
     },
     'color-contrast': {
-      enabled: false,
+      enabled: theme !== 'dark_dimmed',
     },
   },
-}
+})
 
 expect.extend({
   async toHaveNoViolations(page: Page, options = {rules: {}}) {
+    // get color scheme from globals
+
+    const pageUrl = page.url()
+
+    const globals = new URL(pageUrl).searchParams.get('globals')
+    const colorScheme = globals?.split('colorScheme:')[1] ?? 'light'
+
     const runConfig = {
-      ...defaultOptions,
+      ...defaultOptions(colorScheme),
       ...options,
       rules: {
-        ...defaultOptions.rules,
+        ...defaultOptions(colorScheme).rules,
         ...options.rules,
       },
     }

--- a/e2e/matchers/toHaveNoViolations.ts
+++ b/e2e/matchers/toHaveNoViolations.ts
@@ -14,12 +14,15 @@ const COLOR_CONTRAST_SKIP = [
   'components-formcontrol-features--with-leading-visual',
   'components-pageheader-examples--issues-page',
   'components-pageheader-examples--with-page-layout',
+  'components-pageheader-examples--pull-request-page',
+  'experimental-components-hidden-examples--pull-request-page-on-narrow-viewport',
   'components-pagelayout-features--pull-request-page',
   'components-statelabel--default',
   'components-statelabel--playground',
   'components-statelabel-features--issue-opened',
   'components-statelabel-features--pull-opened',
   'components-statelabel-features--small',
+  'deprecated-components-actionlist--complex-list-inset-variant-story', // Deprecated component
   'deprecated-components-actionlist--complex-list-full-variant-story', // Deprecated component
 ]
 

--- a/e2e/matchers/toHaveNoViolations.ts
+++ b/e2e/matchers/toHaveNoViolations.ts
@@ -23,7 +23,6 @@ const COLOR_CONTRAST_SKIP = [
   'components-statelabel-features--issue-opened',
   'components-statelabel-features--pull-opened',
   'components-statelabel-features--small',
-  'hooks-usefocuszone--special-situations',
   'deprecated-components-actionlist--complex-list-inset-variant-story', // Deprecated component
   'deprecated-components-actionlist--complex-list-full-variant-story', // Deprecated component
 ]

--- a/packages/react/.storybook/preview.jsx
+++ b/packages/react/.storybook/preview.jsx
@@ -270,11 +270,11 @@ export const decorators = [
       document.body.setAttribute('data-dark-theme', darkTheme)
     }, [colorScheme])
 
-    // Set data-a11y-link-underlines=true to enable underlines in all stories except the Link DevOnly Inline Story.
+    // Set data-a11y-link-underlines=true to enable underlines in all stories except the Link dev Inline Story.
     let wrapperProps =
-      context.id !== 'components-link-devonly--inline'
+      context.id !== 'components-link-dev--inline'
         ? {
-            'data-a11y-link-underlines': context.id !== 'components-link-devonly--inline',
+            'data-a11y-link-underlines': context.id !== 'components-link-dev--inline',
             className: clsx('story-wrap'),
           }
         : {className: clsx('story-wrap')}

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
@@ -55,7 +55,7 @@ const HeaderAndLayout = ({children}: {children: JSX.Element}) => {
     }
   }, [scrollingElementRef])
   return (
-    <Box position="absolute" top={0} right={0} bottom={0} left={0} padding={4} backgroundColor="lavenderblush">
+    <Box position="absolute" top={0} right={0} bottom={0} left={0} padding={4}>
       <Heading>Header or some such</Heading>
       <Box position="absolute" top={10} right={4} bottom={4} left={4} overflow="scroll" backgroundColor="powderblue">
         {children}

--- a/packages/react/src/Button/Button.dev.stories.tsx
+++ b/packages/react/src/Button/Button.dev.stories.tsx
@@ -5,7 +5,7 @@ import {default as Text} from '../Text'
 import {Stack} from '../Stack'
 
 export default {
-  title: 'Components/Button/DevOnly',
+  title: 'Components/Button/Dev',
 }
 
 export const InvisibleVariants = () => {

--- a/packages/react/src/Button/IconButton.dev.stories.tsx
+++ b/packages/react/src/Button/IconButton.dev.stories.tsx
@@ -5,7 +5,7 @@ import Box from '../Box'
 import {Stack} from '../Stack'
 
 export default {
-  title: 'Components/IconButton/DevOnly',
+  title: 'Components/IconButton/Dev',
 }
 
 export const CustomSize = () => (

--- a/packages/react/src/ButtonGroup/ButtonGroup.dev.stories.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.dev.stories.tsx
@@ -6,7 +6,7 @@ import {CopilotIcon} from '@primer/octicons-react'
 import {Box, Tooltip, ThemeProvider, BaseStyles} from '..'
 
 const meta: Meta<typeof ButtonGroup> = {
-  title: 'Components/ButtonGroup/DevOnly',
+  title: 'Components/ButtonGroup/Dev',
   component: ButtonGroup,
   decorators: [
     Story => {

--- a/packages/react/src/Link/Link.dev.stories.tsx
+++ b/packages/react/src/Link/Link.dev.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import type {ComponentProps} from '../utils/types'
 
 export default {
-  title: 'Components/Link/DevOnly',
+  title: 'Components/Link/Dev',
   component: Link,
 } as Meta<ComponentProps<typeof Link>>
 

--- a/packages/react/src/NavList/NavList.dev.stories.tsx
+++ b/packages/react/src/NavList/NavList.dev.stories.tsx
@@ -5,7 +5,7 @@ import {NavList} from './NavList'
 import {ArrowRightIcon, ArrowLeftIcon, BookIcon, FileDirectoryIcon} from '@primer/octicons-react'
 
 const meta: Meta = {
-  title: 'Components/NavList/DevOnly',
+  title: 'Components/NavList/Dev',
   component: NavList,
   parameters: {
     layout: 'fullscreen',

--- a/packages/react/src/PageHeader/PageHeader.dev.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.dev.stories.tsx
@@ -7,7 +7,7 @@ import {GitBranchIcon, PencilIcon, SidebarExpandIcon} from '@primer/octicons-rea
 import {PageHeader} from './PageHeader'
 
 const meta: Meta<typeof PageHeader> = {
-  title: 'Components/PageHeader/DevOnly',
+  title: 'Components/PageHeader/Dev',
   parameters: {
     layout: 'fullscreen',
     controls: {expanded: true},

--- a/packages/react/src/PageLayout/PageLayout.features.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.features.stories.tsx
@@ -126,7 +126,10 @@ export const StickyPane: StoryFn = args => (
           )
         })}
         <Box as="p">
-          Donec sit amet massa purus. <a href="#foo">Plura de lorem Ispum.</a>
+          Donec sit amet massa purus.{' '}
+          <Link inline href="#foo">
+            Plura de lorem Ispum.
+          </Link>
         </Box>
       </Box>
     </PageLayout.Pane>

--- a/packages/react/src/stories/useFocusZone.stories.tsx
+++ b/packages/react/src/stories/useFocusZone.stories.tsx
@@ -3,6 +3,7 @@ import type {Meta} from '@storybook/react'
 import styled from 'styled-components'
 import {Box, BaseStyles, Flash, theme, ThemeProvider} from '..'
 import {Button} from '../Button'
+import Link from '../Link'
 import {FocusKeys} from '@primer/behaviors'
 import type {Direction} from '@primer/behaviors'
 import {themeGet} from '@styled-system/theme-get'
@@ -385,7 +386,7 @@ export const SpecialSituations = () => {
         <Flash sx={{mb: 3}}>
           This story is very esoteric! It only exists to show some of the nuance of the arrow key focus behavior in
           different situations. Focus treatment within your component should be evaluated for your particular UX using
-          the <a href="https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard">ARIA guidelines</a>.
+          the <Link href="https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard">ARIA guidelines</Link>.
         </Flash>
         <Box position="absolute" right={5} top={2}>
           Last key pressed: {lastKey}

--- a/packages/react/src/stories/useFocusZone.stories.tsx
+++ b/packages/react/src/stories/useFocusZone.stories.tsx
@@ -386,7 +386,11 @@ export const SpecialSituations = () => {
         <Flash sx={{mb: 3}}>
           This story is very esoteric! It only exists to show some of the nuance of the arrow key focus behavior in
           different situations. Focus treatment within your component should be evaluated for your particular UX using
-          the <Link href="https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard">ARIA guidelines</Link>.
+          the{' '}
+          <Link href="https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard" inline>
+            ARIA guidelines
+          </Link>
+          .
         </Flash>
         <Box position="absolute" right={5} top={2}>
           Last key pressed: {lastKey}

--- a/script/generate-e2e-tests.js
+++ b/script/generate-e2e-tests.js
@@ -798,7 +798,7 @@ const components = new Map([
           name: 'With TrailingAction in Sub Item',
         },
         {
-          id: 'components-navlist-devonly--with-bad-example-of-sub-nav-and-trailing-action',
+          id: 'components-navlist-dev--with-bad-example-of-sub-nav-and-trailing-action',
           name: 'With Bad Example of SubNav and TrailingAction',
         },
       ],
@@ -896,7 +896,7 @@ const components = new Map([
           name: 'With Parent Link and Actions of Context Area',
         },
         {
-          id: 'components-pageheader-devonly--large-variant-with-multiline-title',
+          id: 'components-pageheader-dev--large-variant-with-multiline-title',
           name: 'Large Variant with Multiline Title',
         },
       ],


### PR DESCRIPTION
GOAL:

[Remove ~100 instances of this](https://github.com/primer/react/pull/5659/files):
```ts
        test('axe @aat', async ({page}) => {
          await visit(page, {
            id: 'components-button-features--danger',
            globals: {
              colorScheme: theme,
            },
          })
          await expect(page).toHaveNoViolations({
            rules: {
              'color-contrast': {
                enabled: theme !== 'dark_dimmed',
              },
            },
          })
        })
```
By turning `color-contrast` on for all storybook stories except for `dev` stories, `theme !== 'dark_dimmed`, and stories that do not currently pass color contrast.


This PR actually adds coverage since most of our storybook stories are not being tested for color-contrast violations at all.


Additionally, I changed all `DevOnly` Storybook folders to be `Dev` since it seemed like we use both.



### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
