### PR TITLE
fix: apply specificity so that style actually applies to checked radio

### DIFF
--- a/packages/react/src/Radio/Radio.module.css
+++ b/packages/react/src/Radio/Radio.module.css
@@ -4,7 +4,7 @@
     background-color,
     border-color 80ms cubic-bezier(0.33, 1, 0.68, 1); /* checked -> unchecked - add 120ms delay to fully see animation-out */
 
-  &:where(:checked) {
+  &:is(:checked) {
     /* stylelint-disable-next-line primer/colors */
     background-color: var(--control-checked-fgColor-rest);
 


### PR DESCRIPTION
`:where()` has 0 specificity, the consequence of which is that style does not apply, as it is overridden by other css rules. => use `:is()` instead

<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #5672

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->


#### Changed

replace `:where()` css by `:is()`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
