### PR TITLE
Fix axe violation: scrollable-region-focusable

### DIFF
--- a/.changeset/icy-pianos-enjoy.md
+++ b/.changeset/icy-pianos-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+[ScrollableRegion] fix axe violation: scrollable-region-focusable

--- a/packages/react/src/ScrollableRegion/ScrollableRegion.test.tsx
+++ b/packages/react/src/ScrollableRegion/ScrollableRegion.test.tsx
@@ -37,8 +37,8 @@ describe('ScrollableRegion', () => {
     expect(screen.getByTestId('container')).not.toHaveAttribute('aria-labelledby')
     expect(screen.getByTestId('container')).not.toHaveAttribute('aria-label')
 
-    expect(screen.getByTestId('container')).toHaveStyleRule('overflow', 'auto')
-    expect(screen.getByTestId('container')).toHaveStyleRule('position', 'relative')
+    expect(screen.getByTestId('container')).not.toHaveStyleRule('overflow', 'auto')
+    expect(screen.getByTestId('container')).not.toHaveStyleRule('position', 'relative')
   })
 
   test('does render with region props when overflow is present', () => {
@@ -84,5 +84,7 @@ describe('ScrollableRegion', () => {
     expect(screen.getByLabelText('Example label')).toHaveAttribute('role', 'region')
     expect(screen.getByLabelText('Example label')).toHaveAttribute('tabindex', '0')
     expect(screen.getByLabelText('Example label')).toHaveAttribute('aria-label')
+    expect(screen.getByTestId('container')).toHaveStyleRule('overflow', 'auto')
+    expect(screen.getByTestId('container')).toHaveStyleRule('position', 'relative')
   })
 })

--- a/packages/react/src/ScrollableRegion/ScrollableRegion.tsx
+++ b/packages/react/src/ScrollableRegion/ScrollableRegion.tsx
@@ -41,7 +41,7 @@ function ScrollableRegion({
     : {}
 
   return (
-    <Box {...rest} {...regionProps} ref={ref} sx={defaultStyles}>
+    <Box {...rest} {...regionProps} ref={ref} sx={hasOverflow ? defaultStyles : undefined}>
       {children}
     </Box>
   )


### PR DESCRIPTION
Closes #

Fixes: Scrollable-region-focusable axe violations in the primer-docs site. 

The primer-docs site uses the `Table` component which contains a ScrollableRegion. The ScrollableRegion has `overflow: auto` without always adding `tab-index:0`


### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->


#### Changed

Only add `overflow: auto` if there is overflow. 

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [X] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
