### PR TITLE
ActionList: Add `role="option"` if `role="listbox"` is present

### DIFF
--- a/.changeset/soft-webs-study.md
+++ b/.changeset/soft-webs-study.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+ActionList: Ensure `role="option"` is added when `role="listbox"` is used; allow disabled items to remain focusable

--- a/packages/react/src/ActionList/ActionList.features.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.features.stories.tsx
@@ -329,7 +329,35 @@ export const MultiSelect = () => {
   )
 }
 
-export const ListBoxMultiSelect = () => {
+export const ListboxSingleSelect = () => {
+  const [selectedIndice, setSelectedIndice] = React.useState<number>(0)
+  const handleSelect = (index: number) => {
+    setSelectedIndice(index)
+  }
+
+  return (
+    <ActionList selectionVariant="single" role="listbox" aria-label="Projects">
+      {projects.map((project, index) => (
+        <ActionList.Item
+          key={index}
+          selected={selectedIndice === index}
+          aria-checked={selectedIndice === index}
+          onSelect={() => handleSelect(index)}
+          disabled={index === 3 ? true : undefined}
+          role="option"
+        >
+          <ActionList.LeadingVisual>
+            <TableIcon />
+          </ActionList.LeadingVisual>
+          {project.name}
+          <ActionList.Description variant="block">{project.scope}</ActionList.Description>
+        </ActionList.Item>
+      ))}
+    </ActionList>
+  )
+}
+
+export const ListboxMultiSelect = () => {
   const [selectedIndices, setSelectedIndices] = React.useState<number[]>([0])
   const handleSelect = (index: number) => {
     if (selectedIndices.includes(index)) {
@@ -339,7 +367,7 @@ export const ListBoxMultiSelect = () => {
     }
   }
   return (
-    <ActionList role="menu" selectionVariant="multiple" aria-label="Project">
+    <ActionList role="menu" selectionVariant="multiple" aria-label="Projects">
       {projects.map((project, index) => (
         <ActionList.Item
           key={index}

--- a/packages/react/src/ActionList/ActionList.test.tsx
+++ b/packages/react/src/ActionList/ActionList.test.tsx
@@ -94,7 +94,9 @@ describe('ActionList', () => {
     expect(document.activeElement).toHaveTextContent('Option 2')
 
     await userEvent.keyboard('{ArrowDown}')
-    expect(document.activeElement).not.toHaveTextContent('Option 3') // option 3 is disabled
+    expect(document.activeElement).toHaveTextContent('Option 3')
+
+    await userEvent.keyboard('{ArrowDown}')
     expect(document.activeElement).toHaveTextContent('Option 4')
 
     await userEvent.keyboard('{ArrowDown}')

--- a/packages/react/src/ActionList/Item.test.tsx
+++ b/packages/react/src/ActionList/Item.test.tsx
@@ -47,7 +47,6 @@ function SingleSelectListStory(): JSX.Element {
       {projects.map((project, index) => (
         <ActionList.Item
           key={index}
-          role="option"
           selected={index === selectedIndex}
           onSelect={() => setSelectedIndex(index)}
           disabled={project.disabled}
@@ -193,6 +192,7 @@ describe('ActionList.Item', () => {
     await userEvent.tab() // get focus on first element
     await userEvent.keyboard('{ArrowDown}')
     await userEvent.keyboard('{ArrowDown}')
+    await userEvent.keyboard('{ArrowDown}')
     expect(inactiveOption).toHaveFocus()
     expect(document.activeElement).toHaveAccessibleDescription(projects[3].inactiveText as string)
   })
@@ -216,6 +216,7 @@ describe('ActionList.Item', () => {
     const component = HTMLRender(<SingleSelectListStory />)
     const inactiveOption = await waitFor(() => component.getByRole('option', {name: projects[5].name}))
     await userEvent.tab() // get focus on first element
+    await userEvent.keyboard('{ArrowDown}')
     await userEvent.keyboard('{ArrowDown}')
     await userEvent.keyboard('{ArrowDown}')
     await userEvent.keyboard('{ArrowDown}')
@@ -419,5 +420,19 @@ describe('ActionList.Item', () => {
     const button = getByRole('button')
     expect(button.parentElement?.tagName).toBe('LI')
     expect(button.textContent).toBe('Item 5')
+  })
+
+  it('should add `role="option"` if `role="listbox"` and `selectionVariant` is present', async () => {
+    const {getAllByRole} = HTMLRender(
+      <ActionList role="listbox" selectionVariant="single">
+        <ActionList.Item>Item 1</ActionList.Item>
+        <ActionList.Item>Item 2</ActionList.Item>
+        <ActionList.Item>Item 3</ActionList.Item>
+        <ActionList.Item>Item 4</ActionList.Item>
+      </ActionList>,
+    )
+    const options = getAllByRole('option')
+    expect(options[0]).toBeInTheDocument()
+    expect(options).toHaveLength(4)
   })
 })

--- a/packages/react/src/ActionList/Item.tsx
+++ b/packages/react/src/ActionList/Item.tsx
@@ -141,8 +141,8 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       if (selectionVariant === 'single') inferredItemRole = 'menuitemradio'
       else if (selectionVariant === 'multiple') inferredItemRole = 'menuitemcheckbox'
       else inferredItemRole = 'menuitem'
-    } else if (container === 'SelectPanel' && listRole === 'listbox') {
-      if (selectionVariant !== undefined) inferredItemRole = 'option'
+    } else if ((container === 'SelectPanel' && listRole === 'listbox') || listRole === 'listbox') {
+      if (selectionVariant !== undefined && !role) inferredItemRole = 'option'
     }
 
     const itemRole = role || inferredItemRole
@@ -325,8 +325,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
 
     let focusable
 
-    // if item is disabled and is of type (menuitem*, option) it should remain focusable, if inactive, apply the same rules
-    if ((disabled && !inferredItemRole) || showInactiveIndicator) {
+    if (showInactiveIndicator) {
       focusable = true
     }
 

--- a/packages/react/src/ActionList/Item.tsx
+++ b/packages/react/src/ActionList/Item.tsx
@@ -141,7 +141,7 @@ export const Item = React.forwardRef<HTMLLIElement, ActionListItemProps>(
       if (selectionVariant === 'single') inferredItemRole = 'menuitemradio'
       else if (selectionVariant === 'multiple') inferredItemRole = 'menuitemcheckbox'
       else inferredItemRole = 'menuitem'
-    } else if ((container === 'SelectPanel' && listRole === 'listbox') || listRole === 'listbox') {
+    } else if (listRole === 'listbox') {
       if (selectionVariant !== undefined && !role) inferredItemRole = 'option'
     }
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5083

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Adds `role="option"` if `role="listbox"` is applied to `ActionList`. This stemmed from some instances of `ActionList` utilizing `role="listbox"` without adding `role="option"`. This broke functionality, as usage of `selectionVariant` requires either `aria-checked` being present, or `role="option"`. 

Since we can infer what child roles should be based on the parent role, this PR adds `role="option"` if `role="listbox"` is present

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

* Adds `role="option"` if `role="listbox"` is present in `ActionList`

#### Changed

<!-- List of things changed in this PR -->

* Allows `ActionList.Item`(s) to be focused even if `inferredItemRole` is present

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
