### PR TITLE
feat: Support `className` prop in `FormControl.Caption` component

### DIFF
--- a/.changeset/pink-hotels-rescue.md
+++ b/.changeset/pink-hotels-rescue.md
@@ -1,5 +1,5 @@
 ---
-"@primer/react": patch
+"@primer/react": minor
 ---
 
 feat: Support `className` prop in `FormControl.Caption` component

--- a/.changeset/pink-hotels-rescue.md
+++ b/.changeset/pink-hotels-rescue.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+feat: Support `className` prop in `FormControl.Caption` component

--- a/packages/react/src/FormControl/FormControlCaption.tsx
+++ b/packages/react/src/FormControl/FormControlCaption.tsx
@@ -13,16 +13,17 @@ import {toggleStyledComponent} from '../internal/utils/toggleStyledComponent'
 type FormControlCaptionProps = React.PropsWithChildren<
   {
     id?: string
+    className?: string
   } & SxProp
 >
 
-function FormControlCaption({id, children, sx}: FormControlCaptionProps) {
+function FormControlCaption({id, children, sx, className}: FormControlCaptionProps) {
   const enabled = useFeatureFlag(cssModulesFlag)
   const {captionId, disabled} = useFormControlContext()
   return (
     <StyledCaption
       id={id ?? captionId}
-      className={clsx({
+      className={clsx(className, {
         [classes.Caption]: enabled,
       })}
       data-control-disabled={disabled ? '' : undefined}


### PR DESCRIPTION
### What does this PR add?

This PR adds a `className` prop to `FormControl.Caption`. Related components—e.g. [`FormControl`](https://github.com/primer/react/blob/65a197b01fa50d0c4a58bd5eff46dc7f2e6d6dfc/packages/react/src/FormControl/FormControl.tsx#L49) and [`FormControl.Label`](https://github.com/primer/react/blob/65a197b01fa50d0c4a58bd5eff46dc7f2e6d6dfc/packages/react/src/FormControl/FormControlLabel.tsx#L14)—already have a `className` prop.

### Does `FormControl.Caption` need a `className` prop?

Yes! There are basically 3 options for styling `FormControl.Caption`:

1. Option 1: Wrap `FormControl.Caption` in a `<div>`, and style the `<div>`. This option is a non-starter, because GitHub uses [`eslint(primer-react/direct-slot-children)`](https://github.com/primer/eslint-plugin-primer-react/blob/main/docs/rules/direct-slot-children.md) to enforce that `FormControl.Caption` is a direct child of `FormControl`.

2. Option 2: Style `FormControl.Caption` using `sx`. This option is a non-starter, because [`sx` is deprecated](https://github.com/primer/react/blob/65a197b01fa50d0c4a58bd5eff46dc7f2e6d6dfc/packages/react/src/sx.ts#L29-L30).

3. Option 3: Style `FormControl.Caption` using `className`. This option is not possible today, because `FormControl.Caption` is missing a `className` prop, but this is otherwise the best way to style `FormControl.Caption`, ergo this PR.

### Why do you want to style `FormControl.Caption` anyways?

The image below gives an example of the kinds of styles that might be applied—in it, a `FormControl.Label` is positioned atop `FormControl.Caption`, and these (together) are displayed beside a control:

<img src="https://github.com/user-attachments/assets/eac5861c-c6f3-4b18-bb6a-a036ff3e1c42" alt="Screenshot of FormControl grid layout" width="364">

With `sx`, that layout can be accomplished like this:

```JSX
<FormControl sx={{display: 'grid', gap: '0 10px'}}>
    <FormControl.Label sx={{gridColumn: 1, gridRow: 1}}>Increase contrast</FormControl.Label>
    <FormControl.Caption sx={{gridColumn: 1, gridRow: 2}}>
        Enable high contrast for a single theme or for both light and dark mode
    </FormControl.Caption>
    <ActionMenu>
        <ActionMenu.Button sx={{gridColumn: 3, gridRow: '1 / span 2'}} />
        {/* … */}
    </ActionMenu>
</FormControl>
```

I’d like to accomplish the same layout, using `className` in place of `sx`. This PR makes that possible.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

- Added `className` prop to `FormControl.Caption` component

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Do other components have `className`-related tests or previews?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
