### PR TITLE
Removing the primer_react_css_modules_staff feature flag

### DIFF
--- a/.github/workflows/aat-reports.yml
+++ b/.github/workflows/aat-reports.yml
@@ -91,7 +91,6 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     env:
-      VITE_PRIMER_REACT_CSS_MODULES_STAFF: 1
       VITE_PRIMER_REACT_CSS_MODULES_GA: 1
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/vrt-reports.yml
+++ b/.github/workflows/vrt-reports.yml
@@ -91,7 +91,6 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     env:
-      VITE_PRIMER_REACT_CSS_MODULES_STAFF: 1
       VITE_PRIMER_REACT_CSS_MODULES_GA: 1
     steps:
       - uses: actions/checkout@v4

--- a/packages/react/.storybook/preview.jsx
+++ b/packages/react/.storybook/preview.jsx
@@ -224,7 +224,7 @@ const primerThemes = [
 ]
 
 const defaultFeatureFlags = new Map(DefaultFeatureFlags.flags)
-const featureFlagEnvList = new Set(['PRIMER_REACT_CSS_MODULES_STAFF', 'PRIMER_REACT_CSS_MODULES_GA'])
+const featureFlagEnvList = new Set(['PRIMER_REACT_CSS_MODULES_GA'])
 
 for (const flag of featureFlagEnvList) {
   if (import.meta.env[`VITE_${flag}`] === '1') {

--- a/packages/react/src/ActionList/ActionList.test.tsx
+++ b/packages/react/src/ActionList/ActionList.test.tsx
@@ -106,7 +106,6 @@ describe('ActionList', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >
@@ -131,7 +130,6 @@ describe('ActionList', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/ActionList/Description.test.tsx
+++ b/packages/react/src/ActionList/Description.test.tsx
@@ -63,7 +63,6 @@ describe('ActionList.Description', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/ActionList/Group.test.tsx
+++ b/packages/react/src/ActionList/Group.test.tsx
@@ -135,7 +135,6 @@ describe('ActionList.Group', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/ActionList/Heading.test.tsx
+++ b/packages/react/src/ActionList/Heading.test.tsx
@@ -68,7 +68,6 @@ describe('ActionList.Heading', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/ActionList/Item.test.tsx
+++ b/packages/react/src/ActionList/Item.test.tsx
@@ -161,7 +161,6 @@ describe('ActionList.Item', () => {
   })
   it('should render ActionList.Item as button when feature flag is enabled', async () => {
     const featureFlag = {
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }
     const {container} = HTMLRender(
@@ -183,7 +182,6 @@ describe('ActionList.Item', () => {
     const {container} = HTMLRender(
       <FeatureFlags
         flags={{
-          primer_react_css_modules_staff: false,
           primer_react_css_modules_ga: false,
         }}
       >
@@ -210,7 +208,6 @@ describe('ActionList.Item', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: false,
             primer_react_css_modules_ga: false,
           }}
         >
@@ -303,7 +300,6 @@ describe('ActionList.Item', () => {
     const {getByRole} = HTMLRender(
       <FeatureFlags
         flags={{
-          primer_react_css_modules_staff: true,
           primer_react_css_modules_ga: true,
         }}
       >
@@ -322,7 +318,6 @@ describe('ActionList.Item', () => {
     const {getByRole} = HTMLRender(
       <FeatureFlags
         flags={{
-          primer_react_css_modules_staff: true,
           primer_react_css_modules_ga: true,
         }}
       >

--- a/packages/react/src/ActionMenu/ActionMenu.dev.stories.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.dev.stories.tsx
@@ -13,7 +13,6 @@ export default {
 export const WithCss = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >
@@ -47,7 +46,6 @@ export const WithCss = () => (
 export const WithSx = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >
@@ -81,7 +79,6 @@ export const WithSx = () => (
 export const WithSxAndCSS = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >

--- a/packages/react/src/Banner/Banner.test.tsx
+++ b/packages/react/src/Banner/Banner.test.tsx
@@ -36,7 +36,6 @@ describe('Banner', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/BranchName/__tests__/BranchName.test.tsx
+++ b/packages/react/src/BranchName/__tests__/BranchName.test.tsx
@@ -33,7 +33,6 @@ describe('BranchName', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/packages/react/src/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -19,7 +19,6 @@ describe('Breadcrumbs', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/Button/__tests__/Button.test.tsx
@@ -32,7 +32,6 @@ describe('IconButton', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >
@@ -52,7 +51,6 @@ describe('LinkButton', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >
@@ -77,7 +75,6 @@ describe('Button', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.test.tsx
@@ -27,7 +27,6 @@ describe('ButtonGroup', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/Checkbox/Checkbox.test.tsx
@@ -21,7 +21,6 @@ describe('Checkbox', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/CounterLabel/CounterLabel.test.tsx
+++ b/packages/react/src/CounterLabel/CounterLabel.test.tsx
@@ -18,7 +18,6 @@ describe('CounterLabel', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/Dialog/Dialog.dev.stories.tsx
+++ b/packages/react/src/Dialog/Dialog.dev.stories.tsx
@@ -64,7 +64,6 @@ export const WithCss = ({width, height, subtitle}: DialogStoryProps) => {
   return (
     <FeatureFlags
       flags={{
-        primer_react_css_modules_staff: true,
         primer_react_css_modules_ga: true,
       }}
     >
@@ -118,7 +117,6 @@ export const WithSx = ({width, height, subtitle}: DialogStoryProps) => {
   return (
     <FeatureFlags
       flags={{
-        primer_react_css_modules_staff: true,
         primer_react_css_modules_ga: true,
       }}
     >
@@ -180,7 +178,6 @@ export const WithSxAndCss = ({width, height, subtitle}: DialogStoryProps) => {
   return (
     <FeatureFlags
       flags={{
-        primer_react_css_modules_staff: true,
         primer_react_css_modules_ga: true,
       }}
     >

--- a/packages/react/src/Dialog/Dialog.test.tsx
+++ b/packages/react/src/Dialog/Dialog.test.tsx
@@ -251,7 +251,6 @@ describe('Dialog', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/DialogV1/Dialog.test.tsx
+++ b/packages/react/src/DialogV1/Dialog.test.tsx
@@ -120,7 +120,6 @@ describe('Dialog', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
+++ b/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
@@ -1,7 +1,6 @@
 import {FeatureFlagScope} from './FeatureFlagScope'
 
 export const DefaultFeatureFlags = FeatureFlagScope.create({
-  primer_react_css_modules_staff: false,
   primer_react_css_modules_ga: false,
   primer_react_action_list_item_as_button: false,
   primer_react_select_panel_with_modern_action_list: false,

--- a/packages/react/src/Header/Header.dev.stories.tsx
+++ b/packages/react/src/Header/Header.dev.stories.tsx
@@ -17,7 +17,6 @@ export default {
 export const WithCss = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >
@@ -54,7 +53,6 @@ export const WithSx = () => (
 export const WithSxAndCSS = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >

--- a/packages/react/src/Heading/__tests__/Heading.test.tsx
+++ b/packages/react/src/Heading/__tests__/Heading.test.tsx
@@ -42,7 +42,6 @@ describe('Heading', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/Link/__tests__/Link.test.tsx
+++ b/packages/react/src/Link/__tests__/Link.test.tsx
@@ -18,7 +18,6 @@ describe('Link', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/SelectPanel/SelectPanel.dev.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.dev.stories.tsx
@@ -86,7 +86,6 @@ export const WithCss = () => {
   return (
     <FeatureFlags
       flags={{
-        primer_react_css_modules_staff: true,
         primer_react_css_modules_ga: true,
       }}
     >
@@ -137,7 +136,6 @@ export const WithSx = () => {
   return (
     <FeatureFlags
       flags={{
-        primer_react_css_modules_staff: true,
         primer_react_css_modules_ga: true,
       }}
     >
@@ -188,7 +186,6 @@ export const WithSxAndCSS = () => {
   return (
     <FeatureFlags
       flags={{
-        primer_react_css_modules_staff: true,
         primer_react_css_modules_ga: true,
       }}
     >

--- a/packages/react/src/Stack/__tests__/Stack.test.tsx
+++ b/packages/react/src/Stack/__tests__/Stack.test.tsx
@@ -10,7 +10,6 @@ describe('Stack', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/Stack/__tests__/StackItem.test.tsx
+++ b/packages/react/src/Stack/__tests__/StackItem.test.tsx
@@ -16,7 +16,6 @@ describe('StackItem', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/SubNav/SubNav.dev.stories.tsx
+++ b/packages/react/src/SubNav/SubNav.dev.stories.tsx
@@ -17,7 +17,6 @@ export default {
 export const WithCss = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >
@@ -60,7 +59,6 @@ export const WithSx = () => (
 export const WithSxAndCSS = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >

--- a/packages/react/src/TextInput/TextInput.dev.stories.tsx
+++ b/packages/react/src/TextInput/TextInput.dev.stories.tsx
@@ -14,7 +14,6 @@ export default {
 export const WithCSS = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >
@@ -39,7 +38,6 @@ export const WithSx = () => (
 export const WithSxAndCSS = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >

--- a/packages/react/src/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react/src/Timeline/__tests__/Timeline.test.tsx
@@ -29,7 +29,6 @@ describe('Timeline', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >
@@ -65,7 +64,6 @@ describe('Timeline.Item', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >
@@ -93,7 +91,6 @@ describe('Timeline.Badge', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >
@@ -120,7 +117,6 @@ describe('Timeline.Body', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >
@@ -148,7 +144,6 @@ describe('Timeline.Break', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/TreeView/TreeView.test.tsx
+++ b/packages/react/src/TreeView/TreeView.test.tsx
@@ -1655,7 +1655,6 @@ describe('CSS Module Migration', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/Autocomplete.test.tsx
+++ b/packages/react/src/__tests__/Autocomplete.test.tsx
@@ -230,7 +230,6 @@ describe('Autocomplete', () => {
         return (
           <FeatureFlags
             flags={{
-              primer_react_css_modules_staff: true,
               primer_react_css_modules_ga: true,
             }}
           >
@@ -478,7 +477,6 @@ describe('Autocomplete', () => {
         return (
           <FeatureFlags
             flags={{
-              primer_react_css_modules_staff: true,
               primer_react_css_modules_ga: true,
             }}
           >

--- a/packages/react/src/__tests__/Avatar.test.tsx
+++ b/packages/react/src/__tests__/Avatar.test.tsx
@@ -24,7 +24,6 @@ describe('Avatar', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/AvatarStack.test.tsx
+++ b/packages/react/src/__tests__/AvatarStack.test.tsx
@@ -47,7 +47,6 @@ describe('Avatar', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/Box.test.tsx
+++ b/packages/react/src/__tests__/Box.test.tsx
@@ -19,7 +19,6 @@ describe('Box', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/Label.test.tsx
+++ b/packages/react/src/__tests__/Label.test.tsx
@@ -12,7 +12,6 @@ describe('Label', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/Popover.test.tsx
+++ b/packages/react/src/__tests__/Popover.test.tsx
@@ -29,7 +29,6 @@ describe('Popover', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/ProgressBar.test.tsx
+++ b/packages/react/src/__tests__/ProgressBar.test.tsx
@@ -21,7 +21,6 @@ describe('ProgressBar', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/Radio.test.tsx
+++ b/packages/react/src/__tests__/Radio.test.tsx
@@ -26,7 +26,6 @@ describe('Radio', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/Select.test.tsx
+++ b/packages/react/src/__tests__/Select.test.tsx
@@ -23,7 +23,6 @@ describe('Select', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/SubNav.test.tsx
+++ b/packages/react/src/__tests__/SubNav.test.tsx
@@ -18,7 +18,6 @@ describe('SubNav', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/TextInput.test.tsx
+++ b/packages/react/src/__tests__/TextInput.test.tsx
@@ -20,7 +20,6 @@ describe('TextInput', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/TextInputWithTokens.test.tsx
+++ b/packages/react/src/__tests__/TextInputWithTokens.test.tsx
@@ -44,7 +44,6 @@ describe('TextInputWithTokens', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/Textarea.test.tsx
+++ b/packages/react/src/__tests__/Textarea.test.tsx
@@ -28,7 +28,6 @@ describe('Textarea', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/experimental/Skeleton/__tests__/SkeletonBox.test.tsx
+++ b/packages/react/src/experimental/Skeleton/__tests__/SkeletonBox.test.tsx
@@ -10,7 +10,6 @@ describe('SkeletonBox', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/experimental/Skeleton/__tests__/SkeletonText.test.tsx
+++ b/packages/react/src/experimental/Skeleton/__tests__/SkeletonText.test.tsx
@@ -10,7 +10,6 @@ describe('SkeletonText', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.test.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.test.tsx
@@ -172,7 +172,6 @@ describe('UnderlinePanels', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >


### PR DESCRIPTION
Removing the `primer_react_css_modules_staff` flag since it's not in use anymore. 

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

This doesn't effect any user-facing changes, so no rollout is needed.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
