### PR TITLE
Remove `save-exact` from `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,4 @@
 save=true
-save-exact=true
 # we create our tags in Releases now
 git-tag-version=false
 legacy-peer-deps=true


### PR DESCRIPTION
Update our `.npmrc` file to no longer include `save-exact`. This setting is no longer necessary as versions are explicitly managed in `package-lock.json`. It also makes it difficult to make sure that we use ranges, when appropriate, so that downstream users don't have to update to match dependencies that we take on in our packages.