### PR TITLE
Add support for aria-label on ActionList.Group

### DIFF
--- a/.changeset/funny-pans-sneeze.md
+++ b/.changeset/funny-pans-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Add support for aria-label on ActionList.Group

--- a/packages/react/src/ActionList/ActionList.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.stories.tsx
@@ -289,6 +289,9 @@ GroupPlayground.argTypes = {
   title: {
     type: 'string',
   },
+  'aria-label': {
+    type: 'string',
+  },
   auxiliaryText: {
     type: 'string',
   },

--- a/packages/react/src/ActionList/Group.test.tsx
+++ b/packages/react/src/ActionList/Group.test.tsx
@@ -131,17 +131,17 @@ describe('ActionList.Group', () => {
     expect(list).not.toHaveAttribute('aria-labelledby', heading.id)
   })
 
-    it('should label the list with aria-label if it is specified', async () => {
-      const {container, getByText} = HTMLRender(
-        <ActionList>
-          <ActionList.Heading as="h1">Heading</ActionList.Heading>
-          <ActionList.Group aria-label="Animals" data-test-id="ActionList.Group">
-            <ActionList.Item>Item</ActionList.Item>
-          </ActionList.Group>
-        </ActionList>,
-      )
-      const list = container.querySelector(`li[data-test-id='ActionList.Group'] > ul`)
-      expect(list).toHaveAttribute('aria-label', "Animals")
+  it('should label the list with aria-label if it is specified', async () => {
+    const {container} = HTMLRender(
+      <ActionList>
+        <ActionList.Heading as="h1">Heading</ActionList.Heading>
+        <ActionList.Group aria-label="Animals" data-test-id="ActionList.Group">
+          <ActionList.Item>Item</ActionList.Item>
+        </ActionList.Group>
+      </ActionList>,
+    )
+    const list = container.querySelector(`li[data-test-id='ActionList.Group'] > ul`)
+    expect(list).toHaveAttribute('aria-label', 'Animals')
   })
 
   it('should support a custom `className` on the outermost element', () => {

--- a/packages/react/src/ActionList/Group.test.tsx
+++ b/packages/react/src/ActionList/Group.test.tsx
@@ -131,6 +131,19 @@ describe('ActionList.Group', () => {
     expect(list).not.toHaveAttribute('aria-labelledby', heading.id)
   })
 
+    it('should label the list with aria-label if it is specified', async () => {
+      const {container, getByText} = HTMLRender(
+        <ActionList>
+          <ActionList.Heading as="h1">Heading</ActionList.Heading>
+          <ActionList.Group aria-label="Animals" data-test-id="ActionList.Group">
+            <ActionList.Item>Item</ActionList.Item>
+          </ActionList.Group>
+        </ActionList>,
+      )
+      const list = container.querySelector(`li[data-test-id='ActionList.Group'] > ul`)
+      expect(list).toHaveAttribute('aria-label', "Animals")
+  })
+
   it('should support a custom `className` on the outermost element', () => {
     const Element = () => {
       return (

--- a/packages/react/src/ActionList/Group.tsx
+++ b/packages/react/src/ActionList/Group.tsx
@@ -69,6 +69,11 @@ export type ActionListGroupProps = {
    * Custom class name to apply to the `Group`.
    */
   className?: string
+  /**
+   * `aria-label` to set directly on the `role="group"` element. This is used to label the group.
+   */
+  'aria-label'?: string
+
 } & SxProp & {
     /**
      * Whether multiple Items or a single Item can be selected in the Group. Overrides value on ActionList root.
@@ -89,6 +94,7 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
   selectionVariant,
   role,
   className,
+  'aria-label': ariaLabel,
   sx = defaultSxProp,
   ...props
 }) => {
@@ -131,7 +137,10 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
           // because the heading is hidden from the accessibility tree and only used for presentation role.
           // We will instead use aria-label to label the list. See a line below.
           aria-labelledby={listRole ? undefined : groupHeadingId}
-          aria-label={listRole ? (title ?? (slots.groupHeading?.props.children as string)) : undefined}
+          aria-label={
+            ariaLabel ??
+            (listRole ? (title ?? (slots.groupHeading?.props.children as string)) : undefined)
+          }          
           role={role || (listRole && 'group')}
           className={groupClasses.GroupList}
         >

--- a/packages/react/src/ActionList/Group.tsx
+++ b/packages/react/src/ActionList/Group.tsx
@@ -73,7 +73,6 @@ export type ActionListGroupProps = {
    * `aria-label` to set directly on the `role="group"` element. This is used to label the group.
    */
   'aria-label'?: string
-
 } & SxProp & {
     /**
      * Whether multiple Items or a single Item can be selected in the Group. Overrides value on ActionList root.
@@ -137,10 +136,7 @@ export const Group: React.FC<React.PropsWithChildren<ActionListGroupProps>> = ({
           // because the heading is hidden from the accessibility tree and only used for presentation role.
           // We will instead use aria-label to label the list. See a line below.
           aria-labelledby={listRole ? undefined : groupHeadingId}
-          aria-label={
-            ariaLabel ??
-            (listRole ? (title ?? (slots.groupHeading?.props.children as string)) : undefined)
-          }          
+          aria-label={ariaLabel ?? (listRole ? (title ?? (slots.groupHeading?.props.children as string)) : undefined)}
           role={role || (listRole && 'group')}
           className={groupClasses.GroupList}
         >


### PR DESCRIPTION
Relates to: https://github.com/github/github/pull/378062/files
Fixes: https://github.com/github/primer/issues/5202

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

`aria-label` attribute is now forwarded to the `<ul>` element when it's set, rather than the `<li>` element.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
