### PR TITLE
Update ActionListGroupProps to include `className`

### DIFF
--- a/.changeset/five-insects-promise.md
+++ b/.changeset/five-insects-promise.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Broaden the types for ActionListGroupProps to include props that are spread onto the container element

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "37.14.0",
+        "@primer/react": "37.15.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
@@ -103,7 +103,7 @@
       "name": "example-nextjs",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "37.14.0",
+        "@primer/react": "37.15.0",
         "next": "^15.1.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -428,7 +428,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.14.0",
-        "@primer/react": "37.14.0",
+        "@primer/react": "37.15.0",
         "clsx": "^1.2.1",
         "next": "^14.2.15",
         "react": "^18.3.1",
@@ -31443,7 +31443,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "37.14.0",
+      "version": "37.15.0",
       "license": "MIT",
       "dependencies": {
         "@github/relative-time-element": "^4.4.3",

--- a/packages/react/src/ActionList/Group.tsx
+++ b/packages/react/src/ActionList/Group.tsx
@@ -133,7 +133,7 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
               // because the heading is hidden from the accessibility tree and only used for presentation role.
               // We will instead use aria-label to label the list. See a line below.
               aria-labelledby={listRole ? undefined : groupHeadingId}
-              aria-label={listRole ? title ?? (slots.groupHeading?.props.children as string) : undefined}
+              aria-label={listRole ? (title ?? (slots.groupHeading?.props.children as string)) : undefined}
               role={role || (listRole && 'group')}
             >
               {slots.groupHeading ? childrenWithoutSlots : props.children}
@@ -156,7 +156,7 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
             // because the heading is hidden from the accessibility tree and only used for presentation role.
             // We will instead use aria-label to label the list. See a line below.
             aria-labelledby={listRole ? undefined : groupHeadingId}
-            aria-label={listRole ? title ?? (slots.groupHeading?.props.children as string) : undefined}
+            aria-label={listRole ? (title ?? (slots.groupHeading?.props.children as string)) : undefined}
             role={role || (listRole && 'group')}
           >
             {slots.groupHeading ? childrenWithoutSlots : props.children}
@@ -190,7 +190,7 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
           // because the heading is hidden from the accessibility tree and only used for presentation role.
           // We will instead use aria-label to label the list. See a line below.
           aria-labelledby={listRole ? undefined : groupHeadingId}
-          aria-label={listRole ? title ?? (slots.groupHeading?.props.children as string) : undefined}
+          aria-label={listRole ? (title ?? (slots.groupHeading?.props.children as string)) : undefined}
           role={role || (listRole && 'group')}
         >
           {slots.groupHeading ? childrenWithoutSlots : props.children}

--- a/packages/react/src/ActionList/Group.tsx
+++ b/packages/react/src/ActionList/Group.tsx
@@ -47,7 +47,32 @@ const HeadingWrap: React.FC<HeadingWrapProps> = ({as = 'div', children, classNam
   return React.createElement(as, {...rest, className}, children)
 }
 
-export type ActionListGroupProps = {
+export type ActionListGroupProps = React.ComponentPropsWithoutRef<'div'> & {
+  /**
+   * Secondary text which provides additional information about a `Group`.
+   */
+  auxiliaryText?: string
+
+  /**
+   * Provide an optional class name to be passed to the outermost element rendered by the component.
+   */
+  className?: string
+  
+  /**
+   * The ARIA role describing the function of the list inside `Group` component. `listbox` or `menu` are a common values.
+   */
+  role?: AriaRole
+
+  /**
+   * Whether multiple Items or a single Item can be selected in the Group. Overrides value on ActionList root.
+   */
+  selectionVariant?: ActionListProps['selectionVariant'] | false
+
+  /**
+   * @deprecated (Use `ActionList.GroupHeading` instead. i.e. <ActionList.Group title="Group title"> → <ActionList.GroupHeading>Group title</ActionList.GroupHeading>)
+   */
+  title?: string
+
   /**
    * Style variations. Usage is discretionary.
    *
@@ -55,24 +80,7 @@ export type ActionListGroupProps = {
    * - `"subtle"` - Relatively less offset from nearby content
    */
   variant?: 'filled' | 'subtle'
-  /**
-   * @deprecated (Use `ActionList.GroupHeading` instead. i.e. <ActionList.Group title="Group title"> → <ActionList.GroupHeading>Group title</ActionList.GroupHeading>)
-   */
-  title?: string
-  /**
-   * Secondary text which provides additional information about a `Group`.
-   */
-  auxiliaryText?: string
-  /**
-   * The ARIA role describing the function of the list inside `Group` component. `listbox` or `menu` are a common values.
-   */
-  role?: AriaRole
-} & SxProp & {
-    /**
-     * Whether multiple Items or a single Item can be selected in the Group. Overrides value on ActionList root.
-     */
-    selectionVariant?: ActionListProps['selectionVariant'] | false
-  }
+} & SxProp
 
 type ContextProps = Pick<ActionListGroupProps, 'selectionVariant'> & {groupHeadingId: string | undefined}
 export const GroupContext = React.createContext<ContextProps>({

--- a/packages/react/src/ActionList/Group.tsx
+++ b/packages/react/src/ActionList/Group.tsx
@@ -57,7 +57,7 @@ export type ActionListGroupProps = React.ComponentPropsWithoutRef<'div'> & {
    * Provide an optional class name to be passed to the outermost element rendered by the component.
    */
   className?: string
-  
+
   /**
    * The ARIA role describing the function of the list inside `Group` component. `listbox` or `menu` are a common values.
    */

--- a/packages/react/src/ActionList/Group.tsx
+++ b/packages/react/src/ActionList/Group.tsx
@@ -47,7 +47,7 @@ const HeadingWrap: React.FC<HeadingWrapProps> = ({as = 'div', children, classNam
   return React.createElement(as, {...rest, className}, children)
 }
 
-export type ActionListGroupProps = React.ComponentPropsWithoutRef<'div'> & {
+export type ActionListGroupProps = React.HTMLAttributes<HTMLElement> & {
   /**
    * Secondary text which provides additional information about a `Group`.
    */
@@ -133,7 +133,7 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
               // because the heading is hidden from the accessibility tree and only used for presentation role.
               // We will instead use aria-label to label the list. See a line below.
               aria-labelledby={listRole ? undefined : groupHeadingId}
-              aria-label={listRole ? (title ?? (slots.groupHeading?.props.children as string)) : undefined}
+              aria-label={listRole ? title ?? (slots.groupHeading?.props.children as string) : undefined}
               role={role || (listRole && 'group')}
             >
               {slots.groupHeading ? childrenWithoutSlots : props.children}
@@ -156,7 +156,7 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
             // because the heading is hidden from the accessibility tree and only used for presentation role.
             // We will instead use aria-label to label the list. See a line below.
             aria-labelledby={listRole ? undefined : groupHeadingId}
-            aria-label={listRole ? (title ?? (slots.groupHeading?.props.children as string)) : undefined}
+            aria-label={listRole ? title ?? (slots.groupHeading?.props.children as string) : undefined}
             role={role || (listRole && 'group')}
           >
             {slots.groupHeading ? childrenWithoutSlots : props.children}
@@ -190,7 +190,7 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
           // because the heading is hidden from the accessibility tree and only used for presentation role.
           // We will instead use aria-label to label the list. See a line below.
           aria-labelledby={listRole ? undefined : groupHeadingId}
-          aria-label={listRole ? (title ?? (slots.groupHeading?.props.children as string)) : undefined}
+          aria-label={listRole ? title ?? (slots.groupHeading?.props.children as string) : undefined}
           role={role || (listRole && 'group')}
         >
           {slots.groupHeading ? childrenWithoutSlots : props.children}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update the props for `ActionListGroupProps` to include `className` and other props that are spread onto the outermost element.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add support for `className` to the TypeScript types for `ActionListGroupProps`

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->


- [x] Minor release
