### PR TITLE
Remove explicit npm version from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,5 @@
       "webpack": false,
       "running": false
     }
-  ],
-  "packageManager": "npm@10.9.2+sha512.8ab88f10f224a0c614cb717a7f7c30499014f77134120e9c1f0211ea3cf3397592cbe483feb38e0c4b3be1c54e347292c76a1b5edb94a3289d5448484ab8ac81"
+  ]
 }


### PR DESCRIPTION
Remove the explicit npm cli version that we have in our root `package.json`. This was to prevent npm@11 being downloaded which was causing flakiness in our CI suite 😅 

Hopefully with the recent releases of npm@11 this issue has gone away. If not, we can revert this change.