### PR TITLE
fix(Table): update TableContainer to place `className` on outermost element

### DIFF
--- a/.changeset/silent-comics-knock.md
+++ b/.changeset/silent-comics-knock.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Update the `Table.Container` component to place `className` on outermost element

--- a/packages/react/src/DataTable/Table.tsx
+++ b/packages/react/src/DataTable/Table.tsx
@@ -233,9 +233,9 @@ function TableCellPlaceholder({children}: TableCellPlaceholderProps) {
 // ----------------------------------------------------------------------------
 export type TableContainerProps = React.PropsWithChildren<SxProp & React.HTMLAttributes<HTMLDivElement>>
 
-function TableContainer({children, sx: sxProp = defaultSxProp}: TableContainerProps) {
+function TableContainer({children, className, sx: sxProp = defaultSxProp, ...rest}: TableContainerProps) {
   return (
-    <BoxWithFallback className={clsx(classes.TableContainer)} sx={sxProp}>
+    <BoxWithFallback {...rest} className={clsx(className, classes.TableContainer)} sx={sxProp}>
       {children}
     </BoxWithFallback>
   )

--- a/packages/react/src/DataTable/__tests__/Table.test.tsx
+++ b/packages/react/src/DataTable/__tests__/Table.test.tsx
@@ -148,6 +148,16 @@ describe('Table', () => {
   })
 
   describe('Table.Container', () => {
+    it('should support additional props on the outermost element', () => {
+      const {container} = render(<Table.Container data-testid="test" />)
+      expect(container.firstElementChild).toHaveAttribute('data-testid', 'test')
+    })
+
+    it('should support a custom `className` through the `className` prop', () => {
+      const {container} = render(<Table.Container className="test" />)
+      expect(container.firstElementChild).toHaveClass('test')
+    })
+
     it('should support custom styles through the `sx` prop', () => {
       const {container} = render(<Table.Container sx={{m: 0}} />)
       expect(container.firstElementChild).toHaveStyle('margin:0')


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/5185

<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update the `Table.Container` component to correctly place the provided `className` on the outermost element.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `Table.Container` to place provided `className` on outermost element

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
