### PR TITLE
Bug fix: `className` passed to PageLayout twice

### DIFF
--- a/.changeset/metal-carrots-compare.md
+++ b/.changeset/metal-carrots-compare.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Bug fix: `className` passed to PageLayout twice

--- a/packages/react/src/PageLayout/PageLayout.tsx
+++ b/packages/react/src/PageLayout/PageLayout.tsx
@@ -117,7 +117,7 @@ const Root: React.FC<React.PropsWithChildren<PageLayoutProps>> = ({
 
   const contentStylingProps = enabled
     ? {
-        className: clsx(classes.PageLayoutContent, className),
+        className: clsx(classes.PageLayoutContent),
       }
     : {
         sx: {display: 'flex', flex: '1 1 100%', flexWrap: 'wrap', maxWidth: '100%'},


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/4911

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Removed the `className` call from the content wrapper

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
