### PR TITLE
Radio: Remove `aria-required` and `aria-invalid`

### DIFF
--- a/.changeset/red-lies-vanish.md
+++ b/.changeset/red-lies-vanish.md
@@ -1,5 +1,5 @@
 ---
-"@primer/react": patch
+"@primer/react": minor
 ---
 
 Radio: Removes `aria-invalid` and `aria-required` from `Radio`, as they are not supported on the element's role.

--- a/.changeset/red-lies-vanish.md
+++ b/.changeset/red-lies-vanish.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Radio: Removes `aria-invalid` and `aria-required` from `Radio`, as they are not supported on the element's role.

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -77,7 +77,6 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
 
     if (sxProp !== defaultSxProp) {
       return (
-        // eslint-disable-next-line github/a11y-role-supports-aria-props
         <Box
           as="input"
           sx={sxProp}
@@ -89,8 +88,6 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
           checked={checked}
           aria-checked={checked ? 'true' : 'false'}
           required={required}
-          aria-required={required ? 'true' : 'false'}
-          aria-invalid={validationStatus === 'error' ? 'true' : 'false'}
           onChange={handleOnChange}
           className={clsx(className, sharedClasses.Input, classes.Radio)}
           {...rest}
@@ -99,7 +96,6 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
     }
 
     return (
-      // eslint-disable-next-line github/a11y-role-supports-aria-props
       <input
         type="radio"
         value={value}
@@ -109,8 +105,6 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
         checked={checked}
         aria-checked={checked ? 'true' : 'false'}
         required={required}
-        aria-required={required ? 'true' : 'false'}
-        aria-invalid={validationStatus === 'error' ? 'true' : 'false'}
         onChange={handleOnChange}
         className={clsx(className, sharedClasses.Input, classes.Radio)}
         {...rest}

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -1,7 +1,6 @@
 import type {ChangeEventHandler, InputHTMLAttributes, ReactElement} from 'react'
 import React, {useContext} from 'react'
 import type {SxProp} from '../sx'
-import type {FormValidationStatus} from '../utils/types/FormValidationStatus'
 import {RadioGroupContext} from '../RadioGroup/RadioGroup'
 import {clsx} from 'clsx'
 import classes from './Radio.module.css'
@@ -35,10 +34,6 @@ export type RadioProps = {
    * Indicates whether the radio button must be checked before the form can be submitted
    */
   required?: boolean
-  /**
-   * Only used to inform ARIA attributes. Individual radio inputs do not have validation styles.
-   */
-  validationStatus?: FormValidationStatus
 } & InputHTMLAttributes<HTMLInputElement> &
   SxProp
 
@@ -54,7 +49,6 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
       onChange,
       sx: sxProp = defaultSxProp,
       required,
-      validationStatus,
       value,
       className,
       ...rest

--- a/packages/react/src/__tests__/Radio.test.tsx
+++ b/packages/react/src/__tests__/Radio.test.tsx
@@ -150,34 +150,4 @@ describe('Radio', () => {
 
     expect(radio).toHaveAttribute('aria-checked', 'true')
   })
-
-  it('renders an invalid aria state when validation prop indicates an error', () => {
-    const handleChange = jest.fn()
-    const {getByRole, rerender} = render(<Radio {...defaultProps} onChange={handleChange} />)
-
-    const radio = getByRole('radio') as HTMLInputElement
-
-    expect(radio).toHaveAttribute('aria-invalid', 'false')
-
-    rerender(<Radio {...defaultProps} onChange={handleChange} validationStatus="success" />)
-
-    expect(radio).toHaveAttribute('aria-invalid', 'false')
-
-    rerender(<Radio {...defaultProps} onChange={handleChange} validationStatus="error" />)
-
-    expect(radio).toHaveAttribute('aria-invalid', 'true')
-  })
-
-  it('renders an aria state indicating the field is required', () => {
-    const handleChange = jest.fn()
-    const {getByRole, rerender} = render(<Radio {...defaultProps} onChange={handleChange} />)
-
-    const radio = getByRole('radio') as HTMLInputElement
-
-    expect(radio).toHaveAttribute('aria-required', 'false')
-
-    rerender(<Radio {...defaultProps} onChange={handleChange} required />)
-
-    expect(radio).toHaveAttribute('aria-required', 'true')
-  })
 })


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Context https://github.com/github/primer/issues/3726

Removes `aria-required` and `aria-invalid` from the `Radio` component, as they are not required on the component. This change allows us to remove a lint disable for `a11y-role-supports-aria-props`.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

<!-- List of things removed in this PR -->

* Removes `aria-invalid` and `aria-required` from `Radio`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
