### PR TITLE
Wrap `AvatarStack` avatars in `isolation: isolate` to create a new stacking context

### DIFF
--- a/.changeset/strange-pets-stare.md
+++ b/.changeset/strange-pets-stare.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Fix `AvatarStack` stacking `z-index` bugs by creating a new stacking context around the component

--- a/packages/react/src/AvatarStack/AvatarStack.module.css
+++ b/packages/react/src/AvatarStack/AvatarStack.module.css
@@ -9,6 +9,7 @@
   display: flex;
   min-width: var(--avatar-stack-size);
   height: var(--avatar-stack-size);
+  isolation: isolate;
 
   &:where([data-responsive]) {
     @media screen and (--viewportRange-narrow) {

--- a/packages/react/src/AvatarStack/AvatarStack.tsx
+++ b/packages/react/src/AvatarStack/AvatarStack.tsx
@@ -36,6 +36,7 @@ const AvatarStackWrapper = toggleStyledComponent(
     position: relative;
     height: var(--avatar-stack-size);
     min-width: var(--avatar-stack-size);
+    isolation: isolate;
 
     .pc-AvatarStackBody {
       display: flex;

--- a/packages/react/src/__tests__/__snapshots__/AvatarStack.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/AvatarStack.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Avatar respects alignRight props 1`] = `
   position: relative;
   height: var(--avatar-stack-size);
   min-width: var(--avatar-stack-size);
+  isolation: isolate;
   --avatar-stack-size: 20px;
 }
 


### PR DESCRIPTION
The stacking order of the avatars inside `AvatarStack` is controlled via `z-index` because it is reversed from the DOM order (earlier items display on top). This works fine within the component, but the effects of `z-index` can easily leak outside the component and cause unexpected bugs wherever any other component overlays `AvatarStack`. An example of this is https://github.com/github/copilot-productivity/issues/3985 (internal issue link) where the avatars appear on top of a dialog that should cover them.

The stacking order here only matters relative to the other avatars within the same component, so we can easily prevent this type of bug by isolating the `z-index` effects via a new [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context). The most explicit way to create a new stacking context is via the [`isolation`](https://developer.mozilla.org/en-US/docs/Web/CSS/isolation) property:

> The `isolation` CSS property determines whether an element must create a new stacking context.

This PR simply adds `isolation: isolate` to the `AvatarStack` container. 

There is prior art for this approach in `ButtonGroup`; see https://github.com/primer/react/pull/2910.

As a followup, it might be worth considering an audit of all uses of `z-index` within Primer to ensure they are properly isolated. In fact I would even consider an ESLint rule banning the use of `z-index` so that we have to explicitly override the rule and thus verify that we have considered the side effects + stacking context.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

Fixed stacking bugs relating to `AvatarStack`.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
