### PR TITLE
FIx UnderlineNav docs formatting causing MDX parser to fail

### DIFF
--- a/packages/react/src/UnderlineNav/UnderlineNav.docs.json
+++ b/packages/react/src/UnderlineNav/UnderlineNav.docs.json
@@ -72,7 +72,7 @@
           "name": "href",
           "type": "string",
           "defaultValue": "",
-          "description": "The URL that the item navigates to. 'href' is passed to the underlying '<a>' element. If 'as' is specified, the component may need different props and 'href' is ignored. (Required prop for the react router is 'to' for example)"
+          "description": "The URL that the item navigates to. `href` is passed to the underlying `<a>` element. If 'as' is specified, the component may need different props and 'href' is ignored. (Required prop for the react router is 'to' for example)"
         },
         {
           "name": "icon",


### PR DESCRIPTION
When trying to render this as Markdown, the parser gives an error because it thinks we literally wanted to render an anchor tag, not the string `'<a>'`. Using backticks instead of single quotes should fix this.

```
Expected a closing tag for `<a>` (1:73-1:76) before the end of `paragraph`

> 1 | The URL that the item navigates to. 'href' is passed to the underlying '<a>' element. If 'as' is specified, the component may need different props and 'href' is ignored. (Required prop for the react router is 'to' for example)
```