### PR TITLE
Toggling who can bypass the merge queue with the deployment lock

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,9 @@
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {
       "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/github-cli": {
+      "version": "latest"
     }
   },
   "hostRequirements": {

--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -35,25 +35,9 @@ jobs:
             -f "enforcement=${enforcement}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      # - name: Toggle Rule > Update Before Merging
-      #   run: |
-      #     enforcement=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "active" || echo "disabled")
-      #     gh api \
-      #       --method PUT \
-      #       -H "Accept: application/vnd.github+json" \
-      #       -H "X-GitHub-Api-Version: 2022-11-28" \
-      #       /repos/primer/react/rulesets/4089341 \
-      #       -f "enforcement=${enforcement}"
-      #   env:
-      #     GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      # - name: Toggle Rule > Merge Queue
-      #   run: |
-      #     enforcement=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "disabled" || echo "active")
-      #     gh api \
-      #       --method PUT \
-      #       -H "Accept: application/vnd.github+json" \
-      #       -H "X-GitHub-Api-Version: 2022-11-28" \
-      #       /repos/primer/react/rulesets/4089335 \
-      #       -f "enforcement=${enforcement}"
-      #   env:
-      #     GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Toggle Rule > Toggle Merge Queue Bypass
+        run: |
+          team_bypass=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "-F \"bypass_actors[][actor_id]=12276524\" -f \"bypass_actors[][actor_type]=Team\" -f \"bypass_actors[][bypass_mode]=always\"" || echo "-f \"bypass_actors[]\"")
+          eval $(echo "gh api --method PUT -H \"Accept: application/vnd.github+json\" -H \"X-GitHub-Api-Version: 2022-11-28\" /repos/primer/react/rulesets/4089335 $team_bypass")
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -1,6 +1,8 @@
 name: Toggle Release Lock
 
 on:
+  release:
+    types: [released]
   workflow_dispatch:
     inputs:
       action:
@@ -46,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   unlock:
-    if: ${{ github.event.inputs.action == 'unlock' }}
+    if: ${{ github.event.inputs.action == 'unlock' || github.event.action == 'released' }}
     name: Unlock the release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -1,4 +1,4 @@
-name: Lock Release Pull Request
+name: Toggle Release Lock
 
 on:
   workflow_dispatch:
@@ -13,7 +13,8 @@ on:
 
 jobs:
   lock:
-    name: Toggle Release Lock
+    if: ${{ github.event.inputs.action == 'lock' }}
+    name: Lock the release
     runs-on: ubuntu-latest
     steps:
       - name: Get App Token
@@ -24,20 +25,52 @@ jobs:
           owner: primer
           repositories: react
           private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
-      - name: Toggle Rule > Release Conductor
+      - name: Toggle rulesets
         run: |
-          enforcement=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "active" || echo "disabled")
+          # Allow react-release-conductor to bypass merge queue
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/primer/react/rulesets/4089335 \
+            -F "bypass_actors[][actor_id]=12276524" \
+            -f "bypass_actors[][actor_type]=Team" \
+            -f "bypass_actors[][bypass_mode]=always"
           gh api \
             --method PUT \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/primer/react/rulesets/3801256 \
-            -f "enforcement=${enforcement}"
+            -f "enforcement=active"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      - name: Toggle Rule > Toggle Merge Queue Bypass
+
+  unlock:
+    if: ${{ github.event.inputs.action == 'unlock' }}
+    name: Unlock the release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get App Token
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e
+        id: app-token
+        with:
+          app-id: ${{ vars.PRIMER_APP_ID_SHARED }}
+          owner: primer
+          repositories: react
+          private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
+      - name: Toggle rulesets
         run: |
-          team_bypass=$([ "${{ github.event.inputs.action }}" == "lock" ] && echo "-F \"bypass_actors[][actor_id]=12276524\" -f \"bypass_actors[][actor_type]=Team\" -f \"bypass_actors[][bypass_mode]=always\"" || echo "-f \"bypass_actors[]\"")
-          eval $(echo "gh api --method PUT -H \"Accept: application/vnd.github+json\" -H \"X-GitHub-Api-Version: 2022-11-28\" /repos/primer/react/rulesets/4089335 $team_bypass")
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/primer/react/rulesets/4089335 \
+            -F "bypass_actors[]"
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/primer/react/rulesets/3801256 \
+            -f "enforcement=disabled"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This updates the lock_release.yml workflow to toggle bypass restrictions on the merge queue.

Removing the ability to bypass the merge queue when the release is unlocked will remove the bypass check that will always be present. Helping the conductor only be able to bypass when a lock is in place.

I also added another event to unlock. When a release is `released` it will automatically unlock the queue.