### PR TITLE
SelectPanel: Add example of `inactiveText` usage

### DIFF
--- a/packages/react/src/ActionList/ActionList.features.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.features.stories.tsx
@@ -442,6 +442,7 @@ export const InactiveMultiselect = () => {
       {/* menuitem because state is inactive */}
       <ActionList.Item role="menuitem" selected={false} inactiveText="Unavailable due to an outage">
         Inactive item
+        <ActionList.Description variant="block">Some description about the item</ActionList.Description>
       </ActionList.Item>
       <ActionList.Item
         role="menuitemcheckbox"

--- a/packages/react/src/ActionList/ActionList.features.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.features.stories.tsx
@@ -442,7 +442,6 @@ export const InactiveMultiselect = () => {
       {/* menuitem because state is inactive */}
       <ActionList.Item role="menuitem" selected={false} inactiveText="Unavailable due to an outage">
         Inactive item
-        <ActionList.Description variant="block">Some description about the item</ActionList.Description>
       </ActionList.Item>
       <ActionList.Item
         role="menuitemcheckbox"

--- a/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
@@ -805,3 +805,51 @@ export const SingleSelectModal = () => {
     />
   )
 }
+
+type Items = ItemInput & {
+  inactiveText?: string
+}
+
+const itemsWithInactive: Items[] = [
+  ...items,
+  {
+    leadingVisual: getColorCircle('#00ff00'),
+    text: 'request',
+    id: 9,
+    inactiveText: 'Currently inactive due to an outage',
+    description: 'New feature or request',
+    descriptionVariant: 'block',
+  },
+]
+
+export const WithInactiveItems = () => {
+  const [selected, setSelected] = useState<ItemInput[]>(items.slice(1, 3))
+  const [filter, setFilter] = useState('')
+  const filteredItems = itemsWithInactive.filter(item => item.text?.toLowerCase().startsWith(filter.toLowerCase()))
+
+  const [open, setOpen] = useState(false)
+
+  return (
+    <FormControl>
+      <FormControl.Label>Labels</FormControl.Label>
+      <SelectPanel
+        title="Select labels"
+        placeholder="Select labels" // button text when no items are selected
+        subtitle="Use labels to organize issues and pull requests"
+        renderAnchor={({children, ...anchorProps}) => (
+          <Button trailingAction={TriangleDownIcon} {...anchorProps} aria-haspopup="dialog">
+            {children}
+          </Button>
+        )}
+        open={open}
+        onOpenChange={setOpen}
+        items={filteredItems}
+        selected={selected}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
+        width="medium"
+        message={filteredItems.length === 0 ? NoResultsMessage(filter) : undefined}
+      />
+    </FormControl>
+  )
+}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Context: https://github.com/github/primer/issues/5220

Adds example of `inactiveText` usage in `SelectPanel`

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed
* Adds example of `inactive` usage in `SelectPanel`


### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
