### PR TITLE
feat: add automatic transform for jsx runtime

### DIFF
--- a/.changeset/wise-gifts-see.md
+++ b/.changeset/wise-gifts-see.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Update components to use jsx from react/jsx-runtime instead of createElement

--- a/packages/react/babel.config.js
+++ b/packages/react/babel.config.js
@@ -14,7 +14,16 @@ const sharedPlugins = [
 ]
 
 function makePresets(moduleValue) {
-  return ['@babel/preset-typescript', ['@babel/preset-react', {modules: moduleValue}]]
+  return [
+    '@babel/preset-typescript',
+    [
+      '@babel/preset-react',
+      {
+        modules: moduleValue,
+        runtime: 'automatic',
+      },
+    ],
+  ]
 }
 
 module.exports = {

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -78,6 +78,7 @@ const baseConfig = {
           '@babel/preset-react',
           {
             modules: false,
+            runtime: 'automatic',
           },
         ],
       ],

--- a/packages/react/src/Autocomplete/AutocompleteMenu.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteMenu.tsx
@@ -364,10 +364,13 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
                   text,
                   leadingVisual: LeadingVisual,
                   trailingVisual: TrailingVisual,
+                  // @ts-expect-error this is defined in the items above but is
+                  // missing in TS
+                  key,
                   ...itemProps
                 } = item
                 return (
-                  <ActionList.Item key={id} onSelect={() => onAction(item)} {...itemProps} id={id} data-id={id}>
+                  <ActionList.Item key={key ?? id} onSelect={() => onAction(item)} {...itemProps} id={id} data-id={id}>
                     {LeadingVisual && (
                       <ActionList.LeadingVisual>
                         {isElement(LeadingVisual) ? LeadingVisual : <LeadingVisual />}

--- a/packages/react/src/FilteredActionList/FilteredActionListWithModernActionList.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionListWithModernActionList.tsx
@@ -181,15 +181,15 @@ export function FilteredActionList({
                   <ActionList.GroupHeading variant={group.header?.variant ? group.header.variant : undefined}>
                     {group.header?.title ? group.header.title : `Group ${group.groupId}`}
                   </ActionList.GroupHeading>
-                  {getItemListForEachGroup(group.groupId).map((item, index) => {
-                    const key = item.key ?? item.id?.toString() ?? index.toString()
+                  {getItemListForEachGroup(group.groupId).map(({key: itemKey, ...item}, index) => {
+                    const key = itemKey ?? item.id?.toString() ?? index.toString()
                     return <MappedActionListItem key={key} {...item} renderItem={listProps.renderItem} />
                   })}
                 </ActionList.Group>
               )
             })
-          : items.map((item, index) => {
-              const key = item.key ?? item.id?.toString() ?? index.toString()
+          : items.map(({key: itemKey, ...item}, index) => {
+              const key = itemKey ?? item.id?.toString() ?? index.toString()
               return <MappedActionListItem key={key} {...item} renderItem={listProps.renderItem} />
             })}
       </ActionList>

--- a/packages/react/src/__tests__/Pagination/Pagination.test.tsx
+++ b/packages/react/src/__tests__/Pagination/Pagination.test.tsx
@@ -31,7 +31,7 @@ describe('Pagination', () => {
       <Pagination
         pageCount={10}
         currentPage={1}
-        renderPage={({number, ...props}) => <ReactRouterLikeLink to={`#${number}`} {...props} />}
+        renderPage={({key, number, ...props}) => <ReactRouterLikeLink key={key} to={`#${number}`} {...props} />}
       />,
     )
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Realized when going through our eslint setup that we're not using the new jsx transform when building and testing our components. For more information, see: https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update our babel config to use the `automatic` transform instead of `classic` which is default
- Update components that were failing tests since `key` was not being explicitly passed to a component

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release
