### PR TITLE
Change button to accept string in count

### DIFF
--- a/.changeset/yellow-trainers-arrive.md
+++ b/.changeset/yellow-trainers-arrive.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Allowed button count prop to accept a number or a string, to allow for human format, like 3.2k

--- a/packages/react/src/Button/Button.features.stories.tsx
+++ b/packages/react/src/Button/Button.features.stories.tsx
@@ -63,6 +63,10 @@ export const TrailingCounter = () => {
 
 export const TrailingCounterWithNoText = () => <Button aria-label="Comments" leadingVisual={CommentIcon} count={3} />
 
+export const TrailingCounterWithHumanFormat = () => (
+  <Button aria-label="Comments" leadingVisual={CommentIcon} count={'3.2k'} />
+)
+
 export const TrailingCounterAllVariants = () => {
   const [count, setCount] = useState(0)
   const onClick = () => {

--- a/packages/react/src/Button/types.ts
+++ b/packages/react/src/Button/types.ts
@@ -86,7 +86,7 @@ export type ButtonProps = {
 
   children?: React.ReactNode
 
-  count?: number
+  count?: number | string
 } & ButtonBaseProps
 
 export type IconButtonProps = ButtonA11yProps & {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

For the RepoPicker we use a button that shows the count of the selected items. This can easily be more than `1000`. SO we would like to use the _"human format"_, like `3.2k` instead of `3200`.

This PR allows this by changing the type of count to `number | string` as suggested by @mperrotti 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

Type of `count` changed to `number | string`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
