### PR TITLE
chore(lock-release): add step to the Lock/Unlock workflow to update PRs with toggled merge when ready

### DIFF
--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -78,6 +78,11 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Update all PRs that are toggled merge when ready
         run: |
-          gh pr list --state open --json number,mergeable,baseRefName,autoMergeRequest -q '.[] | select(.autoMergeRequest != null) | select(.mergeable == "MERGEABLE") | select(.baseRefName == "main") | .number' | xargs -I {} gh pr update-branch {}
+          PR_NUMBERS=$(gh pr list --state open --json number,mergeable,baseRefName,autoMergeRequest -q '.[] | select(.autoMergeRequest != null) | select(.mergeable == "MERGEABLE") | select(.baseRefName == "main") | .number')
+          if [ -n "$PR_NUMBERS" ]; then
+            echo "$PR_NUMBERS" | xargs -I {} gh pr update-branch {}
+          else
+            echo "No PRs to update."
+          fi
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -76,3 +76,8 @@ jobs:
             -f "enforcement=disabled"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Update all PRs that are toggled merge when ready
+        run: |
+          gh pr list --state open --json number,mergeable,baseRefName,autoMergeRequest -q '.[] | select(.autoMergeRequest != null) | select(.mergeable == "MERGEABLE") | select(.baseRefName == "main") | .number' | xargs -I {} gh pr update-branch {}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
I found that if you update the PR branch with the latest from main while it's in the stuck case, it will auto queue the PR. I tested this here https://github.com/primer/react/pull/5940 and again here https://github.com/primer/react/pull/5929#event-17329242375