### PR TITLE
chore(deps): update typescript to 5.8, enable erasableSyntaxOnly

### DIFF
--- a/examples/codesandbox/package.json
+++ b/examples/codesandbox/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "styled-components": "5.x",
-    "typescript": "^5.7.2",
+    "typescript": "^5.8.2",
     "vite": "^5.4.12"
   }
 }

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -15,7 +15,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "styled-components": "5.x",
-    "typescript": "^5.7.2"
+    "typescript": "^5.8.2"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^15.1.4",

--- a/examples/theming/package.json
+++ b/examples/theming/package.json
@@ -17,7 +17,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "styled-components": "5.x",
-    "typescript": "^5.7.2"
+    "typescript": "^5.8.2"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "size-limit": "11.1.5",
         "stylelint": "16.9.0",
         "typed-css-modules": "0.9.1",
-        "typescript": "^5.7.2"
+        "typescript": "^5.8.2"
       },
       "engines": {
         "node": ">=12",
@@ -95,7 +95,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "styled-components": "5.x",
-        "typescript": "^5.7.2",
+        "typescript": "^5.8.2",
         "vite": "^5.4.12"
       }
     },
@@ -108,7 +108,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "styled-components": "5.x",
-        "typescript": "^5.7.2"
+        "typescript": "^5.8.2"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^15.1.4",
@@ -434,7 +434,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "styled-components": "5.x",
-        "typescript": "^5.7.2"
+        "typescript": "^5.8.2"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "14.1.0",
@@ -29413,7 +29413,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -31299,7 +31301,7 @@
         "postcss": "^8.4.41",
         "postcss-custom-properties-fallback": "^1.0.2",
         "postcss-mixins": "^11.0.1",
-        "typescript": "^5.7.2"
+        "typescript": "^5.8.2"
       },
       "peerDependencies": {
         "postcss": "^8.4.41"
@@ -31565,7 +31567,7 @@
         "terser": "5.36.0",
         "ts-toolbelt": "9.6.0",
         "tsx": "4.7.0",
-        "typescript": "^5.7.2",
+        "typescript": "^5.8.2",
         "typescript-plugin-css-modules": "5.1.0",
         "unist-util-find": "3.0.0",
         "unist-util-find-before": "4.0.0",
@@ -32401,7 +32403,7 @@
         "rimraf": "^5.0.7",
         "rollup-plugin-esbuild": "^6.1.1",
         "rollup-plugin-typescript2": "^0.36.0",
-        "typescript": "^5.7.2"
+        "typescript": "^5.8.2"
       },
       "peerDependencies": {
         "postcss": "^8.4.38",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "size-limit": "11.1.5",
     "stylelint": "16.9.0",
     "typed-css-modules": "0.9.1",
-    "typescript": "^5.7.2"
+    "typescript": "^5.8.2"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.9.6"

--- a/packages/postcss-preset-primer/package.json
+++ b/packages/postcss-preset-primer/package.json
@@ -29,6 +29,6 @@
     "postcss": "^8.4.41",
     "postcss-custom-properties-fallback": "^1.0.2",
     "postcss-mixins": "^11.0.1",
-    "typescript": "^5.7.2"
+    "typescript": "^5.8.2"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -200,7 +200,7 @@
     "terser": "5.36.0",
     "ts-toolbelt": "9.6.0",
     "tsx": "4.7.0",
-    "typescript": "^5.7.2",
+    "typescript": "^5.8.2",
     "typescript-plugin-css-modules": "5.1.0",
     "unist-util-find": "3.0.0",
     "unist-util-find-before": "4.0.0",

--- a/packages/react/src/utils/testing.tsx
+++ b/packages/react/src/utils/testing.tsx
@@ -63,7 +63,7 @@ export function renderRoot(component: React.ReactElement) {
  *   .toEqual(['a', 'b'])
  * ```
  */
-export function renderClasses(component: React.ReactElement): string {
+export function renderClasses(component: React.ReactElement): Array<string> {
   const {
     props: {className},
   } = render(component)

--- a/packages/rollup-plugin-import-css/package.json
+++ b/packages/rollup-plugin-import-css/package.json
@@ -26,7 +26,7 @@
     "rimraf": "^5.0.7",
     "rollup-plugin-esbuild": "^6.1.1",
     "rollup-plugin-typescript2": "^0.36.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.8.2"
   },
   "sideEffects": false
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,7 @@
     "typeRoots": ["./node_modules/@types", "./@types"],
     "isolatedModules": true,
     "moduleDetection": "force",
+    "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update TypeScript to v5.8 and enable the `erasableSyntaxOnly` option in `tsconfig.base.json`

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `package.json` to include `typescript@5.8.2`
- Add `erasableSyntaxOnly` to `tsconfig.base.json`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why
