### PR TITLE
chore: add reset script for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:type-check": "tsc --noEmit",
     "type-check": "tsc --noEmit && npm run type-check -ws --if-present",
     "release": "npm run build && changeset publish",
+    "reset": "script/reset",
     "size": "size-limit"
   },
   "author": "GitHub, Inc.",

--- a/script/reset
+++ b/script/reset
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Remove all build folders, node_modules folders
+npm run clean:all
+
+# Install latest dependencies from lockfile
+npm install
+
+# Build packages
+npm build


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Add a reset script to `script/reset` that can be used to reset primer/react when the project may be in an invalid state. This is helpful for contributors who are trying to re-create something in CI that they are not seeing locally.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add `script/reset` as an alias for resetting the project

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why
