### PR TITLE
DialogV2: Move `DialogOverflowWrapper` class

### DIFF
--- a/.changeset/brown-ducks-lick.md
+++ b/.changeset/brown-ducks-lick.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+DialogV2: Fix CSS issue where `flex-grow` wasn't getting applied via classname

--- a/packages/react/src/Dialog/Dialog.module.css
+++ b/packages/react/src/Dialog/Dialog.module.css
@@ -65,10 +65,6 @@
     justify-content: flex-end;
   }
 
-  .DialogOverflowWrapper {
-    flex-grow: 1;
-  }
-
   @media (max-width: 767px) {
     &[data-position-narrow='center'] {
       align-items: center;
@@ -210,6 +206,10 @@
       }
     }
   }
+}
+
+.DialogOverflowWrapper {
+  flex-grow: 1;
 }
 
 .Header {

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -527,7 +527,7 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
             className={clsx(className, enabled && classes.Dialog)}
           >
             {header}
-            <ScrollableRegion aria-labelledby={dialogLabelId} className="DialogOverflowWrapper">
+            <ScrollableRegion aria-labelledby={dialogLabelId} className={classes.DialogOverflowWrapper}>
               {body}
             </ScrollableRegion>
             {footer}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Moves the `DialogOverflowWrapper` class outside of `.Backdrop`. This ensures that the style `flex-grow` is properly applied to the container.

[Additional context for this PR](https://github.slack.com/archives/C01L618AEP9/p1742571821856919).

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

* Moves class `DialogOverflowWrapper`, so that it is no longer a child of the `.Backdrop` class

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
