### PR TITLE
chore(vrt-workflows): Skip VRT and AAT when the PR doesn't have files changed within the packages/react folder

### DIFF
--- a/.github/workflows/deploy_preview_forks.yml
+++ b/.github/workflows/deploy_preview_forks.yml
@@ -8,17 +8,11 @@ concurrency:
 
 jobs:
   vrt-reports:
-    if: |
-      ${{ github.repository != github.event.pull_request.head.repo.full_name &&
-      (github.event.pull_request.changed_files == 0 ||
-       contains(toJSON(github.event.pull_request.files.*.filename), 'packages/react')) }}
+    if: ${{ github.repository != github.event.pull_request.head.repo.full_name }}
     uses: ./.github/workflows/vrt-reports.yml
 
   aat-reports:
-    if: |
-      ${{ github.repository != github.event.pull_request.head.repo.full_name &&
-      (github.event.pull_request.changed_files == 0 ||
-       contains(toJSON(github.event.pull_request.files.*.filename), 'packages/react')) }}
+    if: ${{ github.repository != github.event.pull_request.head.repo.full_name }}
     uses: ./.github/workflows/aat-reports.yml
 
   build:

--- a/.github/workflows/deploy_preview_forks.yml
+++ b/.github/workflows/deploy_preview_forks.yml
@@ -8,11 +8,17 @@ concurrency:
 
 jobs:
   vrt-reports:
-    if: ${{ github.repository != github.event.pull_request.head.repo.full_name }}
+    if: |
+      ${{ github.repository != github.event.pull_request.head.repo.full_name &&
+      (github.event.pull_request.changed_files == 0 ||
+       contains(toJSON(github.event.pull_request.files.*.filename), 'packages/react')) }}
     uses: ./.github/workflows/vrt-reports.yml
 
   aat-reports:
-    if: ${{ github.repository != github.event.pull_request.head.repo.full_name }}
+    if: |
+      ${{ github.repository != github.event.pull_request.head.repo.full_name &&
+      (github.event.pull_request.changed_files == 0 ||
+       contains(toJSON(github.event.pull_request.files.*.filename), 'packages/react')) }}
     uses: ./.github/workflows/aat-reports.yml
 
   build:

--- a/.github/workflows/vrt-reports.yml
+++ b/.github/workflows/vrt-reports.yml
@@ -20,6 +20,20 @@ jobs:
         shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Get source files changes
+        id: source-files
+        run: |
+          DIFF=$(git diff --name-only origin/main | grep 'packages/react' | grep -Ev '.stories.tsx|.docs.json' || true)
+          if [ -z "$DIFF" ]; then
+            echo "diff=" >> $GITHUB_OUTPUT
+          else
+            echo "diff=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Has diff?
+        if: ${{ steps.source-files.outputs.diff == '' }}
+        run: echo "No changes in source files, skipping VRT tests" && exit 0
+
       - name: Use Node.js 20.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:


### PR DESCRIPTION
I thought maybe we don't need to run these if the changes are outside of the packages/react folder. 

I'm unsure if this runs like we expect, like if the checks will pass when they should.