### PR TITLE
fix Workflow for unlocking release, add the repo argument to gh cli command

### DIFF
--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -78,7 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Update all PRs that are toggled merge when ready
         run: |
-          PR_NUMBERS=$(gh pr list --state open --json number,mergeable,baseRefName,autoMergeRequest -q '.[] | select(.autoMergeRequest != null) | select(.mergeable == "MERGEABLE") | select(.baseRefName == "main") | .number')
+          PR_NUMBERS=$(gh pr list -R primer/react --state open --json number,mergeable,baseRefName,autoMergeRequest -q '.[] | select(.autoMergeRequest != null) | select(.mergeable == "MERGEABLE") | select(.baseRefName == "main") | .number')
           if [ -n "$PR_NUMBERS" ]; then
             echo "$PR_NUMBERS" | xargs -I {} gh pr update-branch {}
           else

--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           PR_NUMBERS=$(gh pr list -R primer/react --state open --json number,mergeable,baseRefName,autoMergeRequest -q '.[] | select(.autoMergeRequest != null) | select(.mergeable == "MERGEABLE") | select(.baseRefName == "main") | .number')
           if [ -n "$PR_NUMBERS" ]; then
-            echo "$PR_NUMBERS" | xargs -I {} gh pr update-branch {}
+            echo "$PR_NUMBERS" | xargs -I {} gh pr update-branch -R primer/react {}
           else
             echo "No PRs to update."
           fi


### PR DESCRIPTION
the workflow failed cause it was trying to infer the repo, even though we didn't check one out.