### PR TITLE
Overlay: Fix fullscreen overlay position

### DIFF
--- a/packages/react/src/Overlay/Overlay.module.css
+++ b/packages/react/src/Overlay/Overlay.module.css
@@ -158,6 +158,7 @@
   }
 
   &:where([data-variant='fullscreen']) {
+    position: fixed;
     top: 0;
     left: 0;
     width: 100vw;

--- a/packages/react/src/Overlay/Overlay.tsx
+++ b/packages/react/src/Overlay/Overlay.tsx
@@ -104,6 +104,7 @@ const StyledOverlay = toggleStyledComponent(
     }
 
     &:where([data-variant='fullscreen']) {
+      position: fixed;
       top: 0;
       left: 0;
       width: 100vw;

--- a/packages/react/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/AnchoredOverlay.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`AnchoredOverlay should render consistently when open 1`] = `
 }
 
 .c1:where([data-variant='fullscreen']) {
+  position: fixed;
   top: 0;
   left: 0;
   width: 100vw;


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

- Bug introduced in https://github.com/primer/react/pull/5759
- More [context on slack](https://github.slack.com/archives/C087S9D3W87/p1743110928716519?thread_ts=1743098399.254969&cid=C087S9D3W87)

Full screen overlay should have `position: fixed` (not `absolute`) so that it renders at `top: 0` even when the page has scrolled

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
