### PR TITLE
DataTable: Add `outline-offset` to `DataTable` pagination buttons

### DIFF
--- a/.changeset/fine-impalas-eat.md
+++ b/.changeset/fine-impalas-eat.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+DataTable: Adds outline-offset to focus indicator on pagination buttons

--- a/packages/react/src/DataTable/Pagination.tsx
+++ b/packages/react/src/DataTable/Pagination.tsx
@@ -81,12 +81,17 @@ const StyledPagination = styled.nav`
   .TablePaginationPage:hover,
   .TablePaginationPage:focus {
     background-color: ${get('colors.actionListItem.default.hoverBg')};
-    transition-duration: 0.1s;
   }
 
   .TablePaginationPage[data-active='true'] {
     background-color: ${get('colors.accent.emphasis')};
     color: ${get('colors.fg.onEmphasis')};
+  }
+
+  .TablePaginationPage[data-active='true']:focus-visible {
+    outline: 2px solid var(--bgColor-accent-emphasis);
+    outline-offset: -2px;
+    box-shadow: inset 0 0 0 3px var(--fgColor-onEmphasis);
   }
 
   .TablePaginationTruncationStep {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Context: https://github.com/github/accessibility-audits/issues/11135

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Adds outline offset to focus outline on pagination buttons in DataTable. 

Before: 

<img width="488" alt="DataTable with first button in pagination focused; the focus outline blends in with the button's background color" src="https://github.com/user-attachments/assets/328aaeff-e304-4401-8527-ddf03a3e59be" />

After: 

<img width="488" alt="DataTable with first button in pagination focused; the focus outline is slightly offset from the button" src="https://github.com/user-attachments/assets/13c1209d-6a37-4a77-9b93-b8cd7796cffc" />

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->

* Adds outline-offset to pagination buttons

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
