### PR TITLE
Update data table pagination pageEnd to handle zero based index

### DIFF
--- a/.changeset/weak-spiders-love.md
+++ b/.changeset/weak-spiders-love.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Update data table pagination pageEnd to handle zero based index

--- a/packages/react/src/DataTable/Pagination.tsx
+++ b/packages/react/src/DataTable/Pagination.tsx
@@ -367,7 +367,7 @@ type RangeProps = {
 
 function Range({pageStart, pageEnd, totalCount}: RangeProps) {
   const start = pageStart + 1
-  const end = pageEnd === totalCount - 1 ? totalCount : pageEnd
+  const end = pageEnd
   return (
     <>
       <Message value={`Showing ${start} through ${end} of ${totalCount}`} />
@@ -524,7 +524,7 @@ function usePagination(config: PaginationConfig): PaginationResult {
     onChange?.({pageIndex: defaultPageIndex})
   }
   const pageStart = pageIndex * pageSize
-  const pageEnd = Math.min(pageIndex * pageSize + pageSize, totalCount - 1)
+  const pageEnd = Math.min((pageIndex + 1) * pageSize, totalCount)
   const hasNextPage = pageIndex + 1 < pageCount
   const hasPreviousPage = pageIndex > 0
 

--- a/packages/react/src/DataTable/__tests__/Pagination.test.tsx
+++ b/packages/react/src/DataTable/__tests__/Pagination.test.tsx
@@ -116,6 +116,14 @@ describe('Table.Pagination', () => {
       expect(getPageRange()).toEqual('1 through 25 of 50')
     })
 
+    it('should display two pages with correct range when totalCount is one plus pageSize', () => {
+      render(<Pagination aria-label="Test label" pageSize={25} totalCount={26} />)
+
+      expect(getPages()).toHaveLength(2)
+      expect(getCurrentPage()).toEqual(getPage(0))
+      expect(getPageRange()).toEqual('1 through 25 of 26')
+    })
+
     it('should call `onChange` when clicking on pages', async () => {
       const user = userEvent.setup()
       const onChange = jest.fn()


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #5909 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

A test that specifically tests the failing case on when the total count is 1 + pageSize

#### Changed

<!-- List of things changed in this PR -->
Changed how pageEnd was being calculated. It now makes pageEnd represent the actual display rather than a zero-based index.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
