### PR TITLE
feat: Add workflow to toggle release lock status

### DIFF
--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -1,0 +1,59 @@
+name: Lock Release Pull Request
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Lock or unlock the release?'
+        required: true
+        type: choice
+        options:
+          - lock
+          - unlock
+
+jobs:
+  lock:
+    name: Toggle Release Lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PRIMER_APP_ID_SHARED }}
+          owner: primer
+          repositories: react
+          private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
+      - name: Toggle Rule > Release Conductor
+        run: |
+          enforcement=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "active" || echo "disabled")
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/primer/react/rulesets/3801256 \
+            -f "enforcement=${enforcement}"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Toggle Rule > Update Before Merging
+        run: |
+          enforcement=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "active" || echo "disabled")
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/primer/react/rulesets/4089341 \
+            -f "enforcement=${enforcement}"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Toggle Rule > Merge Queue
+        run: |
+          enforcement=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "disabled" || echo "active")
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/primer/react/rulesets/4089335 \
+            -f "enforcement=${enforcement}"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This workflow toggles rulesets for the release conductor to block further merges into `main` while allowing the conductor to still merge. This first step makes it a workflow_dispatch that we can run from the actions tab, but I could see in the future more automation around doing this via labeling. 

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

This has to do with internal actions workflows and nothing to add to releases
