### PR TITLE
Remove the CSS modules feature flag from the KeybindingHint Component

### DIFF
--- a/.changeset/rotten-rings-confess.md
+++ b/.changeset/rotten-rings-confess.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Remove the CSS modules feature flag from the KeybindingHint Component.

--- a/packages/react/src/KeybindingHint/KeybindingHint.tsx
+++ b/packages/react/src/KeybindingHint/KeybindingHint.tsx
@@ -3,39 +3,14 @@ import {memo} from 'react'
 import Text from '../Text'
 import type {KeybindingHintProps} from './props'
 import {accessibleSequenceString, Sequence} from './components/Sequence'
-import {useFeatureFlag} from '../FeatureFlags'
 
 import classes from './KeybindingHint.module.css'
 import {clsx} from 'clsx'
 
 /** `kbd` element with style resets. */
 const Kbd = ({children, className}: {children: ReactNode; className?: string}) => {
-  const enabled = useFeatureFlag('primer_react_css_modules_ga')
-
   return (
-    <Text
-      as={'kbd' as 'span'}
-      className={clsx(className, enabled && classes.KeybindingHint)}
-      data-testid="keybinding-hint"
-      sx={
-        enabled
-          ? undefined
-          : {
-              color: 'inherit',
-              fontFamily: 'inherit',
-              fontSize: 'inherit',
-              border: 'none',
-              background: 'none',
-              boxShadow: 'none',
-              p: 0,
-              lineHeight: 'unset',
-              position: 'relative',
-              overflow: 'visible',
-              verticalAlign: 'baseline',
-              textWrap: 'nowrap',
-            }
-      }
-    >
+    <Text as={'kbd' as 'span'} className={clsx(className, classes.KeybindingHint)} data-testid="keybinding-hint">
       {children}
     </Text>
   )


### PR DESCRIPTION
This PR removes the CSS modules feature flag from the `KeybindingHint` component. The component [KeybindingHint](https://primer-query.githubapp.com/?name=keybindinghint&package=%22%40primer%2Freact%22&repo=%22github%2Fgithub%22) is used `28` times in dotcom.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

Removes the CSS modules feature flag from the `KeybindingHint` components. 

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Using Integration testing.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [x] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
