### PR TITLE
refactor(ci): update actions to use sha instead of tag

### DIFF
--- a/.github/workflows/aat-reports.yml
+++ b/.github/workflows/aat-reports.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -48,7 +48,7 @@ jobs:
         run: kill ${{ steps.storybook.outputs.pid }}
       - name: Upload report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: axe-no-flag-${{ matrix.shard }}
           path: blob-report
@@ -59,16 +59,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: aat-runner
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
       - name: install dependencies
         run: npm ci
       - name: download all reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           path: all-blob-reports
           pattern: axe-no-flag-*
@@ -76,7 +76,7 @@ jobs:
       - name: merge all reports
         run: npx playwright merge-reports --reporter html ./all-blob-reports
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: axe
           path: playwright-report
@@ -94,9 +94,9 @@ jobs:
       VITE_PRIMER_REACT_CSS_MODULES_STAFF: 1
       VITE_PRIMER_REACT_CSS_MODULES_GA: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -123,7 +123,7 @@ jobs:
         run: kill ${{ steps.storybook.outputs.pid }}
       - name: Upload report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: axe-all-flags-${{ matrix.shard }}
           path: blob-report
@@ -134,16 +134,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: aat-runner-all-flags
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
       - name: install dependencies
         run: npm ci
       - name: download all reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           path: all-blob-reports
           pattern: axe-all-flags-*
@@ -151,7 +151,7 @@ jobs:
       - name: merge all reports
         run: npx playwright merge-reports --reporter html ./all-blob-reports
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: axe-all-flags
           path: playwright-report

--- a/.github/workflows/accessibility-alt-text-bot.yml
+++ b/.github/workflows/accessibility-alt-text-bot.yml
@@ -23,4 +23,4 @@ jobs:
     if: ${{ github.event.issue || github.event.pull_request || github.event.discussion  }}
     steps:
       - name: Get action 'github/accessibility-alt-text-bot'
-        uses: github/accessibility-alt-text-bot@v1.7.1
+        uses: github/accessibility-alt-text-bot@531a7430c6930a39cae5a0aab2d165284468060f

--- a/.github/workflows/add_to_inbox.yml
+++ b/.github/workflows/add_to_inbox.yml
@@ -13,7 +13,7 @@ jobs:
       PROJECT_ID: 4503
     steps:
       - id: get-primer-access-token
-        uses: camertron/github-app-installation-auth-action@v1
+        uses: camertron/github-app-installation-auth-action@fa97ea3e744a2903ae6078628ad8aa9ed1e65723
         with:
           app-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_ID }}
           private-key: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_PRIVATE_KEY }}
@@ -26,7 +26,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.get-primer-access-token.outputs.access-token }}
       - id: get-github-access-token
-        uses: camertron/github-app-installation-auth-action@v1
+        uses: camertron/github-app-installation-auth-action@fa97ea3e744a2903ae6078628ad8aa9ed1e65723
         with:
           app-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_ID_FOR_GITHUB }}
           private-key: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_PRIVATE_KEY_FOR_GITHUB }}

--- a/.github/workflows/assign_release_conductor.yml
+++ b/.github/workflows/assign_release_conductor.yml
@@ -14,8 +14,8 @@ jobs:
     if: github.head_ref == 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
       - run: npm ci
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.PAGERDUTY_API_KEY_SID }}
       - run: echo ${{ steps.pagerduty.outputs.user }} is release conductor
       - name: Add user as assignee and reviewer
-        uses: actions/github-script@v7
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
         env:
           PR_NUMBER: ${{ github.event.inputs.pull-request || github.event.pull_request.number }}
           RELEASE_CONDUCTOR: ${{ steps.pagerduty.outputs.user }}

--- a/.github/workflows/check-for-integration-result-comment.yml
+++ b/.github/workflows/check-for-integration-result-comment.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get integration result comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/check_for_changeset.yml
+++ b/.github/workflows/check_for_changeset.yml
@@ -16,7 +16,7 @@ jobs:
     name: Check for changeset
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: 'Check for changeset'
         uses: brettcannon/check-for-changed-files@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -72,9 +72,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -89,9 +89,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -104,9 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -126,9 +126,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -11,17 +11,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
         id: file-counts
         with:
           script: |
@@ -66,7 +66,7 @@ jobs:
             core.setOutput('metrics', metrics.join('\n'))
 
       - name: Build count
-        uses: masci/datadog@v1
+        uses: masci/datadog@ec7f9e2a4254f73e638883bc376ca80da6499b0e
         with:
           api-key: ${{ secrets.datadog_api_key }}
           metrics: ${{ steps.file-counts.outputs.metrics }}

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -22,9 +22,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -33,26 +33,26 @@ jobs:
       - name: Build docs preview
         run: npm run build:docs:preview
       - name: Download VRT reports (All flags enabled)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           name: vrt-all-flags
           path: docs/public/vrt-all-flags
       - name: Download VRT reports (No flags enabled)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           name: vrt-no-flag
           path: docs/public/vrt-no-flag
       - name: Download AAT reports (All flags enabled)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           name: axe-all-flags
           path: docs/public/aat-all-flags
       - name: Download AAT reports (No flags enabled)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           name: axe
           path: docs/public/aat-no-flag
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           name: github-pages
           path: docs/public
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
         with:
           preview: true
 
@@ -84,7 +84,7 @@ jobs:
       deployments: write
     runs-on: ubuntu-latest
     steps:
-      - uses: chrnorm/deployment-action@v2.0.7
+      - uses: chrnorm/deployment-action@55729fcebec3d284f60f5bcabbd8376437d696b1
         name: Create GitHub deployment for storybook
         id: storybook
         with:
@@ -93,7 +93,7 @@ jobs:
           environment-url: '${{ needs.deploy-preview.outputs.deployment_url }}storybook'
       - name: Update storybook deployment status (success)
         if: success()
-        uses: chrnorm/deployment-status@v2.0.3
+        uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           environment-url: '${{ needs.deploy-preview.outputs.deployment_url }}storybook'
@@ -101,7 +101,7 @@ jobs:
           deployment-id: ${{ steps.storybook.outputs.deployment_id }}
       - name: Update storybook deployment status (failure)
         if: failure()
-        uses: chrnorm/deployment-status@v2.0.3
+        uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           state: 'failure'
@@ -115,7 +115,7 @@ jobs:
   #     deployments: write
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: chrnorm/deployment-action@v2.0.7
+  #     - uses: chrnorm/deployment-action@55729fcebec3d284f60f5bcabbd8376437d696b1
   #       name: Create GitHub deployment for vrt-no-flag
   #       id: vrt-no-flag
   #       with:
@@ -124,7 +124,7 @@ jobs:
   #         environment-url: '${{ needs.deploy-preview.outputs.deployment_url }}vrt-no-flag'
   #     - name: Update vrt-no-flag deployment status (success)
   #       if: success()
-  #       uses: chrnorm/deployment-status@v2.0.3
+  #       uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}
   #         environment-url: '${{ needs.deploy-preview.outputs.deployment_url }}vrt-no-flag'
@@ -132,7 +132,7 @@ jobs:
   #         deployment-id: ${{ steps.vrt-no-flag.outputs.deployment_id }}
   #     - name: Update vrt-no-flag deployment status (failure)
   #       if: failure()
-  #       uses: chrnorm/deployment-status@v2.0.3
+  #       uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}
   #         state: 'failure'
@@ -146,7 +146,7 @@ jobs:
   #     deployments: write
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: chrnorm/deployment-action@v2.0.7
+  #     - uses: chrnorm/deployment-action@55729fcebec3d284f60f5bcabbd8376437d696b1
   #       name: Create GitHub deployment for vrt-all-flags
   #       id: vrt-all-flags
   #       with:
@@ -155,7 +155,7 @@ jobs:
   #         environment-url: '${{ needs.deploy-preview.outputs.deployment_url }}vrt-all-flags'
   #     - name: Update vrt-all-flags deployment status (success)
   #       if: success()
-  #       uses: chrnorm/deployment-status@v2.0.3
+  #       uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}
   #         environment-url: '${{ needs.deploy-preview.outputs.deployment_url }}vrt-all-flags'
@@ -163,7 +163,7 @@ jobs:
   #         deployment-id: ${{ steps.vrt-all-flags.outputs.deployment_id }}
   #     - name: Update vrt-all-flags deployment status (failure)
   #       if: failure()
-  #       uses: chrnorm/deployment-status@v2.0.3
+  #       uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}
   #         state: 'failure'
@@ -177,7 +177,7 @@ jobs:
   #     deployments: write
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: chrnorm/deployment-action@v2.0.7
+  #     - uses: chrnorm/deployment-action@55729fcebec3d284f60f5bcabbd8376437d696b1
   #       name: Create GitHub deployment for aat-no-flag
   #       id: aat-no-flag
   #       with:
@@ -186,7 +186,7 @@ jobs:
   #         environment-url: '${{ needs.deploy-preview.outputs.deployment_url }}aat-no-flag'
   #     - name: Update aat-no-flag deployment status (success)
   #       if: success()
-  #       uses: chrnorm/deployment-status@v2.0.3
+  #       uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}
   #         environment-url: '${{ needs.deploy-preview.outputs.deployment_url }}aat-no-flag'
@@ -194,7 +194,7 @@ jobs:
   #         deployment-id: ${{ steps.aat-no-flag.outputs.deployment_id }}
   #     - name: Update aat-no-flag deployment status (failure)
   #       if: failure()
-  #       uses: chrnorm/deployment-status@v2.0.3
+  #       uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}
   #         state: 'failure'
@@ -208,7 +208,7 @@ jobs:
   #     deployments: write
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: chrnorm/deployment-action@v2.0.7
+  #     - uses: chrnorm/deployment-action@55729fcebec3d284f60f5bcabbd8376437d696b1
   #       name: Create GitHub deployment for aat-all-flags
   #       id: aat-all-flags
   #       with:
@@ -217,7 +217,7 @@ jobs:
   #         environment-url: '${{ needs.deploy-preview.outputs.deployment_url }}aat-all-flags'
   #     - name: Update aat-all-flags deployment status (success)
   #       if: success()
-  #       uses: chrnorm/deployment-status@v2.0.3
+  #       uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}
   #         environment-url: '${{ needs.deploy-preview.outputs.deployment_url }}aat-all-flags'
@@ -225,7 +225,7 @@ jobs:
   #         deployment-id: ${{ steps.aat-all-flags.outputs.deployment_id }}
   #     - name: Update aat-all-flags deployment status (failure)
   #       if: failure()
-  #       uses: chrnorm/deployment-status@v2.0.3
+  #       uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}
   #         state: 'failure'

--- a/.github/workflows/deploy_preview_forks.yml
+++ b/.github/workflows/deploy_preview_forks.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -33,26 +33,26 @@ jobs:
       - name: Build docs preview
         run: npm run build:docs:preview
       - name: Download VRT reports (All flags enabled)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           name: vrt-all-flags
           path: docs/public/vrt-all-flags
       - name: Download VRT reports (No flags enabled)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           name: vrt-no-flag
           path: docs/public/vrt-no-flag
       - name: Download AAT reports (All flags enabled)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           name: axe-all-flags
           path: docs/public/aat-all-flags
       - name: Download AAT reports (No flags enabled)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           name: axe
           path: docs/public/aat-no-flag
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           name: github-pages
           path: docs/public
@@ -72,6 +72,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
         with:
           preview: true

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -20,7 +20,7 @@ jobs:
       # If it's 0, we deploy.
       should_deploy: ${{ steps.changeset-count.outputs.change_count == 0 && steps.has-pages.outputs.pages == 1 }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - id: changeset-count
         run: echo "::set-output name=change_count::$(ls .changeset/*.md | grep -v README | wc -l | xargs)"

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |

--- a/.github/workflows/figma_connect_publish.yml
+++ b/.github/workflows/figma_connect_publish.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e
         id: app-token
         with:
           app-id: ${{ vars.PRIMER_APP_ID_SHARED }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
 
       - name: Get or Create Comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/recommend-integration-tests.yml
+++ b/.github/workflows/recommend-integration-tests.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
 
@@ -31,7 +31,7 @@ jobs:
 
       - name: Add label and comment
         if: ${{ steps.source-files.outputs.diff != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -21,20 +21,20 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/pagerduty
         id: pagerduty
         with:
           schedule-id: 'P3IIVC4'
           token: ${{ secrets.PAGERDUTY_API_KEY_SID }}
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
       - name: Install packages for github-script
         run: npm i date-fns
       - name: Create Release Issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
         env:
           RELEASE_CONDUCTOR: ${{ steps.pagerduty.outputs.user }}
           SCHEDULE_START: ${{ steps.pagerduty.outputs.start }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e
         id: app-token
         with:
           app-id: ${{ vars.PRIMER_APP_ID_SHARED }}

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -46,7 +46,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Output canary version
-        uses: actions/github-script@v4.0.2
+        uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293
         with:
           script: |
             const package = require(`${process.env.GITHUB_WORKSPACE}/packages/react/package.json`)

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Output candidate version
-        uses: actions/github-script@v4.0.2
+        uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293
         with:
           script: |
             const package = require(`${process.env.GITHUB_WORKSPACE}/packages/react/package.json`)

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -7,7 +7,7 @@ jobs:
     env:
       CI_JOB_NUMBER: 1
     steps:
-      - uses: actions/checkout@v4
-      - uses: andresz1/size-limit-action@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: andresz1/size-limit-action@f7a56ece616db5bddde81de219695c920a8ae137
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'primer/react' }}
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
         with:
           # General settings
           days-before-stale: 60

--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -14,13 +14,13 @@ jobs:
     if: ${{ github.repository == 'primer/react' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
       - name: Install node deps

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -10,8 +10,8 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -21,7 +21,7 @@ jobs:
       number: ${{ steps.pr.outputs.number }}
     steps:
       - name: 'Get Pull Request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
         with:
           script: |
             const fs = require('fs');
@@ -43,7 +43,7 @@ jobs:
       - run: |
           mkdir PR
           unzip PR.zip -d PR
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
         id: pr
         with:
           script: |
@@ -62,20 +62,20 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
       # Warning: we are checking out an untrusted source at this point in order
       # to push to the head pull request. Code from this checkout must not be
       # used in any of the following steps.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           token: ${{ steps.generate_token.outputs.token }}
       - name: 'Download artifact'
-        uses: actions/github-script@v7
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
         with:
           script: |
             const fs = require('fs');
@@ -110,7 +110,7 @@ jobs:
             rm snapshots.zip
             rm $filepath
           done
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a
         with:
           commit_message: 'test(vrt): update snapshots'
 
@@ -122,7 +122,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Remove label
-        uses: actions/github-script@v7
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/vrt-reports.yml
+++ b/.github/workflows/vrt-reports.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -48,7 +48,7 @@ jobs:
         run: kill ${{ steps.storybook.outputs.pid }}
       - name: Upload report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: vrt-no-flag-${{ matrix.shard }}
           path: blob-report
@@ -59,16 +59,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: vrt-runner
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
       - name: install dependencies
         run: npm ci
       - name: download all reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           path: all-blob-reports
           pattern: vrt-no-flag-*
@@ -76,7 +76,7 @@ jobs:
       - name: merge all reports
         run: npx playwright merge-reports --reporter html ./all-blob-reports
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: vrt-no-flag
           path: playwright-report
@@ -94,9 +94,9 @@ jobs:
       VITE_PRIMER_REACT_CSS_MODULES_STAFF: 1
       VITE_PRIMER_REACT_CSS_MODULES_GA: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -123,7 +123,7 @@ jobs:
         run: kill ${{ steps.storybook.outputs.pid }}
       - name: Upload report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: vrt-all-flags-${{ matrix.shard }}
           path: blob-report
@@ -134,16 +134,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: vrt-runner-all-flags
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
       - name: install dependencies
         run: npm ci
       - name: download all reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
         with:
           path: all-blob-reports
           pattern: vrt-all-flags-*
@@ -151,7 +151,7 @@ jobs:
       - name: merge all reports
         run: npx playwright merge-reports --reporter html ./all-blob-reports
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: vrt-all-flags
           path: playwright-report

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -19,7 +19,7 @@ jobs:
           echo $NUMBER > ./PR/number
         env:
           NUMBER: ${{ github.event.number }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: pull-request
           path: ./PR
@@ -33,9 +33,9 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 22
           cache: 'npm'
@@ -66,7 +66,7 @@ jobs:
             git ls-files --others --exclude-standard --modified | zip snapshots -@
           fi
       - name: Upload snapshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: snapshots-${{ matrix.shard }}
           path: snapshots.zip


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update our actions to use a sha instead of a tag. These will help out if a tag is pointed to a different commit and they are still supported by dependabot.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `.github/workflows` to use sha in actions instead of tags

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to CI and will not impact consumers of a library