### PR TITLE
Remove the CSS modules feature flag from the Hidden component

### DIFF
--- a/.changeset/violet-ladybugs-melt.md
+++ b/.changeset/violet-ladybugs-melt.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Remove the CSS modules feature flag from the Hidden component

--- a/packages/react/src/Hidden/Hidden.test.tsx
+++ b/packages/react/src/Hidden/Hidden.test.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import {render} from '@testing-library/react'
 import {Hidden} from '.'
 import MatchMediaMock from 'jest-matchmedia-mock'
-import {behavesAsComponent, checkExports, renderStyles, checkStoriesForAxeViolations} from '../utils/testing'
-import {mediaQueries} from '../utils/layout'
+import {behavesAsComponent, checkExports, checkStoriesForAxeViolations} from '../utils/testing'
 
 let matchMedia: MatchMediaMock
 describe('Hidden', () => {

--- a/packages/react/src/Hidden/Hidden.test.tsx
+++ b/packages/react/src/Hidden/Hidden.test.tsx
@@ -40,37 +40,31 @@ describe('Hidden', () => {
   })
 
   it('renders the styles as expected when a single viewport value is provided as a string via `when` prop', () => {
-    const expectedStyles = {
-      // `.replace` is used because renderStyles return the JSON object without a space after the column
-      [`${mediaQueries.regular.replace(': ', ':')}`]: {
-        display: 'none',
-      },
-    }
-    expect(
-      renderStyles(
+    const hiddenElement = render(
+      <div data-testid="hidden-regular">
         <Hidden when="regular">
           <div>This is hidden when regular viewports</div>
-        </Hidden>,
-      ),
-    ).toEqual(expect.objectContaining(expectedStyles))
+        </Hidden>
+      </div>,
+    )
+    expect(hiddenElement.getAllByTestId('hidden-regular')[0].firstChild).toHaveAttribute(
+      'style',
+      '--hiddenDisplay-regular: none;',
+    )
   })
 
   it('renders the styles as expected when multiple viewport values are provided as an array via `when` prop', () => {
-    const expectedStyles = {
-      [`${mediaQueries.narrow.replace(': ', ':')}`]: {
-        display: 'none',
-      },
-      [`${mediaQueries.wide.replace(': ', ':')}`]: {
-        display: 'none',
-      },
-    }
-    expect(
-      renderStyles(
+    const hiddenElement = render(
+      <div data-testid="hidden-regular">
         <Hidden when={['narrow', 'wide']}>
-          <div>This is hidden when regular and wide viewports</div>
-        </Hidden>,
-      ),
-    ).toEqual(expect.objectContaining(expectedStyles))
+          <div>This is hidden when regular viewports</div>
+        </Hidden>
+      </div>,
+    )
+    expect(hiddenElement.getAllByTestId('hidden-regular')[0].firstChild).toHaveAttribute(
+      'style',
+      '--hiddenDisplay-narrow: none; --hiddenDisplay-wide: none;',
+    )
   })
 })
 

--- a/packages/react/src/Hidden/Hidden.tsx
+++ b/packages/react/src/Hidden/Hidden.tsx
@@ -1,12 +1,7 @@
 import React, {type CSSProperties} from 'react'
 import {clsx} from 'clsx'
 import type {ResponsiveValue} from '../hooks/useResponsiveValue'
-import {getBreakpointDeclarations} from '../utils/getBreakpointDeclarations'
-import Box from '../Box'
-import {useFeatureFlag} from '../FeatureFlags'
 import classes from './Hidden.module.css'
-
-const CSS_MODULES_FEATURE_FLAG = 'primer_react_css_modules_staff'
 
 type Viewport = 'narrow' | 'regular' | 'wide'
 
@@ -39,15 +34,11 @@ function normalize(hiddenViewports: Array<Viewport> | Viewport): ResponsiveValue
 }
 
 export const Hidden = ({when, className, style, children}: HiddenProps) => {
-  const enabled = useFeatureFlag(CSS_MODULES_FEATURE_FLAG)
   const normalizedStyles = normalize(when)
 
-  // Get breakpoint declarations for the normalized ResponsiveValue object
-  const breakpointSx = getBreakpointDeclarations(normalizedStyles, 'display', () => 'none')
-
-  return enabled ? (
+  return (
     <div
-      className={clsx(className, {[classes.Hidden]: enabled})}
+      className={clsx(className, classes.Hidden)}
       style={
         {
           '--hiddenDisplay-narrow': normalizedStyles.narrow ? 'none' : undefined,
@@ -59,8 +50,6 @@ export const Hidden = ({when, className, style, children}: HiddenProps) => {
     >
       {children}
     </div>
-  ) : (
-    <Box sx={breakpointSx}>{children}</Box>
   )
 }
 

--- a/packages/react/src/Hidden/__snapshots__/Hidden.test.tsx.snap
+++ b/packages/react/src/Hidden/__snapshots__/Hidden.test.tsx.snap
@@ -1,15 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Hidden renders \`when\` prop as expected 1`] = `
-@media screen and (max-width:calc(768px - 0.02px)) {
-  .c0 {
-    display: none;
-  }
-}
-
 <div>
   <div
-    class="c0"
+    class="Hidden"
+    style="--hiddenDisplay-narrow: none;"
   >
     <div>
       Hidden when narrow


### PR DESCRIPTION
The [Hidden component has no uses in dotcom](https://primer-query.githubapp.com/?name=%22Hidden%22&repo=%22github%2Fgithub%22) so I thought I would skip past to the end for this component.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

CSS modules feature flag, fully converting to CSS modules

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
