### PR TITLE
ActionBar: Add `disabled` support to `ActionBar`

### DIFF
--- a/.changeset/sixty-otters-lie.md
+++ b/.changeset/sixty-otters-lie.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+ActionBar: Improves `disabled` state on `ActionBar.IconButton`; includes `disabled` state in overflow menu

--- a/packages/react/src/ActionBar/ActionBar.docs.json
+++ b/packages/react/src/ActionBar/ActionBar.docs.json
@@ -75,6 +75,12 @@
           "type": "string",
           "defaultValue": "",
           "description": "Use an aria label to describe the functionality of the button. Please refer to [our guidance on alt text](https://primer.style/guides/accessibility/alternative-text-for-images) for tips on writing good alternative text."
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "defaultValue": "",
+          "description": "Provides a disabled state for the button. The button will remain focusable, and have `aria-disabled` applied."
         }
       ],
       "passthrough": {

--- a/packages/react/src/ActionBar/ActionBar.examples.stories.tsx
+++ b/packages/react/src/ActionBar/ActionBar.examples.stories.tsx
@@ -47,6 +47,22 @@ export const SmallActionBar = () => (
   </ActionBar>
 )
 
+export const WithDisabledItems = () => (
+  <ActionBar aria-label="Toolbar">
+    <ActionBar.IconButton icon={BoldIcon} aria-label="Bold"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={ItalicIcon} aria-label="Italic"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={CodeIcon} aria-label="Code"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={LinkIcon} aria-label="Link"></ActionBar.IconButton>
+    <ActionBar.Divider />
+    <ActionBar.IconButton disabled icon={FileAddedIcon} aria-label="File Added"></ActionBar.IconButton>
+    <ActionBar.IconButton disabled icon={SearchIcon} aria-label="Search"></ActionBar.IconButton>
+    <ActionBar.IconButton disabled icon={QuoteIcon} aria-label="Insert Quote"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={ListUnorderedIcon} aria-label="Unordered List"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={ListOrderedIcon} aria-label="Ordered List"></ActionBar.IconButton>
+    <ActionBar.IconButton icon={TasklistIcon} aria-label="Task List"></ActionBar.IconButton>
+  </ActionBar>
+)
+
 type CommentBoxProps = {'aria-label': string}
 
 export const CommentBox = (props: CommentBoxProps) => {

--- a/packages/react/src/ActionBar/ActionBar.test.tsx
+++ b/packages/react/src/ActionBar/ActionBar.test.tsx
@@ -64,15 +64,10 @@ describe('ActionBar', () => {
 
   it('should not trigger disabled button with spacebar or enter', async () => {
     const user = userEvent.setup()
-    const onKeyDown = jest.fn()
+    const onClick = jest.fn()
     const {getByRole} = HTMLRender(
       <ActionBar aria-label="Toolbar">
-        <ActionBar.IconButton
-          icon={BoldIcon}
-          aria-label="Default"
-          onKeyDown={onKeyDown}
-          disabled
-        ></ActionBar.IconButton>
+        <ActionBar.IconButton icon={BoldIcon} aria-label="Default" onClick={onClick} disabled></ActionBar.IconButton>
       </ActionBar>,
     )
 
@@ -84,15 +79,15 @@ describe('ActionBar', () => {
 
     await user.keyboard('{Enter}')
 
-    expect(onKeyDown).not.toHaveBeenCalled()
+    expect(onClick).not.toHaveBeenCalled()
   })
 
   it('should trigger non-disabled button with spacebar or enter', async () => {
     const user = userEvent.setup()
-    const onKeyDown = jest.fn()
+    const onClick = jest.fn()
     const {getByRole} = HTMLRender(
       <ActionBar aria-label="Toolbar">
-        <ActionBar.IconButton icon={BoldIcon} aria-label="Default" onKeyDown={onKeyDown}></ActionBar.IconButton>
+        <ActionBar.IconButton icon={BoldIcon} aria-label="Default" onClick={onClick}></ActionBar.IconButton>
       </ActionBar>,
     )
 
@@ -104,6 +99,6 @@ describe('ActionBar', () => {
 
     await user.keyboard('{Enter}')
 
-    expect(onKeyDown).toHaveBeenCalled()
+    expect(onClick).toHaveBeenCalled()
   })
 })

--- a/packages/react/src/ActionBar/ActionBar.test.tsx
+++ b/packages/react/src/ActionBar/ActionBar.test.tsx
@@ -32,4 +32,18 @@ describe('ActionBar', () => {
     const results = await axe.run(container)
     expect(results).toHaveNoViolations()
   })
+
+  it('should not trigger disabled button', () => {
+    const onClick = jest.fn()
+    const {getByRole} = HTMLRender(
+      <ActionBar aria-label="Toolbar">
+        <ActionBar.IconButton icon={BoldIcon} aria-label="Default" onClick={onClick} disabled></ActionBar.IconButton>
+      </ActionBar>,
+    )
+
+    const button = getByRole('button')
+    button.click()
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
 })

--- a/packages/react/src/ActionBar/ActionBar.test.tsx
+++ b/packages/react/src/ActionBar/ActionBar.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {behavesAsComponent} from '../utils/testing'
-import {render as HTMLRender} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {render as HTMLRender, act} from '@testing-library/react'
 import axe from 'axe-core'
 
 import ActionBar from './'
@@ -45,5 +46,64 @@ describe('ActionBar', () => {
     button.click()
 
     expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('should trigger non-disabled button', () => {
+    const onClick = jest.fn()
+    const {getByRole} = HTMLRender(
+      <ActionBar aria-label="Toolbar">
+        <ActionBar.IconButton icon={BoldIcon} aria-label="Default" onClick={onClick}></ActionBar.IconButton>
+      </ActionBar>,
+    )
+
+    const button = getByRole('button')
+    button.click()
+
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('should not trigger disabled button with spacebar or enter', async () => {
+    const user = userEvent.setup()
+    const onKeyDown = jest.fn()
+    const {getByRole} = HTMLRender(
+      <ActionBar aria-label="Toolbar">
+        <ActionBar.IconButton
+          icon={BoldIcon}
+          aria-label="Default"
+          onKeyDown={onKeyDown}
+          disabled
+        ></ActionBar.IconButton>
+      </ActionBar>,
+    )
+
+    const button = getByRole('button')
+
+    act(() => {
+      button.focus()
+    })
+
+    await user.keyboard('{Enter}')
+
+    expect(onKeyDown).not.toHaveBeenCalled()
+  })
+
+  it('should trigger non-disabled button with spacebar or enter', async () => {
+    const user = userEvent.setup()
+    const onKeyDown = jest.fn()
+    const {getByRole} = HTMLRender(
+      <ActionBar aria-label="Toolbar">
+        <ActionBar.IconButton icon={BoldIcon} aria-label="Default" onKeyDown={onKeyDown}></ActionBar.IconButton>
+      </ActionBar>,
+    )
+
+    const button = getByRole('button')
+
+    act(() => {
+      button.focus()
+    })
+
+    await user.keyboard('{Enter}')
+
+    expect(onKeyDown).toHaveBeenCalled()
   })
 })

--- a/packages/react/src/ActionBar/ActionBar.tsx
+++ b/packages/react/src/ActionBar/ActionBar.tsx
@@ -252,22 +252,6 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
   )
 }
 
-interface RepoPickerProps {
-  id: string
-  name: string
-  ownerLogin: string
-  visibility: 'public' | 'private' | 'internal'
-  selected?: boolean
-}
-
-// {
-//     id: string, required: false
-//     name: string, required: true
-//     ownerLogin: string, required: true
-//     visibility: 'public' | 'private' | 'internal', required: true
-//     selected: boolean, required: false
-// }
-
 export const ActionBarIconButton = forwardRef(
   ({disabled, onClick, onKeyDown, ...props}: ActionBarIconButtonProps, forwardedRef) => {
     const backupRef = useRef<HTMLElement>(null)

--- a/packages/react/src/ActionBar/ActionBar.tsx
+++ b/packages/react/src/ActionBar/ActionBar.tsx
@@ -46,7 +46,7 @@ export type ActionBarProps = {
   className?: string
 } & A11yProps
 
-export type ActionBarIconButtonProps = IconButtonProps
+export type ActionBarIconButtonProps = {disabled?: boolean} & IconButtonProps
 
 const MORE_BTN_WIDTH = 86
 
@@ -215,7 +215,13 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
                     if (menuItem.type === ActionList.Divider) {
                       return <ActionList.Divider key={index} />
                     } else {
-                      const {children: menuItemChildren, onClick, icon: Icon, 'aria-label': ariaLabel} = menuItem.props
+                      const {
+                        children: menuItemChildren,
+                        onClick,
+                        icon: Icon,
+                        'aria-label': ariaLabel,
+                        disabled,
+                      } = menuItem.props
                       return (
                         <ActionList.Item
                           key={menuItemChildren}
@@ -224,6 +230,7 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
                             focusOnMoreMenuBtn()
                             typeof onClick === 'function' && onClick(event)
                           }}
+                          disabled={disabled}
                         >
                           {Icon ? (
                             <ActionList.LeadingVisual>
@@ -254,7 +261,7 @@ export const ActionBarIconButton = forwardRef((props: ActionBarIconButtonProps, 
     const domRect = (ref as MutableRefObject<HTMLElement>).current.getBoundingClientRect()
     setChildrenWidth({text, width: domRect.width})
   }, [ref, setChildrenWidth])
-  return <IconButton ref={ref} size={size} {...props} variant="invisible" />
+  return <IconButton aria-disabled={props.disabled} ref={ref} size={size} {...props} variant="invisible" />
 })
 
 export const VerticalDivider = () => {

--- a/packages/react/src/ActionBar/ActionBar.tsx
+++ b/packages/react/src/ActionBar/ActionBar.tsx
@@ -252,17 +252,39 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
   )
 }
 
-export const ActionBarIconButton = forwardRef((props: ActionBarIconButtonProps, forwardedRef) => {
-  const backupRef = useRef<HTMLElement>(null)
-  const ref = (forwardedRef ?? backupRef) as RefObject<HTMLAnchorElement>
-  const {size, setChildrenWidth} = React.useContext(ActionBarContext)
-  useIsomorphicLayoutEffect(() => {
-    const text = props['aria-label'] ? props['aria-label'] : ''
-    const domRect = (ref as MutableRefObject<HTMLElement>).current.getBoundingClientRect()
-    setChildrenWidth({text, width: domRect.width})
-  }, [ref, setChildrenWidth])
-  return <IconButton aria-disabled={props.disabled} ref={ref} size={size} {...props} variant="invisible" />
-})
+export const ActionBarIconButton = forwardRef(
+  ({disabled, onClick, ...props}: ActionBarIconButtonProps, forwardedRef) => {
+    const backupRef = useRef<HTMLElement>(null)
+    const ref = (forwardedRef ?? backupRef) as RefObject<HTMLAnchorElement>
+    const {size, setChildrenWidth} = React.useContext(ActionBarContext)
+    useIsomorphicLayoutEffect(() => {
+      const text = props['aria-label'] ? props['aria-label'] : ''
+      const domRect = (ref as MutableRefObject<HTMLElement>).current.getBoundingClientRect()
+      setChildrenWidth({text, width: domRect.width})
+    }, [ref, setChildrenWidth])
+
+    const clickHandler = useCallback(
+      (event: React.MouseEvent<HTMLButtonElement>) => {
+        if (disabled) {
+          return
+        }
+        onClick?.(event)
+      },
+      [disabled, onClick],
+    )
+
+    return (
+      <IconButton
+        aria-disabled={disabled}
+        ref={ref}
+        size={size}
+        onClick={clickHandler}
+        {...props}
+        variant="invisible"
+      />
+    )
+  },
+)
 
 export const VerticalDivider = () => {
   const ref = useRef<HTMLDivElement>(null)

--- a/packages/react/src/ActionBar/ActionBar.tsx
+++ b/packages/react/src/ActionBar/ActionBar.tsx
@@ -253,7 +253,7 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
 }
 
 export const ActionBarIconButton = forwardRef(
-  ({disabled, onClick, onKeyDown, ...props}: ActionBarIconButtonProps, forwardedRef) => {
+  ({disabled, onClick, ...props}: ActionBarIconButtonProps, forwardedRef) => {
     const backupRef = useRef<HTMLElement>(null)
     const ref = (forwardedRef ?? backupRef) as RefObject<HTMLAnchorElement>
     const {size, setChildrenWidth} = React.useContext(ActionBarContext)
@@ -271,26 +271,12 @@ export const ActionBarIconButton = forwardRef(
       [disabled, onClick],
     )
 
-    const keyDownHandler = React.useCallback(
-      (event: React.KeyboardEvent<HTMLButtonElement>) => {
-        if (disabled) return
-        if ([' ', 'Enter'].includes(event.key)) {
-          if (event.key === ' ') {
-            event.preventDefault()
-          }
-          onKeyDown?.(event)
-        }
-      },
-      [disabled, onKeyDown],
-    )
-
     return (
       <IconButton
         aria-disabled={disabled}
         ref={ref}
         size={size}
         onClick={clickHandler}
-        onKeyDown={keyDownHandler}
         {...props}
         variant="invisible"
       />

--- a/packages/react/src/ActionBar/ActionBar.tsx
+++ b/packages/react/src/ActionBar/ActionBar.tsx
@@ -252,6 +252,22 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
   )
 }
 
+interface RepoPickerProps {
+  id: string
+  name: string
+  ownerLogin: string
+  visibility: 'public' | 'private' | 'internal'
+  selected?: boolean
+}
+
+// {
+//     id: string, required: false
+//     name: string, required: true
+//     ownerLogin: string, required: true
+//     visibility: 'public' | 'private' | 'internal', required: true
+//     selected: boolean, required: false
+// }
+
 export const ActionBarIconButton = forwardRef(
   ({disabled, onClick, onKeyDown, ...props}: ActionBarIconButtonProps, forwardedRef) => {
     const backupRef = useRef<HTMLElement>(null)
@@ -265,9 +281,7 @@ export const ActionBarIconButton = forwardRef(
 
     const clickHandler = useCallback(
       (event: React.MouseEvent<HTMLButtonElement>) => {
-        if (disabled) {
-          return
-        }
+        if (disabled) return
         onClick?.(event)
       },
       [disabled, onClick],

--- a/packages/react/src/ActionBar/ActionBar.tsx
+++ b/packages/react/src/ActionBar/ActionBar.tsx
@@ -253,7 +253,7 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
 }
 
 export const ActionBarIconButton = forwardRef(
-  ({disabled, onClick, ...props}: ActionBarIconButtonProps, forwardedRef) => {
+  ({disabled, onClick, onKeyDown, ...props}: ActionBarIconButtonProps, forwardedRef) => {
     const backupRef = useRef<HTMLElement>(null)
     const ref = (forwardedRef ?? backupRef) as RefObject<HTMLAnchorElement>
     const {size, setChildrenWidth} = React.useContext(ActionBarContext)
@@ -273,12 +273,26 @@ export const ActionBarIconButton = forwardRef(
       [disabled, onClick],
     )
 
+    const keyDownHandler = React.useCallback(
+      (event: React.KeyboardEvent<HTMLButtonElement>) => {
+        if (disabled) return
+        if ([' ', 'Enter'].includes(event.key)) {
+          if (event.key === ' ') {
+            event.preventDefault()
+          }
+          onKeyDown?.(event)
+        }
+      },
+      [disabled, onKeyDown],
+    )
+
     return (
       <IconButton
         aria-disabled={disabled}
         ref={ref}
         size={size}
         onClick={clickHandler}
+        onKeyDown={keyDownHandler}
         {...props}
         variant="invisible"
       />


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

https://github.com/github/primer/issues/4613

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

* Improves `disabled` support on `ActionBar.IconButton`
* Ensures that the overflow menu respects the `disabled` state

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
