### PR TITLE
fix(SelectPanel): differentiate onCancel gesture from escape

### DIFF
--- a/.changeset/olive-kangaroos-wonder.md
+++ b/.changeset/olive-kangaroos-wonder.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+fix(SelectPanel): differentiate onCancel gesture from escape

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -74,7 +74,7 @@ interface SelectPanelBaseProps {
   subtitle?: string | React.ReactElement
   onOpenChange: (
     open: boolean,
-    gesture: 'anchor-click' | 'anchor-key-press' | 'click-outside' | 'escape' | 'selection',
+    gesture: 'anchor-click' | 'anchor-key-press' | 'click-outside' | 'escape' | 'selection' | 'cancel',
   ) => void
   placeholder?: string
   // TODO: Make `inputLabel` required in next major version
@@ -333,6 +333,10 @@ export function SelectPanel({
     [onOpenChange],
   )
 
+  const onCancelRequested = useCallback(() => {
+    onOpenChange(false, 'cancel')
+  }, [onOpenChange])
+
   const renderMenuAnchor = useMemo(() => {
     if (renderAnchor === null) {
       return null
@@ -473,7 +477,7 @@ export function SelectPanel({
               className={classes.ResponsiveCloseButton}
               onClick={() => {
                 onCancel()
-                onClose('escape')
+                onCancelRequested()
               }}
             />
           )}
@@ -523,7 +527,7 @@ export function SelectPanel({
                 size="medium"
                 onClick={() => {
                   onCancel()
-                  onClose('escape')
+                  onCancelRequested()
                 }}
               >
                 Cancel


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

'escape' is used to save the selection by design, adding a different gesture for onCancel so that consumers can catch the difference. 

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->
- 'cancel' gesture for onOpenChange in SelectPanel

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
