### PR TITLE
In the lock-release workflow only toggle the Release Conductor ruleset instead of the merge queue and update rule also

### DIFF
--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -35,25 +35,25 @@ jobs:
             -f "enforcement=${enforcement}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      - name: Toggle Rule > Update Before Merging
-        run: |
-          enforcement=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "active" || echo "disabled")
-          gh api \
-            --method PUT \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/primer/react/rulesets/4089341 \
-            -f "enforcement=${enforcement}"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      - name: Toggle Rule > Merge Queue
-        run: |
-          enforcement=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "disabled" || echo "active")
-          gh api \
-            --method PUT \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/primer/react/rulesets/4089335 \
-            -f "enforcement=${enforcement}"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      # - name: Toggle Rule > Update Before Merging
+      #   run: |
+      #     enforcement=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "active" || echo "disabled")
+      #     gh api \
+      #       --method PUT \
+      #       -H "Accept: application/vnd.github+json" \
+      #       -H "X-GitHub-Api-Version: 2022-11-28" \
+      #       /repos/primer/react/rulesets/4089341 \
+      #       -f "enforcement=${enforcement}"
+      #   env:
+      #     GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      # - name: Toggle Rule > Merge Queue
+      #   run: |
+      #     enforcement=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "disabled" || echo "active")
+      #     gh api \
+      #       --method PUT \
+      #       -H "Accept: application/vnd.github+json" \
+      #       -H "X-GitHub-Api-Version: 2022-11-28" \
+      #       /repos/primer/react/rulesets/4089335 \
+      #       -f "enforcement=${enforcement}"
+      #   env:
+      #     GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
I figured out a way we can keep this workflow and things won't get stuck like they were with the other way https://github.slack.com/archives/C02NUUQ9C30/p1742324598550379?thread_ts=1742311618.634649&cid=C02NUUQ9C30

The way I'm doing this, is I also added the ability for react-release-conductor to bypass the merge queue. This allows the release conductor to bypass both merge queue and main lock when active. 

The only downside is the release conductor will always be able to bypass the merge queue 
![CleanShot 2025-03-27 at 19 30 26@2x](https://github.com/user-attachments/assets/3468f674-9eda-47ba-921b-fd04132ff8e0)

I think might be an acceptable tradeoff if the enabled to merge PRs will queue automatically when the lock is removed.