### PR TITLE
chore(UnderlinePanels): Adding the option to pass in className

### DIFF
--- a/.changeset/fifty-deers-applaud.md
+++ b/.changeset/fifty-deers-applaud.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+The `UnderlinePanels` component wasn't supporting passing in `className`. Adding to the prop list

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.test.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.test.tsx
@@ -5,6 +5,7 @@ import {render, screen} from '@testing-library/react'
 import UnderlinePanels from './UnderlinePanels'
 import {behavesAsComponent} from '../../utils/testing'
 import TabContainerElement from '@github/tab-container-element'
+import {FeatureFlags} from '../../FeatureFlags'
 
 TabContainerElement.prototype.selectTab = jest.fn()
 
@@ -157,5 +158,29 @@ describe('UnderlinePanels', () => {
     }).toThrow('Only one tab can be selected at a time.')
     expect(spy).toHaveBeenCalled()
     spy.mockRestore()
+  })
+  it('should support `className` on the outermost element', () => {
+    const Element = () => (
+      <UnderlinePanels className={'test-class-name'}>
+        <UnderlinePanels.Tab aria-selected={true}>Tab 1</UnderlinePanels.Tab>
+        <UnderlinePanels.Tab aria-selected={false}>Tab 2</UnderlinePanels.Tab>
+        <UnderlinePanels.Panel>Panel 1</UnderlinePanels.Panel>
+        <UnderlinePanels.Panel>Panel 2</UnderlinePanels.Panel>
+      </UnderlinePanels>
+    )
+    const FeatureFlagElement = () => {
+      return (
+        <FeatureFlags
+          flags={{
+            primer_react_css_modules_staff: true,
+            primer_react_css_modules_ga: true,
+          }}
+        >
+          <Element />
+        </FeatureFlags>
+      )
+    }
+    expect(render(<Element />).baseElement.firstChild?.firstChild?.firstChild).toHaveClass('test-class-name')
+    expect(render(<FeatureFlagElement />).baseElement.firstChild?.firstChild?.firstChild).toHaveClass('test-class-name')
   })
 })

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.tsx
@@ -27,6 +27,7 @@ import useIsomorphicLayoutEffect from '../../utils/useIsomorphicLayoutEffect'
 import {useFeatureFlag} from '../../FeatureFlags'
 import classes from './UnderlinePanels.module.css'
 import {toggleStyledComponent} from '../../internal/utils/toggleStyledComponent'
+import {clsx} from 'clsx'
 
 const CSS_MODULES_FEATURE_FLAG = 'primer_react_css_modules_staff'
 
@@ -51,6 +52,10 @@ export type UnderlinePanelsProps = {
    * Loading state for all counters. It displays loading animation for individual counters until all are resolved. It is needed to prevent multiple layout shift.
    */
   loadingCounters?: boolean
+  /**
+   * Class name for custom styling
+   */
+  className?: string
 } & SxProp
 
 export type TabProps = PropsWithChildren<{
@@ -89,6 +94,7 @@ const UnderlinePanels: FC<UnderlinePanelsProps> = ({
   children,
   loadingCounters,
   sx: sxProp = defaultSxProp,
+  className,
   ...props
 }) => {
   const [iconsVisible, setIconsVisible] = useState(true)
@@ -184,7 +190,7 @@ const UnderlinePanels: FC<UnderlinePanelsProps> = ({
           slot="tablist-wrapper"
           data-icons-visible={iconsVisible}
           sx={sxProp}
-          className={classes.StyledUnderlineWrapper}
+          className={clsx(className, classes.StyledUnderlineWrapper)}
           {...props}
         >
           <StyledUnderlineItemList ref={listRef} aria-label={ariaLabel} aria-labelledby={ariaLabelledBy} role="tablist">
@@ -214,6 +220,7 @@ const UnderlinePanels: FC<UnderlinePanelsProps> = ({
           },
           sxProp as SxProp,
         )}
+        className={className}
         {...props}
       >
         <StyledUnderlineItemList ref={listRef} aria-label={ariaLabel} aria-labelledby={ariaLabelledBy} role="tablist">


### PR DESCRIPTION
### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

The `UnderlinePanels` component wasn't supporting passing in `className`. Adding to the prop list

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
