### PR TITLE
chore: update vitest, add node config and disable screenshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@primer/stylelint-config": "13.1.1",
         "@size-limit/preset-big-lib": "11.2.0",
         "@types/jest": "29.5.14",
-        "@vitest/browser": "^3.1.2",
+        "@vitest/browser": "^3.2.0",
         "eslint": "^9.25.1",
         "eslint-import-resolver-typescript": "3.7.0",
         "eslint-plugin-clsx": "^0.0.10",
@@ -57,7 +57,7 @@
         "typed-css-modules": "0.9.1",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.33.0",
-        "vitest": "^3.1.2"
+        "vitest": "^3.2.0"
       },
       "engines": {
         "node": ">=12",
@@ -9691,6 +9691,16 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/concat-stream": {
       "version": "2.0.3",
       "dev": true,
@@ -9706,6 +9716,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/doctrine": {
       "version": "0.0.9",
@@ -10759,27 +10776,27 @@
       }
     },
     "node_modules/@vitest/browser": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.1.2.tgz",
-      "integrity": "sha512-dwL6hQg3NSDP3Z4xzIZL0xHq/AkQAPQ4StFpWVlY2zbRJtK3Y2YqdFZ7YmZjszTETN1BDQZRn/QOrcP+c8ATgg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.2.0.tgz",
+      "integrity": "sha512-sVpX5m53lX9/0ehAqkcTSQeJK1SVlTlvBrwE8rPQ2KJQgb/Iiorx+3y+VQdzIJ+CDqfG89bQEA5l1Z02VogDsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
-        "@vitest/mocker": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@vitest/mocker": "3.2.0",
+        "@vitest/utils": "3.2.0",
         "magic-string": "^0.30.17",
         "sirv": "^3.0.1",
         "tinyrainbow": "^2.0.0",
-        "ws": "^8.18.1"
+        "ws": "^8.18.2"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "playwright": "*",
-        "vitest": "3.1.2",
+        "vitest": "3.2.0",
         "webdriverio": "^7.0.0 || ^8.0.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
@@ -10809,9 +10826,9 @@
       }
     },
     "node_modules/@vitest/browser/node_modules/@vitest/pretty-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.0.tgz",
+      "integrity": "sha512-gUUhaUmPBHFkrqnOokmfMGRBMHhgpICud9nrz/xpNV3/4OXCn35oG+Pl8rYYsKaTNd/FAIrqRHnwpDpmYxCYZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10822,13 +10839,13 @@
       }
     },
     "node_modules/@vitest/browser/node_modules/@vitest/utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
-      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.0.tgz",
+      "integrity": "sha512-gXXOe7Fj6toCsZKVQouTRLJftJwmvbhH5lKOBR6rlP950zUq9AitTUjnFoXS/CqjBC2aoejAztLPzzuva++XBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.2.0",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -10847,9 +10864,9 @@
       }
     },
     "node_modules/@vitest/browser/node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10924,13 +10941,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
-      "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.0.tgz",
+      "integrity": "sha512-HFcW0lAMx3eN9vQqis63H0Pscv0QcVMo1Kv8BNysZbxcmHu3ZUYv59DS6BGYiGQ8F5lUkmsfMMlPm4DJFJdf/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.2",
+        "@vitest/spy": "3.2.0",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -10939,7 +10956,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -10951,13 +10968,13 @@
       }
     },
     "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
-      "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.0.tgz",
+      "integrity": "sha512-s3+TkCNUIEOX99S0JwNDfsHRaZDDZZR/n8F0mop0PmsEbQGKZikCGpTGZ6JRiHuONKew3Fb5//EPwCP+pUX9cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -10971,6 +10988,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/pretty-format": {
@@ -10987,13 +11014,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
-      "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.0.tgz",
+      "integrity": "sha512-bXdmnHxuB7fXJdh+8vvnlwi/m1zvu+I06i1dICVcDQFhyV4iKw2RExC/acavtDn93m/dRuawUObKsrNE1gJacA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.1.2",
+        "@vitest/utils": "3.2.0",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -11001,9 +11028,9 @@
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.0.tgz",
+      "integrity": "sha512-gUUhaUmPBHFkrqnOokmfMGRBMHhgpICud9nrz/xpNV3/4OXCn35oG+Pl8rYYsKaTNd/FAIrqRHnwpDpmYxCYZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11014,13 +11041,13 @@
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
-      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.0.tgz",
+      "integrity": "sha512-gXXOe7Fj6toCsZKVQouTRLJftJwmvbhH5lKOBR6rlP950zUq9AitTUjnFoXS/CqjBC2aoejAztLPzzuva++XBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.2.0",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -11039,13 +11066,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
-      "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.0.tgz",
+      "integrity": "sha512-z7P/EneBRMe7hdvWhcHoXjhA6at0Q4ipcoZo6SqgxLyQQ8KSMMCmvw1cSt7FHib3ozt0wnRHc37ivuUMbxzG/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.2.0",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -11054,9 +11081,9 @@
       }
     },
     "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.0.tgz",
+      "integrity": "sha512-gUUhaUmPBHFkrqnOokmfMGRBMHhgpICud9nrz/xpNV3/4OXCn35oG+Pl8rYYsKaTNd/FAIrqRHnwpDpmYxCYZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14430,9 +14457,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -29537,9 +29564,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -29565,9 +29592,9 @@
       }
     },
     "node_modules/tinypool": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
-      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
+      "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -31636,17 +31663,17 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
-      "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.0.tgz",
+      "integrity": "sha512-8Fc5Ko5Y4URIJkmMF/iFP1C0/OJyY+VGVe9Nw6WAdZyw4bTO+eVg9mwxWkQp/y8NnAoQY3o9KAvE1ZdA2v+Vmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.4.0",
-        "es-module-lexer": "^1.6.0",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
         "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
@@ -31659,9 +31686,9 @@
       }
     },
     "node_modules/vite-node/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -31709,32 +31736,34 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
-      "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.0.tgz",
+      "integrity": "sha512-P7Nvwuli8WBNmeMHHek7PnGW4oAZl9za1fddfRVidZar8wDZRi7hpznLKQePQ8JPLwSBEYDK11g+++j7uFJV8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.1.2",
-        "@vitest/mocker": "3.1.2",
-        "@vitest/pretty-format": "^3.1.2",
-        "@vitest/runner": "3.1.2",
-        "@vitest/snapshot": "3.1.2",
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.0",
+        "@vitest/mocker": "3.2.0",
+        "@vitest/pretty-format": "^3.2.0",
+        "@vitest/runner": "3.2.0",
+        "@vitest/snapshot": "3.2.0",
+        "@vitest/spy": "3.2.0",
+        "@vitest/utils": "3.2.0",
         "chai": "^5.2.0",
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "expect-type": "^1.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
         "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.13",
-        "tinypool": "^1.0.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.0",
         "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.1.2",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -31750,8 +31779,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.1.2",
-        "@vitest/ui": "3.1.2",
+        "@vitest/browser": "3.2.0",
+        "@vitest/ui": "3.2.0",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -31780,14 +31809,15 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/expect": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
-      "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.0.tgz",
+      "integrity": "sha512-0v4YVbhDKX3SKoy0PHWXpKhj44w+3zZkIoVES9Ex2pq+u6+Bijijbi2ua5kE+h3qT6LBWFTNZSCOEU37H8Y5sA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.0",
+        "@vitest/utils": "3.2.0",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -31796,9 +31826,9 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/pretty-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.0.tgz",
+      "integrity": "sha512-gUUhaUmPBHFkrqnOokmfMGRBMHhgpICud9nrz/xpNV3/4OXCn35oG+Pl8rYYsKaTNd/FAIrqRHnwpDpmYxCYZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -31809,26 +31839,26 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/spy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
-      "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.0.tgz",
+      "integrity": "sha512-s3+TkCNUIEOX99S0JwNDfsHRaZDDZZR/n8F0mop0PmsEbQGKZikCGpTGZ6JRiHuONKew3Fb5//EPwCP+pUX9cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest/node_modules/@vitest/utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
-      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.0.tgz",
+      "integrity": "sha512-gXXOe7Fj6toCsZKVQouTRLJftJwmvbhH5lKOBR6rlP950zUq9AitTUjnFoXS/CqjBC2aoejAztLPzzuva++XBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.2.0",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -31837,9 +31867,9 @@
       }
     },
     "node_modules/vitest/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -31861,10 +31891,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vitest/node_modules/tinyrainbow": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
       "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@primer/stylelint-config": "13.1.1",
     "@size-limit/preset-big-lib": "11.2.0",
     "@types/jest": "29.5.14",
-    "@vitest/browser": "^3.1.2",
+    "@vitest/browser": "^3.2.0",
     "eslint": "^9.25.1",
     "eslint-import-resolver-typescript": "3.7.0",
     "eslint-plugin-clsx": "^0.0.10",
@@ -89,7 +89,7 @@
     "typed-css-modules": "0.9.1",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.33.0",
-    "vitest": "^3.1.2"
+    "vitest": "^3.2.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.41.1"

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/utils/test-matchers.tsx', '<rootDir>/src/utils/test-deprecations.tsx'],
   testMatch: ['<rootDir>/**/*.test.[jt]s?(x)', '!**/*.types.test.[jt]s?(x)'],
   modulePathIgnorePatterns: [
+    '<rootDir>/src/__tests__/exports.test.ts',
     '<rootDir>/src/ActionBar/',
     '<rootDir>/src/AnchoredOverlay/',
     '<rootDir>/src/Banner/',

--- a/packages/react/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`@primer/react should not update exports without a semver change 1`] = `
+exports[`@primer/react > should not update exports without a semver change 1`] = `
 [
   "ActionBar",
   "type ActionBarProps",
@@ -219,7 +219,7 @@ exports[`@primer/react should not update exports without a semver change 1`] = `
 ]
 `;
 
-exports[`@primer/react/deprecated should not update exports without a semver change 1`] = `
+exports[`@primer/react/deprecated > should not update exports without a semver change 1`] = `
 [
   "ActionList",
   "type ActionListGroupedListProps",
@@ -249,7 +249,7 @@ exports[`@primer/react/deprecated should not update exports without a semver cha
 ]
 `;
 
-exports[`@primer/react/experimental should not update exports without a semver change 1`] = `
+exports[`@primer/react/experimental > should not update exports without a semver change 1`] = `
 [
   "ActionBar",
   "type ActionBarProps",

--- a/packages/react/src/__tests__/exports.test.ts
+++ b/packages/react/src/__tests__/exports.test.ts
@@ -1,6 +1,7 @@
 import {existsSync} from 'node:fs'
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import {beforeAll, describe, expect, it} from 'vitest'
 // eslint-disable-next-line import/no-namespace
 import * as parser from '@babel/parser'
 import {traverse} from '@babel/core'

--- a/packages/react/vitest.config.browser.mts
+++ b/packages/react/vitest.config.browser.mts
@@ -1,0 +1,71 @@
+import {defineConfig} from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    __DEV__: true,
+  },
+  test: {
+    name: '@primer/react',
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/lib-esm/**',
+      '**/lib/**',
+      '**/generated/**',
+      '**/*.figma.tsx',
+      '**/*.types.test.tsx',
+    ],
+    include: [
+      'src/ActionBar/**/*.test.?(c|m)[jt]s?(x)',
+      'src/AnchoredOverlay/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Banner/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Blankslate/**/*.test.?(c|m)[jt]s?(x)',
+      'src/BranchName/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Breadcrumbs/**/*.test.?(c|m)[jt]s?(x)',
+      'src/ButtonGroup/**/*.test.?(c|m)[jt]s?(x)',
+      'src/CheckboxGroup/**/*.test.?(c|m)[jt]s?(x)',
+      'src/CircleBadge/**/*.test.?(c|m)[jt]s?(x)',
+      'src/CircleOcticon/**/*.test.?(c|m)[jt]s?(x)',
+      'src/DataTable/**/*.test.?(c|m)[jt]s?(x)',
+      'src/FeatureFlags/**/*.test.?(c|m)[jt]s?(x)',
+      'src/ProgressBar/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Radio/**/*.test.?(c|m)[jt]s?(x)',
+      'src/RadioGroup/**/*.test.?(c|m)[jt]s?(x)',
+      'src/RelativeTime/**/*.test.?(c|m)[jt]s?(x)',
+      'src/ScrollableRegion/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Select/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Skeleton/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Spinner/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Stack/**/*.test.?(c|m)[jt]s?(x)',
+      'src/StateLabel/**/*.test.?(c|m)[jt]s?(x)',
+      'src/SubNav/**/*.test.?(c|m)[jt]s?(x)',
+      'src/TabNav/**/*.test.?(c|m)[jt]s?(x)',
+      'src/TextInputWithTokens/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Textarea/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Timeline/**/*.test.?(c|m)[jt]s?(x)',
+      'src/ToggleSwitch/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Tooltip/**/*.test.?(c|m)[jt]s?(x)',
+      'src/TooltipV2/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Truncate/**/*.test.?(c|m)[jt]s?(x)',
+      'src/UnderlineNav/**/*.test.?(c|m)[jt]s?(x)',
+      'src/hooks/**/*.test.?(c|m)[jt]s?(x)',
+    ],
+    setupFiles: ['config/vitest/setup.ts'],
+    css: {
+      include: [/.+/],
+    },
+    browser: {
+      provider: 'playwright',
+      enabled: true,
+      headless: process.env.DEBUG_BROWSER_TESTS === 'true' ? false : true,
+      instances: [
+        {
+          browser: 'chromium',
+        },
+      ],
+      screenshotFailures: false,
+    },
+  },
+})

--- a/packages/react/vitest.config.mts
+++ b/packages/react/vitest.config.mts
@@ -1,69 +1,9 @@
 import {defineConfig} from 'vitest/config'
-import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  plugins: [react()],
-  define: {
-    __DEV__: true,
-  },
   test: {
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/lib-esm/**',
-      '**/lib/**',
-      '**/generated/**',
-      '**/*.figma.tsx',
-      '**/*.types.test.tsx',
-    ],
-    include: [
-      'src/ActionBar/**/*.test.?(c|m)[jt]s?(x)',
-      'src/AnchoredOverlay/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Banner/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Blankslate/**/*.test.?(c|m)[jt]s?(x)',
-      'src/BranchName/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Breadcrumbs/**/*.test.?(c|m)[jt]s?(x)',
-      'src/ButtonGroup/**/*.test.?(c|m)[jt]s?(x)',
-      'src/CheckboxGroup/**/*.test.?(c|m)[jt]s?(x)',
-      'src/CircleBadge/**/*.test.?(c|m)[jt]s?(x)',
-      'src/CircleOcticon/**/*.test.?(c|m)[jt]s?(x)',
-      'src/DataTable/**/*.test.?(c|m)[jt]s?(x)',
-      'src/FeatureFlags/**/*.test.?(c|m)[jt]s?(x)',
-      'src/ProgressBar/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Radio/**/*.test.?(c|m)[jt]s?(x)',
-      'src/RadioGroup/**/*.test.?(c|m)[jt]s?(x)',
-      'src/RelativeTime/**/*.test.?(c|m)[jt]s?(x)',
-      'src/ScrollableRegion/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Select/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Skeleton/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Spinner/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Stack/**/*.test.?(c|m)[jt]s?(x)',
-      'src/StateLabel/**/*.test.?(c|m)[jt]s?(x)',
-      'src/SubNav/**/*.test.?(c|m)[jt]s?(x)',
-      'src/TabNav/**/*.test.?(c|m)[jt]s?(x)',
-      'src/TextInputWithTokens/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Textarea/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Timeline/**/*.test.?(c|m)[jt]s?(x)',
-      'src/ToggleSwitch/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Tooltip/**/*.test.?(c|m)[jt]s?(x)',
-      'src/TooltipV2/**/*.test.?(c|m)[jt]s?(x)',
-      'src/Truncate/**/*.test.?(c|m)[jt]s?(x)',
-      'src/UnderlineNav/**/*.test.?(c|m)[jt]s?(x)',
-      'src/hooks/**/*.test.?(c|m)[jt]s?(x)',
-    ],
-    setupFiles: ['config/vitest/setup.ts'],
-    css: {
-      include: [/.+/],
-    },
-    browser: {
-      provider: 'playwright',
-      enabled: true,
-      headless: process.env.DEBUG_BROWSER_TESTS === 'true' ? false : true,
-      instances: [
-        {
-          browser: 'chromium',
-        },
-      ],
-    },
+    name: '@primer/react (node)',
+    include: ['src/__tests__/exports.test.ts'],
+    environment: 'node',
   },
 })

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -2,6 +2,6 @@ import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
   test: {
-    workspace: ['packages/*/vitest.config.ts', 'packages/*/vitest.config.mts'],
+    projects: ['packages/*/vitest.config.ts', 'packages/*/vitest.config.mts', 'packages/*/vitest.config.browser.mts'],
   },
 })


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update vitest to 3.2.0, including migrating from the deprecated "workspaces" config to the new "projects". This also adds support for running tests in a Node.js environment, where appropriate, along with disabling screenshots on failure.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add support for Node.js-based vitest tests in packages/react

#### Changed

<!-- List of things changed in this PR -->

- Update vitest to 3.2.0
- Update workspaces config to use projects
- Update exports.test.ts to be in vitest

#### Removed

<!-- List of things removed in this PR -->
