### PR TITLE
bugfix(SelectPanel): Set border-top-color on selectpanel footer

### DIFF
--- a/.changeset/clean-planets-sleep.md
+++ b/.changeset/clean-planets-sleep.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+bugfix(SelectPanel): Set border-top-color on selectpanel footer

--- a/packages/react/src/SelectPanel/SelectPanel.module.css
+++ b/packages/react/src/SelectPanel/SelectPanel.module.css
@@ -23,8 +23,8 @@
 .Footer {
   display: flex;
   padding: var(--base-size-8);
-  border-color: var(--borderColor-default);
   border-top: var(--borderWidth-thin) solid;
+  border-top-color: var(--borderColor-default);
 }
 
 .FilteredActionList {


### PR DESCRIPTION
@langermank noticed an issue with the selectpanel footer that had a dark line 
![image](https://github.com/user-attachments/assets/1a8c89b1-d6ea-488f-a469-599f5788c1f7)



### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

Set `border-top-color` for SelectPanel footer

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
