### PR TITLE
Fixes AvatarStack styling bugs (focus on stacking context issues)

### DIFF
--- a/packages/react/src/AvatarStack/AvatarStack.module.css
+++ b/packages/react/src/AvatarStack/AvatarStack.module.css
@@ -2,8 +2,11 @@
 /* stylelint-disable selector-max-specificity */
 .AvatarStack {
   --avatar-border-width: 1px;
-  --avatar-two-margin: calc(var(--avatar-stack-size) * -0.55);
-  --avatar-three-margin: calc(var(--avatar-stack-size) * -0.85);
+  --overlap-size: calc(var(--avatar-stack-size) * 0.55);
+  --overlap-size-avatar-three-plus: calc(var(--avatar-stack-size) * 0.85);
+  --mask-size: calc(100% + (var(--avatar-border-width) * 2));
+  --mask-start: -1;
+  --opacity-step: 15%;
 
   position: relative;
   display: flex;
@@ -32,47 +35,42 @@
   }
 
   &:where([data-avatar-count='2']) {
-    /* this calc explained: */
-
-    /* 1. avatar size + the non-overlapping part of the second avatar */
-
-    /* 2. + the border widths of the first two avatars */
-    min-width: calc(
-      var(--avatar-stack-size) + calc(var(--avatar-stack-size) + var(--avatar-two-margin)) + var(--avatar-border-width)
-    );
+    /*
+    MIN-WIDTH CALC FORMULA EXPLAINED:
+    avatar size ➡️ var(--avatar-stack-size)
+    plus the visible part of the 2nd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
+    */
+    min-width: calc(var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)));
   }
 
   &:where([data-avatar-count='3']) {
-    /* this calc explained: */
-
-    /* 1. avatar size + the non-overlapping part of the second avatar */
-
-    /* 2. + the non-overlapping part of the third avatar */
+    /*
+    MIN-WIDTH CALC FORMULA EXPLAINED:
+    avatar size ➡️ var(--avatar-stack-size)
+    plus the visible part of the 2nd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
+    plus the visible part of the 3rd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus)
+    */
     min-width: calc(
-      var(--avatar-stack-size) +
-        calc(
-          calc(var(--avatar-stack-size) + var(--avatar-two-margin)) +
-            calc(var(--avatar-stack-size) + var(--avatar-three-margin))
-        )
+      var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)) +
+        (var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus))
     );
   }
 
   &:where([data-avatar-count='3+']) {
-    /* this calc explained: */
-
-    /* 1. avatar size + the non-overlapping part of the second avatar */
-
-    /* 2. + the non-overlapping part of the third and fourth avatar */
+    /*
+    MIN-WIDTH CALC FORMULA EXPLAINED:
+    avatar size ➡️ var(--avatar-stack-size)
+    plus the visible part of the 2nd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
+    plus the visible part of the 3rd AND 4th avatar ➡️ (var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus)) * 2
+    */
     min-width: calc(
-      var(--avatar-stack-size) +
-        calc(
-          calc(var(--avatar-stack-size) + var(--avatar-two-margin)) +
-            calc(var(--avatar-stack-size) + var(--avatar-three-margin)) * 2
-        )
+      var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)) +
+        (var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus)) * 2
     );
   }
 
   &:where([data-align-right]) {
+    --mask-start: 1;
     justify-content: flex-end;
 
     .AvatarItem {
@@ -84,12 +82,7 @@
 
       &:nth-child(n + 2) {
         /* stylelint-disable-next-line primer/spacing */
-        margin-right: var(--avatar-two-margin);
-      }
-
-      &:nth-child(n + 3) {
-        /* stylelint-disable-next-line primer/spacing */
-        margin-right: var(--avatar-three-margin);
+        margin-right: calc(var(--overlap-size) * -1);
       }
     }
 
@@ -129,43 +122,58 @@
   height: var(--avatar-stack-size);
   overflow: hidden;
   flex-shrink: 0;
+  transition:
+    margin 0.2s ease-in-out,
+    opacity 0.2s ease-in-out,
+    mask-position 0.2s ease-in-out,
+    mask-size 0.2s ease-in-out;
 
   &:is(img) {
     /* stylelint-disable-next-line primer/box-shadow */
-    box-shadow: 0 0 0 var(--avatar-border-width) var(--bgColor-default);
+    box-shadow: 0 0 0 var(--avatar-border-width) transparent;
   }
 
   &:first-child {
-    z-index: 10;
     margin-left: 0;
   }
 
   &:nth-child(n + 2) {
-    z-index: 9;
     /* stylelint-disable-next-line primer/spacing */
-    margin-left: var(--avatar-two-margin);
+    margin-left: calc(var(--overlap-size) * -1);
+    mask-image: radial-gradient(at 50% 50%, rgb(0, 0, 0) 70%, rgba(0, 0, 0, 0) 71%),
+      linear-gradient(rgb(0, 0, 0) 0px, rgb(0, 0, 0) 0px);
+    mask-repeat: no-repeat, no-repeat;
+    mask-size:
+      var(--mask-size) var(--mask-size),
+      auto;
+    mask-composite: exclude;
+    /*
+    HORIZONTAL POSITION CALC FORMULA EXPLAINED:
+    width of the visible part of the avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
+    multiply by -1 for left-aligned, 1 for right-aligned ➡️ var(--mask-start)
+    subtract the avatar border width ➡️ var(--avatar-border-width)
+    */
+    mask-position:
+      calc((var(--avatar-stack-size) - var(--overlap-size)) * var(--mask-start) - var(--avatar-border-width)) center,
+      0 0;
   }
 
   &:nth-child(n + 3) {
-    z-index: 8;
-    /* stylelint-disable-next-line primer/spacing */
-    margin-left: var(--avatar-three-margin);
-    opacity: 0.55;
+    --overlap-size: var(--overlap-size-avatar-three-plus);
+    opacity: calc(100% - 2 * var(--opacity-step));
   }
 
   &:nth-child(n + 4) {
-    z-index: 7;
-    opacity: 0.4;
+    opacity: calc(100% - 3 * var(--opacity-step));
   }
 
   &:nth-child(n + 5) {
-    z-index: 6;
-    opacity: 0.25;
+    opacity: calc(100% - 4 * var(--opacity-step));
   }
 
   &:nth-child(n + 6) {
-    visibility: hidden;
     opacity: 0;
+    visibility: hidden;
   }
 }
 
@@ -174,14 +182,18 @@
   width: auto;
 
   .AvatarItem {
+    --mask-size: 100%; /* reset size of the mask to prevent unintentially clipping due to the additional size created by the border width */
     margin-left: var(--base-size-4);
     visibility: visible;
     opacity: 1;
-    transition:
-      margin 0.2s ease-in-out,
-      opacity 0.2s ease-in-out,
-      visibility 0.2s ease-in-out,
-      box-shadow 0.1s ease-in-out;
+    /*
+    HORIZONTAL POSITION CALC FORMULA EXPLAINED:
+    width of the full avatar ➡️ var(--avatar-stack-size)
+    multiply by -1 for left-aligned, 1 for right-aligned ➡️ var(--mask-start)
+    */
+    mask-position:
+      calc(var(--avatar-stack-size) * var(--mask-start)) center,
+      0 0;
 
     &:first-child {
       margin-left: 0;

--- a/packages/react/src/AvatarStack/AvatarStack.module.css
+++ b/packages/react/src/AvatarStack/AvatarStack.module.css
@@ -71,36 +71,7 @@
 
   &:where([data-align-right]) {
     --mask-start: 1;
-    justify-content: flex-end;
-
-    .AvatarItem {
-      margin-left: 0 !important;
-
-      &:first-child {
-        margin-right: 0;
-      }
-
-      &:nth-child(n + 2) {
-        /* stylelint-disable-next-line primer/spacing */
-        margin-right: calc(var(--overlap-size) * -1);
-      }
-    }
-
-    .AvatarStackBody {
-      flex-direction: row-reverse;
-
-      &:not([data-disable-expand]):hover,
-      &:not([data-disable-expand]):focus-within {
-        .AvatarItem {
-          margin-right: var(--base-size-4) !important;
-          margin-left: 0 !important;
-
-          &:first-child {
-            margin-right: 0 !important;
-          }
-        }
-      }
-    }
+    direction: rtl;
   }
 }
 
@@ -134,12 +105,12 @@
   }
 
   &:first-child {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 
   &:nth-child(n + 2) {
     /* stylelint-disable-next-line primer/spacing */
-    margin-left: calc(var(--overlap-size) * -1);
+    margin-inline-start: calc(var(--overlap-size) * -1);
     mask-image: radial-gradient(at 50% 50%, rgb(0, 0, 0) 70%, rgba(0, 0, 0, 0) 71%),
       linear-gradient(rgb(0, 0, 0) 0px, rgb(0, 0, 0) 0px);
     mask-repeat: no-repeat, no-repeat;
@@ -183,7 +154,7 @@
 
   .AvatarItem {
     --mask-size: 100%; /* reset size of the mask to prevent unintentially clipping due to the additional size created by the border width */
-    margin-left: var(--base-size-4);
+    margin-inline-start: var(--base-size-4);
     visibility: visible;
     opacity: 1;
     /*
@@ -196,7 +167,7 @@
       0 0;
 
     &:first-child {
-      margin-left: 0;
+      margin-inline-start: 0;
     }
   }
 }

--- a/packages/react/src/AvatarStack/AvatarStack.tsx
+++ b/packages/react/src/AvatarStack/AvatarStack.tsx
@@ -29,8 +29,11 @@ const AvatarStackWrapper = toggleStyledComponent(
   'span',
   styled.span<StyledAvatarStackWrapperProps>`
     --avatar-border-width: 1px;
-    --avatar-two-margin: calc(var(--avatar-stack-size) * -0.55);
-    --avatar-three-margin: calc(var(--avatar-stack-size) * -0.85);
+    --overlap-size: calc(var(--avatar-stack-size) * 0.55);
+    --overlap-size-avatar-three-plus: calc(var(--avatar-stack-size) * 0.85);
+    --mask-size: calc(100% + (var(--avatar-border-width) * 2));
+    --mask-start: -1;
+    --opacity-step: 15%;
 
     display: flex;
     position: relative;
@@ -52,36 +55,50 @@ const AvatarStackWrapper = toggleStyledComponent(
       position: relative;
       overflow: hidden;
       display: flex;
+      transition:
+        margin 0.2s ease-in-out,
+        opacity 0.2s ease-in-out,
+        mask-position 0.2s ease-in-out,
+        mask-size 0.2s ease-in-out;
 
       &:is(img) {
         box-shadow: 0 0 0 var(--avatar-border-width)
-          ${props => (props.count === 1 ? get('colors.avatar.border') : get('colors.canvas.default'))};
+          ${props => (props.count === 1 ? get('colors.avatar.border') : 'transparent')};
       }
 
       &:first-child {
         margin-left: 0;
-        z-index: 10;
       }
 
       &:nth-child(n + 2) {
-        margin-left: var(--avatar-two-margin);
-        z-index: 9;
+        margin-left: calc(var(--overlap-size) * -1);
+        mask-image: radial-gradient(at 50% 50%, rgb(0, 0, 0) 70%, rgba(0, 0, 0, 0) 71%),
+          linear-gradient(rgb(0, 0, 0) 0px, rgb(0, 0, 0) 0px);
+        mask-repeat: no-repeat, no-repeat;
+        mask-size:
+          var(--mask-size) var(--mask-size),
+          auto;
+        mask-composite: exclude;
+        // HORIZONTAL POSITION CALC FORMULA EXPLAINED:
+        // width of the visible part of the avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
+        // multiply by -1 for left-aligned, 1 for right-aligned ➡️ var(--mask-start)
+        // subtract the avatar border width ➡️ var(--avatar-border-width)
+        mask-position:
+          calc((var(--avatar-stack-size) - var(--overlap-size)) * var(--mask-start) - var(--avatar-border-width)) center,
+          0 0;
       }
 
       &:nth-child(n + 3) {
-        margin-left: var(--avatar-three-margin);
-        opacity: ${100 - 3 * 15}%;
-        z-index: 8;
+        --overlap-size: var(--overlap-size-avatar-three-plus);
+        opacity: calc(100% - 2 * var(--opacity-step));
       }
 
       &:nth-child(n + 4) {
-        opacity: ${100 - 4 * 15}%;
-        z-index: 7;
+        opacity: calc(100% - 3 * var(--opacity-step));
       }
 
       &:nth-child(n + 5) {
-        opacity: ${100 - 5 * 15}%;
-        z-index: 6;
+        opacity: calc(100% - 4 * var(--opacity-step));
       }
 
       &:nth-child(n + 6) {
@@ -91,42 +108,36 @@ const AvatarStackWrapper = toggleStyledComponent(
     }
 
     &.pc-AvatarStack--two {
-      // this calc explained:
-      // 1. avatar size + the non-overlapping part of the second avatar
-      // 2. + the border widths of the first two avatars
-      min-width: calc(
-        var(--avatar-stack-size) + calc(var(--avatar-stack-size) + var(--avatar-two-margin)) +
-          var(--avatar-border-width)
-      );
+      // MIN-WIDTH CALC FORMULA EXPLAINED:
+      // avatar size ➡️ var(--avatar-stack-size)
+      // plus the visible part of the 2nd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
+      min-width: calc(var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)));
     }
 
     &.pc-AvatarStack--three {
-      // this calc explained:
-      // 1. avatar size + the non-overlapping part of the second avatar
-      // 2. + the non-overlapping part of the third avatar
+      // MIN-WIDTH CALC FORMULA EXPLAINED:
+      // avatar size ➡️ var(--avatar-stack-size)
+      // plus the visible part of the 2nd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
+      // plus the visible part of the 3rd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus)
       min-width: calc(
-        var(--avatar-stack-size) +
-          calc(
-            calc(var(--avatar-stack-size) + var(--avatar-two-margin)) +
-              calc(var(--avatar-stack-size) + var(--avatar-three-margin))
-          )
+        var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)) +
+          (var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus))
       );
     }
 
     &.pc-AvatarStack--three-plus {
-      // this calc explained:
-      // 1. avatar size + the non-overlapping part of the second avatar
-      // 2. + the non-overlapping part of the third and fourth avatar
+      // MIN-WIDTH CALC FORMULA EXPLAINED:
+      // avatar size ➡️ var(--avatar-stack-size)
+      // plus the visible part of the 2nd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
+      // plus the visible part of the 3rd AND 4th avatar ➡️ (var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus)) * 2
       min-width: calc(
-        var(--avatar-stack-size) +
-          calc(
-            calc(var(--avatar-stack-size) + var(--avatar-two-margin)) +
-              calc(var(--avatar-stack-size) + var(--avatar-three-margin)) * 2
-          )
+        var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)) +
+          (var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus)) * 2
       );
     }
 
     &.pc-AvatarStack--right {
+      --mask-start: 1;
       justify-content: flex-end;
       .pc-AvatarItem {
         margin-left: 0 !important;
@@ -136,11 +147,7 @@ const AvatarStackWrapper = toggleStyledComponent(
         }
 
         &:nth-child(n + 2) {
-          margin-right: var(--avatar-two-margin);
-        }
-
-        &:nth-child(n + 3) {
-          margin-right: var(--avatar-three-margin);
+          margin-right: calc(var(--overlap-size) * -1);
         }
       }
 
@@ -166,15 +173,17 @@ const AvatarStackWrapper = toggleStyledComponent(
       width: auto;
 
       .pc-AvatarItem {
+        // reset size of the mask to prevent unintentially clipping due to the additional size created by the border width
+        --mask-size: 100%;
         margin-left: ${get('space.1')};
-        opacity: 100%;
+        opacity: 1;
         visibility: visible;
-        ${props => (props.count === 1 ? '' : `box-shadow: inset 0 0 0 4px ${get('colors.canvas.default')};`)}
-        transition:
-        margin 0.2s ease-in-out,
-        opacity 0.2s ease-in-out,
-        visibility 0.2s ease-in-out,
-        box-shadow 0.1s ease-in-out;
+        // HORIZONTAL POSITION CALC FORMULA EXPLAINED:
+        // width of the full avatar ➡️ var(--avatar-stack-size)
+        // multiply by -1 for left-aligned, 1 for right-aligned ➡️ var(--mask-start)
+        mask-position:
+          calc(var(--avatar-stack-size) * var(--mask-start)) center,
+          0 0;
 
         ${getGlobalFocusStyles('1px')}
 

--- a/packages/react/src/AvatarStack/AvatarStack.tsx
+++ b/packages/react/src/AvatarStack/AvatarStack.tsx
@@ -67,11 +67,11 @@ const AvatarStackWrapper = toggleStyledComponent(
       }
 
       &:first-child {
-        margin-left: 0;
+        margin-inline-start: 0;
       }
 
       &:nth-child(n + 2) {
-        margin-left: calc(var(--overlap-size) * -1);
+        margin-inline-start: calc(var(--overlap-size) * -1);
         mask-image: radial-gradient(at 50% 50%, rgb(0, 0, 0) 70%, rgba(0, 0, 0, 0) 71%),
           linear-gradient(rgb(0, 0, 0) 0px, rgb(0, 0, 0) 0px);
         mask-repeat: no-repeat, no-repeat;
@@ -138,34 +138,7 @@ const AvatarStackWrapper = toggleStyledComponent(
 
     &.pc-AvatarStack--right {
       --mask-start: 1;
-      justify-content: flex-end;
-      .pc-AvatarItem {
-        margin-left: 0 !important;
-
-        &:first-child {
-          margin-right: 0;
-        }
-
-        &:nth-child(n + 2) {
-          margin-right: calc(var(--overlap-size) * -1);
-        }
-      }
-
-      .pc-AvatarStackBody {
-        flex-direction: row-reverse;
-
-        &:not(.pc-AvatarStack--disableExpand):hover,
-        &:not(.pc-AvatarStack--disableExpand):focus-within {
-          .pc-AvatarItem {
-            margin-right: ${get('space.1')}!important;
-            margin-left: 0 !important;
-
-            &:first-child {
-              margin-right: 0 !important;
-            }
-          }
-        }
-      }
+      direction: rtl;
     }
 
     .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover,
@@ -175,7 +148,7 @@ const AvatarStackWrapper = toggleStyledComponent(
       .pc-AvatarItem {
         // reset size of the mask to prevent unintentially clipping due to the additional size created by the border width
         --mask-size: 100%;
-        margin-left: ${get('space.1')};
+        margin-inline-start: ${get('space.1')};
         opacity: 1;
         visibility: visible;
         // HORIZONTAL POSITION CALC FORMULA EXPLAINED:
@@ -188,7 +161,7 @@ const AvatarStackWrapper = toggleStyledComponent(
         ${getGlobalFocusStyles('1px')}
 
         &:first-child {
-          margin-left: 0;
+          margin-inline-start: 0;
         }
       }
     }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Relates to https://github.com/github/copilot-productivity/issues/3985
An alternative approach: https://github.com/primer/react/pull/5705

Benefits of this approach:
- `AvatarStack` can now be used on any background color without seeing the `var(--bgColor-default)` border around each avatar
- Transparent 3rd, and 4th avatars no longer show n+3 avatars underneath eachother
- Animates back to "stacked" layout after hovering instead of just snapping immediately into place
- Uses `direction` property to remove redundant styles and `!important` flags

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Demos

**Both demos are zoomed in x10.**

#### Before

https://github.com/user-attachments/assets/86ef0331-f0cc-4c67-b9a7-abf3399f69dc

#### After

https://github.com/user-attachments/assets/e615ae43-da41-4a49-869a-3ebe59427f50

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

Replaces `z-index` and `box-shadow` AvatarStack styling with [`mask`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask)

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
