### PR TITLE
Update lock release to include 100 items and output numbers

### DIFF
--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -78,8 +78,9 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Update all PRs that are toggled merge when ready
         run: |
-          PR_NUMBERS=$(gh pr list -R primer/react --state open --json number,mergeable,baseRefName,autoMergeRequest -q '.[] | select(.autoMergeRequest != null) | select(.mergeable == "MERGEABLE") | select(.baseRefName == "main") | .number')
+          PR_NUMBERS=$(gh pr list -L 100 -R primer/react --state open --json number,mergeable,baseRefName,autoMergeRequest -q '.[] | select(.autoMergeRequest != null) | select(.mergeable == "MERGEABLE") | select(.baseRefName == "main") | .number')
           if [ -n "$PR_NUMBERS" ]; then
+            echo "Updating $PR_NUMBERS"
             echo "$PR_NUMBERS" | xargs -I {} gh pr update-branch -R primer/react {}
           else
             echo "No PRs to update."


### PR DESCRIPTION
Couple of updates to the Toggle Lock Release.

Get more items when looking for PRs to merge, and output the PR numbers we found