### PR TITLE
Remove CSS modules feature flag from VisuallyHidden

### DIFF
--- a/.changeset/gold-ducks-grin.md
+++ b/.changeset/gold-ducks-grin.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Remove CSS modules feature flag from VisuallyHidden

--- a/packages/react/src/CounterLabel/__snapshots__/CounterLabel.test.tsx.snap
+++ b/packages/react/src/CounterLabel/__snapshots__/CounterLabel.test.tsx.snap
@@ -1,16 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CounterLabel renders with secondary scheme when no "scheme" prop is provided 1`] = `
-.c0:not(:focus):not(:active):not(:focus-within) {
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
 <div>
   <span
     aria-hidden="true"
@@ -20,7 +10,7 @@ exports[`CounterLabel renders with secondary scheme when no "scheme" prop is pro
     1234
   </span>
   <span
-    class="c0"
+    class="VisuallyHidden"
   >
      (
     1234
@@ -30,16 +20,6 @@ exports[`CounterLabel renders with secondary scheme when no "scheme" prop is pro
 `;
 
 exports[`CounterLabel respects the primary "scheme" prop 1`] = `
-.c0:not(:focus):not(:active):not(:focus-within) {
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
 <div>
   <span
     aria-hidden="true"
@@ -49,7 +29,7 @@ exports[`CounterLabel respects the primary "scheme" prop 1`] = `
     1234
   </span>
   <span
-    class="c0"
+    class="VisuallyHidden"
   >
      (
     1234

--- a/packages/react/src/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/VisuallyHidden/VisuallyHidden.tsx
@@ -1,13 +1,9 @@
-import styled from 'styled-components'
 import type {SxProp} from '../sx'
-import sx from '../sx'
-import {toggleStyledComponent} from '../internal/utils/toggleStyledComponent'
 import {clsx} from 'clsx'
-import {useFeatureFlag} from '../FeatureFlags'
 import React, {type HTMLAttributes} from 'react'
 import classes from './VisuallyHidden.module.css'
-
-const CSS_MODULES_FEATURE_FLAG = 'primer_react_css_modules_ga'
+import {defaultSxProp} from '../utils/defaultSxProp'
+import Box from '../Box'
 
 /**
  * Provides a component that implements the "visually hidden" technique. This is
@@ -19,29 +15,19 @@ const CSS_MODULES_FEATURE_FLAG = 'primer_react_css_modules_ga'
  *
  * @see https://www.scottohara.me/blog/2023/03/21/visually-hidden-hack.html
  */
-const StyledVisuallyHidden = toggleStyledComponent(
-  CSS_MODULES_FEATURE_FLAG,
-  'span',
-  styled.span<SxProp>`
-    &:not(:focus):not(:active):not(:focus-within) {
-      clip-path: inset(50%);
-      height: 1px;
-      overflow: hidden;
-      position: absolute;
-      white-space: nowrap;
-      width: 1px;
-    }
+export const VisuallyHidden = ({className, children, sx: sxProp = defaultSxProp, ...rest}: VisuallyHiddenProps) => {
+  if (sxProp !== defaultSxProp) {
+    return (
+      <Box sx={sxProp} className={clsx(className, classes.VisuallyHidden)} {...rest}>
+        {children}
+      </Box>
+    )
+  }
 
-    ${sx}
-  `,
-)
-
-export const VisuallyHidden = ({className, children, ...rest}: VisuallyHiddenProps) => {
-  const enabled = useFeatureFlag(CSS_MODULES_FEATURE_FLAG)
   return (
-    <StyledVisuallyHidden className={clsx(className, enabled && classes.VisuallyHidden)} {...rest}>
+    <span className={clsx(className, classes.VisuallyHidden)} {...rest}>
       {children}
-    </StyledVisuallyHidden>
+    </span>
   )
 }
 

--- a/packages/react/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -539,16 +539,6 @@ exports[`snapshots renders a loading state 1`] = `
   justify-content: center;
 }
 
-.c2:not(:focus):not(:active):not(:focus-within) {
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
 .c0 {
   position: absolute;
   width: 1px;
@@ -603,7 +593,7 @@ exports[`snapshots renders a loading state 1`] = `
           />
         </svg>
         <span
-          className="c2"
+          className="VisuallyHidden"
           id=":r2h:"
         >
           Loading


### PR DESCRIPTION
This PR removes the CSS modules feature flag from the `VisuallyHidden` component. The component [VisuallyHidden](https://primer-query.githubapp.com/?constant=dialog&name=%22VisuallyHidden%22&entrypoint=%22%40primer%2Freact%22&repo=%22github%2Fgithub%22) is used `8` times in dotcom.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

Removes the CSS modules feature flag from the `SubNav` component. 

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Using Integration testing.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
