### PR TITLE
Use `SecondaryActionButton` and `SecondaryActionLink` in the SelectPanel docs

### DIFF
--- a/packages/react/src/SelectPanel/SelectPanel.docs.json
+++ b/packages/react/src/SelectPanel/SelectPanel.docs.json
@@ -24,7 +24,10 @@
       "id": "components-selectpanel-features--with-external-anchor"
     },
     {
-      "id": "components-selectpanel-features--with-secondary-action"
+      "id": "components-selectpanel-features--with-secondary-action-button"
+    },
+    {
+      "id": "components-selectpanel-features--with-secondary-action-link"
     },
     {
       "id": "components-selectpanel-features--with-groups"
@@ -173,7 +176,7 @@
       "name": "secondaryAction",
       "type": "React.ReactElement",
       "defaultValue": "null",
-      "description": "Secondary action, it will be rendered in the footer of the panel"
+      "description": "Secondary action, it will be rendered in the footer of the panel. Use `SecondaryActionButton` or `SecondaryActionLink` for the action."
     }
   ],
   "subcomponents": []

--- a/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
@@ -260,7 +260,7 @@ export const WithExternalAnchor = () => {
   )
 }
 
-export const WithSecondaryAction = () => {
+export const WithSecondaryActionButton = () => {
   const [selected, setSelected] = useState<ItemInput[]>(items.slice(1, 3))
   const [filter, setFilter] = useState('')
   const filteredItems = items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
@@ -283,7 +283,38 @@ export const WithSecondaryAction = () => {
         onSelectedChange={setSelected}
         onFilterChange={setFilter}
         overlayProps={{width: 'small', height: 'medium'}}
-        secondaryAction={<Button block>Edit labels</Button>}
+        secondaryAction={<SelectPanel.SecondaryActionButton>Edit labels</SelectPanel.SecondaryActionButton>}
+        width="medium"
+        message={filteredItems.length === 0 ? NoResultsMessage(filter) : undefined}
+      />
+    </FormControl>
+  )
+}
+
+export const WithSecondaryActionLink = () => {
+  const [selected, setSelected] = useState<ItemInput[]>(items.slice(1, 3))
+  const [filter, setFilter] = useState('')
+  const filteredItems = items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
+  const [open, setOpen] = useState(false)
+
+  return (
+    <FormControl>
+      <FormControl.Label>Labels</FormControl.Label>
+      <SelectPanel
+        renderAnchor={({children, ...anchorProps}) => (
+          <Button trailingAction={TriangleDownIcon} {...anchorProps}>
+            {children}
+          </Button>
+        )}
+        placeholder="Select labels" // button text when no items are selected
+        open={open}
+        onOpenChange={setOpen}
+        items={filteredItems}
+        selected={selected}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
+        overlayProps={{width: 'small', height: 'medium'}}
+        secondaryAction={<SelectPanel.SecondaryActionLink href="#">Edit labels</SelectPanel.SecondaryActionLink>}
         width="medium"
         message={filteredItems.length === 0 ? NoResultsMessage(filter) : undefined}
       />


### PR DESCRIPTION
This pull request introduces updates to the `SelectPanel` component to use the `SecondaryActionButton` and `SecondaryActionLink` components in the secondary action prop. 

SecondaryActionButton:
<img width="287" alt="Screenshot 2025-05-02 at 10 31 35" src="https://github.com/user-attachments/assets/e971f686-b664-439e-969b-cb1b6baa9087" />

SecondaryActionLink:
<img width="299" alt="Screenshot 2025-05-02 at 10 31 41" src="https://github.com/user-attachments/assets/d4d8a177-e342-402f-8cf0-8fc3543fd0b0" />


<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

It includes changes to the documentation, stories, and implementation to provide examples for the two distinct types of secondary actions.


### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [X] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [X] Added/updated documentation
- [X] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [X] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
