### PR TITLE
SubNav: Update selected styles to only apply to `data-selected='true'`

### DIFF
--- a/.changeset/strong-lemons-rescue.md
+++ b/.changeset/strong-lemons-rescue.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+SubNav: Update selected styles to only apply to `data-selected='true'`

--- a/packages/react/src/SubNav/SubNav.module.css
+++ b/packages/react/src/SubNav/SubNav.module.css
@@ -60,7 +60,7 @@
     transition: background-color 0.2s ease;
   }
 
-  &:is([data-selected]) {
+  &:is([data-selected='true']) {
     color: var(--fgColor-onEmphasis);
     background-color: var(--bgColor-accent-emphasis);
     /* stylelint-disable-next-line primer/colors */


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

When the SunNav component is used in an environment with practical data, it is high likely that the `selected` attribute will be used in each SubNav children and their value will be conditionally rendered to true or false. Therefore the generated HTML will be 

```html
<a data-selected="false" aria-current="false" href="#nav1">Nav 1</a>
<a data-selected="true" aria-current="true" href="#nav2">Nav 2</a>
<a data-selected="false" aria-current="false" href="#nav3">Nav 3</a>
```

Currently the way we apply the selected styles are causing bug because the styles are applied to all links because all have `data-selected` property.

Here is an example from RL that shows the bug

<img width="238" alt="sub nav had two items and both are highlighted with the selected color" src="https://github.com/user-attachments/assets/6520a009-80f8-44e8-82fa-4d44ee47fad7" />

There is currently no usage of SubNav at dotcom - this is why we probably didn't noticed the issue so far.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

- Instead of selecting `data-selected` attribute to apply selected styles, I updated the code to select `data-selected="true"`

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

If you could edit the Selected story so that each children have selected prop. You can repro the issue and with the change in this PR, you can verify the fix.

```js
export const Selected = () => {
  const [selectedItem, setSelectedItem] = React.useState('home')

  return (
    <SubNav aria-label="Main">
      <SubNav.Links>
        <SubNav.Link href="#home" selected={selectedItem === 'home'}>
          Home
        </SubNav.Link>
        <SubNav.Link href="#documentation" selected={selectedItem === 'documentation'}>
          Documentation
        </SubNav.Link>
        <SubNav.Link href="#support" selected={selectedItem === 'support'}>
          Support
        </SubNav.Link>
      </SubNav.Links>
    </SubNav>
  )
}
```

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
