### PR TITLE
fix: update CheckboxOrRadioGroup to spread empty object instead of false-y value

### DIFF
--- a/.changeset/perfect-plants-trade.md
+++ b/.changeset/perfect-plants-trade.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Update base component for Checkbox and Radio to pass along correct prop type in React 19

--- a/packages/react/src/internal/components/CheckboxOrRadioGroup/CheckboxOrRadioGroup.tsx
+++ b/packages/react/src/internal/components/CheckboxOrRadioGroup/CheckboxOrRadioGroup.tsx
@@ -108,10 +108,12 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
             <Box
               className={clsx(className, classes.GroupFieldset)}
               data-validation={validationChild ? '' : undefined}
-              {...(labelChild ? {
-                as: 'fieldset',
-                disabled,
-              } : {})}
+              {...(labelChild
+                ? {
+                    as: 'fieldset',
+                    disabled,
+                  }
+                : {})}
               sx={sx}
             >
               {labelChild ? (
@@ -138,12 +140,14 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
 
               <Body
                 className={classes.Body}
-                {...(!labelChild ? {
-                  ['aria-labelledby']: ariaLabelledby,
-                  ['aria-describedby']: [validationMessageId, captionId].filter(Boolean).join(' '),
-                  as: 'div',
-                  role: 'group',
-                } : {})}
+                {...(!labelChild
+                  ? {
+                      ['aria-labelledby']: ariaLabelledby,
+                      ['aria-describedby']: [validationMessageId, captionId].filter(Boolean).join(' '),
+                      as: 'div',
+                      role: 'group',
+                    }
+                  : {})}
               >
                 {React.Children.toArray(rest).filter(child => React.isValidElement(child))}
               </Body>
@@ -174,10 +178,12 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
           <fieldset
             className={clsx(className, classes.GroupFieldset)}
             data-validation={validationChild ? '' : undefined}
-            {...(labelChild ? {
-              as: 'fieldset',
-              disabled,
-            } : {})}
+            {...(labelChild
+              ? {
+                  as: 'fieldset',
+                  disabled,
+                }
+              : {})}
           >
             {labelChild ? (
               /*
@@ -203,12 +209,14 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
 
             <Body
               className={classes.Body}
-              {...(!labelChild ? {
-                ['aria-labelledby']: ariaLabelledby,
-                ['aria-describedby']: [validationMessageId, captionId].filter(Boolean).join(' '),
-                as: 'div',
-                role: 'group',
-              } : {})}
+              {...(!labelChild
+                ? {
+                    ['aria-labelledby']: ariaLabelledby,
+                    ['aria-describedby']: [validationMessageId, captionId].filter(Boolean).join(' '),
+                    as: 'div',
+                    role: 'group',
+                  }
+                : {})}
             >
               {React.Children.toArray(rest).filter(child => React.isValidElement(child))}
             </Body>
@@ -242,10 +250,12 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
           margin={0}
           mb={validationChild ? 2 : undefined}
           padding={0}
-          {...(labelChild ? {
-            as: 'fieldset',
-            disabled,
-          } : {})}
+          {...(labelChild
+            ? {
+                as: 'fieldset',
+                disabled,
+              }
+            : {})}
           className={className}
           sx={sx}
         >
@@ -272,12 +282,14 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
           )}
 
           <Body
-            {...(!labelChild ? {
-              ['aria-labelledby']: ariaLabelledby,
-              ['aria-describedby']: [validationMessageId, captionId].filter(Boolean).join(' '),
-              as: 'div',
-              role: 'group',
-            } : {})}
+            {...(!labelChild
+              ? {
+                  ['aria-labelledby']: ariaLabelledby,
+                  ['aria-describedby']: [validationMessageId, captionId].filter(Boolean).join(' '),
+                  as: 'div',
+                  role: 'group',
+                }
+              : {})}
           >
             {React.Children.toArray(rest).filter(child => React.isValidElement(child))}
           </Body>

--- a/packages/react/src/internal/components/CheckboxOrRadioGroup/CheckboxOrRadioGroup.tsx
+++ b/packages/react/src/internal/components/CheckboxOrRadioGroup/CheckboxOrRadioGroup.tsx
@@ -108,10 +108,10 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
             <Box
               className={clsx(className, classes.GroupFieldset)}
               data-validation={validationChild ? '' : undefined}
-              {...(labelChild && {
+              {...(labelChild ? {
                 as: 'fieldset',
                 disabled,
-              })}
+              } : {})}
               sx={sx}
             >
               {labelChild ? (
@@ -138,12 +138,12 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
 
               <Body
                 className={classes.Body}
-                {...(!labelChild && {
+                {...(!labelChild ? {
                   ['aria-labelledby']: ariaLabelledby,
                   ['aria-describedby']: [validationMessageId, captionId].filter(Boolean).join(' '),
                   as: 'div',
                   role: 'group',
-                })}
+                } : {})}
               >
                 {React.Children.toArray(rest).filter(child => React.isValidElement(child))}
               </Body>
@@ -174,10 +174,10 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
           <fieldset
             className={clsx(className, classes.GroupFieldset)}
             data-validation={validationChild ? '' : undefined}
-            {...(labelChild && {
+            {...(labelChild ? {
               as: 'fieldset',
               disabled,
-            })}
+            } : {})}
           >
             {labelChild ? (
               /*
@@ -203,12 +203,12 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
 
             <Body
               className={classes.Body}
-              {...(!labelChild && {
+              {...(!labelChild ? {
                 ['aria-labelledby']: ariaLabelledby,
                 ['aria-describedby']: [validationMessageId, captionId].filter(Boolean).join(' '),
                 as: 'div',
                 role: 'group',
-              })}
+              } : {})}
             >
               {React.Children.toArray(rest).filter(child => React.isValidElement(child))}
             </Body>
@@ -242,10 +242,10 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
           margin={0}
           mb={validationChild ? 2 : undefined}
           padding={0}
-          {...(labelChild && {
+          {...(labelChild ? {
             as: 'fieldset',
             disabled,
-          })}
+          } : {})}
           className={className}
           sx={sx}
         >
@@ -272,12 +272,12 @@ const CheckboxOrRadioGroup: React.FC<React.PropsWithChildren<CheckboxOrRadioGrou
           )}
 
           <Body
-            {...(!labelChild && {
+            {...(!labelChild ? {
               ['aria-labelledby']: ariaLabelledby,
               ['aria-describedby']: [validationMessageId, captionId].filter(Boolean).join(' '),
               as: 'div',
               role: 'group',
-            })}
+            } : {})}
           >
             {React.Children.toArray(rest).filter(child => React.isValidElement(child))}
           </Body>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Address an issue that comes up in React 19 that looks like:


```
Uncaught TypeError: Cannot use 'in' operator to search for '__self' in false
    at exports.createElement (react.development.js:1294:13)
    at CheckboxOrRadioGroup (CheckboxOrRadioGroup.js:174:38)
    at react-stack-bottom-frame (react-dom-client.development.js:22428:20)
    at renderWithHooks (react-dom-client.development.js:5757:22)
    at updateFunctionComponent (react-dom-client.development.js:8018:19)
    at beginWork (react-dom-client.development.js:9683:18)
    at runWithFiberInDEV (react-dom-client.development.js:543:16)
    at performUnitOfWork (react-dom-client.development.js:15044:22)
    at workLoopSync (react-dom-client.development.js:14870:41)
    at renderRootSync (react-dom-client.development.js:14850:11)
exports.createElement @ react.development.js:1294
CheckboxOrRadioGroup @ CheckboxOrRadioGroup.js:174
react-stack-bottom-frame @ react-dom-client.development.js:22428
renderWithHooks @ react-dom-client.development.js:5757
```

This seems to come from this transpiled code:

```
/*#__PURE__*/React.createElement(Body, !labelChild && {
    ['aria-labelledby']: ariaLabelledby,
    ['aria-describedby']: [validationMessageId, captionId].filter(Boolean).join(' '),
    as: 'div',
    role: 'group'
  }
```

Specifically where we are short circuiting the second argument to `createElement` to be `false` which is what is triggering the error above. This updates the checks in these files to pass along an empty object instead. 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `labelChild` values to pass in empty object in the alternative case

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
