### PR TITLE
Remove the CSS modules feature flag from the Autocomplete component

### DIFF
--- a/.changeset/long-suns-type.md
+++ b/.changeset/long-suns-type.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Remove the CSS modules feature flag from the Autocomplete component.

--- a/packages/react/src/Autocomplete/AutocompleteMenu.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteMenu.tsx
@@ -7,7 +7,6 @@ import type {ActionListItemProps} from '../ActionList'
 import {ActionList} from '../ActionList'
 import {useFocusZone} from '../hooks/useFocusZone'
 import type {ComponentProps, MandateProps} from '../utils/types'
-import Box from '../Box'
 import Spinner from '../Spinner'
 import {useId} from '../hooks/useId'
 import {AutocompleteContext} from './AutocompleteContext'
@@ -15,7 +14,6 @@ import type {IconProps} from '@primer/octicons-react'
 import {PlusIcon} from '@primer/octicons-react'
 import VisuallyHidden from '../_VisuallyHidden'
 import {isElement} from 'react-is'
-import {useFeatureFlag} from '../FeatureFlags'
 
 import classes from './AutocompleteMenu.module.css'
 
@@ -121,8 +119,6 @@ export type AutocompleteMenuInternalProps<T extends AutocompleteItemProps> = {
   // TODO: instead of making this required, maybe we can infer aria-labelledby from the ID of the text input somehow?
   ['aria-labelledby']: string
 }
-
-const CSS_MODULES_FEATURE_FLAG = 'primer_react_css_modules_ga'
 
 /**
  * Announces a message to screen readers at a slowed-down rate. This is useful when you want to announce don't want to
@@ -345,20 +341,12 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
     throw new Error('Autocomplete: selectionVariant "single" cannot be used with multiple selected items')
   }
 
-  const enabled = useFeatureFlag(CSS_MODULES_FEATURE_FLAG)
-
   return (
     <VisuallyHidden isVisible={showMenu}>
       {loading ? (
-        enabled ? (
-          <Box className={classes.SpinnerWrapper}>
-            <Spinner />
-          </Box>
-        ) : (
-          <Box p={3} display="flex" justifyContent="center">
-            <Spinner />
-          </Box>
-        )
+        <div className={classes.SpinnerWrapper}>
+          <Spinner />
+        </div>
       ) : (
         <div ref={listContainerRef}>
           {allItemsToRender.length ? (
@@ -396,11 +384,7 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
               })}
             </ActionList>
           ) : emptyStateText !== false && emptyStateText !== null ? (
-            enabled ? (
-              <Box className={classes.EmptyStateWrapper}>{emptyStateText}</Box>
-            ) : (
-              <Box p={3}>{emptyStateText}</Box>
-            )
+            <div className={classes.EmptyStateWrapper}>{emptyStateText}</div>
           ) : null}
         </div>
       )}

--- a/packages/react/src/Autocomplete/AutocompleteOverlay.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteOverlay.tsx
@@ -6,7 +6,6 @@ import type {ComponentProps} from '../utils/types'
 import {AutocompleteContext} from './AutocompleteContext'
 import {useRefObjectAsForwardedRef} from '../hooks/useRefObjectAsForwardedRef'
 import VisuallyHidden from '../_VisuallyHidden'
-import {useFeatureFlag} from '../FeatureFlags'
 
 import classes from './AutocompleteOverlay.module.css'
 
@@ -50,8 +49,6 @@ function AutocompleteOverlay({
     setShowMenu(false)
   }, [setShowMenu])
 
-  const enabled = useFeatureFlag('primer_react_css_modules_ga')
-
   if (typeof window === 'undefined') {
     return null
   }
@@ -65,14 +62,7 @@ function AutocompleteOverlay({
       ref={floatingElementRef as React.RefObject<HTMLDivElement>}
       top={position?.top}
       left={position?.left}
-      sx={
-        enabled
-          ? undefined
-          : {
-              overflow: 'auto',
-            }
-      }
-      className={enabled ? classes.Overlay : undefined}
+      className={classes.Overlay}
       {...overlayProps}
     >
       {children}

--- a/packages/react/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -246,11 +246,7 @@ exports[`snapshots renders a custom empty state message 1`] = `
       type="text"
     />
   </span>,
-  .c1 {
-  padding: 16px;
-}
-
-.c0 {
+  .c0 {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -272,7 +268,7 @@ exports[`snapshots renders a custom empty state message 1`] = `
   >
     <div>
       <div
-        className="c1"
+        className="EmptyStateWrapper"
       >
         No results
       </div>
@@ -527,19 +523,7 @@ exports[`snapshots renders a loading state 1`] = `
       type="text"
     />
   </span>,
-  .c1 {
-  padding: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c0 {
+  .c0 {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -560,8 +544,7 @@ exports[`snapshots renders a loading state 1`] = `
     className="c0"
   >
     <div
-      className="c1"
-      display="flex"
+      className="SpinnerWrapper"
     >
       <span
         className="Box"
@@ -4916,11 +4899,7 @@ exports[`snapshots renders with an input value 1`] = `
       type="text"
     />
   </span>,
-  .c1 {
-  padding: 16px;
-}
-
-.c0 {
+  .c0 {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -4950,7 +4929,7 @@ exports[`snapshots renders with an input value 1`] = `
   >
     <div>
       <div
-        className="c1"
+        className="EmptyStateWrapper"
       >
         No selectable options
       </div>


### PR DESCRIPTION
This PR removes the CSS modules feature flag from the `Autocomplete` component. The component [Autocomplete](https://primer-query.githubapp.com/?name=Autocomplete&package=%22%40primer%2Freact%22&repo=%22github%2Fgithub%22) is used `28` times in dotcom.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

Removes the CSS modules feature flag from the `Autocomplete` components. 

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Using Integration testing.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [x] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
