### PR TITLE
fix(SelectPanel): always show x button on single select

### DIFF
--- a/.changeset/light-snakes-deny.md
+++ b/.changeset/light-snakes-deny.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+fix(SelectPanel): always show x button on single select

--- a/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
@@ -191,7 +191,6 @@ export const SingleSelect = () => {
         selected={selected}
         onSelectedChange={setSelected}
         onFilterChange={setFilter}
-        onCancel={() => setOpen(false)}
         width="medium"
         message={selectedItemsSortedFirst.length === 0 ? NoResultsMessage(filter) : undefined}
       />

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -431,6 +431,9 @@ export function SelectPanel({
     }
   }
 
+  // because of instant selection, canceling on single select is the same as closing the panel, no onCancel needed
+  const shouldShowXButton = (onCancel || !isMultiSelectVariant(selected)) && usingFullScreenOnNarrow
+
   return (
     <AnchoredOverlay
       renderAnchor={renderMenuAnchor}
@@ -468,7 +471,7 @@ export function SelectPanel({
               </div>
             ) : null}
           </div>
-          {onCancel && usingFullScreenOnNarrow && (
+          {shouldShowXButton ? (
             <IconButton
               type="button"
               variant="invisible"
@@ -476,11 +479,11 @@ export function SelectPanel({
               aria-label="Cancel and close"
               className={classes.ResponsiveCloseButton}
               onClick={() => {
-                onCancel()
+                onCancel?.()
                 onCancelRequested()
               }}
             />
-          )}
+          ) : null}
         </div>
         {notice && (
           <div aria-live="polite" data-variant={notice.variant} className={classes.Notice}>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Small improvement to onCancel behavior. Always showing the close icon on single select (otherwise the user gets "stuck" and the only way to dismiss the SelectPanel is by making a selection.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->
- Always show x button on single select

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
