### PR TITLE
chore: update script to use migrated

### DIFF
--- a/script/styled-components-migration-status.mts
+++ b/script/styled-components-migration-status.mts
@@ -92,7 +92,7 @@ There are ${migrated.length} files that do not include styled-components in Prim
 | Filepath | Size (kB) |
 | :------- | :-------- |`)
 
-for (const {filepath, size} of notMigrated) {
+for (const {filepath, size} of migrated) {
   const relativePath = path.relative(directory, filepath)
   const link = `[\`${relativePath}\`](https://github.com/primer/react/blob/main/${relativePath})`
   console.log(`| ${link} | ${round(size / 1024)}kB |`)


### PR DESCRIPTION
Noticed that we were reporting `notMigrated` for both 😅 This PR updates our script to use `migrated` instead.