### PR TITLE
add missing className props and update behavesAsComponent test check

### DIFF
--- a/.changeset/rare-words-sin.md
+++ b/.changeset/rare-words-sin.md
@@ -2,4 +2,5 @@
 '@primer/react': minor
 ---
 
-chore(className): add missing className props and update behavesAsComponent test check
+ActionList.Group + ActionList.TrailingAction: add missing className prop
+LabelGroup: add missing className prop

--- a/.changeset/rare-words-sin.md
+++ b/.changeset/rare-words-sin.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+chore(className): add missing className props and update behavesAsComponent test check

--- a/packages/react/src/ActionBar/ActionBar.test.tsx
+++ b/packages/react/src/ActionBar/ActionBar.test.tsx
@@ -24,7 +24,7 @@ describe('ActionBar', () => {
 
   behavesAsComponent({
     Component: ActionBar,
-    options: {skipAs: true, skipSx: true},
+    options: {skipAs: true, skipSx: true, skipClassName: true},
     toRender: () => <SimpleActionBar />,
   })
 

--- a/packages/react/src/ActionList/ActionList.test.tsx
+++ b/packages/react/src/ActionList/ActionList.test.tsx
@@ -34,6 +34,18 @@ describe('ActionList', () => {
     toRender: () => <ActionList />,
   })
 
+  behavesAsComponent({
+    Component: ActionList.Divider,
+    options: {skipAs: true, skipSx: true},
+    toRender: () => <ActionList.Divider />,
+  })
+
+  behavesAsComponent({
+    Component: ActionList.TrailingAction,
+    options: {skipAs: true, skipSx: true},
+    toRender: () => <ActionList.TrailingAction label="Action">Action</ActionList.TrailingAction>,
+  })
+
   checkExports('ActionList', {
     default: undefined,
     ActionList,
@@ -143,5 +155,47 @@ describe('ActionList', () => {
       'test-class-name',
     )
     expect(HTMLRender(<Element />).container.querySelector('li[aria-hidden="true"]')).toHaveClass('test-class-name')
+  })
+
+  it('list and its sub-components support classname', () => {
+    const {container} = HTMLRender(
+      <ActionList className="list">
+        <ActionList.Heading as="h2" className="heading">
+          Heading
+        </ActionList.Heading>
+        <ActionList.Item className="item">
+          Item
+          <ActionList.TrailingAction label="action" className="trailing_action">
+            Trailing Action
+          </ActionList.TrailingAction>
+        </ActionList.Item>
+        <ActionList.Divider className="divider" />
+        <ActionList.LinkItem className="link" href="//github.com" title="anchor" aria-keyshortcuts="d">
+          Link Item
+        </ActionList.LinkItem>
+        <ActionList.Group className="group">
+          <ActionList.GroupHeading as="h2" className="group_heading">
+            Group Heading
+          </ActionList.GroupHeading>
+          <ActionList.Item className="item">
+            <ActionList.TrailingVisual className="trailing">Trailing Visual</ActionList.TrailingVisual>
+            <ActionList.LeadingVisual className="leading">Leading Visual</ActionList.LeadingVisual>
+            <ActionList.Description className="description">Description</ActionList.Description>
+          </ActionList.Item>
+        </ActionList.Group>
+      </ActionList>,
+    )
+
+    expect(container.querySelector('.list')).toBeInTheDocument()
+    expect(container.querySelector('.heading')).toBeInTheDocument()
+    expect(container.querySelector('.item')).toBeInTheDocument()
+    expect(container.querySelector('.trailing_action')).toBeInTheDocument()
+    expect(container.querySelector('.divider')).toBeInTheDocument()
+    expect(container.querySelector('.link')).toBeInTheDocument()
+    expect(container.querySelector('.group')).toBeInTheDocument()
+    expect(container.querySelector('.group_heading')).toBeInTheDocument()
+    expect(container.querySelector('.trailing')).toBeInTheDocument()
+    expect(container.querySelector('.leading')).toBeInTheDocument()
+    expect(container.querySelector('.description')).toBeInTheDocument()
   })
 })

--- a/packages/react/src/ActionList/Description.tsx
+++ b/packages/react/src/ActionList/Description.tsx
@@ -130,3 +130,4 @@ export const Description: React.FC<React.PropsWithChildren<ActionListDescription
     </Truncate>
   )
 }
+Description.displayName = 'ActionList.Description'

--- a/packages/react/src/ActionList/Divider.tsx
+++ b/packages/react/src/ActionList/Divider.tsx
@@ -52,3 +52,4 @@ export const Divider: React.FC<React.PropsWithChildren<ActionListDividerProps>> 
     />
   )
 }
+Divider.displayName = 'ActionList.Divider'

--- a/packages/react/src/ActionList/Group.test.tsx
+++ b/packages/react/src/ActionList/Group.test.tsx
@@ -4,8 +4,21 @@ import theme from '../theme'
 import {ActionList} from '.'
 import {BaseStyles, ThemeProvider, ActionMenu} from '..'
 import {FeatureFlags} from '../FeatureFlags'
+import {behavesAsComponent} from '../utils/testing'
 
 describe('ActionList.Group', () => {
+  behavesAsComponent({
+    Component: ActionList.Group,
+    options: {skipAs: true, skipSx: true},
+    toRender: () => <ActionList.Group />,
+  })
+
+  behavesAsComponent({
+    Component: ActionList.GroupHeading,
+    options: {skipAs: true, skipSx: true},
+    toRender: () => <ActionList.GroupHeading />,
+  })
+
   it('should throw an error when ActionList.GroupHeading has an `as` prop when it is used within ActionMenu context', async () => {
     const spy = jest.spyOn(console, 'error').mockImplementation(() => jest.fn())
     expect(() =>

--- a/packages/react/src/ActionList/Group.tsx
+++ b/packages/react/src/ActionList/Group.tsx
@@ -67,6 +67,10 @@ export type ActionListGroupProps = {
    * The ARIA role describing the function of the list inside `Group` component. `listbox` or `menu` are a common values.
    */
   role?: AriaRole
+  /**
+   * Custom class name to apply to the `Group`.
+   */
+  className?: string
 } & SxProp & {
     /**
      * Whether multiple Items or a single Item can be selected in the Group. Overrides value on ActionList root.
@@ -86,6 +90,7 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
   auxiliaryText,
   selectionVariant,
   role,
+  className,
   sx = defaultSxProp,
   ...props
 }) => {
@@ -112,7 +117,13 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
   if (enabled) {
     if (sx !== defaultSxProp) {
       return (
-        <Box as="li" className={groupClasses.Group} role={listRole ? 'none' : undefined} sx={sx} {...props}>
+        <Box
+          as="li"
+          className={clsx(className, groupClasses.Group)}
+          role={listRole ? 'none' : undefined}
+          sx={sx}
+          {...props}
+        >
           <GroupContext.Provider value={{selectionVariant, groupHeadingId}}>
             {title && !slots.groupHeading ? (
               // Escape hatch: supports old API <ActionList.Group title="group title"> in a non breaking way
@@ -135,7 +146,7 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
       )
     }
     return (
-      <li className={groupClasses.Group} role={listRole ? 'none' : undefined} {...props}>
+      <li className={clsx(className, groupClasses.Group)} role={listRole ? 'none' : undefined} {...props}>
         <GroupContext.Provider value={{selectionVariant, groupHeadingId}}>
           {title && !slots.groupHeading ? (
             // Escape hatch: supports old API <ActionList.Group title="group title"> in a non breaking way
@@ -166,6 +177,7 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
         listStyle: 'none', // hide the ::marker inserted by browser's stylesheet
         ...sx,
       }}
+      className={className}
       {...props}
     >
       <GroupContext.Provider value={{selectionVariant, groupHeadingId}}>
@@ -292,3 +304,6 @@ export const GroupHeading: React.FC<React.PropsWithChildren<ActionListGroupHeadi
     </>
   )
 }
+
+GroupHeading.displayName = 'ActionList.GroupHeading'
+Group.displayName = 'ActionList.Group'

--- a/packages/react/src/ActionList/Heading.test.tsx
+++ b/packages/react/src/ActionList/Heading.test.tsx
@@ -4,8 +4,15 @@ import theme from '../theme'
 import {ActionList} from '.'
 import {BaseStyles, ThemeProvider, ActionMenu} from '..'
 import {FeatureFlags} from '../FeatureFlags'
+import {behavesAsComponent} from '../utils/testing'
 
 describe('ActionList.Heading', () => {
+  behavesAsComponent({
+    Component: ActionList.Heading,
+    options: {skipAs: true, skipSx: true},
+    toRender: () => <ActionList.Heading as="h1" />,
+  })
+
   it('should render the ActionList.Heading component as a heading with the given heading level', async () => {
     const container = HTMLRender(
       <ActionList>

--- a/packages/react/src/ActionList/Item.test.tsx
+++ b/packages/react/src/ActionList/Item.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import {ActionList} from '.'
 import {BookIcon} from '@primer/octicons-react'
 import {FeatureFlags} from '../FeatureFlags'
+import {behavesAsComponent} from '../utils/testing'
 
 function SimpleActionList(): JSX.Element {
   return (
@@ -57,6 +58,48 @@ function SingleSelectListStory(): JSX.Element {
 }
 
 describe('ActionList.Item', () => {
+  behavesAsComponent({
+    Component: ActionList.Item,
+    options: {skipAs: true, skipSx: true},
+    toRender: () => <ActionList.Item />,
+  })
+
+  behavesAsComponent({
+    Component: ActionList.LinkItem,
+    options: {skipAs: true, skipSx: true},
+    toRender: () => <ActionList.LinkItem />,
+  })
+
+  behavesAsComponent({
+    Component: ActionList.TrailingVisual,
+    options: {skipAs: true, skipSx: true, skipClassName: true},
+    toRender: () => (
+      <ActionList.Item>
+        <ActionList.TrailingVisual>Trailing Visual</ActionList.TrailingVisual>
+      </ActionList.Item>
+    ),
+  })
+
+  behavesAsComponent({
+    Component: ActionList.LeadingVisual,
+    options: {skipAs: true, skipSx: true, skipClassName: true},
+    toRender: () => (
+      <ActionList.Item>
+        <ActionList.LeadingVisual>Leading Visual</ActionList.LeadingVisual>
+      </ActionList.Item>
+    ),
+  })
+
+  behavesAsComponent({
+    Component: ActionList.Description,
+    options: {skipAs: true, skipSx: true, skipClassName: true},
+    toRender: () => (
+      <ActionList.Item>
+        <ActionList.Description>Description</ActionList.Description>
+      </ActionList.Item>
+    ),
+  })
+
   it('should have aria-keyshortcuts applied to the correct element', async () => {
     const {container} = HTMLRender(<SimpleActionList />)
     const linkOptions = await waitFor(() => container.querySelectorAll('a'))

--- a/packages/react/src/ActionList/LinkItem.tsx
+++ b/packages/react/src/ActionList/LinkItem.tsx
@@ -137,3 +137,5 @@ export const LinkItem = React.forwardRef(
     )
   },
 ) as PolymorphicForwardRefComponent<'a', ActionListLinkItemProps>
+
+LinkItem.displayName = 'ActionList.LinkItem'

--- a/packages/react/src/ActionList/TrailingAction.tsx
+++ b/packages/react/src/ActionList/TrailingAction.tsx
@@ -67,6 +67,7 @@ export const TrailingAction = forwardRef(
         sx={{
           flexShrink: 0,
         }}
+        className={className}
       >
         {icon ? (
           <IconButton

--- a/packages/react/src/ActionList/Visuals.tsx
+++ b/packages/react/src/ActionList/Visuals.tsx
@@ -182,3 +182,6 @@ export const VisualOrIndicator: React.FC<
     </VisualComponent>
   )
 }
+
+LeadingVisual.displayName = 'ActionList.LeadingVisual'
+TrailingVisual.displayName = 'ActionList.TrailingVisual'

--- a/packages/react/src/ConfirmationDialog/ConfirmationDialog.test.tsx
+++ b/packages/react/src/ConfirmationDialog/ConfirmationDialog.test.tsx
@@ -73,7 +73,7 @@ describe('ConfirmationDialog', () => {
   behavesAsComponent({
     Component: ConfirmationDialog,
     toRender: () => <Basic />,
-    options: {skipAs: true, skipSx: true},
+    options: {skipAs: true, skipSx: true, skipClassName: true},
   })
 
   checkExports('ConfirmationDialog/ConfirmationDialog', {

--- a/packages/react/src/Dialog/Dialog.test.tsx
+++ b/packages/react/src/Dialog/Dialog.test.tsx
@@ -21,7 +21,7 @@ describe('Dialog', () => {
 
   behavesAsComponent({
     Component: Dialog,
-    options: {skipAs: true, skipSx: true},
+    options: {skipAs: true, skipSx: true, skipClassName: true},
     toRender: () => (
       <Dialog onClose={() => {}}>
         <div>Hidden when narrow</div>

--- a/packages/react/src/DialogV1/Dialog.test.tsx
+++ b/packages/react/src/DialogV1/Dialog.test.tsx
@@ -107,11 +107,11 @@ describe('Dialog', () => {
   behavesAsComponent({
     Component: Dialog,
     toRender: () => comp,
-    options: {skipAs: true, skipSx: true},
+    options: {skipAs: true, skipSx: true, skipClassName: true},
   })
 
   describe('Dialog.Header', () => {
-    behavesAsComponent({Component: Dialog.Header})
+    behavesAsComponent({Component: Dialog.Header, options: {skipClassName: true}})
   })
 
   it('should support `className` on the Dialog element', () => {

--- a/packages/react/src/LabelGroup/LabelGroup.tsx
+++ b/packages/react/src/LabelGroup/LabelGroup.tsx
@@ -18,6 +18,7 @@ export type LabelGroupProps = {
   overflowStyle?: 'inline' | 'overlay'
   /** How many tokens to show. `'auto'` truncates the tokens to fit in the parent container. Passing a number will truncate after that number tokens. If this is undefined, tokens will never be truncated. */
   visibleChildCount?: 'auto' | number
+  className?: string
 } & SxProp
 
 const StyledLabelGroupContainer = styled.div<SxProp>`
@@ -158,6 +159,7 @@ const LabelGroup: React.FC<React.PropsWithChildren<LabelGroupProps>> = ({
   overflowStyle = 'overlay',
   sx: sxProp,
   as = 'ul',
+  className,
 }) => {
   const containerRef = React.useRef<HTMLElement>(null)
   const collapseButtonRef = React.useRef<HTMLButtonElement>(null)
@@ -337,6 +339,7 @@ const LabelGroup: React.FC<React.PropsWithChildren<LabelGroupProps>> = ({
       data-overflow={overflowStyle === 'inline' && isOverflowShown ? 'inline' : undefined}
       data-list={isList || undefined}
       sx={sxProp}
+      className={className}
       as={as}
     >
       {React.Children.map(children, (child, index) => (
@@ -378,7 +381,13 @@ const LabelGroup: React.FC<React.PropsWithChildren<LabelGroupProps>> = ({
       </ToggleWrapper>
     </StyledLabelGroupContainer>
   ) : (
-    <StyledLabelGroupContainer data-overflow="inline" data-list={isList || undefined} sx={sxProp} as={as}>
+    <StyledLabelGroupContainer
+      data-overflow="inline"
+      data-list={isList || undefined}
+      sx={sxProp}
+      as={as}
+      className={className}
+    >
       {isList
         ? React.Children.map(children, (child, index) => {
             return <li key={index}>{child}</li>

--- a/packages/react/src/__tests__/ActionMenu.test.tsx
+++ b/packages/react/src/__tests__/ActionMenu.test.tsx
@@ -131,7 +131,7 @@ function ExampleWithSubmenus(): JSX.Element {
 describe('ActionMenu', () => {
   behavesAsComponent({
     Component: ActionList,
-    options: {skipAs: true, skipSx: true},
+    options: {skipAs: true, skipSx: true, skipClassName: true},
     toRender: () => <Example />,
   })
 

--- a/packages/react/src/__tests__/AnchoredOverlay.test.tsx
+++ b/packages/react/src/__tests__/AnchoredOverlay.test.tsx
@@ -56,7 +56,7 @@ const AnchoredOverlayTestComponent = ({
 describe('AnchoredOverlay', () => {
   behavesAsComponent({
     Component: AnchoredOverlay,
-    options: {skipAs: true, skipSx: true},
+    options: {skipAs: true, skipSx: true, skipClassName: true},
     toRender: () => <AnchoredOverlayTestComponent />,
   })
 

--- a/packages/react/src/__tests__/LabelGroup.test.tsx
+++ b/packages/react/src/__tests__/LabelGroup.test.tsx
@@ -32,7 +32,7 @@ describe('LabelGroup', () => {
     thresholds: [],
   })) as jest.Mock<IntersectionObserver>
 
-  behavesAsComponent({Component: LabelGroup, options: {skipAs: true}})
+  behavesAsComponent({Component: LabelGroup, options: {skipAs: true, skipClassName: true}})
 
   checkExports('LabelGroup', {
     default: LabelGroup,

--- a/packages/react/src/__tests__/deprecated/ActionMenu.test.tsx
+++ b/packages/react/src/__tests__/deprecated/ActionMenu.test.tsx
@@ -38,7 +38,7 @@ describe('ActionMenu', () => {
 
   behavesAsComponent({
     Component: ActionMenu,
-    options: {skipAs: true, skipSx: true},
+    options: {skipAs: true, skipSx: true, skipClassName: true},
     toRender: () => <ActionMenu items={[]} />,
   })
 

--- a/packages/react/src/utils/testing.tsx
+++ b/packages/react/src/utils/testing.tsx
@@ -199,6 +199,7 @@ export function unloadCSS(path: string) {
 interface Options {
   skipAs?: boolean
   skipSx?: boolean
+  skipClassName?: boolean
   skipDisplayName?: boolean
 }
 
@@ -231,6 +232,15 @@ export function behavesAsComponent({Component, toRender, options}: BehavesAsComp
   if (!options.skipDisplayName) {
     it('sets a valid displayName', () => {
       expect(Component.displayName).toMatch(COMPONENT_DISPLAY_NAME_REGEX)
+    })
+  }
+
+  if (!options.skipClassName) {
+    it('supports className prop', () => {
+      const className = 'test-class'
+      const elem = React.cloneElement(getElement(), {className})
+      const {container} = HTMLRender(elem)
+      expect(container.querySelector('.test-class')).not.toBeNull()
     })
   }
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

- Relates to https://github.com/github/primer/issues/4643

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

I noticed that `ActionList.Group` was missing className so I decided to add it. I also added a test for `ActionList` sub-components to ensure they all support `className`. Then I realized we could update `behavesAsComponent` to do the check wherever it is being used. While doing so, it causing a few places that were missing displayName and className, which I also updated 

- Adds `className` prop to components missing them
- Adds `displayName` to components missing them
- Adds tests for `ActionList` sub-components
- Updates `behavesAsComponent` to test for className
- Adds `skipClassName` to component checks that require wrapper to render or do not support it

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
