### PR TITLE
Don't fail stress tests on Alert

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -45,10 +45,10 @@ jobs:
           output-file-path: results.json
           # Where the previous data file is stored
           external-data-json-path: ./cache/stress-tests-benchmark-data.json
-          # Workflow will fail when an alert happens
-          fail-on-alert: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '150%'
+          alert-threshold: '200%'
+          # Workflow will fail when an alert happens
+          fail-on-alert: false
           # Enable alert commit comment
           comment-on-alert: true
           # Mention @rhysd in the commit comment


### PR DESCRIPTION
Stress tests have been flaky as there's not much historic data.

This makes it so it only leaves a comment and doesn't fail the job.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [X] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
