### PR TITLE
ci: add checkout for staff label workflow

### DIFF
--- a/.github/workflows/add_staff_label.yml
+++ b/.github/workflows/add_staff_label.yml
@@ -13,6 +13,8 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Add label to issue
         if: ${{ github.event.issue.author_association == 'MEMBER' }}
         run: |


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Noticed that our action was failing with this message:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

This PR adds a checkout before running the command to avoid this.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add checkout to add staff label workflow

#### Removed

<!-- List of things removed in this PR -->