### PR TITLE
Add workaround for Chrome bug where `KeybindingHint` in combination with `aria-labelledby` results in incorrect label

### DIFF
--- a/.changeset/curvy-ties-breathe.md
+++ b/.changeset/curvy-ties-breathe.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Add workaround for Chrome bug where `KeybindingHint` in combination with `aria-labelledby` results in incorrect label

--- a/packages/react/src/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/Button/__tests__/Button.test.tsx
@@ -338,7 +338,7 @@ describe('Button', () => {
   })
   it('should append the keyshortcuts to the tooltip text that labels the icon button when keyshortcuts prop is passed', () => {
     const {getByRole} = render(<IconButton icon={HeartIcon} aria-label="Heart" keyshortcuts="Command+H" />)
-    const triggerEl = getByRole('button', {name: 'Heart ( command h )'})
+    const triggerEl = getByRole('button', {name: 'Heart (command h)'})
     expect(triggerEl).toBeInTheDocument()
   })
   it('should render aria-keyshortcuts on an icon button when keyshortcuts prop is passed (Description Type)', () => {
@@ -353,6 +353,6 @@ describe('Button', () => {
       <IconButton icon={HeartIcon} aria-label="Heart" description="Love is all around" keyshortcuts="Command+H" />,
     )
     const triggerEl = getByRole('button', {name: 'Heart'})
-    expect(triggerEl).toHaveAccessibleDescription('Love is all around ( command h )')
+    expect(triggerEl).toHaveAccessibleDescription('Love is all around (command h)')
   })
 })

--- a/packages/react/src/KeybindingHint/KeybindingHint.tsx
+++ b/packages/react/src/KeybindingHint/KeybindingHint.tsx
@@ -26,8 +26,7 @@ export const KeybindingHint = memo(({className, ...props}: KeybindingHintProps) 
 KeybindingHint.displayName = 'KeybindingHint'
 
 /**
- * AVOID: `KeybindingHint` is nearly always sufficient for providing both visible and accessible keyboard hints, and
- * will result in a good screen reader experience when used as the target for `aria-describedby` and `aria-labelledby`.
+ * AVOID: `KeybindingHint` is nearly always sufficient for providing both visible and accessible keyboard hints.
  * However, there may be cases where we need a plain string version, such as when building `aria-label` or
  * `aria-description`. In that case, this plain string builder can be used instead.
  *

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -1,7 +1,7 @@
 import React, {Children, useEffect, useRef, useState, useMemo} from 'react'
 import type {SxProp} from '../sx'
 import sx from '../sx'
-import {useId, useProvidedRefOrCreate, useOnEscapePress} from '../hooks'
+import {useId, useProvidedRefOrCreate, useOnEscapePress, useIsMacOS} from '../hooks'
 import {invariant} from '../utils/invariant'
 import {warning} from '../utils/warning'
 import styled from 'styled-components'
@@ -13,7 +13,7 @@ import {toggleStyledComponent} from '../internal/utils/toggleStyledComponent'
 import {clsx} from 'clsx'
 import classes from './Tooltip.module.css'
 import {useFeatureFlag} from '../FeatureFlags'
-import {KeybindingHint, type KeybindingHintProps} from '../KeybindingHint'
+import {getAccessibleKeybindingHintString, KeybindingHint, type KeybindingHintProps} from '../KeybindingHint'
 import VisuallyHidden from '../_VisuallyHidden'
 import useSafeTimeout from '../hooks/useSafeTimeout'
 
@@ -348,6 +348,8 @@ export const Tooltip = React.forwardRef(
       [isPopoverOpen],
     )
 
+    const isMacOS = useIsMacOS()
+
     return (
       <TooltipContext.Provider value={value}>
         <>
@@ -400,17 +402,24 @@ export const Tooltip = React.forwardRef(
             role={type === 'description' ? 'tooltip' : undefined}
             // stop AT from announcing the tooltip twice: when it is a label type it will be announced with "aria-labelledby",when it is a description type it will be announced with "aria-describedby"
             aria-hidden={true}
-            id={tooltipId}
             // mouse leave and enter on the tooltip itself is needed to keep the tooltip open when the mouse is over the tooltip
             onMouseEnter={openTooltip}
             onMouseLeave={closeTooltip}
           >
-            {text}
+            <span id={tooltipId}>
+              {text}
+              {/* There is a bug in Chrome browsers where `aria-hidden` text inside the target of an `aria-labelledby`
+               still gets included in the accessible label. `KeybindingHint` renders the symbols as `aria-hidden` text
+               and renders full key names as `VisuallyHidden` text. Due to the browser bug this causes the label text
+               to duplicate the symbols and key names. To work around this, we exclude the hint from being part of the
+               label and instead render the plain keybinding description string. */}
+              {keybindingHint && (
+                <VisuallyHidden>({getAccessibleKeybindingHintString(keybindingHint, isMacOS)})</VisuallyHidden>
+              )}
+            </span>
             {keybindingHint && (
-              <span className={clsx(classes.KeybindingHintContainer, text && classes.HasTextBefore)}>
-                <VisuallyHidden>(</VisuallyHidden>
+              <span className={clsx(classes.KeybindingHintContainer, text && classes.HasTextBefore)} aria-hidden>
                 <KeybindingHint keys={keybindingHint} format="condensed" variant="onEmphasis" size="small" />
-                <VisuallyHidden>)</VisuallyHidden>
               </span>
             )}
           </StyledTooltip>

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -428,4 +428,3 @@ export const Tooltip = React.forwardRef(
     )
   },
 )
- 

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -428,3 +428,4 @@ export const Tooltip = React.forwardRef(
     )
   },
 )
+ 

--- a/packages/react/src/TooltipV2/__tests__/Tooltip.test.tsx
+++ b/packages/react/src/TooltipV2/__tests__/Tooltip.test.tsx
@@ -38,11 +38,11 @@ describe('Tooltip', () => {
 
   it('renders `data-direction="s"` by default', () => {
     const {getByText} = HTMLRender(<TooltipComponent />)
-    expect(getByText('Tooltip text')).toHaveAttribute('data-direction', 's')
+    expect(getByText('Tooltip text').closest('[role=tooltip]')).toHaveAttribute('data-direction', 's')
   })
   it('renders `data-direction` attribute with the correct value when the `direction` prop is specified', () => {
     const {getByText} = HTMLRender(<TooltipComponent direction="n" />)
-    expect(getByText('Tooltip text')).toHaveAttribute('data-direction', 'n')
+    expect(getByText('Tooltip text').closest('[role=tooltip]')).toHaveAttribute('data-direction', 'n')
   })
   it('should label the trigger element by its tooltip when the tooltip type is label', () => {
     const {getByRole, getByText} = HTMLRender(<TooltipComponent type="label" />)
@@ -52,11 +52,11 @@ describe('Tooltip', () => {
   })
   it('should render aria-hidden on the tooltip element when the tooltip is label type', () => {
     const {getByText} = HTMLRender(<TooltipComponent type="label" />)
-    expect(getByText('Tooltip text')).toHaveAttribute('aria-hidden', 'true')
+    expect(getByText('Tooltip text').parentElement).toHaveAttribute('aria-hidden', 'true')
   })
   it('should render aria-hidden on the tooltip element when the tooltip is description type', () => {
     const {getByText} = HTMLRender(<TooltipComponent type="description" />)
-    expect(getByText('Tooltip text')).toHaveAttribute('aria-hidden', 'true')
+    expect(getByText('Tooltip text').closest('[role=tooltip]')).toHaveAttribute('aria-hidden', 'true')
   })
   it('should describe the trigger element by its tooltip when the tooltip type is description (by default)', () => {
     const {getByRole, getByText} = HTMLRender(<TooltipComponent />)
@@ -66,7 +66,7 @@ describe('Tooltip', () => {
   })
   it('should render the tooltip element with role="tooltip" when the tooltip type is description (by default)', () => {
     const {getByText} = HTMLRender(<TooltipComponent />)
-    expect(getByText('Tooltip text')).toHaveAttribute('role', 'tooltip')
+    expect(getByText('Tooltip text').closest('[role=tooltip]')).toHaveAttribute('role', 'tooltip')
   })
 
   it('should spread the accessibility attributes correctly on the trigger (ActionMenu.Button) when tooltip is used in an action menu', () => {

--- a/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -3354,11 +3354,14 @@ exports[`TextInput renders trailingAction icon button 1`] = `
       aria-hidden={true}
       className="c5"
       data-direction="s"
-      id=":r2j:"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >
-      Icon label
+      <span
+        id=":r2j:"
+      >
+        Icon label
+      </span>
     </span>
   </span>
 </span>
@@ -4115,12 +4118,15 @@ exports[`TextInput renders trailingAction text button with a tooltip 1`] = `
       aria-hidden={true}
       className="c6"
       data-direction="s"
-      id=":r2d:"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       role="tooltip"
     >
-      Clear input
+      <span
+        id=":r2d:"
+      >
+        Clear input
+      </span>
     </span>
   </span>
 </span>


### PR DESCRIPTION
`KeybindingHint` renders the key symbols as `aria-hidden` spans and the key names as `VisuallyHidden` spans to provide a good experience for both sighted and screen reader users. 

However, there is a bug in Chrome where `aria-hidden` text is included in a label generated using `aria-labelledby`. More context from https://github.com/github/accessibility/issues/8018#issuecomment-2751656621: 

> `KeybindingHint` (the Primer component we are using under the hood here) does try to account for this by rendering the symbol in an `aria-hidden` span and rendering the name of that symbol in an `sr-only` span next to it. However, there seems to be a bug in Chrome where the accessibility tree is incorrectly accounting for `aria-hidden` text in the target of an `aria-labelledby`. So we get the following (abridged) HTML:
> 
> <button class="IconButton" type="button" aria-labelledby=":rg:">
>   <svg>...</svg>
> </button>
> <span class="TooltipV2" aria-hidden="true" id=":rg:" popover="auto">
>   Add attachment
>   <span class="TooltipV2">
>     <span class="VisuallyHidden">(</span>
>     <kbd class="KeybindingHint" data-testid="keybinding-hint">
>       <span>
>         <span class="VisuallyHidden">command</span>
>         <span aria-hidden="true">⌘</span>
>         <span class="VisuallyHidden">shift</span>
>         <span aria-hidden="true">⇧</span>
>         <span class="VisuallyHidden">at</span>
>         <span aria-hidden="true">@</span>
>       </span>
>     </kbd>
>     <span class="VisuallyHidden">)</span>
>   </span>
> </span>
> This results in an incorrectly calculated accessible label of "Add attachment ( command ⌘ shift ⇧ at @ )".
> 
> If the label was being calculated correctly by the browser, we'd get a label of "Add attachment (command shift at)" (which looks wrong at first glance but sounds correct when read aloud by a screen reader - you don't say "command plus shift plus at" out loud).
> 
> Ideally we really want to fix this bug in the component so that consumers don't have to manually work around, so the approach used in [primer/react#5626](https://github.com/primer/react/pull/5626) works but it isn't ideal - it relies on consumers doing things correctly.
> 
> I don't think the way `KeybindingHint` itself works can really be improved much. If we were to update it to render the hidden keys and label next to each other, rather than mixed in, it would slightly improve what is being read but the data would still be duplicated. `KeybindingHint`'s approach does work well in cases that don't involve `aria-labelledby` - when read as part of the document flow the output is correct.
> 
> I think the solution probably has to be in `IconButton` or `TooltipV2`. `KeybindingHint` does export a helper function that gives you the plain accessible string representation of a shortcut, so we could build the `aria-label` string ourselves rather than using `aria-labelledby` in `IconButton`. Or, a more robust approach might be to update `TooltipV2` to move the `id` prop into a child element so that the tooltip could better control exactly what makes it into the label; then we could move `KeybindingHint` outside that element and add an `sr-only` element inside with just the string representation of the shortcut.

To work around this bug, I've taken the approach proposed in the quote to update `TooltipV2` to exclude the keybinding hint from the id-tagged container. Then I added the keybinding hint text as a plain hidden string inside that container.

Before in VoiceOver/Chrome:

<img width="663" alt="VoiceOver text readout reading 'link, Learn More( shift ⇧ question mark ?)" src="https://github.com/user-attachments/assets/e132550b-5a5a-4a19-8412-a1253f3d013e" />

After:

<img width="663" alt="VoiceOver text readout reading 'link, Learn More (shift question mark)" src="https://github.com/user-attachments/assets/d6768555-6dc2-425d-b409-05a91499188a" />

Note this isn't a perfect example because obviously "question mark" is combined with "shift", but it's pulled from storybook so I just kept it. Intuitively you might think the label should be "shift + question mark", but when read by a screen reader this can result in the awkward label "shift plus question mark" - it's better to just exclude the punctuation here.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

Fixed a Chrome bug impacting accessible labels rendered by `TooltipV2` with the `keybindingHint` prop.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
