### PR TITLE
chore(deps): add additional groups to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,10 +14,36 @@ updates:
       - 'dependencies'
       - 'skip changeset'
     groups:
+      babel:
+        patterns:
+          - '@babel/*'
+          - 'babel-plugin-*'
+      eslint:
+        patterns:
+          - '@eslint/*'
+          - 'eslint'
+          - 'eslint-plugin-*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - 'react-is'
+          - '@types/react'
+          - '@types/react-dom'
+          - '@types/react-is'
+      rollup:
+        patterns:
+          - '@rollup/*'
+          - 'rollup'
+          - 'rollup-plugin-*'
       storybook:
         patterns:
           - '@storybook/*'
           - 'storybook'
+      vitest:
+        patterns:
+          - '@vitest/*'
+          - 'vitest'
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Add additional groups to dependabot to help group related dependencies together.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update `dependabot.yml` to include additional groups for babel, rollup, vitest, and more

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This changes the internal dependabot config for the project that is used to manage dependencies.