### PR TITLE
chore: Cleanup the primer_react_css_modules_staff flag from the codebase

### DIFF
--- a/.changeset/heavy-mangos-stay.md
+++ b/.changeset/heavy-mangos-stay.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Remove the primer_react_css_modules_staff feature flag. Also needed to rework the feature flag logic for the NavList component.

--- a/.github/workflows/aat-reports.yml
+++ b/.github/workflows/aat-reports.yml
@@ -91,7 +91,6 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     env:
-      VITE_PRIMER_REACT_CSS_MODULES_STAFF: 1
       VITE_PRIMER_REACT_CSS_MODULES_GA: 1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/vrt-reports.yml
+++ b/.github/workflows/vrt-reports.yml
@@ -91,7 +91,6 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     env:
-      VITE_PRIMER_REACT_CSS_MODULES_STAFF: 1
       VITE_PRIMER_REACT_CSS_MODULES_GA: 1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/packages/react/.storybook/preview.jsx
+++ b/packages/react/.storybook/preview.jsx
@@ -224,7 +224,7 @@ const primerThemes = [
 ]
 
 const defaultFeatureFlags = new Map(DefaultFeatureFlags.flags)
-const featureFlagEnvList = new Set(['PRIMER_REACT_CSS_MODULES_STAFF', 'PRIMER_REACT_CSS_MODULES_GA'])
+const featureFlagEnvList = new Set(['PRIMER_REACT_CSS_MODULES_GA'])
 
 for (const flag of featureFlagEnvList) {
   if (import.meta.env[`VITE_${flag}`] === '1') {

--- a/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
+++ b/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
@@ -1,7 +1,6 @@
 import {FeatureFlagScope} from './FeatureFlagScope'
 
 export const DefaultFeatureFlags = FeatureFlagScope.create({
-  primer_react_css_modules_staff: false,
   primer_react_css_modules_ga: false,
   primer_react_action_list_item_as_button: false,
   primer_react_select_panel_with_modern_action_list: false,

--- a/packages/react/src/NavList/NavList.tsx
+++ b/packages/react/src/NavList/NavList.tsx
@@ -513,29 +513,31 @@ export const GroupExpand = React.forwardRef<HTMLButtonElement, NavListGroupExpan
           </Box>
         ) : null}
         {(currentPage < pages || currentPage === 0) && teamEnabled ? (
-          <ActionList.Item
-            as="button"
-            aria-expanded="false"
-            ref={forwardedRef}
-            onClick={() => {
-              flushSync(() => {
-                setCurrentPage(currentPage + 1)
-              })
-              const focusTarget: HTMLElement[] | null = Array.from(
-                document.querySelectorAll(`[data-expand-focus-target="${groupId}"]`),
-              )
-
-              if (focusTarget.length > 0) {
-                focusTarget[focusTarget.length - 1].focus()
-              }
-            }}
-            {...props}
-          >
-            {label}
-            <TrailingVisual>
-              <PlusIcon />
-            </TrailingVisual>
-          </ActionList.Item>
+          <li>
+            <ActionList.Item
+              as="button"
+              aria-expanded="false"
+              ref={forwardedRef}
+              onClick={() => {
+                flushSync(() => {
+                  setCurrentPage(currentPage + 1)
+                })
+                const focusTarget: HTMLElement[] | null = Array.from(
+                  document.querySelectorAll(`[data-expand-focus-target="${groupId}"]`),
+                )
+  
+                if (focusTarget.length > 0) {
+                  focusTarget[focusTarget.length - 1].focus()
+                }
+              }}
+              {...props}
+            >
+              {label}
+              <TrailingVisual>
+                <PlusIcon />
+              </TrailingVisual>
+            </ActionList.Item>
+          </li>
         ) : null}
       </>
     )

--- a/packages/react/src/NavList/NavList.tsx
+++ b/packages/react/src/NavList/NavList.tsx
@@ -437,7 +437,7 @@ export const GroupExpand = React.forwardRef<HTMLButtonElement, NavListGroupExpan
     const [currentPage, setCurrentPage] = React.useState(0)
     const groupId = useId()
 
-    const teamEnabled = useFeatureFlag('primer_react_css_modules_team')
+    const gaEnabled = useFeatureFlag('primer_react_css_modules_ga')
 
     const itemsPerPage = items.length / pages
     const amountToShow = pages === 0 ? items.length : Math.ceil(itemsPerPage * currentPage)
@@ -485,7 +485,7 @@ export const GroupExpand = React.forwardRef<HTMLButtonElement, NavListGroupExpan
             })}
           </>
         ) : null}
-        {(currentPage < pages || currentPage === 0) && !teamEnabled ? (
+        {(currentPage < pages || currentPage === 0) && !gaEnabled ? (
           <Box as="li" sx={{listStyle: 'none'}}>
             <ActionList.Item
               as="button"
@@ -512,32 +512,30 @@ export const GroupExpand = React.forwardRef<HTMLButtonElement, NavListGroupExpan
             </ActionList.Item>
           </Box>
         ) : null}
-        {(currentPage < pages || currentPage === 0) && teamEnabled ? (
-          <li>
-            <ActionList.Item
-              as="button"
-              aria-expanded="false"
-              ref={forwardedRef}
-              onClick={() => {
-                flushSync(() => {
-                  setCurrentPage(currentPage + 1)
-                })
-                const focusTarget: HTMLElement[] | null = Array.from(
-                  document.querySelectorAll(`[data-expand-focus-target="${groupId}"]`),
-                )
+        {(currentPage < pages || currentPage === 0) && gaEnabled ? (
+          <ActionList.Item
+            as="button"
+            aria-expanded="false"
+            ref={forwardedRef}
+            onClick={() => {
+              flushSync(() => {
+                setCurrentPage(currentPage + 1)
+              })
+              const focusTarget: HTMLElement[] | null = Array.from(
+                document.querySelectorAll(`[data-expand-focus-target="${groupId}"]`),
+              )
 
-                if (focusTarget.length > 0) {
-                  focusTarget[focusTarget.length - 1].focus()
-                }
-              }}
-              {...props}
-            >
-              {label}
-              <TrailingVisual>
-                <PlusIcon />
-              </TrailingVisual>
-            </ActionList.Item>
-          </li>
+              if (focusTarget.length > 0) {
+                focusTarget[focusTarget.length - 1].focus()
+              }
+            }}
+            {...props}
+          >
+            {label}
+            <TrailingVisual>
+              <PlusIcon />
+            </TrailingVisual>
+          </ActionList.Item>
         ) : null}
       </>
     )

--- a/packages/react/src/NavList/NavList.tsx
+++ b/packages/react/src/NavList/NavList.tsx
@@ -438,7 +438,6 @@ export const GroupExpand = React.forwardRef<HTMLButtonElement, NavListGroupExpan
     const groupId = useId()
 
     const teamEnabled = useFeatureFlag('primer_react_css_modules_team')
-    const staffEnabled = useFeatureFlag('primer_react_css_modules_staff')
 
     const itemsPerPage = items.length / pages
     const amountToShow = pages === 0 ? items.length : Math.ceil(itemsPerPage * currentPage)
@@ -486,7 +485,7 @@ export const GroupExpand = React.forwardRef<HTMLButtonElement, NavListGroupExpan
             })}
           </>
         ) : null}
-        {(currentPage < pages || currentPage === 0) && !teamEnabled && !staffEnabled ? (
+        {(currentPage < pages || currentPage === 0) && !teamEnabled ? (
           <Box as="li" sx={{listStyle: 'none'}}>
             <ActionList.Item
               as="button"
@@ -513,7 +512,7 @@ export const GroupExpand = React.forwardRef<HTMLButtonElement, NavListGroupExpan
             </ActionList.Item>
           </Box>
         ) : null}
-        {(currentPage < pages || currentPage === 0) && (teamEnabled || staffEnabled) ? (
+        {(currentPage < pages || currentPage === 0) && teamEnabled ? (
           <ActionList.Item
             as="button"
             aria-expanded="false"

--- a/packages/react/src/NavList/NavList.tsx
+++ b/packages/react/src/NavList/NavList.tsx
@@ -525,7 +525,7 @@ export const GroupExpand = React.forwardRef<HTMLButtonElement, NavListGroupExpan
                 const focusTarget: HTMLElement[] | null = Array.from(
                   document.querySelectorAll(`[data-expand-focus-target="${groupId}"]`),
                 )
-  
+
                 if (focusTarget.length > 0) {
                   focusTarget[focusTarget.length - 1].focus()
                 }


### PR DESCRIPTION
The `primer_react_css_modules_staff` flag has been removed from components, this PR cleans up the codebase of the flag.