### PR TITLE
[Accessibility][Autocomplete] Announce "no selectable options"

### DIFF
--- a/.changeset/chilled-rules-yell.md
+++ b/.changeset/chilled-rules-yell.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Autocomplete: Use aria-live to announce "no selectable options".

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@changesets/cli": "2.27.1",
         "@github/axe-github": "0.6.1",
         "@github/markdownlint-github": "^0.6.0",
+        "@github/mini-throttle": "2.1.1",
         "@github/prettier-config": "0.0.6",
         "@mdx-js/react": "1.6.22",
         "@playwright/test": "^1.50.0",
@@ -4654,6 +4655,13 @@
       "dependencies": {
         "lodash": "^4.17.15"
       }
+    },
+    "node_modules/@github/mini-throttle": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@github/mini-throttle/-/mini-throttle-2.1.1.tgz",
+      "integrity": "sha512-KtOPaB+FiKJ6jcKm9UKyaM5fPURHGf+xcp+b4Mzoi81hOc6M1sIGpMZMAVbNzfa2lW5+RPGKq888Px0j76OZ/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@github/prettier-config": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@changesets/changelog-github": "0.5.0",
     "@changesets/cli": "2.27.1",
     "@github/axe-github": "0.6.1",
+    "@github/mini-throttle": "2.1.1",
     "@github/markdownlint-github": "^0.6.0",
     "@github/prettier-config": "0.0.6",
     "@mdx-js/react": "1.6.22",

--- a/packages/react/src/Autocomplete/AutocompleteMenu.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteMenu.tsx
@@ -1,4 +1,5 @@
 import React, {useContext, useEffect, useMemo, useRef, useState} from 'react'
+import {Announce} from '../live-region'
 import {scrollIntoView} from '@primer/behaviors'
 import type {ScrollIntoViewOptions} from '@primer/behaviors'
 import type {ActionListItemProps} from '../ActionList'
@@ -381,9 +382,9 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
             </ActionList>
           ) : emptyStateText !== false && emptyStateText !== null ? (
             enabled ? (
-              <Box className={classes.EmptyStateWrapper}>{emptyStateText}</Box>
+              <Announce className={classes.EmptyStateWrapper}>{emptyStateText}</Announce>
             ) : (
-              <Box p={3}>{emptyStateText}</Box>
+              <Announce p={3}>{emptyStateText}</Announce>
             )
           ) : null}
         </div>

--- a/packages/react/src/Autocomplete/AutocompleteMenu.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteMenu.tsx
@@ -281,7 +281,7 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
     if (allItemsToRender.length === 0) {
       debounceAnnouncement(emptyStateText as string)
     }
-  }, [allItemsToRender])
+  }, [allItemsToRender, emptyStateText])
 
   useFocusZone(
     {

--- a/packages/react/src/Autocomplete/AutocompleteMenu.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteMenu.tsx
@@ -1,5 +1,6 @@
 import React, {useContext, useEffect, useMemo, useRef, useState} from 'react'
-import {Announce} from '../live-region'
+import {debounce} from '@github/mini-throttle'
+import {announce} from '@primer/live-region-element'
 import {scrollIntoView} from '@primer/behaviors'
 import type {ScrollIntoViewOptions} from '@primer/behaviors'
 import type {ActionListItemProps} from '../ActionList'
@@ -122,6 +123,14 @@ export type AutocompleteMenuInternalProps<T extends AutocompleteItemProps> = {
 }
 
 const CSS_MODULES_FEATURE_FLAG = 'primer_react_css_modules_staff'
+
+/**
+ * Announces a message to screen readers at a slowed-down rate. This is useful when you want to announce don't want to
+ * overwhelm the user with too many announcements in rapid succession.
+ */
+const debounceAnnouncement = debounce((announcement: string) => {
+  announce(announcement)
+}, 250)
 
 function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMenuInternalProps<T>) {
   const autocompleteContext = useContext(AutocompleteContext)
@@ -268,6 +277,12 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
     allItemsToRenderRef.current = allItemsToRender
   })
 
+  React.useEffect(() => {
+    if (allItemsToRender.length === 0) {
+      debounceAnnouncement(emptyStateText as string)
+    }
+  }, [allItemsToRender])
+
   useFocusZone(
     {
       containerRef: listContainerRef,
@@ -382,9 +397,9 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
             </ActionList>
           ) : emptyStateText !== false && emptyStateText !== null ? (
             enabled ? (
-              <Announce className={classes.EmptyStateWrapper}>{emptyStateText}</Announce>
+              <Box className={classes.EmptyStateWrapper}>{emptyStateText}</Box>
             ) : (
-              <Announce p={3}>{emptyStateText}</Announce>
+              <Box p={3}>{emptyStateText}</Box>
             )
           ) : null}
         </div>


### PR DESCRIPTION
Closes #

Closes: https://github.com/github/accessibility-audits/issues/10123


Use the `Announce` component to announce "no selectable options" when a user filters options and there are no results in the Autocomplete component. 

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [X] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [X] Tested in Chrome (NVDA)
- [ ] Tested in Firefox
- [X] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
