### PR TITLE
chore: Cleanup test feature flag calls from already shipped components

### DIFF
--- a/packages/react/src/ActionList/ActionList.test.tsx
+++ b/packages/react/src/ActionList/ActionList.test.tsx
@@ -119,7 +119,6 @@ describe('ActionList', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >
@@ -144,7 +143,6 @@ describe('ActionList', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/ActionList/Description.test.tsx
+++ b/packages/react/src/ActionList/Description.test.tsx
@@ -63,7 +63,6 @@ describe('ActionList.Description', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/ActionList/Group.test.tsx
+++ b/packages/react/src/ActionList/Group.test.tsx
@@ -148,7 +148,6 @@ describe('ActionList.Group', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/ActionList/Item.test.tsx
+++ b/packages/react/src/ActionList/Item.test.tsx
@@ -238,7 +238,6 @@ describe('ActionList.Item', () => {
   })
   it('should render ActionList.Item as button when feature flag is enabled', async () => {
     const featureFlag = {
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }
     const {container} = HTMLRender(
@@ -260,7 +259,6 @@ describe('ActionList.Item', () => {
     const {container} = HTMLRender(
       <FeatureFlags
         flags={{
-          primer_react_css_modules_staff: false,
           primer_react_css_modules_ga: false,
         }}
       >
@@ -287,7 +285,6 @@ describe('ActionList.Item', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: false,
             primer_react_css_modules_ga: false,
           }}
         >
@@ -380,7 +377,6 @@ describe('ActionList.Item', () => {
     const {getByRole} = HTMLRender(
       <FeatureFlags
         flags={{
-          primer_react_css_modules_staff: true,
           primer_react_css_modules_ga: true,
         }}
       >
@@ -399,7 +395,6 @@ describe('ActionList.Item', () => {
     const {getByRole} = HTMLRender(
       <FeatureFlags
         flags={{
-          primer_react_css_modules_staff: true,
           primer_react_css_modules_ga: true,
         }}
       >

--- a/packages/react/src/ActionMenu/ActionMenu.dev.stories.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.dev.stories.tsx
@@ -13,7 +13,6 @@ export default {
 export const WithCss = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >
@@ -47,7 +46,6 @@ export const WithCss = () => (
 export const WithSx = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >
@@ -81,7 +79,6 @@ export const WithSx = () => (
 export const WithSxAndCSS = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >

--- a/packages/react/src/Banner/Banner.test.tsx
+++ b/packages/react/src/Banner/Banner.test.tsx
@@ -2,7 +2,6 @@ import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import {Banner} from '../Banner'
-import {FeatureFlags} from '../FeatureFlags'
 
 describe('Banner', () => {
   let spy: jest.SpyInstance
@@ -32,20 +31,7 @@ describe('Banner', () => {
 
   it('should support a custom `className` on the outermost element', () => {
     const Element = () => <Banner title="test" className="test-class-name" />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(render(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(render(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 
   it('should label the landmark element with the corresponding variant label text', () => {

--- a/packages/react/src/BranchName/__tests__/BranchName.test.tsx
+++ b/packages/react/src/BranchName/__tests__/BranchName.test.tsx
@@ -3,7 +3,6 @@ import BranchName from '../BranchName'
 import {render, behavesAsComponent, checkExports} from '../../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
 import axe from 'axe-core'
-import {FeatureFlags} from '../../FeatureFlags'
 
 describe('BranchName', () => {
   behavesAsComponent({
@@ -29,19 +28,6 @@ describe('BranchName', () => {
 
   it('should support `className` on the outermost element', () => {
     const Element = () => <BranchName className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(HTMLRender(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(HTMLRender(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 })

--- a/packages/react/src/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/packages/react/src/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -3,7 +3,6 @@ import Breadcrumbs, {Breadcrumb} from '..'
 import {render, behavesAsComponent, checkExports} from '../../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
 import axe from 'axe-core'
-import {FeatureFlags} from '../../FeatureFlags'
 
 describe('Breadcrumbs', () => {
   behavesAsComponent({Component: Breadcrumbs, options: {skipAs: true}})
@@ -15,20 +14,7 @@ describe('Breadcrumbs', () => {
 
   it('should support `className` on the outermost element', () => {
     const Element = () => <Breadcrumbs className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(HTMLRender(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(HTMLRender(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 
   it('should have no axe violations', async () => {

--- a/packages/react/src/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/Button/__tests__/Button.test.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 import {IconButton, Button, LinkButton} from '../../Button'
 import type {ButtonProps} from '../../Button'
 import {behavesAsComponent} from '../../utils/testing'
-import {FeatureFlags} from '../../FeatureFlags'
 
 type StatefulLoadingButtonProps = {
   children?: React.ReactNode
@@ -28,40 +27,14 @@ const StatefulLoadingButton = (props: StatefulLoadingButtonProps) => {
 describe('IconButton', () => {
   it('should support `className` on the outermost element', () => {
     const Element = () => <IconButton className={'test-class-name'} icon={SearchIcon} aria-label="Search button" />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(render(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(render(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 })
 
 describe('LinkButton', () => {
   it('should support `className` on the outermost element', () => {
     const Element = () => <LinkButton className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(render(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(render(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 })
 
@@ -73,20 +46,7 @@ describe('Button', () => {
 
   it('should support `className` on the outermost element', () => {
     const Element = () => <Button className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(render(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(render(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 
   it('renders a <button>', () => {

--- a/packages/react/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.test.tsx
@@ -1,7 +1,6 @@
 import {Button} from '../Button'
 import {render, screen} from '@testing-library/react'
 import axe from 'axe-core'
-import {FeatureFlags} from '../FeatureFlags'
 import {behavesAsComponent} from '../utils/testing'
 import type {ButtonGroupProps} from './ButtonGroup'
 import ButtonGroup from './ButtonGroup'
@@ -23,20 +22,7 @@ describe('ButtonGroup', () => {
 
   it('should support `className` on the outermost element', () => {
     const Element = () => <ButtonGroup className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(render(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(render(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 
   it('renders a <div>', () => {

--- a/packages/react/src/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/Checkbox/Checkbox.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event'
 import React from 'react'
 import Checkbox from '../Checkbox'
 import {behavesAsComponent, checkExports} from '../utils/testing'
-import {FeatureFlags} from '../FeatureFlags'
 
 describe('Checkbox', () => {
   beforeEach(() => {
@@ -17,20 +16,7 @@ describe('Checkbox', () => {
 
   it('should support `className` on the outermost element', () => {
     const Element = () => <Checkbox className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(render(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(render(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 
   it('renders a valid checkbox input', () => {

--- a/packages/react/src/CounterLabel/CounterLabel.test.tsx
+++ b/packages/react/src/CounterLabel/CounterLabel.test.tsx
@@ -3,7 +3,6 @@ import {CounterLabel} from '..'
 import {behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
 import axe from 'axe-core'
-import {FeatureFlags} from '../FeatureFlags'
 
 describe('CounterLabel', () => {
   behavesAsComponent({Component: CounterLabel, options: {skipAs: true, skipSx: true}})
@@ -14,20 +13,7 @@ describe('CounterLabel', () => {
 
   it('should support `className` on the outermost element', () => {
     const Element = () => <CounterLabel className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(HTMLRender(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(HTMLRender(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 
   it('renders a <span>', () => {

--- a/packages/react/src/Dialog/Dialog.dev.stories.tsx
+++ b/packages/react/src/Dialog/Dialog.dev.stories.tsx
@@ -64,7 +64,6 @@ export const WithCss = ({width, height, subtitle}: DialogStoryProps) => {
   return (
     <FeatureFlags
       flags={{
-        primer_react_css_modules_staff: true,
         primer_react_css_modules_ga: true,
       }}
     >
@@ -118,7 +117,6 @@ export const WithSx = ({width, height, subtitle}: DialogStoryProps) => {
   return (
     <FeatureFlags
       flags={{
-        primer_react_css_modules_staff: true,
         primer_react_css_modules_ga: true,
       }}
     >
@@ -180,7 +178,6 @@ export const WithSxAndCss = ({width, height, subtitle}: DialogStoryProps) => {
   return (
     <FeatureFlags
       flags={{
-        primer_react_css_modules_staff: true,
         primer_react_css_modules_ga: true,
       }}
     >

--- a/packages/react/src/Dialog/Dialog.test.tsx
+++ b/packages/react/src/Dialog/Dialog.test.tsx
@@ -251,7 +251,6 @@ describe('Dialog', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/DialogV1/Dialog.test.tsx
+++ b/packages/react/src/DialogV1/Dialog.test.tsx
@@ -120,7 +120,6 @@ describe('Dialog', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/Header/Header.dev.stories.tsx
+++ b/packages/react/src/Header/Header.dev.stories.tsx
@@ -7,7 +7,6 @@ import Avatar from '../Avatar'
 import Octicon from '../Octicon'
 
 import classes from './Header.dev.module.css'
-import {FeatureFlags} from '../FeatureFlags'
 
 export default {
   title: 'Components/Header/Dev',
@@ -15,25 +14,18 @@ export default {
 } as Meta<typeof Header>
 
 export const WithCss = () => (
-  <FeatureFlags
-    flags={{
-      primer_react_css_modules_staff: true,
-      primer_react_css_modules_ga: true,
-    }}
-  >
-    <Header className={classes.HeaderDev}>
-      <Header.Item id="github">
-        <Header.Link href="#" className={classes.HeaderDevLink}>
-          <Octicon icon={MarkGithubIcon} size={32} sx={{mr: 2}} />
-          <span>GitHub</span>
-        </Header.Link>
-      </Header.Item>
-      <Header.Item full>Menu</Header.Item>
-      <Header.Item className={classes.HeaderDevItem}>
-        <Avatar src="https://github.com/octocat.png" size={20} square alt="@octocat" />
-      </Header.Item>
-    </Header>
-  </FeatureFlags>
+  <Header className={classes.HeaderDev}>
+    <Header.Item id="github">
+      <Header.Link href="#" className={classes.HeaderDevLink}>
+        <Octicon icon={MarkGithubIcon} size={32} sx={{mr: 2}} />
+        <span>GitHub</span>
+      </Header.Link>
+    </Header.Item>
+    <Header.Item full>Menu</Header.Item>
+    <Header.Item className={classes.HeaderDevItem}>
+      <Avatar src="https://github.com/octocat.png" size={20} square alt="@octocat" />
+    </Header.Item>
+  </Header>
 )
 
 export const WithSx = () => (
@@ -52,23 +44,16 @@ export const WithSx = () => (
 )
 
 export const WithSxAndCSS = () => (
-  <FeatureFlags
-    flags={{
-      primer_react_css_modules_staff: true,
-      primer_react_css_modules_ga: true,
-    }}
-  >
-    <Header className={classes.HeaderDev} sx={{backgroundColor: 'orange', color: 'black'}}>
-      <Header.Item id="github">
-        <Header.Link href="#" className={classes.HeaderDevLink} sx={{p: 0, color: 'black'}}>
-          <Octicon icon={MarkGithubIcon} size={32} sx={{mr: 2}} />
-          <span>GitHub</span>
-        </Header.Link>
-      </Header.Item>
-      <Header.Item full>Menu</Header.Item>
-      <Header.Item className={classes.HeaderDevItem} sx={{m: 0}}>
-        <Avatar src="https://github.com/octocat.png" size={20} square alt="@octocat" />
-      </Header.Item>
-    </Header>
-  </FeatureFlags>
+  <Header className={classes.HeaderDev} sx={{backgroundColor: 'orange', color: 'black'}}>
+    <Header.Item id="github">
+      <Header.Link href="#" className={classes.HeaderDevLink} sx={{p: 0, color: 'black'}}>
+        <Octicon icon={MarkGithubIcon} size={32} sx={{mr: 2}} />
+        <span>GitHub</span>
+      </Header.Link>
+    </Header.Item>
+    <Header.Item full>Menu</Header.Item>
+    <Header.Item className={classes.HeaderDevItem} sx={{m: 0}}>
+      <Avatar src="https://github.com/octocat.png" size={20} square alt="@octocat" />
+    </Header.Item>
+  </Header>
 )

--- a/packages/react/src/Heading/__tests__/Heading.test.tsx
+++ b/packages/react/src/Heading/__tests__/Heading.test.tsx
@@ -4,7 +4,6 @@ import {render, behavesAsComponent, checkExports} from '../../utils/testing'
 import {render as HTMLRender, screen} from '@testing-library/react'
 import axe from 'axe-core'
 import ThemeProvider from '../../ThemeProvider'
-import {FeatureFlags} from '../../FeatureFlags'
 
 const theme = {
   breakpoints: ['400px', '640px', '960px', '1280px'],
@@ -38,20 +37,7 @@ describe('Heading', () => {
 
   it('should support `className` on the outermost element', () => {
     const Element = () => <Heading className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(HTMLRender(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(HTMLRender(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 
   it('renders <h2> by default', () => {

--- a/packages/react/src/Link/__tests__/Link.test.tsx
+++ b/packages/react/src/Link/__tests__/Link.test.tsx
@@ -3,7 +3,6 @@ import Link from '..'
 import {render, behavesAsComponent, checkExports} from '../../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
 import axe from 'axe-core'
-import {FeatureFlags} from '../../FeatureFlags'
 
 describe('Link', () => {
   behavesAsComponent({Component: Link})
@@ -14,20 +13,7 @@ describe('Link', () => {
 
   it('should support `className` on the outermost element', () => {
     const Element = () => <Link href="#" className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(HTMLRender(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(HTMLRender(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 
   it('should have no axe violations', async () => {

--- a/packages/react/src/SelectPanel/SelectPanel.dev.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.dev.stories.tsx
@@ -6,7 +6,6 @@ import Box from '../Box'
 import {Button} from '../Button'
 import {SelectPanel} from '.'
 import type {ItemInput} from '../deprecated/ActionList/List'
-import {FeatureFlags} from '../FeatureFlags'
 import FormControl from '../FormControl'
 
 const meta: Meta<typeof SelectPanel> = {
@@ -86,34 +85,27 @@ export const WithCss = () => {
   const [open, setOpen] = useState(false)
 
   return (
-    <FeatureFlags
-      flags={{
-        primer_react_css_modules_staff: true,
-        primer_react_css_modules_ga: true,
-      }}
-    >
-      <FormControl>
-        <FormControl.Label>Labels</FormControl.Label>
-        <SelectPanel
-          title="Select labels"
-          placeholder="Select labels" // button text when no items are selected
-          subtitle="Use labels to organize issues and pull requests"
-          renderAnchor={({children, ...anchorProps}) => (
-            <Button trailingAction={TriangleDownIcon} {...anchorProps} aria-haspopup="dialog">
-              {children}
-            </Button>
-          )}
-          open={open}
-          onOpenChange={setOpen}
-          items={selectedItemsSortedFirst}
-          selected={selected}
-          onSelectedChange={setSelected}
-          onFilterChange={setFilter}
-          className="testCustomClassnameMono"
-          message={selectedItemsSortedFirst.length === 0 ? NoResultsMessage(filter) : undefined}
-        />
-      </FormControl>
-    </FeatureFlags>
+    <FormControl>
+      <FormControl.Label>Labels</FormControl.Label>
+      <SelectPanel
+        title="Select labels"
+        placeholder="Select labels" // button text when no items are selected
+        subtitle="Use labels to organize issues and pull requests"
+        renderAnchor={({children, ...anchorProps}) => (
+          <Button trailingAction={TriangleDownIcon} {...anchorProps} aria-haspopup="dialog">
+            {children}
+          </Button>
+        )}
+        open={open}
+        onOpenChange={setOpen}
+        items={selectedItemsSortedFirst}
+        selected={selected}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
+        className="testCustomClassnameMono"
+        message={selectedItemsSortedFirst.length === 0 ? NoResultsMessage(filter) : undefined}
+      />
+    </FormControl>
   )
 }
 
@@ -132,34 +124,27 @@ export const WithSx = () => {
   const [open, setOpen] = useState(false)
 
   return (
-    <FeatureFlags
-      flags={{
-        primer_react_css_modules_staff: true,
-        primer_react_css_modules_ga: true,
-      }}
-    >
-      <FormControl>
-        <FormControl.Label>Labels</FormControl.Label>
-        <SelectPanel
-          title="Select labels"
-          placeholder="Select labels" // button text when no items are selected
-          subtitle="Use labels to organize issues and pull requests"
-          renderAnchor={({children, ...anchorProps}) => (
-            <Button trailingAction={TriangleDownIcon} {...anchorProps} aria-haspopup="dialog">
-              {children}
-            </Button>
-          )}
-          open={open}
-          onOpenChange={setOpen}
-          items={selectedItemsSortedFirst}
-          selected={selected}
-          onSelectedChange={setSelected}
-          onFilterChange={setFilter}
-          sx={{fontFamily: 'Times New Roman'}}
-          message={selectedItemsSortedFirst.length === 0 ? NoResultsMessage(filter) : undefined}
-        />
-      </FormControl>
-    </FeatureFlags>
+    <FormControl>
+      <FormControl.Label>Labels</FormControl.Label>
+      <SelectPanel
+        title="Select labels"
+        placeholder="Select labels" // button text when no items are selected
+        subtitle="Use labels to organize issues and pull requests"
+        renderAnchor={({children, ...anchorProps}) => (
+          <Button trailingAction={TriangleDownIcon} {...anchorProps} aria-haspopup="dialog">
+            {children}
+          </Button>
+        )}
+        open={open}
+        onOpenChange={setOpen}
+        items={selectedItemsSortedFirst}
+        selected={selected}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
+        sx={{fontFamily: 'Times New Roman'}}
+        message={selectedItemsSortedFirst.length === 0 ? NoResultsMessage(filter) : undefined}
+      />
+    </FormControl>
   )
 }
 
@@ -178,34 +163,27 @@ export const WithSxAndCSS = () => {
   const [open, setOpen] = useState(false)
 
   return (
-    <FeatureFlags
-      flags={{
-        primer_react_css_modules_staff: true,
-        primer_react_css_modules_ga: true,
-      }}
-    >
-      <FormControl>
-        <FormControl.Label>Labels</FormControl.Label>
-        <SelectPanel
-          title="Select labels"
-          placeholder="Select labels" // button text when no items are selected
-          subtitle="Use labels to organize issues and pull requests"
-          renderAnchor={({children, ...anchorProps}) => (
-            <Button trailingAction={TriangleDownIcon} {...anchorProps} aria-haspopup="dialog">
-              {children}
-            </Button>
-          )}
-          open={open}
-          onOpenChange={setOpen}
-          items={selectedItemsSortedFirst}
-          selected={selected}
-          onSelectedChange={setSelected}
-          onFilterChange={setFilter}
-          sx={{fontFamily: 'Times New Roman'}}
-          className="testCustomClassnameMono"
-          message={selectedItemsSortedFirst.length === 0 ? NoResultsMessage(filter) : undefined}
-        />
-      </FormControl>
-    </FeatureFlags>
+    <FormControl>
+      <FormControl.Label>Labels</FormControl.Label>
+      <SelectPanel
+        title="Select labels"
+        placeholder="Select labels" // button text when no items are selected
+        subtitle="Use labels to organize issues and pull requests"
+        renderAnchor={({children, ...anchorProps}) => (
+          <Button trailingAction={TriangleDownIcon} {...anchorProps} aria-haspopup="dialog">
+            {children}
+          </Button>
+        )}
+        open={open}
+        onOpenChange={setOpen}
+        items={selectedItemsSortedFirst}
+        selected={selected}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
+        sx={{fontFamily: 'Times New Roman'}}
+        className="testCustomClassnameMono"
+        message={selectedItemsSortedFirst.length === 0 ? NoResultsMessage(filter) : undefined}
+      />
+    </FormControl>
   )
 }

--- a/packages/react/src/Stack/__tests__/StackItem.test.tsx
+++ b/packages/react/src/Stack/__tests__/StackItem.test.tsx
@@ -1,7 +1,6 @@
 import {render, screen} from '@testing-library/react'
 import React from 'react'
 import {Stack, StackItem} from '../Stack'
-import {FeatureFlags} from '../../FeatureFlags'
 
 describe('StackItem', () => {
   it('should support `className` on the outermost element', () => {
@@ -12,20 +11,7 @@ describe('StackItem', () => {
         </StackItem>
       </Stack>
     )
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(render(<Element />).getAllByTestId('stack-item')[0]).toHaveClass('test-class-name')
-    expect(render(<FeatureFlagElement />).getAllByTestId('stack-item')[1]).toHaveClass('test-class-name')
   })
 
   it('should render its children', () => {

--- a/packages/react/src/TextInput/TextInput.dev.stories.tsx
+++ b/packages/react/src/TextInput/TextInput.dev.stories.tsx
@@ -14,7 +14,6 @@ export default {
 export const WithCSS = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >
@@ -39,7 +38,6 @@ export const WithSx = () => (
 export const WithSxAndCSS = () => (
   <FeatureFlags
     flags={{
-      primer_react_css_modules_staff: true,
       primer_react_css_modules_ga: true,
     }}
   >

--- a/packages/react/src/TreeView/TreeView.test.tsx
+++ b/packages/react/src/TreeView/TreeView.test.tsx
@@ -1655,7 +1655,6 @@ describe('CSS Module Migration', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/Autocomplete.test.tsx
+++ b/packages/react/src/__tests__/Autocomplete.test.tsx
@@ -8,7 +8,6 @@ import BaseStyles from '../BaseStyles'
 import theme from '../theme'
 import {ThemeProvider} from '../ThemeProvider'
 import {render} from '../utils/testing'
-import {FeatureFlags} from '../FeatureFlags'
 
 const mockItems = [
   {text: 'zero', id: '0'},
@@ -226,20 +225,7 @@ describe('Autocomplete', () => {
           <Autocomplete.Input className={'test-class-name'} />
         </Autocomplete>
       )
-      const FeatureFlagElement = () => {
-        return (
-          <FeatureFlags
-            flags={{
-              primer_react_css_modules_staff: true,
-              primer_react_css_modules_ga: true,
-            }}
-          >
-            <Element />
-          </FeatureFlags>
-        )
-      }
       expect(HTMLRender(<Element />).container.firstChild).toHaveClass('test-class-name')
-      expect(HTMLRender(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
     })
   })
 
@@ -474,33 +460,12 @@ describe('Autocomplete', () => {
           </Autocomplete>
         </ThemeProvider>
       )
-      const FeatureFlagElement = () => {
-        return (
-          <FeatureFlags
-            flags={{
-              primer_react_css_modules_staff: true,
-              primer_react_css_modules_ga: true,
-            }}
-          >
-            <Element className="test-class-name-2" />
-          </FeatureFlags>
-        )
-      }
-      const {container: elementContainer, getByRole, rerender} = HTMLRender(<Element className="test-class-name" />)
-      let inputNode = getByRole('combobox')
+      const {container: elementContainer, getByRole} = HTMLRender(<Element className="test-class-name" />)
+      const inputNode = getByRole('combobox')
       await userEvent.click(inputNode)
       await userEvent.keyboard('{ArrowDown}')
       // overlay is a sibling of elementContainer
       expect(elementContainer.parentElement?.querySelectorAll('.test-class-name')).toHaveLength(1)
-
-      rerender(<FeatureFlagElement />)
-      expect(elementContainer.parentElement?.querySelectorAll('.test-class-name')).toHaveLength(0)
-      inputNode = getByRole('combobox')
-      await userEvent.click(inputNode)
-      await userEvent.keyboard('{ArrowDown}')
-
-      // overlay is a sibling of ffContainer
-      expect(elementContainer.parentElement?.querySelectorAll('.test-class-name-2')).toHaveLength(1)
     })
   })
 

--- a/packages/react/src/__tests__/Avatar.test.tsx
+++ b/packages/react/src/__tests__/Avatar.test.tsx
@@ -4,7 +4,6 @@ import theme from '../theme'
 import {px, render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
 import axe from 'axe-core'
-import {FeatureFlags} from '../FeatureFlags'
 
 describe('Avatar', () => {
   behavesAsComponent({
@@ -20,20 +19,7 @@ describe('Avatar', () => {
 
   it('should support `className` on the outermost element', () => {
     const Element = () => <Avatar src="primer.png" className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(HTMLRender(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(HTMLRender(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 
   it('should have no axe violations', async () => {

--- a/packages/react/src/__tests__/AvatarStack.test.tsx
+++ b/packages/react/src/__tests__/AvatarStack.test.tsx
@@ -3,7 +3,6 @@ import {AvatarStack} from '..'
 import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {render as HTMLRender} from '@testing-library/react'
 import axe from 'axe-core'
-import {FeatureFlags} from '../FeatureFlags'
 
 const avatarComp = (
   <AvatarStack>
@@ -43,20 +42,7 @@ describe('Avatar', () => {
         <img src="https://avatars.githubusercontent.com/github" alt="" />
       </AvatarStack>
     )
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(HTMLRender(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(HTMLRender(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 
   it('should have no axe violations', async () => {

--- a/packages/react/src/__tests__/Box.test.tsx
+++ b/packages/react/src/__tests__/Box.test.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import {Box} from '..'
 import theme from '../theme'
 import {behavesAsComponent, checkExports, render} from '../utils/testing'
-import {FeatureFlags} from '../FeatureFlags'
 
 describe('Box', () => {
   behavesAsComponent({Component: Box})
@@ -15,20 +14,7 @@ describe('Box', () => {
 
   it('should support `className` on the outermost element', () => {
     const Element = () => <Box className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(HTMLRender(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(HTMLRender(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
 
   it('should have no axe violations', async () => {

--- a/packages/react/src/__tests__/Label.test.tsx
+++ b/packages/react/src/__tests__/Label.test.tsx
@@ -3,25 +3,11 @@ import {render} from '@testing-library/react'
 import axe from 'axe-core'
 import type {LabelColorOptions} from '../Label'
 import Label, {variants} from '../Label'
-import {FeatureFlags} from '../FeatureFlags'
 
 describe('Label', () => {
   it('should support `className` on the outermost element', () => {
     const Element = () => <Label className={'test-class-name'} />
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(render(<Element />).container.firstChild).toHaveClass('test-class-name')
-    expect(render(<FeatureFlagElement />).container.firstChild).toHaveClass('test-class-name')
   })
   it('renders text node child', () => {
     const container = render(<Label>Default</Label>)

--- a/packages/react/src/__tests__/Popover.test.tsx
+++ b/packages/react/src/__tests__/Popover.test.tsx
@@ -29,7 +29,6 @@ describe('Popover', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/ProgressBar.test.tsx
+++ b/packages/react/src/__tests__/ProgressBar.test.tsx
@@ -21,7 +21,6 @@ describe('ProgressBar', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/Radio.test.tsx
+++ b/packages/react/src/__tests__/Radio.test.tsx
@@ -26,7 +26,6 @@ describe('Radio', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/Select.test.tsx
+++ b/packages/react/src/__tests__/Select.test.tsx
@@ -23,7 +23,6 @@ describe('Select', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/TextInput.test.tsx
+++ b/packages/react/src/__tests__/TextInput.test.tsx
@@ -20,7 +20,6 @@ describe('TextInput', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/__tests__/TextInputWithTokens.test.tsx
+++ b/packages/react/src/__tests__/TextInputWithTokens.test.tsx
@@ -44,7 +44,6 @@ describe('TextInputWithTokens', () => {
       return (
         <FeatureFlags
           flags={{
-            primer_react_css_modules_staff: true,
             primer_react_css_modules_ga: true,
           }}
         >

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.test.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.test.tsx
@@ -5,7 +5,6 @@ import {render, screen} from '@testing-library/react'
 import UnderlinePanels from './UnderlinePanels'
 import {behavesAsComponent} from '../../utils/testing'
 import TabContainerElement from '@github/tab-container-element'
-import {FeatureFlags} from '../../FeatureFlags'
 
 TabContainerElement.prototype.selectTab = jest.fn()
 

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.test.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.test.tsx
@@ -168,19 +168,6 @@ describe('UnderlinePanels', () => {
         <UnderlinePanels.Panel>Panel 2</UnderlinePanels.Panel>
       </UnderlinePanels>
     )
-    const FeatureFlagElement = () => {
-      return (
-        <FeatureFlags
-          flags={{
-            primer_react_css_modules_staff: true,
-            primer_react_css_modules_ga: true,
-          }}
-        >
-          <Element />
-        </FeatureFlags>
-      )
-    }
     expect(render(<Element />).baseElement.firstChild?.firstChild?.firstChild).toHaveClass('test-class-name')
-    expect(render(<FeatureFlagElement />).baseElement.firstChild?.firstChild?.firstChild).toHaveClass('test-class-name')
   })
 })


### PR DESCRIPTION
This cleans up some of the tests in the components that use CSS modules feature flags even after the component has shipped fully or is on a different feature flag.

I went though each test and verified the component is fully shipped or off of the staff feature flag. 