### PR TITLE
Fixes issue with Tooltip description id overriding existing description ids

### DIFF
--- a/.changeset/two-aliens-wait.md
+++ b/.changeset/two-aliens-wait.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fixes issue with Tooltip description id overriding existing description ids

--- a/packages/react/src/TooltipV2/Tooltip.features.stories.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.features.stories.tsx
@@ -1,4 +1,4 @@
-import {IconButton, Button, Box, Link, ActionMenu, ActionList} from '..'
+import {IconButton, Button, Box, Link, ActionMenu, ActionList, VisuallyHidden} from '..'
 import Octicon from '../Octicon'
 import {Tooltip} from './Tooltip'
 import {SearchIcon, BookIcon, CheckIcon, TriangleDownIcon, GitBranchIcon, InfoIcon} from '@primer/octicons-react'
@@ -32,6 +32,16 @@ export const DescriptionType = () => (
     <Tooltip text="Supplementary text" direction="n">
       <Button>Save</Button>
     </Tooltip>
+  </Box>
+)
+
+// As a supplementary description for a button
+export const DescriptionTypeWithExternalDescription = () => (
+  <Box sx={{p: 5}}>
+    <Tooltip text="Supplementary text" direction="n">
+      <Button aria-describedby="external-description">Save</Button>
+    </Tooltip>
+    <VisuallyHidden id="external-description">External description</VisuallyHidden>
   </Box>
 )
 

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -247,7 +247,10 @@ export const Tooltip = React.forwardRef(
             React.cloneElement(child as React.ReactElement<TriggerPropsType>, {
               ref: triggerRef,
               // If it is a type description, we use tooltip to describe the trigger
-              'aria-describedby': type === 'description' ? tooltipId : child.props['aria-describedby'],
+              'aria-describedby':
+                type === 'description'
+                  ? `${child.props['aria-describedby']} ${tooltipId}`
+                  : child.props['aria-describedby'],
               // If it is a label type, we use tooltip to label the trigger
               'aria-labelledby': type === 'label' ? tooltipId : child.props['aria-labelledby'],
               onBlur: (event: React.FocusEvent) => {

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -249,7 +249,9 @@ export const Tooltip = React.forwardRef(
               // If it is a type description, we use tooltip to describe the trigger
               'aria-describedby':
                 type === 'description'
-                  ? `${child.props['aria-describedby']} ${tooltipId}`
+                  ? child.props['aria-describedby']
+                    ? `${child.props['aria-describedby']} ${tooltipId}`
+                    : tooltipId
                   : child.props['aria-describedby'],
               // If it is a label type, we use tooltip to label the trigger
               'aria-labelledby': type === 'label' ? tooltipId : child.props['aria-labelledby'],

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -247,12 +247,21 @@ export const Tooltip = React.forwardRef(
             React.cloneElement(child as React.ReactElement<TriggerPropsType>, {
               ref: triggerRef,
               // If it is a type description, we use tooltip to describe the trigger
-              'aria-describedby':
-                type === 'description'
-                  ? child.props['aria-describedby']
-                    ? `${child.props['aria-describedby']} ${tooltipId}`
-                    : tooltipId
-                  : child.props['aria-describedby'],
+              'aria-describedby': (() => {
+                // If tooltip is not a description type, keep the original aria-describedby
+                if (type !== 'description') {
+                  return child.props['aria-describedby']
+                }
+
+                // If tooltip is a description type, append our tooltipId
+                const existingDescribedBy = child.props['aria-describedby']
+                if (existingDescribedBy) {
+                  return `${existingDescribedBy} ${tooltipId}`
+                }
+
+                // If no existing aria-describedby, use our tooltipId
+                return tooltipId
+              })(),
               // If it is a label type, we use tooltip to label the trigger
               'aria-labelledby': type === 'label' ? tooltipId : child.props['aria-labelledby'],
               onBlur: (event: React.FocusEvent) => {

--- a/packages/react/src/TooltipV2/__tests__/Tooltip.test.tsx
+++ b/packages/react/src/TooltipV2/__tests__/Tooltip.test.tsx
@@ -13,6 +13,15 @@ const TooltipComponent = (props: Omit<TooltipProps, 'text'> & {text?: string}) =
   </Tooltip>
 )
 
+const TooltipComponentWithExistingDescription = (props: Omit<TooltipProps, 'text'> & {text?: string}) => (
+  <>
+    <span id="external-description">External description</span>
+    <Tooltip text="Tooltip text" {...props}>
+      <Button aria-describedby="external-description">Button Text</Button>
+    </Tooltip>
+  </>
+)
+
 function ExampleWithActionMenu(actionMenuTrigger: React.ReactElement): JSX.Element {
   return (
     <ThemeProvider theme={theme}>
@@ -161,5 +170,17 @@ describe('Tooltip', () => {
       <TooltipComponent type="label" keybindingHint="Control+K" aria-label="Overridden label" />,
     )
     expect(getByRole('button', {name: 'Overridden label'})).toBeInTheDocument()
+  })
+
+  it('should append tooltip id to existing aria-describedby value on the trigger element', () => {
+    const {getByRole, getByText} = HTMLRender(<TooltipComponentWithExistingDescription />)
+    const triggerEL = getByRole('button')
+    const tooltipEl = getByText('Tooltip text')
+    const externalDescription = getByText('External description')
+
+    // Check that aria-describedby contains both the external description ID and the tooltip ID
+    const describedBy = triggerEL.getAttribute('aria-describedby')
+    expect(describedBy).toContain(externalDescription.id)
+    expect(describedBy).toContain(tooltipEl.id)
   })
 })


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Relates to https://github.com/github/accessibility-audits/issues/10890

Blocks rollout of this PR: https://github.com/github/github/pull/383309

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->
N/A

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->
The TooltipV2 no longer clears the existing `aria-describedby` property when using description type.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
It seems like the test I added isn't run using `npm run test` - I think because it's in the Ignore Modules list. I managed to run it with the following command:

> npx vitest run "TooltipV2"

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
