### PR TITLE
chore(AvatarStack): Remove the CSS modules feature flag from the AvatarStack component

### DIFF
--- a/.changeset/famous-emus-chew.md
+++ b/.changeset/famous-emus-chew.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Remove the CSS modules feature flag from the AvatarStack component

--- a/packages/react/src/AvatarStack/AvatarStack.tsx
+++ b/packages/react/src/AvatarStack/AvatarStack.tsx
@@ -1,188 +1,22 @@
 import {clsx} from 'clsx'
 import React, {useEffect, useRef, useState} from 'react'
-import styled from 'styled-components'
-import {get} from '../constants'
-import Box from '../Box'
-import type {BetterCssProperties, BetterSystemStyleObject, SxProp} from '../sx'
-import sx, {merge} from '../sx'
+import type {SxProp} from '../sx'
 import type {AvatarProps} from '../Avatar/Avatar'
 import {DEFAULT_AVATAR_SIZE} from '../Avatar/Avatar'
 import type {ResponsiveValue} from '../hooks/useResponsiveValue'
 import {isResponsiveValue} from '../hooks/useResponsiveValue'
-import {getBreakpointDeclarations} from '../utils/getBreakpointDeclarations'
 import {defaultSxProp} from '../utils/defaultSxProp'
 import type {WidthOnlyViewportRangeKeys} from '../utils/types/ViewportRangeKeys'
 import classes from './AvatarStack.module.css'
-import {toggleStyledComponent} from '../internal/utils/toggleStyledComponent'
-import {useFeatureFlag} from '../FeatureFlags'
 import {hasInteractiveNodes} from '../internal/utils/hasInteractiveNodes'
-import getGlobalFocusStyles from '../internal/utils/getGlobalFocusStyles'
+import {toggleSxComponent} from '../internal/utils/toggleSxComponent'
 
-type StyledAvatarStackWrapperProps = {
-  count?: number
-} & SxProp
-
-const CSS_MODULES_FEATURE_FLAG = 'primer_react_css_modules_ga'
-
-const AvatarStackWrapper = toggleStyledComponent(
-  CSS_MODULES_FEATURE_FLAG,
-  'span',
-  styled.span<StyledAvatarStackWrapperProps>`
-    --avatar-border-width: 1px;
-    --overlap-size: calc(var(--avatar-stack-size) * 0.55);
-    --overlap-size-avatar-three-plus: calc(var(--avatar-stack-size) * 0.85);
-    --mask-size: calc(100% + (var(--avatar-border-width) * 2));
-    --mask-start: -1;
-    --opacity-step: 15%;
-
-    display: flex;
-    position: relative;
-    height: var(--avatar-stack-size);
-    min-width: var(--avatar-stack-size);
-    isolation: isolate;
-
-    .pc-AvatarStackBody {
-      display: flex;
-      position: absolute;
-
-      ${getGlobalFocusStyles('1px')}
-    }
-
-    .pc-AvatarItem {
-      --avatar-size: var(--avatar-stack-size);
-      flex-shrink: 0;
-      height: var(--avatar-stack-size);
-      width: var(--avatar-stack-size);
-      position: relative;
-      overflow: hidden;
-      display: flex;
-      transition:
-        margin 0.2s ease-in-out,
-        opacity 0.2s ease-in-out,
-        mask-position 0.2s ease-in-out,
-        mask-size 0.2s ease-in-out;
-
-      &:is(img) {
-        box-shadow: 0 0 0 var(--avatar-border-width)
-          ${props => (props.count === 1 ? get('colors.avatar.border') : 'transparent')};
-      }
-
-      &:first-child {
-        margin-inline-start: 0;
-      }
-
-      &:nth-child(n + 2) {
-        margin-inline-start: calc(var(--overlap-size) * -1);
-        mask-image: radial-gradient(at 50% 50%, rgb(0, 0, 0) 70%, rgba(0, 0, 0, 0) 71%),
-          linear-gradient(rgb(0, 0, 0) 0 0);
-        mask-repeat: no-repeat, no-repeat;
-        mask-size:
-          var(--mask-size) var(--mask-size),
-          auto;
-        mask-composite: exclude;
-        // HORIZONTAL POSITION CALC FORMULA EXPLAINED:
-        // width of the visible part of the avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
-        // multiply by -1 for left-aligned, 1 for right-aligned ➡️ var(--mask-start)
-        // subtract the avatar border width ➡️ var(--avatar-border-width)
-        mask-position:
-          calc((var(--avatar-stack-size) - var(--overlap-size)) * var(--mask-start) - var(--avatar-border-width)) center,
-          0 0;
-        // HACK: This padding fixes a weird rendering bug where a tiiiiny outline is visible at the edges of the element
-        padding: 0.1px;
-      }
-
-      &:nth-child(n + 3) {
-        --overlap-size: var(--overlap-size-avatar-three-plus);
-        opacity: calc(100% - 2 * var(--opacity-step));
-      }
-
-      &:nth-child(n + 4) {
-        opacity: calc(100% - 3 * var(--opacity-step));
-      }
-
-      &:nth-child(n + 5) {
-        opacity: calc(100% - 4 * var(--opacity-step));
-      }
-
-      &:nth-child(n + 6) {
-        opacity: 0;
-        visibility: hidden;
-      }
-    }
-
-    &.pc-AvatarStack--two {
-      // MIN-WIDTH CALC FORMULA EXPLAINED:
-      // avatar size ➡️ var(--avatar-stack-size)
-      // plus the visible part of the 2nd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
-      min-width: calc(var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)));
-    }
-
-    &.pc-AvatarStack--three {
-      // MIN-WIDTH CALC FORMULA EXPLAINED:
-      // avatar size ➡️ var(--avatar-stack-size)
-      // plus the visible part of the 2nd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
-      // plus the visible part of the 3rd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus)
-      min-width: calc(
-        var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)) +
-          (var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus))
-      );
-    }
-
-    &.pc-AvatarStack--three-plus {
-      // MIN-WIDTH CALC FORMULA EXPLAINED:
-      // avatar size ➡️ var(--avatar-stack-size)
-      // plus the visible part of the 2nd avatar ➡️ var(--avatar-stack-size) - var(--overlap-size)
-      // plus the visible part of the 3rd AND 4th avatar ➡️ (var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus)) * 2
-      min-width: calc(
-        var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)) +
-          (var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus)) * 2
-      );
-    }
-
-    &.pc-AvatarStack--right {
-      --mask-start: 1;
-      direction: rtl;
-    }
-
-    .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover,
-    .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):focus-within {
-      width: auto;
-
-      .pc-AvatarItem {
-        // reset size of the mask to prevent unintentially clipping due to the additional size created by the border width
-        --mask-size: 100%;
-        margin-inline-start: ${get('space.1')};
-        opacity: 1;
-        visibility: visible;
-        // HORIZONTAL POSITION CALC FORMULA EXPLAINED:
-        // width of the full avatar ➡️ var(--avatar-stack-size)
-        // multiply by -1 for left-aligned, 1 for right-aligned ➡️ var(--mask-start)
-        mask-position:
-          calc(var(--avatar-stack-size) * var(--mask-start)) center,
-          0 0;
-
-        ${getGlobalFocusStyles('1px')}
-
-        &:first-child {
-          margin-inline-start: 0;
-        }
-      }
-    }
-
-    .pc-AvatarStack--disableExpand {
-      position: relative;
-    }
-
-    ${sx};
-  `,
-)
-
-const transformChildren = (children: React.ReactNode, enabled: boolean) => {
+const transformChildren = (children: React.ReactNode) => {
   return React.Children.map(children, child => {
     if (!React.isValidElement(child)) return child
     return React.cloneElement(child, {
       ...child.props,
-      className: clsx(child.props.className, 'pc-AvatarItem', {[classes.AvatarItem]: enabled}),
+      className: clsx(child.props.className, 'pc-AvatarItem', classes.AvatarItem),
     })
   })
 }
@@ -209,28 +43,16 @@ const AvatarStackBody = ({
   const bodyClassNames = clsx('pc-AvatarStackBody', {
     'pc-AvatarStack--disableExpand': disableExpand,
   })
-  const enabled = useFeatureFlag(CSS_MODULES_FEATURE_FLAG)
 
-  if (enabled) {
-    return (
-      <div
-        data-disable-expand={disableExpand ? '' : undefined}
-        className={clsx(bodyClassNames, classes.AvatarStackBody)}
-        tabIndex={!hasInteractiveChildren && !disableExpand ? 0 : undefined}
-        ref={stackContainer}
-      >
-        {children}
-      </div>
-    )
-  }
   return (
-    <Box
-      className={bodyClassNames}
+    <div
+      data-disable-expand={disableExpand ? '' : undefined}
+      className={clsx(bodyClassNames, classes.AvatarStackBody)}
       tabIndex={!hasInteractiveChildren && !disableExpand ? 0 : undefined}
       ref={stackContainer}
     >
       {children}
-    </Box>
+    </div>
   )
 }
 
@@ -243,7 +65,6 @@ const AvatarStack = ({
   style,
   sx: sxProp = defaultSxProp,
 }: AvatarStackProps) => {
-  const enabled = useFeatureFlag(CSS_MODULES_FEATURE_FLAG)
   const [hasInteractiveChildren, setHasInteractiveChildren] = useState<boolean | undefined>(false)
   const stackContainer = useRef<HTMLDivElement>(null)
 
@@ -321,56 +142,36 @@ const AvatarStack = ({
   const getResponsiveAvatarSizeStyles = () => {
     // if there is no size set on the AvatarStack, use the `size` props of the Avatar children to set the `--avatar-stack-size` CSS variable
     if (!size) {
-      if (enabled) {
-        return {
-          '--stackSize-narrow': `${childSizes.narrow}px`,
-          '--stackSize-regular': `${childSizes.regular}px`,
-          '--stackSize-wide': `${childSizes.wide}px`,
-        }
+      return {
+        '--stackSize-narrow': `${childSizes.narrow}px`,
+        '--stackSize-regular': `${childSizes.regular}px`,
+        '--stackSize-wide': `${childSizes.wide}px`,
       }
-
-      return getBreakpointDeclarations(
-        childSizes,
-        '--avatar-stack-size' as keyof React.CSSProperties,
-        value => `${value}px`,
-      )
     }
 
     // if the `size` prop is set and responsive, set the `--avatar-stack-size` CSS variable for each viewport
     if (isResponsiveValue(size)) {
-      if (enabled) {
-        return {
-          '--stackSize-narrow': `${size.narrow || DEFAULT_AVATAR_SIZE}px`,
-          '--stackSize-regular': `${size.regular || DEFAULT_AVATAR_SIZE}px`,
-          '--stackSize-wide': `${size.wide || DEFAULT_AVATAR_SIZE}px`,
-        }
+      return {
+        '--stackSize-narrow': `${size.narrow || DEFAULT_AVATAR_SIZE}px`,
+        '--stackSize-regular': `${size.regular || DEFAULT_AVATAR_SIZE}px`,
+        '--stackSize-wide': `${size.wide || DEFAULT_AVATAR_SIZE}px`,
       }
-
-      return getBreakpointDeclarations(
-        size,
-        '--avatar-stack-size' as keyof React.CSSProperties,
-        value => `${value || DEFAULT_AVATAR_SIZE}px`,
-      )
     }
 
     // if the `size` prop is set and not responsive, it is a number, so we can just set the `--avatar-stack-size` CSS variable to that number
     return {'--avatar-stack-size': `${size}px`} as React.CSSProperties
   }
 
-  const avatarStackSx = merge<BetterCssProperties | BetterSystemStyleObject>(
-    !enabled && getResponsiveAvatarSizeStyles(),
-    sxProp as SxProp,
-  )
+  const BaseComponentWrapper = toggleSxComponent('div')
 
   return (
-    <AvatarStackWrapper
-      count={enabled ? undefined : count}
-      data-avatar-count={enabled ? (count > 3 ? '3+' : count) : undefined}
-      data-align-right={enabled && alignRight ? '' : undefined}
-      data-responsive={enabled && (!size || isResponsiveValue(size)) ? '' : undefined}
-      className={clsx(wrapperClassNames, {[classes.AvatarStack]: enabled})}
-      style={enabled ? {...getResponsiveAvatarSizeStyles(), style} : style}
-      sx={avatarStackSx}
+    <BaseComponentWrapper
+      data-avatar-count={count > 3 ? '3+' : count}
+      data-align-right={alignRight ? '' : undefined}
+      data-responsive={!size || isResponsiveValue(size) ? '' : undefined}
+      className={clsx(wrapperClassNames, classes.AvatarStack)}
+      style={{...getResponsiveAvatarSizeStyles(), ...style}}
+      sx={sxProp}
     >
       <AvatarStackBody
         disableExpand={disableExpand}
@@ -378,9 +179,9 @@ const AvatarStack = ({
         stackContainer={stackContainer}
       >
         {' '}
-        {transformChildren(children, enabled)}
+        {transformChildren(children)}
       </AvatarStackBody>
-    </AvatarStackWrapper>
+    </BaseComponentWrapper>
   )
 }
 

--- a/packages/react/src/__tests__/__snapshots__/AvatarStack.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/AvatarStack.test.tsx.snap
@@ -1,194 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Avatar respects alignRight props 1`] = `
-.c0 {
-  --avatar-border-width: 1px;
-  --overlap-size: calc(var(--avatar-stack-size) * 0.55);
-  --overlap-size-avatar-three-plus: calc(var(--avatar-stack-size) * 0.85);
-  --mask-size: calc(100% + (var(--avatar-border-width) * 2));
-  --mask-start: -1;
-  --opacity-step: 15%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  position: relative;
-  height: var(--avatar-stack-size);
-  min-width: var(--avatar-stack-size);
-  isolation: isolate;
-  --avatar-stack-size: 20px;
-}
-
-.c0 .pc-AvatarStackBody {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  position: absolute;
-}
-
-.c0 .pc-AvatarStackBody:focus:not(:disabled) {
-  box-shadow: none;
-  outline: 2px solid var(--fgColor-accent,var(--color-accent-fg,#0969da));
-  outline-offset: 1px;
-}
-
-.c0 .pc-AvatarStackBody:focus:not(:disabled):not(:focus-visible) {
-  outline: solid 1px transparent;
-}
-
-.c0 .pc-AvatarStackBody:focus-visible:not(:disabled) {
-  box-shadow: none;
-  outline: 2px solid var(--fgColor-accent,var(--color-accent-fg,#0969da));
-  outline-offset: 1px;
-}
-
-.c0 .pc-AvatarItem {
-  --avatar-size: var(--avatar-stack-size);
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  height: var(--avatar-stack-size);
-  width: var(--avatar-stack-size);
-  position: relative;
-  overflow: hidden;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-transition: margin 0.2s ease-in-out,opacity 0.2s ease-in-out,mask-position 0.2s ease-in-out,mask-size 0.2s ease-in-out;
-  transition: margin 0.2s ease-in-out,opacity 0.2s ease-in-out,mask-position 0.2s ease-in-out,mask-size 0.2s ease-in-out;
-}
-
-.c0 .pc-AvatarItem:is(img) {
-  box-shadow: 0 0 0 var(--avatar-border-width) transparent;
-}
-
-.c0 .pc-AvatarItem:first-child {
-  margin-inline-start: 0;
-}
-
-.c0 .pc-AvatarItem:nth-child(n + 2) {
-  margin-inline-start: calc(var(--overlap-size) * -1);
-  -webkit-mask-image: radial-gradient(at 50% 50%,rgb(0,0,0) 70%,rgba(0,0,0,0) 71%),linear-gradient(rgb(0,0,0) 0 0);
-  mask-image: radial-gradient(at 50% 50%,rgb(0,0,0) 70%,rgba(0,0,0,0) 71%),linear-gradient(rgb(0,0,0) 0 0);
-  -webkit-mask-repeat: no-repeat,no-repeat;
-  mask-repeat: no-repeat,no-repeat;
-  -webkit-mask-size: var(--mask-size) var(--mask-size),auto;
-  mask-size: var(--mask-size) var(--mask-size),auto;
-  -webkit-mask-composite: exclude;
-  mask-composite: exclude;
-  -webkit-mask-position: calc((var(--avatar-stack-size) - var(--overlap-size)) * var(--mask-start) - var(--avatar-border-width)) center,0 0;
-  mask-position: calc((var(--avatar-stack-size) - var(--overlap-size)) * var(--mask-start) - var(--avatar-border-width)) center,0 0;
-  padding: 0.1px;
-}
-
-.c0 .pc-AvatarItem:nth-child(n + 3) {
-  --overlap-size: var(--overlap-size-avatar-three-plus);
-  opacity: calc(100% - 2 * var(--opacity-step));
-}
-
-.c0 .pc-AvatarItem:nth-child(n + 4) {
-  opacity: calc(100% - 3 * var(--opacity-step));
-}
-
-.c0 .pc-AvatarItem:nth-child(n + 5) {
-  opacity: calc(100% - 4 * var(--opacity-step));
-}
-
-.c0 .pc-AvatarItem:nth-child(n + 6) {
-  opacity: 0;
-  visibility: hidden;
-}
-
-.c0.pc-AvatarStack--two {
-  min-width: calc(var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)));
-}
-
-.c0.pc-AvatarStack--three {
-  min-width: calc( var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)) + (var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus)) );
-}
-
-.c0.pc-AvatarStack--three-plus {
-  min-width: calc( var(--avatar-stack-size) + (var(--avatar-stack-size) - var(--overlap-size)) + (var(--avatar-stack-size) - var(--overlap-size-avatar-three-plus)) * 2 );
-}
-
-.c0.pc-AvatarStack--right {
-  --mask-start: 1;
-  direction: rtl;
-}
-
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover,
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):focus-within {
-  width: auto;
-}
-
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover .pc-AvatarItem,
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):focus-within .pc-AvatarItem {
-  --mask-size: 100%;
-  margin-inline-start: 4px;
-  opacity: 1;
-  visibility: visible;
-  -webkit-mask-position: calc(var(--avatar-stack-size) * var(--mask-start)) center,0 0;
-  mask-position: calc(var(--avatar-stack-size) * var(--mask-start)) center,0 0;
-}
-
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover .pc-AvatarItem:focus:not(:disabled),
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):focus-within .pc-AvatarItem:focus:not(:disabled) {
-  box-shadow: none;
-  outline: 2px solid var(--fgColor-accent,var(--color-accent-fg,#0969da));
-  outline-offset: 1px;
-}
-
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover .pc-AvatarItem:focus:not(:disabled):not(:focus-visible),
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):focus-within .pc-AvatarItem:focus:not(:disabled):not(:focus-visible) {
-  outline: solid 1px transparent;
-}
-
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover .pc-AvatarItem:focus-visible:not(:disabled),
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):focus-within .pc-AvatarItem:focus-visible:not(:disabled) {
-  box-shadow: none;
-  outline: 2px solid var(--fgColor-accent,var(--color-accent-fg,#0969da));
-  outline-offset: 1px;
-}
-
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):hover .pc-AvatarItem:first-child,
-.c0 .pc-AvatarStackBody:not(.pc-AvatarStack--disableExpand):focus-within .pc-AvatarItem:first-child {
-  margin-inline-start: 0;
-}
-
-.c0 .pc-AvatarStack--disableExpand {
-  position: relative;
-}
-
-<span
-  className="c0 pc-AvatarStack--three-plus pc-AvatarStack--right"
+<div
+  className="pc-AvatarStack--three-plus pc-AvatarStack--right AvatarStack"
+  data-align-right=""
+  data-avatar-count="3+"
+  data-responsive=""
+  style={
+    {
+      "--stackSize-narrow": "20px",
+      "--stackSize-regular": "20px",
+      "--stackSize-wide": "20px",
+    }
+  }
 >
   <div
-    className="pc-AvatarStackBody"
+    className="pc-AvatarStackBody AvatarStackBody"
     tabIndex={0}
   >
      
     <img
       alt=""
-      className="pc-AvatarItem"
+      className="pc-AvatarItem AvatarItem"
       src="https://avatars.githubusercontent.com/primer"
     />
     <img
       alt=""
-      className="pc-AvatarItem"
+      className="pc-AvatarItem AvatarItem"
       src="https://avatars.githubusercontent.com/github"
     />
     <img
       alt=""
-      className="pc-AvatarItem"
+      className="pc-AvatarItem AvatarItem"
       src="https://avatars.githubusercontent.com/primer"
     />
     <img
       alt=""
-      className="pc-AvatarItem"
+      className="pc-AvatarItem AvatarItem"
       src="https://avatars.githubusercontent.com/github"
     />
   </div>
-</span>
+</div>
 `;

--- a/packages/react/src/internal/utils/toggleSxComponent.tsx
+++ b/packages/react/src/internal/utils/toggleSxComponent.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import Box from '../../Box'
 import {defaultSxProp} from '../../utils/defaultSxProp'
+import type {BetterSystemStyleObject} from '../../sx'
 
 type CSSModulesProps = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   as?: string | React.ComponentType<any>
-  sx?: React.CSSProperties
-}
+  sx?: React.CSSProperties | BetterSystemStyleObject
+} & React.HTMLAttributes<HTMLElement>
 
 /**
  * Utility to toggle rendering a Box component that receives sx props


### PR DESCRIPTION
### Changelog

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

Remove the CSS modules feature flag from the AvatarStack component

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

This shouldn't have any visual effect in production, the only thing to watch for is integration testing with the CI

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
