### PR TITLE
fix(LinkItem): pass through variant prop when flag is disabled

### DIFF
--- a/.changeset/mighty-shrimps-shake.md
+++ b/.changeset/mighty-shrimps-shake.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Update ActionList.LinkItem to pass through the `variant` prop when the CSS Modules flag is disabled

--- a/packages/react/src/ActionList/LinkItem.tsx
+++ b/packages/react/src/ActionList/LinkItem.tsx
@@ -109,6 +109,7 @@ export const LinkItem = React.forwardRef(
         sx={{paddingY: 0, paddingX: 0}}
         inactiveText={inactiveText}
         data-inactive={inactiveText ? true : undefined}
+        variant={variant}
         _PrivateItemWrapper={({children, onClick, ...rest}) => {
           const clickHandler = (event: React.MouseEvent<HTMLElement>) => {
             onClick && onClick(event)


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5117

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `ActionList.LinkItem` to pass through the `variant` prop in the branch where the CSS Modules flag is disabled

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
