### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/packages/react/src/TooltipV2/Tooltip.docs.json
+++ b/packages/react/src/TooltipV2/Tooltip.docs.json
@@ -51,7 +51,7 @@
       "name": "type",
       "type": "'label' | 'description'",
       "defaultValue": "description",
-      "description": "The type of tooltip. `label` is used for labelling the element that triggers tooltip. `description` is used for describing or adding a suplementary information to the element that triggers the tooltip."
+      "description": "The type of tooltip. `label` is used for labelling the element that triggers tooltip. `description` is used for describing or adding a supplementary information to the element that triggers the tooltip."
     },
     {
       "name": "keybindingHint",

--- a/packages/react/src/utils/polymorphic.ts
+++ b/packages/react/src/utils/polymorphic.ts
@@ -41,7 +41,7 @@ interface ForwardRefComponent<
   /**
    * When `as` prop is passed, use this overload.
    * Merges original own props (without DOM props) and the inferred props
-   * from `as` element with the own props taking precendence.
+   * from `as` element with the own props taking precedence.
    *
    * We explicitly avoid `React.ElementType` and manually narrow the prop types
    * so that events are typed when using JSX.IntrinsicElements.


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in the codebase:
- In Tooltip documentation, "suplementary" was corrected to "supplementary".
- In polymorphic utility comments, "own props taking precendence" was corrected to "own props taking precedence".

These changes improve the clarity and accuracy of the documentation and comments. No functional code changes were made.
