### PR TITLE
Fix Markdown UnderlineNav component API docs

### DIFF
--- a/packages/react/src/UnderlineNav/UnderlineNav.docs.json
+++ b/packages/react/src/UnderlineNav/UnderlineNav.docs.json
@@ -32,7 +32,7 @@
       "name": "aria-label",
       "type": "string",
       "defaultValue": "",
-      "description": "A unique name for the rendered nav landmark."
+      "description": "A unique name for the rendered nav landmark. It will also be used to label the arrow\nbuttons that control the scroll behaviour on coarse pointer devices. (I.e.\n'Scroll _aria-label_ left/right')\n"
     },
     {
       "name": "children",

--- a/packages/react/src/UnderlineNav/UnderlineNav.docs.json
+++ b/packages/react/src/UnderlineNav/UnderlineNav.docs.json
@@ -32,7 +32,7 @@
       "name": "aria-label",
       "type": "string",
       "defaultValue": "",
-      "description": "A unique name for the rendered 'nav' landmark. It will also be used to label the arrow\nbuttons that control the scroll behaviour on coarse pointer devices. (I.e.\n'Scroll {aria-label} left/right')\n"
+      "description": "A unique name for the rendered nav landmark."
     },
     {
       "name": "children",

--- a/packages/react/src/UnderlineNav/UnderlineNav.docs.json
+++ b/packages/react/src/UnderlineNav/UnderlineNav.docs.json
@@ -32,7 +32,7 @@
       "name": "aria-label",
       "type": "string",
       "defaultValue": "",
-      "description": "A unique name for the rendered 'nav' landmark. It will also be used to label the arrow\nbuttons that control the scroll behaviour on coarse pointer devices. (I.e.\n'Scroll ${aria-label} left/right')\n"
+      "description": "A unique name for the rendered 'nav' landmark. It will also be used to label the arrow\nbuttons that control the scroll behaviour on coarse pointer devices. (I.e.\n'Scroll {aria-label} left/right')\n"
     },
     {
       "name": "children",


### PR DESCRIPTION
Unblocks https://github.com/github/primer-docs/pull/403

Latest release still gives an error:
```
hook.js:608 ReferenceError: aria is not defined
    at _createMdxContent (eval at MDXRemote.useMemo[Content] (index.js:1:1), <anonymous>:13:193)
    at MDXContent (eval at MDXRemote.useMemo[Content] (index.js:1:1), <anonymous>:34:14)
    at react-stack-bottom-frame (react-dom-client.development.js:23610:20)
    at renderWithHooks (react-dom-client.development.js:4646:22)
    at updateFunctionComponent (react-dom-client.development.js:8032:19)
    at beginWork (react-dom-client.development.js:9689:18)
    at runWithFiberInDEV (react-dom-client.development.js:544:16)
    at performUnitOfWork (react-dom-client.development.js:15064:22)
    at workLoopSync (react-dom-client.development.js:14888:41)
    at renderRootSync (react-dom-client.development.js:14868:11)
    at performWorkOnRoot (react-dom-client.development.js:14394:44)
    at performWorkOnRootViaSchedulerTask (react-dom-client.development.js:15955:7)
    at MessagePort.performWorkUntilDeadline (scheduler.development.js:44:48)

The above error occurred in the <MDXContent> component. It was handled by the <ErrorBoundaryHandler> error boundary. Error Component Stack
    at MDXContent (eval at MDXRemote.useMemo[Content] (index.js:1:1), <anonymous>:22:8)
    at MDXProvider (index.js:75:18)
    at MDXRemote (index.js:21:11)
    at InlineMDX (InlineMDX.tsx:6:36)
 ....
```