### PR TITLE
feat: Introduce Tooltip to SegmentedControlIconButton

### DIFF
--- a/.changeset/sharp-flowers-repair.md
+++ b/.changeset/sharp-flowers-repair.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+feat: Introduce Tooltip to SegmentedControlIconButton

--- a/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
+++ b/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
@@ -6,4 +6,5 @@ export const DefaultFeatureFlags = FeatureFlagScope.create({
   primer_react_action_list_item_as_button: false,
   primer_react_select_panel_with_modern_action_list: false,
   primer_react_overlay_overflow: false,
+  primer_react_segmented_control_tooltip: false,
 })

--- a/packages/react/src/SegmentedControl/SegmentedControl.docs.json
+++ b/packages/react/src/SegmentedControl/SegmentedControl.docs.json
@@ -169,12 +169,6 @@
           "required": false
         },
         {
-          "name": "unsafeDisableTooltip",
-          "type": "boolean",
-          "defaultValue": "false",
-          "required": false
-        },
-        {
           "name": "description",
           "type": "string",
           "required": false,

--- a/packages/react/src/SegmentedControl/SegmentedControl.docs.json
+++ b/packages/react/src/SegmentedControl/SegmentedControl.docs.json
@@ -144,7 +144,7 @@
           "description": "Whether the segment is selected. This is used for controlled SegmentedControls, and needs to be updated using the onChange handler on SegmentedControl."
         },
         {
-          "name": "selected",
+          "name": "size",
           "type": "'small' | 'medium'",
           "defaultValue": "",
           "description": "The size of the buttons"
@@ -162,6 +162,24 @@
         {
           "name": "ref",
           "type": "React.RefObject<HTMLButtonElement>"
+        },
+        {
+          "name": "tooltipDirection",
+          "type": "'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw'",
+          "required": false
+        },
+        {
+          "name": "unsafeDisableTooltip",
+          "type": "boolean",
+          "defaultValue": "false",
+          "required": false
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": false,
+          "description": "If `description` is provided, we will use a Tooltip to describe the button. Then `aria-label` is used to label the button.",
+          "defaultValue": ""
         }
       ]
     }

--- a/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
@@ -11,9 +11,9 @@ import {act} from 'react-test-renderer'
 import {viewportRanges} from '../hooks/useResponsiveValue'
 
 const segmentData = [
-  {label: 'Preview', id: 'preview', iconLabel: 'EyeIcon', icon: () => <EyeIcon aria-label="EyeIcon" />},
-  {label: 'Raw', id: 'raw', iconLabel: 'FileCodeIcon', icon: () => <FileCodeIcon aria-label="FileCodeIcon" />},
-  {label: 'Blame', id: 'blame', iconLabel: 'PeopleIcon', icon: () => <PeopleIcon aria-label="PeopleIcon" />},
+  {label: 'Preview', description: 'This preview does blah.', id: 'preview', iconLabel: 'EyeIcon', icon: () => <EyeIcon aria-label="EyeIcon" />},
+  {label: 'Raw', description: 'This shows the raw content.', id: 'raw', iconLabel: 'FileCodeIcon', icon: () => <FileCodeIcon aria-label="FileCodeIcon" />},
+  {label: 'Blame', description: 'This shows the blame.', id: 'blame', iconLabel: 'PeopleIcon', icon: () => <PeopleIcon aria-label="PeopleIcon" />},
 ]
 
 let matchMedia: MatchMediaMock
@@ -164,8 +164,8 @@ describe('SegmentedControl', () => {
     }
   })
 
-  it('renders icon button with tooltip label', () => {
-    const {getByLabelText} = render(
+  it('renders icon button with tooltip as label', () => {
+    const {getByRole, getByText, getAllByRole} = render(
       <SegmentedControl aria-label="File view">
         {segmentData.map(({label, icon}) => (
           <SegmentedControl.IconButton icon={icon} aria-label={label} key={label} />
@@ -174,29 +174,33 @@ describe('SegmentedControl', () => {
     )
 
     for (const datum of segmentData) {
-      const labelledButton = getByLabelText(datum.label)
-      expect(labelledButton).toBeDefined()
-      // expect tooltip
+      const labelledButton = getByRole('button', {name: datum.label})
+      const tooltipElement = getByText(datum.label)
+      expect(labelledButton).toHaveAttribute('aria-labelledby', tooltipElement.id)
+      expect(labelledButton).not.toHaveAttribute('aria-label')
     }
   })
 
   it('renders icon button with tooltip description', () => {
-    const {getByLabelText} = render(
+    const {getByRole, getByText} = render(
       <SegmentedControl aria-label="File view">
-        {segmentData.map(({label, icon}) => (
-          <SegmentedControl.IconButton icon={icon} aria-label={label} description="I am some description" key={label} />
+        {segmentData.map(({label, icon, description}) => (
+          <SegmentedControl.IconButton icon={icon} aria-label={label} description={description} key={label} />
         ))}
       </SegmentedControl>,
     )
 
     for (const datum of segmentData) {
-      // butotn has `aria-label`
-      // button has `aria-describedby` pointing to tooltip
+      const labelledButton = getByRole('button', {name: datum.label})
+      const tooltipElement = getByText(datum.description)
+      expect(labelledButton).toHaveAttribute('aria-describedby', tooltipElement.id)
+      expect(labelledButton).toHaveAccessibleName(datum.label)
+      expect(labelledButton).toHaveAttribute('aria-label', datum.label)
     }
   })
 
-  it('renders icon button without tooltip by setting `unsafeDisableTooltip`', () => {
-    const {getByLabelText} = render(
+  it('renders icon button with aria-label and no tooltip when unsafeDisableTooltip is true', () => {
+    const {getByRole} = render(
       <SegmentedControl aria-label="File view">
         {segmentData.map(({label, icon}) => (
           <SegmentedControl.IconButton icon={icon} unsafeDisableTooltip={true} aria-label={label} key={label} />
@@ -205,8 +209,8 @@ describe('SegmentedControl', () => {
     )
 
     for (const datum of segmentData) {
-      // no tooltip
-      // button has `aria-label`
+      const labelledButton = getByRole('button', {name: datum.label})
+      expect(labelledButton).toHaveAttribute('aria-label', datum.label)
     }
   })
 

--- a/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
@@ -11,9 +11,27 @@ import {act} from 'react-test-renderer'
 import {viewportRanges} from '../hooks/useResponsiveValue'
 
 const segmentData = [
-  {label: 'Preview', description: 'This preview does blah.', id: 'preview', iconLabel: 'EyeIcon', icon: () => <EyeIcon aria-label="EyeIcon" />},
-  {label: 'Raw', description: 'This shows the raw content.', id: 'raw', iconLabel: 'FileCodeIcon', icon: () => <FileCodeIcon aria-label="FileCodeIcon" />},
-  {label: 'Blame', description: 'This shows the blame.', id: 'blame', iconLabel: 'PeopleIcon', icon: () => <PeopleIcon aria-label="PeopleIcon" />},
+  {
+    label: 'Preview',
+    description: 'This preview does blah.',
+    id: 'preview',
+    iconLabel: 'EyeIcon',
+    icon: () => <EyeIcon aria-label="EyeIcon" />,
+  },
+  {
+    label: 'Raw',
+    description: 'This shows the raw content.',
+    id: 'raw',
+    iconLabel: 'FileCodeIcon',
+    icon: () => <FileCodeIcon aria-label="FileCodeIcon" />,
+  },
+  {
+    label: 'Blame',
+    description: 'This shows the blame.',
+    id: 'blame',
+    iconLabel: 'PeopleIcon',
+    icon: () => <PeopleIcon aria-label="PeopleIcon" />,
+  },
 ]
 
 let matchMedia: MatchMediaMock
@@ -165,7 +183,7 @@ describe('SegmentedControl', () => {
   })
 
   it('renders icon button with tooltip as label', () => {
-    const {getByRole, getByText, getAllByRole} = render(
+    const {getByRole, getByText} = render(
       <SegmentedControl aria-label="File view">
         {segmentData.map(({label, icon}) => (
           <SegmentedControl.IconButton icon={icon} aria-label={label} key={label} />

--- a/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
@@ -164,6 +164,52 @@ describe('SegmentedControl', () => {
     }
   })
 
+  it('renders icon button with tooltip label', () => {
+    const {getByLabelText} = render(
+      <SegmentedControl aria-label="File view">
+        {segmentData.map(({label, icon}) => (
+          <SegmentedControl.IconButton icon={icon} aria-label={label} key={label} />
+        ))}
+      </SegmentedControl>,
+    )
+
+    for (const datum of segmentData) {
+      const labelledButton = getByLabelText(datum.label)
+      expect(labelledButton).toBeDefined()
+      // expect tooltip
+    }
+  })
+
+  it('renders icon button with tooltip description', () => {
+    const {getByLabelText} = render(
+      <SegmentedControl aria-label="File view">
+        {segmentData.map(({label, icon}) => (
+          <SegmentedControl.IconButton icon={icon} aria-label={label} description="I am some description" key={label} />
+        ))}
+      </SegmentedControl>,
+    )
+
+    for (const datum of segmentData) {
+      // butotn has `aria-label`
+      // button has `aria-describedby` pointing to tooltip
+    }
+  })
+
+  it('renders icon button without tooltip by setting `unsafeDisableTooltip`', () => {
+    const {getByLabelText} = render(
+      <SegmentedControl aria-label="File view">
+        {segmentData.map(({label, icon}) => (
+          <SegmentedControl.IconButton icon={icon} unsafeDisableTooltip={true} aria-label={label} key={label} />
+        ))}
+      </SegmentedControl>,
+    )
+
+    for (const datum of segmentData) {
+      // no tooltip
+      // button has `aria-label`
+    }
+  })
+
   it('calls onChange with index of clicked segment button', async () => {
     const user = userEvent.setup()
     const handleChange = jest.fn()

--- a/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
@@ -9,6 +9,7 @@ import theme from '../theme'
 import {BaseStyles, ThemeProvider} from '..'
 import {act} from 'react-test-renderer'
 import {viewportRanges} from '../hooks/useResponsiveValue'
+import {FeatureFlags} from '../FeatureFlags'
 
 const segmentData = [
   {
@@ -182,13 +183,19 @@ describe('SegmentedControl', () => {
     }
   })
 
-  it('renders icon button with tooltip as label', () => {
+  it('renders icon button with tooltip as label when feature flag is enabled', () => {
     const {getByRole, getByText} = render(
-      <SegmentedControl aria-label="File view">
-        {segmentData.map(({label, icon}) => (
-          <SegmentedControl.IconButton icon={icon} aria-label={label} key={label} />
-        ))}
-      </SegmentedControl>,
+      <FeatureFlags
+        flags={{
+          primer_react_segmented_control_tooltip: true,
+        }}
+      >
+        <SegmentedControl aria-label="File view">
+          {segmentData.map(({label, icon}) => (
+            <SegmentedControl.IconButton icon={icon} aria-label={label} key={label} />
+          ))}
+        </SegmentedControl>
+      </FeatureFlags>,
     )
 
     for (const datum of segmentData) {
@@ -199,13 +206,19 @@ describe('SegmentedControl', () => {
     }
   })
 
-  it('renders icon button with tooltip description', () => {
+  it('renders icon button with tooltip description when feature flag is enabled', () => {
     const {getByRole, getByText} = render(
-      <SegmentedControl aria-label="File view">
-        {segmentData.map(({label, icon, description}) => (
-          <SegmentedControl.IconButton icon={icon} aria-label={label} description={description} key={label} />
-        ))}
-      </SegmentedControl>,
+      <FeatureFlags
+        flags={{
+          primer_react_segmented_control_tooltip: true,
+        }}
+      >
+        <SegmentedControl aria-label="File view">
+          {segmentData.map(({label, icon, description}) => (
+            <SegmentedControl.IconButton icon={icon} aria-label={label} description={description} key={label} />
+          ))}
+        </SegmentedControl>
+      </FeatureFlags>,
     )
 
     for (const datum of segmentData) {
@@ -217,11 +230,11 @@ describe('SegmentedControl', () => {
     }
   })
 
-  it('renders icon button with aria-label and no tooltip when unsafeDisableTooltip is true', () => {
+  it('renders icon button with aria-label and no tooltip', () => {
     const {getByRole} = render(
       <SegmentedControl aria-label="File view">
         {segmentData.map(({label, icon}) => (
-          <SegmentedControl.IconButton icon={icon} unsafeDisableTooltip={true} aria-label={label} key={label} />
+          <SegmentedControl.IconButton icon={icon} aria-label={label} key={label} />
         ))}
       </SegmentedControl>,
     )

--- a/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
@@ -28,8 +28,6 @@ export type SegmentedControlIconButtonProps = {
   selected?: boolean
   /** Whether the segment is selected. This is used for uncontrolled SegmentedControls to pick one SegmentedControlButton that is selected on the initial render. */
   defaultSelected?: boolean
-  /** Whether the tooltip should shown. This is meant to be a temporary prop until default tooltip on icon buttons are fully rolled out.*/
-  unsafeDisableTooltip?: boolean
   /** Supplementary description that renders inside tooltip in place of the label.*/
   description?: string
   /** The direction for the tooltip.*/
@@ -53,8 +51,7 @@ export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<Segmen
   sx: sxProp = defaultSxProp,
   className,
   description,
-  tooltipDirection,
-  unsafeDisableTooltip = false,
+  tooltipDirection
   ...rest
 }) => {
   const enabled = useFeatureFlag(SEGMENTED_CONTROL_CSS_MODULES_FEATURE_FLAG)
@@ -68,28 +65,8 @@ export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<Segmen
         sxProp as SxProp,
       )
 
-  if (unsafeDisableTooltip) {
-    return (
-      <Box
-        as="li"
-        sx={mergedSx}
-        className={clsx(enabled && classes.Item, className)}
-        data-selected={selected || undefined}
-      >
-        <SegmentedControlIconButtonStyled
-          aria-label={ariaLabel}
-          aria-current={selected}
-          sx={enabled ? undefined : getSegmentedControlButtonStyles({selected})}
-          className={clsx(enabled && classes.Button, enabled && classes.IconButton)}
-          {...rest}
-        >
-          <span className={clsx(enabled ? classes.Content : 'segmentedControl-content')}>
-            {isElement(Icon) ? Icon : <Icon />}
-          </span>
-        </SegmentedControlIconButtonStyled>
-      </Box>
-    )
-  } else {
+  const tooltipFlagEnabled = useFeatureFlag('primer_react_segmented_control_tooltip')
+  if (tooltipFlagEnabled) {
     return (
       <Box
         as="li"
@@ -115,6 +92,28 @@ export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<Segmen
             </span>
           </SegmentedControlIconButtonStyled>
         </Tooltip>
+      </Box>
+    )
+  } else {
+    // This can be removed when primer_react_segmented_control_tooltip feature flag is GA-ed.
+    return (
+      <Box
+        as="li"
+        sx={mergedSx}
+        className={clsx(enabled && classes.Item, className)}
+        data-selected={selected || undefined}
+      >
+        <SegmentedControlIconButtonStyled
+          aria-label={ariaLabel}
+          aria-current={selected}
+          sx={enabled ? undefined : getSegmentedControlButtonStyles({selected})}
+          className={clsx(enabled && classes.Button, enabled && classes.IconButton)}
+          {...rest}
+        >
+          <span className={clsx(enabled ? classes.Content : 'segmentedControl-content')}>
+            {isElement(Icon) ? Icon : <Icon />}
+          </span>
+        </SegmentedControlIconButtonStyled>
       </Box>
     )
   }

--- a/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
@@ -67,28 +67,28 @@ export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<Segmen
         },
         sxProp as SxProp,
       )
-  
+
   if (unsafeDisableTooltip) {
-      return (
-        <Box
-          as="li"
-          sx={mergedSx}
-          className={clsx(enabled && classes.Item, className)}
-          data-selected={selected || undefined}
+    return (
+      <Box
+        as="li"
+        sx={mergedSx}
+        className={clsx(enabled && classes.Item, className)}
+        data-selected={selected || undefined}
+      >
+        <SegmentedControlIconButtonStyled
+          aria-label={ariaLabel}
+          aria-current={selected}
+          sx={enabled ? undefined : getSegmentedControlButtonStyles({selected})}
+          className={clsx(enabled && classes.Button, enabled && classes.IconButton)}
+          {...rest}
         >
-          <SegmentedControlIconButtonStyled
-            aria-label={ariaLabel}
-            aria-current={selected}
-            sx={enabled ? undefined : getSegmentedControlButtonStyles({selected})}
-            className={clsx(enabled && classes.Button, enabled && classes.IconButton)}
-            {...rest}
-            >
-            <span className={clsx(enabled ? classes.Content : 'segmentedControl-content')}>
-              {isElement(Icon) ? Icon : <Icon />}
-            </span>
-          </SegmentedControlIconButtonStyled>
-        </Box>
-      ) 
+          <span className={clsx(enabled ? classes.Content : 'segmentedControl-content')}>
+            {isElement(Icon) ? Icon : <Icon />}
+          </span>
+        </SegmentedControlIconButtonStyled>
+      </Box>
+    )
   } else {
     return (
       <Box
@@ -97,7 +97,7 @@ export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<Segmen
         className={clsx(enabled && classes.Item, className)}
         data-selected={selected || undefined}
       >
-        <Tooltip 
+        <Tooltip
           type={description ? undefined : 'label'}
           text={description ? description : ariaLabel}
           direction={tooltipDirection}
@@ -109,7 +109,7 @@ export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<Segmen
             sx={enabled ? undefined : getSegmentedControlButtonStyles({selected})}
             className={clsx(enabled && classes.Button, enabled && classes.IconButton)}
             {...rest}
-            >
+          >
             <span className={clsx(enabled ? classes.Content : 'segmentedControl-content')}>
               {isElement(Icon) ? Icon : <Icon />}
             </span>

--- a/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
@@ -99,7 +99,7 @@ export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<Segmen
       >
         <Tooltip 
           type={description ? undefined : 'label'}
-          text={ariaLabel}
+          text={description ? description : ariaLabel}
           direction={tooltipDirection}
         >
           <SegmentedControlIconButtonStyled

--- a/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
@@ -51,7 +51,7 @@ export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<Segmen
   sx: sxProp = defaultSxProp,
   className,
   description,
-  tooltipDirection
+  tooltipDirection,
   ...rest
 }) => {
   const enabled = useFeatureFlag(SEGMENTED_CONTROL_CSS_MODULES_FEATURE_FLAG)

--- a/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
@@ -14,10 +14,11 @@ import {defaultSxProp} from '../utils/defaultSxProp'
 import {isElement} from 'react-is'
 import getGlobalFocusStyles from '../internal/utils/getGlobalFocusStyles'
 import {useFeatureFlag} from '../FeatureFlags'
-
+import type {TooltipDirection} from '../TooltipV2'
 import classes from './SegmentedControl.module.css'
 import {clsx} from 'clsx'
 import {toggleStyledComponent} from '../internal/utils/toggleStyledComponent'
+import {Tooltip} from '../TooltipV2'
 
 export type SegmentedControlIconButtonProps = {
   'aria-label': string
@@ -27,6 +28,12 @@ export type SegmentedControlIconButtonProps = {
   selected?: boolean
   /** Whether the segment is selected. This is used for uncontrolled SegmentedControls to pick one SegmentedControlButton that is selected on the initial render. */
   defaultSelected?: boolean
+  /** Whether the tooltip should shown. This is meant to be a temporary prop until default tooltip on icon buttons are fully rolled out.*/
+  unsafeDisableTooltip?: boolean
+  /** Supplementary description that renders inside tooltip in place of the label.*/
+  description?: string
+  /** The direction for the tooltip.*/
+  tooltipDirection?: TooltipDirection
 } & SxProp &
   ButtonHTMLAttributes<HTMLButtonElement | HTMLLIElement>
 
@@ -39,18 +46,15 @@ const SegmentedControlIconButtonStyled = toggleStyledComponent(
   `,
 )
 
-// TODO: update this component to be accessible when we update the Tooltip component
-// - we wouldn't render tooltip content inside a pseudoelement
-// - users can pass custom tooltip text in addition to `ariaLabel`
-//
-// See Slack thread: https://github.slack.com/archives/C02NUUQ9C30/p1656444474509599
-//
 export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<SegmentedControlIconButtonProps>> = ({
   'aria-label': ariaLabel,
   icon: Icon,
   selected,
   sx: sxProp = defaultSxProp,
   className,
+  description,
+  tooltipDirection,
+  unsafeDisableTooltip = false,
   ...rest
 }) => {
   const enabled = useFeatureFlag(SEGMENTED_CONTROL_CSS_MODULES_FEATURE_FLAG)
@@ -63,28 +67,57 @@ export const SegmentedControlIconButton: React.FC<React.PropsWithChildren<Segmen
         },
         sxProp as SxProp,
       )
-
-  return (
-    <Box
-      as="li"
-      sx={mergedSx}
-      className={clsx(enabled && classes.Item, className)}
-      data-selected={selected || undefined}
-    >
-      {/* TODO: Once the tooltip remediations are resolved (especially https://github.com/github/primer/issues/1909) - bring it back */}
-      <SegmentedControlIconButtonStyled
-        aria-label={ariaLabel}
-        aria-current={selected}
-        sx={enabled ? undefined : getSegmentedControlButtonStyles({selected})}
-        className={clsx(enabled && classes.Button, enabled && classes.IconButton)}
-        {...rest}
+  
+  if (unsafeDisableTooltip) {
+      return (
+        <Box
+          as="li"
+          sx={mergedSx}
+          className={clsx(enabled && classes.Item, className)}
+          data-selected={selected || undefined}
+        >
+          <SegmentedControlIconButtonStyled
+            aria-label={ariaLabel}
+            aria-current={selected}
+            sx={enabled ? undefined : getSegmentedControlButtonStyles({selected})}
+            className={clsx(enabled && classes.Button, enabled && classes.IconButton)}
+            {...rest}
+            >
+            <span className={clsx(enabled ? classes.Content : 'segmentedControl-content')}>
+              {isElement(Icon) ? Icon : <Icon />}
+            </span>
+          </SegmentedControlIconButtonStyled>
+        </Box>
+      ) 
+  } else {
+    return (
+      <Box
+        as="li"
+        sx={mergedSx}
+        className={clsx(enabled && classes.Item, className)}
+        data-selected={selected || undefined}
       >
-        <span className={clsx(enabled ? classes.Content : 'segmentedControl-content')}>
-          {isElement(Icon) ? Icon : <Icon />}
-        </span>
-      </SegmentedControlIconButtonStyled>
-    </Box>
-  )
+        <Tooltip 
+          type={description ? undefined : 'label'}
+          text={ariaLabel}
+          direction={tooltipDirection}
+        >
+          <SegmentedControlIconButtonStyled
+            aria-current={selected}
+            // If description is provided, we will use the tooltip to describe the button, so we need to keep the aria-label to label the button.
+            aria-label={description ? ariaLabel : undefined}
+            sx={enabled ? undefined : getSegmentedControlButtonStyles({selected})}
+            className={clsx(enabled && classes.Button, enabled && classes.IconButton)}
+            {...rest}
+            >
+            <span className={clsx(enabled ? classes.Content : 'segmentedControl-content')}>
+              {isElement(Icon) ? Icon : <Icon />}
+            </span>
+          </SegmentedControlIconButtonStyled>
+        </Tooltip>
+      </Box>
+    )
+  }
 }
 
 export default SegmentedControlIconButton


### PR DESCRIPTION
To do:

* [x] add test coverage
* [x] add story with tooltip (happens by default, and can be poked around using playground controls)
* [x] update docs
* [x] create integration PR in dotcom (kicked off - https://github.com/github/github/actions/runs/13248924209)
* [x] Introduce feature flag to dotcom - https://github.com/github/primer/issues/4775

Relates to: 

* https://github.com/github/accessibility-audits/issues/10092
* https://github.com/github/accessibility-audits/issues/10065

This enables a tooltip by default on the SegmentedControl.IconButton. For safe rollout, this wraps the updates in a new feature flag, `primer_react_segmented_control_tooltip` which will be tracked in https://github.com/github/primer/issues/4775. 

We can enable this feature flag for 1-2 weeks in dotcom, before we clean it up and formally GA.

I welcome others thoughts.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

* Shows tooltip by default for `SegmentedControl.IconButton`.
* Wraps changes in a new feature flag.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
