### PR TITLE
chore: update eslint-plugin-storybook to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "eslint-plugin-react-compiler": "^19.1.0-rc.2",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-ssr-friendly": "1.3.0",
-        "eslint-plugin-storybook": "^0.12.0",
+        "eslint-plugin-storybook": "^9.0.12",
         "eslint-plugin-testing-library": "^7.1.1",
         "globals": "^16.2.0",
         "jest": "29.7.0",
@@ -8876,16 +8876,6 @@
         }
       }
     },
-    "node_modules/@storybook/csf": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.12.tgz",
-      "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/@storybook/csf-plugin": {
       "version": "8.6.14",
       "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.14.tgz",
@@ -8901,17 +8891,6 @@
       },
       "peerDependencies": {
         "storybook": "^8.6.14"
-      }
-    },
-    "node_modules/@storybook/csf/node_modules/type-fest": {
-      "version": "2.19.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/global": {
@@ -16346,21 +16325,20 @@
       }
     },
     "node_modules/eslint-plugin-storybook": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.12.0.tgz",
-      "integrity": "sha512-Lg5I0+npTgiYgZ4KSvGWGDFZi3eOCNJPaWX0c9rTEEXC5wvooOClsP9ZtbI4hhFKyKgYR877KiJxbRTSJq9gWA==",
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-9.0.12.tgz",
+      "integrity": "sha512-dSzcozoI7tQRqfMODWfxahrRmKWsK88yKSUcO0+s361oYcX7nf8nEu99TQ/wuDLRHh+Zi7E2j43cPMH8gFo8OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf": "^0.1.11",
-        "@typescript-eslint/utils": "^8.8.1",
-        "ts-dedent": "^2.2.0"
+        "@typescript-eslint/utils": "^8.8.1"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=8"
+        "eslint": ">=8",
+        "storybook": "^9.0.12"
       }
     },
     "node_modules/eslint-plugin-testing-library": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-ssr-friendly": "1.3.0",
-    "eslint-plugin-storybook": "^0.12.0",
+    "eslint-plugin-storybook": "^9.0.12",
     "eslint-plugin-testing-library": "^7.1.1",
     "globals": "^16.2.0",
     "jest": "29.7.0",

--- a/packages/react/src/ActionBar/ActionBar.examples.stories.tsx
+++ b/packages/react/src/ActionBar/ActionBar.examples.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import ActionBar from '.'
 import Text from '../Text'
 import {

--- a/packages/react/src/ActionBar/ActionBar.stories.tsx
+++ b/packages/react/src/ActionBar/ActionBar.stories.tsx
@@ -11,7 +11,7 @@ import {
   ListOrderedIcon,
   TasklistIcon,
 } from '@primer/octicons-react'
-import type {Meta, StoryObj} from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
 
 const meta: Meta<typeof ActionBar> = {
   title: 'Experimental/Components/ActionBar',

--- a/packages/react/src/ActionList/ActionList.dev.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.dev.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {ActionList} from '.'
 import {Item} from './Item'
 import {LinkItem} from './LinkItem'

--- a/packages/react/src/ActionList/ActionList.examples.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.examples.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import React, {forwardRef} from 'react'
 import {
   TypographyIcon,

--- a/packages/react/src/ActionList/ActionList.features.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.features.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {ActionList} from '.'
 import {Item} from './Item'
 import {LinkItem} from './LinkItem'

--- a/packages/react/src/ActionList/ActionList.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 import type {ActionListProps, ActionListGroupProps} from '.'
 import {ActionList} from '.'
 import {Item} from './Item'

--- a/packages/react/src/ActionList/ActionList.stress.dev.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.stress.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import {StressTest} from '../utils/StressTest'
 import {TableIcon} from '@primer/octicons-react'

--- a/packages/react/src/ActionMenu/ActionMenu.dev.stories.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import {ActionMenu} from './ActionMenu'
 import {ActionList} from '../ActionList'

--- a/packages/react/src/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import {ActionMenu} from './ActionMenu'
 import {ActionList} from '../ActionList'

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.dev.stories.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import React, {useState} from 'react'
 
 import {Button} from '../Button'

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useRef, useState} from 'react'
-import type {Args, Meta} from '@storybook/react'
+import type {Args, Meta} from '@storybook/react-vite'
 import {FocusKeys} from '@primer/behaviors'
 
 import {Avatar, Box, Link, Text} from '..'

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.stories.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.stories.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import type {Args, Meta} from '@storybook/react'
+import type {Args, Meta} from '@storybook/react-vite'
 import {LocationIcon, RepoIcon} from '@primer/octicons-react'
 
 import {Avatar, Link, Text} from '..'

--- a/packages/react/src/Autocomplete/Autocomplete.dev.stories.tsx
+++ b/packages/react/src/Autocomplete/Autocomplete.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 
 import Autocomplete from './Autocomplete'
 import FormControl from '../FormControl'

--- a/packages/react/src/Autocomplete/Autocomplete.features.stories.tsx
+++ b/packages/react/src/Autocomplete/Autocomplete.features.stories.tsx
@@ -1,6 +1,6 @@
 import type {ChangeEventHandler, RefObject} from 'react'
 import React, {useCallback, useEffect, useRef, useState} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 
 import {BaseStyles, Box, Stack, ThemeProvider, registerPortalRoot} from '..'
 import {Dialog} from '../DialogV1'

--- a/packages/react/src/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/react/src/Autocomplete/Autocomplete.stories.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import {useCallback, useState} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 
 import {BaseStyles, Box, ThemeProvider} from '..'
 

--- a/packages/react/src/Avatar/Avatar.features.stories.tsx
+++ b/packages/react/src/Avatar/Avatar.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Avatar from './Avatar'
 
 export default {

--- a/packages/react/src/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/Avatar/Avatar.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {AvatarProps} from './Avatar'
 import Avatar, {DEFAULT_AVATAR_SIZE} from './Avatar'
 import {parseSizeFromArgs} from './storyHelpers'

--- a/packages/react/src/AvatarPair/AvatarPair.features.stories.tsx
+++ b/packages/react/src/AvatarPair/AvatarPair.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import AvatarPair from './AvatarPair'
 import Avatar from '../Avatar'
 

--- a/packages/react/src/AvatarPair/AvatarPair.stories.tsx
+++ b/packages/react/src/AvatarPair/AvatarPair.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import AvatarPair from './AvatarPair'
 import Avatar from '../Avatar'
 

--- a/packages/react/src/AvatarStack/AvatarStack.dev.stories.tsx
+++ b/packages/react/src/AvatarStack/AvatarStack.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import AvatarStack from './AvatarStack'
 import Avatar from '../Avatar'
 import Link from '../Link'

--- a/packages/react/src/AvatarStack/AvatarStack.features.stories.tsx
+++ b/packages/react/src/AvatarStack/AvatarStack.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import AvatarStack from './AvatarStack'
 import Avatar from '../Avatar'
 

--- a/packages/react/src/AvatarStack/AvatarStack.stories.tsx
+++ b/packages/react/src/AvatarStack/AvatarStack.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {AvatarStackProps} from './AvatarStack'
 import AvatarStack from './AvatarStack'
 import Avatar from '../Avatar'

--- a/packages/react/src/Banner/Banner.examples.stories.tsx
+++ b/packages/react/src/Banner/Banner.examples.stories.tsx
@@ -1,7 +1,7 @@
 import {Banner} from '../Banner'
 import {action} from '@storybook/addon-actions'
 import Link from '../Link'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {AriaAlert, AriaStatus} from '../live-region'
 import FormControl from '../FormControl'
 import RadioGroup from '../RadioGroup'

--- a/packages/react/src/Banner/Banner.features.stories.tsx
+++ b/packages/react/src/Banner/Banner.features.stories.tsx
@@ -1,6 +1,6 @@
 import {CopilotIcon, GitPullRequestIcon} from '@primer/octicons-react'
 import {action} from '@storybook/addon-actions'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Banner} from '../Banner'
 import Link from '../Link'
 

--- a/packages/react/src/Banner/Banner.stories.tsx
+++ b/packages/react/src/Banner/Banner.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryObj} from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
 import Link from '../Link'
 import {Banner} from '../Banner'
 import {PageLayout} from '../PageLayout'

--- a/packages/react/src/BaseStyles.dev.stories.tsx
+++ b/packages/react/src/BaseStyles.dev.stories.tsx
@@ -1,5 +1,5 @@
 import {BaseStyles} from '.'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from './utils/types'
 
 export default {

--- a/packages/react/src/Blankslate/Blankslate.stories.tsx
+++ b/packages/react/src/Blankslate/Blankslate.stories.tsx
@@ -1,5 +1,5 @@
 import {BookIcon} from '@primer/octicons-react'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {Blankslate} from '../Blankslate'
 import type {ComponentProps} from '../utils/types'
 

--- a/packages/react/src/Box/Box.features.stories.tsx
+++ b/packages/react/src/Box/Box.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Box from './Box'
 
 export default {

--- a/packages/react/src/Box/Box.stories.tsx
+++ b/packages/react/src/Box/Box.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import Box from './Box'
 
 export default {

--- a/packages/react/src/BranchName/BranchName.features.stories.tsx
+++ b/packages/react/src/BranchName/BranchName.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import BranchName from './BranchName'
 import {Stack} from '../Stack'
 import Octicon from '../Octicon'

--- a/packages/react/src/BranchName/BranchName.stories.tsx
+++ b/packages/react/src/BranchName/BranchName.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import BranchName from './BranchName'
 
 export default {

--- a/packages/react/src/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/react/src/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Breadcrumbs from './Breadcrumbs'
 

--- a/packages/react/src/Button/Button.examples.stories.tsx
+++ b/packages/react/src/Button/Button.examples.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Button} from '.'
 import {DownloadIcon} from '@primer/octicons-react'
 import {Banner} from '../experimental'

--- a/packages/react/src/Button/Button.stories.tsx
+++ b/packages/react/src/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
 import {EyeClosedIcon, EyeIcon, SearchIcon, TriangleDownIcon, XIcon, HeartIcon} from '@primer/octicons-react'
-import type {Meta, StoryObj} from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
 import {Button} from '.'
 import {OcticonArgType} from '../utils/story-helpers'
 

--- a/packages/react/src/Button/Button.stress.dev.stories.tsx
+++ b/packages/react/src/Button/Button.stress.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import {StressTest} from '../utils/StressTest'
 import {Button} from '.'

--- a/packages/react/src/Button/IconButton.stories.tsx
+++ b/packages/react/src/Button/IconButton.stories.tsx
@@ -1,6 +1,6 @@
 import type {ComponentProps} from 'react'
 import {EyeClosedIcon, EyeIcon, SearchIcon, XIcon, HeartIcon} from '@primer/octicons-react'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {IconButton} from '.'
 import {OcticonArgType} from '../utils/story-helpers'
 

--- a/packages/react/src/Button/LinkButton.stories.tsx
+++ b/packages/react/src/Button/LinkButton.stories.tsx
@@ -1,5 +1,5 @@
 import {EyeClosedIcon, EyeIcon, SearchIcon, XIcon, HeartIcon, ChevronRightIcon} from '@primer/octicons-react'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {LinkButton} from '.'
 import {OcticonArgType} from '../utils/story-helpers'
 

--- a/packages/react/src/ButtonGroup/ButtonGroup.dev.stories.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import ButtonGroup from './ButtonGroup'
 import {Button, IconButton, LinkButton} from '../Button'
 import {CopilotIcon} from '@primer/octicons-react'

--- a/packages/react/src/ButtonGroup/ButtonGroup.features.stories.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.features.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import ButtonGroup from './ButtonGroup'
 import {IconButton, Button} from '../Button'
 import {PlusIcon, DashIcon, TriangleDownIcon} from '@primer/octicons-react'

--- a/packages/react/src/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 import ButtonGroup from './ButtonGroup'
 import type {ButtonProps} from '../Button'
 import {Button} from '../Button'

--- a/packages/react/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {CheckboxProps} from '..'
 import {Box, Checkbox} from '..'
 import FormControl from '../FormControl'

--- a/packages/react/src/CheckboxGroup/CheckboxGroup.dev.stories.tsx
+++ b/packages/react/src/CheckboxGroup/CheckboxGroup.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Checkbox, CheckboxGroup, FormControl} from '..'
 
 export default {

--- a/packages/react/src/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/packages/react/src/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Checkbox, CheckboxGroup, FormControl} from '..'
 import type {CheckboxOrRadioGroupArgs} from '../utils/form-story-helpers'
 

--- a/packages/react/src/CircleBadge/CircleBadge.stories.tsx
+++ b/packages/react/src/CircleBadge/CircleBadge.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import CircleBadge from './CircleBadge'
 import {ZapIcon} from '@primer/octicons-react'
 

--- a/packages/react/src/CircleOcticon/CircleOcticon.stories.tsx
+++ b/packages/react/src/CircleOcticon/CircleOcticon.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import CircleOcticon from './CircleOcticon'
 import type {CircleOcticonProps} from './CircleOcticon'
 import {CheckIcon} from '@primer/octicons-react'

--- a/packages/react/src/ConfirmationDialog/ConfirmationDialog.features.stories.tsx
+++ b/packages/react/src/ConfirmationDialog/ConfirmationDialog.features.stories.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import {useState, useCallback} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Box, useTheme} from '..'
 import {Button} from '../Button'
 import {ActionMenu} from '../ActionMenu'

--- a/packages/react/src/ConfirmationDialog/ConfirmationDialog.stories.tsx
+++ b/packages/react/src/ConfirmationDialog/ConfirmationDialog.stories.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useRef, useState} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {BaseStyles, Button, ThemeProvider} from '..'
 import {ConfirmationDialog} from './ConfirmationDialog'
 

--- a/packages/react/src/CounterLabel/CounterLabel.features.stories.tsx
+++ b/packages/react/src/CounterLabel/CounterLabel.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 import CounterLabel from './CounterLabel'
 
 export default {

--- a/packages/react/src/CounterLabel/CounterLabel.stories.tsx
+++ b/packages/react/src/CounterLabel/CounterLabel.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta, StoryObj} from '@storybook/react'
+import type {StoryFn, Meta, StoryObj} from '@storybook/react-vite'
 import CounterLabel from './CounterLabel'
 
 export default {

--- a/packages/react/src/DataTable/DataTable.features.stories.tsx
+++ b/packages/react/src/DataTable/DataTable.features.stories.tsx
@@ -8,7 +8,7 @@ import {
   TrashIcon,
 } from '@primer/octicons-react'
 import {action} from '@storybook/addon-actions'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import React from 'react'
 import {ActionList} from '../ActionList'
 import {ActionMenu} from '../ActionMenu'

--- a/packages/react/src/DataTable/DataTable.stories.tsx
+++ b/packages/react/src/DataTable/DataTable.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryObj} from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
 import React from 'react'
 import type {DataTableProps} from '../DataTable'
 import {DataTable, Table} from '../DataTable'

--- a/packages/react/src/Details/Details.dev.stories.tsx
+++ b/packages/react/src/Details/Details.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 import Details from './Details'
 import {Button} from '../Button'
 import useDetails from '../hooks/useDetails'

--- a/packages/react/src/Details/Details.stories.tsx
+++ b/packages/react/src/Details/Details.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 import Details from './Details'
 import {Button} from '../Button'
 import useDetails from '../hooks/useDetails'

--- a/packages/react/src/Dialog/Dialog.stories.tsx
+++ b/packages/react/src/Dialog/Dialog.stories.tsx
@@ -1,5 +1,5 @@
 import {useState, useRef, useCallback} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Button, Text} from '..'
 import type {DialogProps} from './Dialog'
 import {Dialog} from './Dialog'

--- a/packages/react/src/DialogV1/Dialog.stories.tsx
+++ b/packages/react/src/DialogV1/Dialog.stories.tsx
@@ -1,5 +1,5 @@
 import {useState, useRef} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Button} from '../Button'
 import {Box, Text} from '..'
 import {Banner} from '../Banner'

--- a/packages/react/src/FilteredActionList/FilteredActionList.stories.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionList.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import React from 'react'
 import {ThemeProvider} from '..'
 import {FilteredActionList} from '../FilteredActionList'

--- a/packages/react/src/Flash/Flash.features.stories.tsx
+++ b/packages/react/src/Flash/Flash.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Flash from './Flash'
 import Octicon from '../Octicon'
 import {AlertIcon, CheckCircleIcon, InfoIcon, XIcon} from '@primer/octicons-react'

--- a/packages/react/src/Flash/Flash.stories.tsx
+++ b/packages/react/src/Flash/Flash.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import Flash from './Flash'
 
 export default {

--- a/packages/react/src/FormControl/FormControl.features.stories.tsx
+++ b/packages/react/src/FormControl/FormControl.features.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {
   Autocomplete,
   BaseStyles,

--- a/packages/react/src/FormControl/FormControl.stories.tsx
+++ b/packages/react/src/FormControl/FormControl.stories.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Box, Checkbox, FormControl, TextInput, TextInputWithTokens} from '..'
 import type {FormValidationStatus} from '../utils/types/FormValidationStatus'
 

--- a/packages/react/src/FormControl/useFormControlForwardedProps.stories.tsx
+++ b/packages/react/src/FormControl/useFormControlForwardedProps.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {BaseStyles, FormControl, ThemeProvider, theme, useFormControlForwardedProps} from '..'
 
 export default {

--- a/packages/react/src/Header/Header.dev.stories.tsx
+++ b/packages/react/src/Header/Header.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {MarkGithubIcon} from '@primer/octicons-react'
 
 import Header from './Header'

--- a/packages/react/src/Header/Header.features.stories.tsx
+++ b/packages/react/src/Header/Header.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 
 import Header from './Header'
 import Avatar from '../Avatar'

--- a/packages/react/src/Header/Header.stories.tsx
+++ b/packages/react/src/Header/Header.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {MarkGithubIcon} from '@primer/octicons-react'
 
 import Header from './Header'

--- a/packages/react/src/Heading/Heading.features.stories.tsx
+++ b/packages/react/src/Heading/Heading.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn} from '@storybook/react'
+import type {StoryFn} from '@storybook/react-vite'
 import Heading from './Heading'
 
 export default {

--- a/packages/react/src/Heading/Heading.stories.tsx
+++ b/packages/react/src/Heading/Heading.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 import Heading from './Heading'
 
 export default {

--- a/packages/react/src/Hidden/Hidden.examples.stories.tsx
+++ b/packages/react/src/Hidden/Hidden.examples.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Button, Link, Text, StateLabel, BranchName, Box} from '..'
 import {ArrowRightIcon} from '@primer/octicons-react'
 

--- a/packages/react/src/Hidden/Hidden.features.stories.tsx
+++ b/packages/react/src/Hidden/Hidden.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Hidden} from './Hidden'
 import {Box, Button} from '..'
 

--- a/packages/react/src/Hidden/Hidden.stories.tsx
+++ b/packages/react/src/Hidden/Hidden.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 
 import Hidden from '.'
 import Text from '../Text'

--- a/packages/react/src/InlineMessage/InlineMessage.dev.stories.tsx
+++ b/packages/react/src/InlineMessage/InlineMessage.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {InlineMessage} from '.'
 
 const meta = {

--- a/packages/react/src/InlineMessage/InlineMessage.features.stories.tsx
+++ b/packages/react/src/InlineMessage/InlineMessage.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {InlineMessage} from '../InlineMessage'
 
 const meta = {

--- a/packages/react/src/InlineMessage/InlineMessage.stories.tsx
+++ b/packages/react/src/InlineMessage/InlineMessage.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryObj} from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
 import {InlineMessage} from '../InlineMessage'
 
 const meta = {

--- a/packages/react/src/KeybindingHint/KeybindingHint.examples.stories.tsx
+++ b/packages/react/src/KeybindingHint/KeybindingHint.examples.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryObj} from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
 import {KeybindingHint, type KeybindingHintProps} from '.'
 import {Button, ActionList, FormControl, TextInput} from '..'
 

--- a/packages/react/src/KeybindingHint/KeybindingHint.features.stories.tsx
+++ b/packages/react/src/KeybindingHint/KeybindingHint.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryObj} from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
 import {KeybindingHint, type KeybindingHintProps} from '.'
 import Box from '../Box'
 

--- a/packages/react/src/KeybindingHint/KeybindingHint.stories.tsx
+++ b/packages/react/src/KeybindingHint/KeybindingHint.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {KeybindingHint} from './KeybindingHint'
 
 export default {

--- a/packages/react/src/Label/Label.dev.stories.tsx
+++ b/packages/react/src/Label/Label.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Label from './Label'
 

--- a/packages/react/src/Label/Label.features.stories.tsx
+++ b/packages/react/src/Label/Label.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Label from './Label'
 

--- a/packages/react/src/Label/Label.stories.tsx
+++ b/packages/react/src/Label/Label.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Label from './Label'
 

--- a/packages/react/src/LabelGroup/LabelGroup.features.stories.tsx
+++ b/packages/react/src/LabelGroup/LabelGroup.features.stories.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import LabelGroup from './LabelGroup'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import Token from '../Token/Token'
 import Label from '../Label/Label'
 import classes from './LabelGroupStories.module.css'

--- a/packages/react/src/LabelGroup/LabelGroup.stories.tsx
+++ b/packages/react/src/LabelGroup/LabelGroup.stories.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import type {LabelGroupProps} from './LabelGroup'
 import LabelGroup from './LabelGroup'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import Label from '../Label/Label'
 import classes from './LabelGroupStories.module.css'
 

--- a/packages/react/src/Link/Link.dev.stories.tsx
+++ b/packages/react/src/Link/Link.dev.stories.tsx
@@ -1,5 +1,5 @@
 import Link from '.'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 
 export default {

--- a/packages/react/src/Link/Link.features.stories.tsx
+++ b/packages/react/src/Link/Link.features.stories.tsx
@@ -1,5 +1,5 @@
 import Link from '../Link'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 
 export default {

--- a/packages/react/src/Link/Link.stories.tsx
+++ b/packages/react/src/Link/Link.stories.tsx
@@ -1,5 +1,5 @@
 import Link from '../Link'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 
 export default {

--- a/packages/react/src/NavList/NavList.dev.stories.tsx
+++ b/packages/react/src/NavList/NavList.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {PageLayout} from '../PageLayout'
 import {NavList} from './NavList'
 import {ArrowRightIcon, ArrowLeftIcon, BookIcon, FileDirectoryIcon} from '@primer/octicons-react'

--- a/packages/react/src/NavList/NavList.stories.tsx
+++ b/packages/react/src/NavList/NavList.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import React from 'react'
 import {PageLayout} from '../PageLayout'
 import {NavList} from './NavList'

--- a/packages/react/src/Octicon/Octicon.stories.tsx
+++ b/packages/react/src/Octicon/Octicon.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import Octicon from './Octicon'
 import {HeartFillIcon} from '@primer/octicons-react'
 

--- a/packages/react/src/Overlay/Overlay.dev.stories.tsx
+++ b/packages/react/src/Overlay/Overlay.dev.stories.tsx
@@ -1,5 +1,5 @@
 import {useRef, useState} from 'react'
-import type {Args, Meta} from '@storybook/react'
+import type {Args, Meta} from '@storybook/react-vite'
 import Text from '../Text'
 import {Button, IconButton} from '../Button'
 import Overlay from './Overlay'

--- a/packages/react/src/Overlay/Overlay.features.stories.tsx
+++ b/packages/react/src/Overlay/Overlay.features.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useRef, useCallback} from 'react'
-import type {Args, Meta} from '@storybook/react'
+import type {Args, Meta} from '@storybook/react-vite'
 import {TriangleDownIcon, PlusIcon, IssueDraftIcon, XIcon} from '@primer/octicons-react'
 import {
   Overlay,

--- a/packages/react/src/Overlay/Overlay.stories.tsx
+++ b/packages/react/src/Overlay/Overlay.stories.tsx
@@ -1,5 +1,5 @@
 import {useState, useRef, type ComponentProps} from 'react'
-import type {Args, Meta} from '@storybook/react'
+import type {Args, Meta} from '@storybook/react-vite'
 import {XIcon} from '@primer/octicons-react'
 import {Button, Text, useFocusTrap, Box, IconButton} from '..'
 import Overlay from '../Overlay'

--- a/packages/react/src/PageHeader/PageHeader.dev.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Button, IconButton, Box} from '..'
 import Label from '../Label'
 import {GitBranchIcon, PencilIcon, SidebarExpandIcon} from '@primer/octicons-react'

--- a/packages/react/src/PageHeader/PageHeader.examples.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.examples.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {
   Button,
   IconButton,

--- a/packages/react/src/PageHeader/PageHeader.features.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {IconButton, Breadcrumbs, Text, Link, Button, Box, Label, UnderlineNav} from '..'
 import {
   PencilIcon,

--- a/packages/react/src/PageHeader/PageHeader.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {Button, IconButton, Breadcrumbs, Link, Text, StateLabel, BranchName, Box} from '..'
 import {UnderlineNav} from '../UnderlineNav'
 import Label from '../Label'

--- a/packages/react/src/PageLayout/PageLayout.dev.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {Placeholder} from '../Placeholder'
 import {PageLayout} from './PageLayout'
 

--- a/packages/react/src/PageLayout/PageLayout.examples.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.examples.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {PageLayout} from './PageLayout'
 import {Placeholder} from '../Placeholder'
 import {ActionList, Box, Breadcrumbs, Button, Flash, LinkButton, NavList} from '..'

--- a/packages/react/src/PageLayout/PageLayout.features.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {PageLayout} from './PageLayout'
 import {Placeholder} from '../Placeholder'
 import {Box, BranchName, Heading, Link, StateLabel, Text} from '..'

--- a/packages/react/src/PageLayout/PageLayout.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {Placeholder} from '../Placeholder'
 import {PageLayout} from './PageLayout'
 

--- a/packages/react/src/Pagehead/Pagehead.dev.stories.tsx
+++ b/packages/react/src/Pagehead/Pagehead.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Pagehead from './Pagehead'
 import Heading from '../Heading'
 

--- a/packages/react/src/Pagehead/Pagehead.stories.tsx
+++ b/packages/react/src/Pagehead/Pagehead.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import Pagehead from './Pagehead'
 import Heading from '../Heading'
 

--- a/packages/react/src/Pagination/Pagination.dev.stories.tsx
+++ b/packages/react/src/Pagination/Pagination.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Pagination from './Pagination'
 

--- a/packages/react/src/Pagination/Pagination.features.stories.tsx
+++ b/packages/react/src/Pagination/Pagination.features.stories.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Pagination from './Pagination'
 import {ReactRouterLikeLink} from '../__tests__/mocks/ReactRouterLink'

--- a/packages/react/src/Pagination/Pagination.stories.tsx
+++ b/packages/react/src/Pagination/Pagination.stories.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Pagination from './Pagination'
 

--- a/packages/react/src/Pagination/Pagination.stress.dev.stories.tsx
+++ b/packages/react/src/Pagination/Pagination.stress.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Pagination from './Pagination'
 import {StressTest} from '../utils/StressTest'

--- a/packages/react/src/PointerBox/PointerBox.stories.tsx
+++ b/packages/react/src/PointerBox/PointerBox.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 import PointerBox from './PointerBox'
 import type {ComponentProps} from '../utils/types'
 

--- a/packages/react/src/Popover/Popover.dev.stories.tsx
+++ b/packages/react/src/Popover/Popover.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Heading from '../Heading'
 import Popover from './Popover'
 import Text from '../Text'

--- a/packages/react/src/Popover/Popover.stories.tsx
+++ b/packages/react/src/Popover/Popover.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import Heading from '../Heading'
 import Popover from './Popover'
 import Text from '../Text'

--- a/packages/react/src/Portal/Portal.features.stories.tsx
+++ b/packages/react/src/Portal/Portal.features.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Box from '../Box'
 import {Portal, registerPortalRoot} from './Portal'
 

--- a/packages/react/src/Portal/Portal.stories.tsx
+++ b/packages/react/src/Portal/Portal.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 
 import {Box} from '..'
 import {Portal} from './Portal'

--- a/packages/react/src/ProgressBar/ProgressBar.features.stories.tsx
+++ b/packages/react/src/ProgressBar/ProgressBar.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {ProgressBar} from '..'
 
 export default {

--- a/packages/react/src/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/react/src/ProgressBar/ProgressBar.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {ProgressBar, type ProgressBarProps} from '..'
 
 const sectionColorsDefault = [

--- a/packages/react/src/Radio/Radio.stories.tsx
+++ b/packages/react/src/Radio/Radio.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {RadioProps} from '..'
 import {Box, FormControl, Radio} from '..'
 import type {FormControlArgs} from '../utils/form-story-helpers'

--- a/packages/react/src/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/react/src/RadioGroup/RadioGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Radio, RadioGroup, FormControl} from '..'
 import type {CheckboxOrRadioGroupArgs} from '../utils/form-story-helpers'
 

--- a/packages/react/src/RelativeTime/RelativeTime.features.stories.tsx
+++ b/packages/react/src/RelativeTime/RelativeTime.features.stories.tsx
@@ -1,5 +1,5 @@
 import RelativeTime from './RelativeTime'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 
 const meta: Meta = {
   title: 'Components/RelativeTime/Features',

--- a/packages/react/src/RelativeTime/RelativeTime.stories.tsx
+++ b/packages/react/src/RelativeTime/RelativeTime.stories.tsx
@@ -1,5 +1,5 @@
 import RelativeTime from './RelativeTime'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 
 const meta: Meta = {
   title: 'Components/RelativeTime',

--- a/packages/react/src/ScrollableRegion/ScrollableRegion.stories.tsx
+++ b/packages/react/src/ScrollableRegion/ScrollableRegion.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryObj} from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
 import {ScrollableRegion} from '../ScrollableRegion'
 
 const meta = {

--- a/packages/react/src/SegmentedControl/SegmentedControl.dev.stories.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {SegmentedControl} from '.'
 import SegmentedControlIconButton from './SegmentedControlIconButton'
 import SegmentedControlButton from './SegmentedControlButton'

--- a/packages/react/src/SegmentedControl/SegmentedControl.features.stories.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.features.stories.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {SegmentedControl} from '.'
 import {EyeIcon, FileCodeIcon, PeopleIcon} from '@primer/octicons-react'
 import {Box, Text} from '..'

--- a/packages/react/src/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 import {SegmentedControl} from '.'
 import SegmentedControlIconButton from './SegmentedControlIconButton'
 import SegmentedControlButton from './SegmentedControlButton'

--- a/packages/react/src/SegmentedControl/SegmentedControlButton.stories.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControlButton.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {SegmentedControlButtonProps} from './SegmentedControlButton'
 import SegmentedControlButton from './SegmentedControlButton'
 import {SegmentedControl} from '.'

--- a/packages/react/src/SegmentedControl/SegmentedControlIconButton.stories.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControlIconButton.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {SegmentedControlIconButtonProps} from './SegmentedControlIconButton'
 import SegmentedControlIconButton from './SegmentedControlIconButton'
 import {SegmentedControl} from '.'

--- a/packages/react/src/Select/Select.dev.stories.tsx
+++ b/packages/react/src/Select/Select.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {FormControl, Box} from '..'
 import Select from './Select'
 

--- a/packages/react/src/Select/Select.stories.tsx
+++ b/packages/react/src/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {FormControl, Box} from '..'
 import Select from './Select'
 import type {SelectProps} from './Select'

--- a/packages/react/src/SelectPanel/SelectPanel.dev.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.dev.stories.tsx
@@ -1,5 +1,5 @@
 import {TriangleDownIcon} from '@primer/octicons-react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type React from 'react'
 import {useState} from 'react'
 

--- a/packages/react/src/SelectPanel/SelectPanel.examples.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.examples.stories.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useMemo} from 'react'
 import Box from '../Box'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Button} from '../Button'
 import type {ItemInput} from '../deprecated/ActionList/List'
 import {SelectPanel} from './SelectPanel'

--- a/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useRef} from 'react'
-import type {Meta, StoryObj} from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
 import Box from '../Box'
 import {Button} from '../Button'
 import type {ItemInput, GroupedListProps} from '../deprecated/ActionList/List'

--- a/packages/react/src/SelectPanel/SelectPanel.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.stories.tsx
@@ -1,5 +1,5 @@
 import {TriangleDownIcon} from '@primer/octicons-react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {useState} from 'react'
 
 import Box from '../Box'

--- a/packages/react/src/Skeleton/SkeletonBox.features.stories.tsx
+++ b/packages/react/src/Skeleton/SkeletonBox.features.stories.tsx
@@ -1,5 +1,5 @@
 import {type ComponentProps} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {SkeletonBox} from './SkeletonBox'
 
 export default {

--- a/packages/react/src/Skeleton/SkeletonBox.stories.tsx
+++ b/packages/react/src/Skeleton/SkeletonBox.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {SkeletonBox} from './SkeletonBox'
 import type {ComponentProps} from '../utils/types'
 

--- a/packages/react/src/Spinner/Spinner.dev.stories.tsx
+++ b/packages/react/src/Spinner/Spinner.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Spinner from './Spinner'
 
 export default {

--- a/packages/react/src/Spinner/Spinner.examples.stories.tsx
+++ b/packages/react/src/Spinner/Spinner.examples.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Spinner from './Spinner'
 import {Box, Button} from '..'
 import {VisuallyHidden} from '../VisuallyHidden'

--- a/packages/react/src/Spinner/Spinner.features.stories.tsx
+++ b/packages/react/src/Spinner/Spinner.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Spinner from './Spinner'
 import {Box} from '..'
 import {AriaStatus} from '../live-region'

--- a/packages/react/src/Spinner/Spinner.stories.tsx
+++ b/packages/react/src/Spinner/Spinner.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import Spinner from './Spinner'
 
 export default {

--- a/packages/react/src/SplitPageLayout/SplitPageLayout.features.stories.tsx
+++ b/packages/react/src/SplitPageLayout/SplitPageLayout.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 
 import {Box, Button, Heading, Text} from '..'
 import {NavList} from '../NavList'

--- a/packages/react/src/SplitPageLayout/SplitPageLayout.stories.tsx
+++ b/packages/react/src/SplitPageLayout/SplitPageLayout.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {Placeholder} from '../Placeholder'
 import {SplitPageLayout} from '../SplitPageLayout'
 

--- a/packages/react/src/Stack/Stack.stories.tsx
+++ b/packages/react/src/Stack/Stack.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryObj} from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
 import {Stack} from '../Stack'
 import type {ResponsiveValue} from '../hooks/useResponsiveValue'
 

--- a/packages/react/src/StateLabel/StateLabel.features.stories.tsx
+++ b/packages/react/src/StateLabel/StateLabel.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import StateLabel from './StateLabel'
 import VisuallyHidden from '../_VisuallyHidden'

--- a/packages/react/src/StateLabel/StateLabel.stories.tsx
+++ b/packages/react/src/StateLabel/StateLabel.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import StateLabel from './StateLabel'
 

--- a/packages/react/src/SubNav/SubNav.dev.stories.tsx
+++ b/packages/react/src/SubNav/SubNav.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import SubNav from './SubNav'
 import type {ComponentProps} from '../utils/types'
 

--- a/packages/react/src/SubNav/SubNav.features.stories.tsx
+++ b/packages/react/src/SubNav/SubNav.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import SubNav from './SubNav'
 import type {ComponentProps} from '../utils/types'
 

--- a/packages/react/src/SubNav/SubNav.stories.tsx
+++ b/packages/react/src/SubNav/SubNav.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import SubNav from './SubNav'
 import type {ComponentProps} from '../utils/types'
 

--- a/packages/react/src/TabNav/TabNav.features.stories.tsx
+++ b/packages/react/src/TabNav/TabNav.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import TabNav from './TabNav'
 import type {ComponentProps} from '../utils/types'
 

--- a/packages/react/src/TabNav/TabNav.stories.tsx
+++ b/packages/react/src/TabNav/TabNav.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import TabNav from './TabNav'
 import type {ComponentProps} from '../utils/types'
 

--- a/packages/react/src/Text/Text.features.stories.tsx
+++ b/packages/react/src/Text/Text.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Box from '../Box'
 import Text from '.'
 

--- a/packages/react/src/Text/Text.stories.tsx
+++ b/packages/react/src/Text/Text.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 import Text from './Text'
 
 export default {

--- a/packages/react/src/TextInput/TextInput.dev.stories.tsx
+++ b/packages/react/src/TextInput/TextInput.dev.stories.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Box, FormControl} from '..'
 import TextInput from '.'
 import {textInputExcludedControlKeys} from '../utils/story-helpers'

--- a/packages/react/src/TextInput/TextInput.stories.tsx
+++ b/packages/react/src/TextInput/TextInput.stories.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import {useState} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Box, FormControl} from '..'
 import type {TextInputProps} from '../TextInput'
 import TextInput from '../TextInput'

--- a/packages/react/src/TextInputWithTokens/TextInputWithTokens.stories.tsx
+++ b/packages/react/src/TextInputWithTokens/TextInputWithTokens.stories.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import {useCallback, useState} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Box, FormControl} from '..'
 import type {TextInputWithTokensProps} from '../TextInputWithTokens'
 import TextInputWithTokens from '../TextInputWithTokens'

--- a/packages/react/src/Textarea/Textarea.dev.stories.tsx
+++ b/packages/react/src/Textarea/Textarea.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Box, FormControl, Textarea} from '..'
 
 export default {

--- a/packages/react/src/Textarea/Textarea.stories.tsx
+++ b/packages/react/src/Textarea/Textarea.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {TextareaProps} from '..'
 import {Box, FormControl, Textarea} from '..'
 import {DEFAULT_TEXTAREA_COLS, DEFAULT_TEXTAREA_RESIZE, DEFAULT_TEXTAREA_ROWS} from '../Textarea'

--- a/packages/react/src/Timeline/Timeline.dev.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Timeline from './Timeline'
 import Octicon from '../Octicon'

--- a/packages/react/src/Timeline/Timeline.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Timeline from './Timeline'
 import Octicon from '../Octicon'

--- a/packages/react/src/Timeline/Timeline.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Timeline from './Timeline'
 import Octicon from '../Octicon'

--- a/packages/react/src/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/packages/react/src/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import ToggleSwitch from './ToggleSwitch'
 import {Text} from '..'

--- a/packages/react/src/Token/AvatarToken.stories.tsx
+++ b/packages/react/src/Token/AvatarToken.stories.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {action} from '@storybook/addon-actions'
 
 import {get} from '../constants'

--- a/packages/react/src/Token/Token.dev.stories.tsx
+++ b/packages/react/src/Token/Token.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Token from './Token'
 
 export default {

--- a/packages/react/src/Token/Token.features.stories.tsx
+++ b/packages/react/src/Token/Token.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {action} from '@storybook/addon-actions'
 import {get} from '../constants'
 import {BaseStyles, ThemeProvider} from '..'

--- a/packages/react/src/Token/Token.stories.tsx
+++ b/packages/react/src/Token/Token.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {action} from '@storybook/addon-actions'
 import Token from './Token'
 import {GitBranchIcon} from '@primer/octicons-react'

--- a/packages/react/src/Tooltip/Tooltip.features.stories.tsx
+++ b/packages/react/src/Tooltip/Tooltip.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {BaseStyles, ThemeProvider, IconButton, Button} from '..'
 import Box from '../Box'
 import Tooltip from './Tooltip'

--- a/packages/react/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {BaseStyles, ThemeProvider, Button} from '..'
 import Box from '../Box'
 import Link from '../Link'

--- a/packages/react/src/TooltipV2/Tooltip.playground.stories.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.playground.stories.tsx
@@ -1,6 +1,6 @@
 import {Button, Box} from '..'
 import {Tooltip} from './Tooltip'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 
 const meta: Meta<typeof Tooltip> = {
   title: 'Components/TooltipV2/Playground',

--- a/packages/react/src/TreeView/TreeView.examples.stories.tsx
+++ b/packages/react/src/TreeView/TreeView.examples.stories.tsx
@@ -1,5 +1,5 @@
 import {GrabberIcon} from '@primer/octicons-react'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import React from 'react'
 import Box from '../Box'
 import {TreeView} from './TreeView'

--- a/packages/react/src/TreeView/TreeView.features.stories.tsx
+++ b/packages/react/src/TreeView/TreeView.features.stories.tsx
@@ -6,7 +6,7 @@ import {
   FileIcon,
   KebabHorizontalIcon,
 } from '@primer/octicons-react'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import React from 'react'
 import Box from '../Box'
 import {Button, IconButton} from '../Button'

--- a/packages/react/src/TreeView/TreeView.stories.tsx
+++ b/packages/react/src/TreeView/TreeView.stories.tsx
@@ -1,5 +1,5 @@
 import {DiffAddedIcon, DiffModifiedIcon, FileIcon} from '@primer/octicons-react'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import Box from '../Box'
 import Octicon from '../Octicon'
 import {TreeView} from './TreeView'

--- a/packages/react/src/TreeView/TreeView.stress.dev.stories.tsx
+++ b/packages/react/src/TreeView/TreeView.stress.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import {StressTest} from '../utils/StressTest'
 import {TreeView} from './TreeView'

--- a/packages/react/src/TreeView/TreeViewWithLeadingAction.stories.tsx
+++ b/packages/react/src/TreeView/TreeViewWithLeadingAction.stories.tsx
@@ -1,5 +1,5 @@
 import {GrabberIcon, IssueClosedIcon, IssueOpenedIcon} from '@primer/octicons-react'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import Box from '../Box'
 import Link from '../Link'
 import {Banner} from '../Banner'

--- a/packages/react/src/Truncate/Truncate.features.stories.tsx
+++ b/packages/react/src/Truncate/Truncate.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import Truncate from './Truncate'
 import {ArrowLeftIcon, ArrowRightIcon} from '@primer/octicons-react'
 

--- a/packages/react/src/Truncate/Truncate.stories.tsx
+++ b/packages/react/src/Truncate/Truncate.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {TruncateProps} from './Truncate'
 import Truncate from './Truncate'
 

--- a/packages/react/src/UnderlineNav/UnderlineNav.Item.stories.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNav.Item.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {UnderlineNav} from './index'
 import {UnderlineNavItem} from './UnderlineNavItem'
 import {CodeIcon, GitPullRequestIcon, PeopleIcon} from '@primer/octicons-react'

--- a/packages/react/src/UnderlineNav/UnderlineNav.examples.stories.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNav.examples.stories.tsx
@@ -20,7 +20,7 @@ import {
   ThreeBarsIcon,
   PeopleIcon,
 } from '@primer/octicons-react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {UnderlineNav} from './index'
 import {Avatar, Button, Box, Heading, Link, Text, StateLabel, BranchName} from '..'
 import Octicon from '../Octicon'

--- a/packages/react/src/UnderlineNav/UnderlineNav.features.stories.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNav.features.stories.tsx
@@ -12,7 +12,7 @@ import {
   ShieldLockIcon,
   GearIcon,
 } from '@primer/octicons-react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {UnderlineNav} from './index'
 import {INITIAL_VIEWPORTS} from '@storybook/addon-viewport'
 

--- a/packages/react/src/UnderlineNav/UnderlineNav.interactions.stories.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNav.interactions.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {within, userEvent, expect} from '@storybook/test'
 import {OverflowTemplate} from './UnderlineNav.features.stories'
 

--- a/packages/react/src/UnderlineNav/UnderlineNav.stories.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNav.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import {UnderlineNav} from './index'
 import {UnderlineNavItem} from './UnderlineNavItem'
 

--- a/packages/react/src/VisuallyHidden/VisuallyHidden.dev.stories.tsx
+++ b/packages/react/src/VisuallyHidden/VisuallyHidden.dev.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {VisuallyHidden} from './VisuallyHidden'
 
 export default {

--- a/packages/react/src/deprecated/FilteredSearch/FilteredSearch.stories.tsx
+++ b/packages/react/src/deprecated/FilteredSearch/FilteredSearch.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import FilteredSearch from './FilteredSearch'
 import {ActionList} from '../../ActionList'
 import {ActionMenu} from '../../ActionMenu'

--- a/packages/react/src/deprecated/UnderlineNav/UnderlineNav.features.stories.tsx
+++ b/packages/react/src/deprecated/UnderlineNav/UnderlineNav.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 import UnderlineNav from './UnderlineNav'
 import {Button} from '../../Button'
 

--- a/packages/react/src/deprecated/UnderlineNav/UnderlineNav.stories.tsx
+++ b/packages/react/src/deprecated/UnderlineNav/UnderlineNav.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryFn, Meta} from '@storybook/react'
+import type {StoryFn, Meta} from '@storybook/react-vite'
 import type {UnderlineNavProps} from './UnderlineNav'
 import UnderlineNav from './UnderlineNav'
 

--- a/packages/react/src/experimental/CSSComponent/Component.stories.tsx
+++ b/packages/react/src/experimental/CSSComponent/Component.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Component} from '.'
 
 export default {

--- a/packages/react/src/experimental/IssueLabel/IssueLabel.features.stories.tsx
+++ b/packages/react/src/experimental/IssueLabel/IssueLabel.features.stories.tsx
@@ -1,5 +1,5 @@
 import {IssueLabel} from '../IssueLabel'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Stack} from '../../Stack'
 
 const meta = {

--- a/packages/react/src/experimental/IssueLabel/IssueLabel.stories.tsx
+++ b/packages/react/src/experimental/IssueLabel/IssueLabel.stories.tsx
@@ -1,5 +1,5 @@
 import {IssueLabel} from '../IssueLabel'
-import type {Meta, StoryObj} from '@storybook/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
 
 const meta = {
   title: 'Experimental/Components/IssueLabel',

--- a/packages/react/src/experimental/SelectPanel2/SelectPanel.playground.stories.tsx
+++ b/packages/react/src/experimental/SelectPanel2/SelectPanel.playground.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {SelectPanelProps} from './SelectPanel'
 import {SelectPanel} from './SelectPanel'
 import {ActionList, Box} from '../../index'

--- a/packages/react/src/experimental/Skeleton/Skeleton.examples.stories.tsx
+++ b/packages/react/src/experimental/Skeleton/Skeleton.examples.stories.tsx
@@ -1,5 +1,5 @@
 import React, {Suspense} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../../utils/types'
 import {SkeletonText} from './SkeletonText'
 import {Avatar, Box, Button, IconButton, Text} from '../../'

--- a/packages/react/src/experimental/Skeleton/SkeletonAvatar.features.stories.tsx
+++ b/packages/react/src/experimental/Skeleton/SkeletonAvatar.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../../utils/types'
 import {SkeletonAvatar} from './SkeletonAvatar'
 import {AvatarStack, AvatarPair} from '../../'

--- a/packages/react/src/experimental/Skeleton/SkeletonAvatar.stories.tsx
+++ b/packages/react/src/experimental/Skeleton/SkeletonAvatar.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {ComponentProps} from '../../utils/types'
 import {SkeletonAvatar, type SkeletonAvatarProps} from './SkeletonAvatar'
 import {parseSizeFromArgs} from '../../Avatar/storyHelpers'

--- a/packages/react/src/experimental/Skeleton/SkeletonText.features.stories.tsx
+++ b/packages/react/src/experimental/Skeleton/SkeletonText.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../../utils/types'
 import {SkeletonText} from './SkeletonText'
 

--- a/packages/react/src/experimental/Skeleton/SkeletonText.stories.tsx
+++ b/packages/react/src/experimental/Skeleton/SkeletonText.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import type {ComponentProps} from '../../utils/types'
 import {SkeletonText} from './SkeletonText'
 

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.dev.stories.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.dev.stories.tsx
@@ -1,5 +1,5 @@
 import type {ComponentProps} from '../../utils/types'
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import UnderlinePanels from './UnderlinePanels'
 
 export default {

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.features.stories.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {INITIAL_VIEWPORTS} from '@storybook/addon-viewport'
 import UnderlinePanels from './UnderlinePanels'
 import type {ComponentProps} from '../../utils/types'

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.stories.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 import UnderlinePanels from './UnderlinePanels'
 
 const meta: Meta<typeof UnderlinePanels> = {

--- a/packages/react/src/live-region/Announce.features.stories.tsx
+++ b/packages/react/src/live-region/Announce.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryObj} from '@storybook/react'
+import type {StoryObj} from '@storybook/react-vite'
 import {useEffect, useState} from 'react'
 import {Announce} from './Announce'
 import {VisuallyHidden} from '../VisuallyHidden'

--- a/packages/react/src/live-region/Announce.stories.tsx
+++ b/packages/react/src/live-region/Announce.stories.tsx
@@ -1,6 +1,6 @@
 import {useEffect, useState} from 'react'
 import {Announce} from './Announce'
-import type {StoryObj} from '@storybook/react'
+import type {StoryObj} from '@storybook/react-vite'
 
 export default {
   title: 'Experimental/Components/Announce',

--- a/packages/react/src/live-region/AriaAlert.features.stories.tsx
+++ b/packages/react/src/live-region/AriaAlert.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryObj} from '@storybook/react'
+import type {StoryObj} from '@storybook/react-vite'
 import {AriaAlert} from './AriaAlert'
 import {VisuallyHidden} from '../VisuallyHidden'
 

--- a/packages/react/src/live-region/AriaAlert.stories.tsx
+++ b/packages/react/src/live-region/AriaAlert.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryObj} from '@storybook/react'
+import type {StoryObj} from '@storybook/react-vite'
 import {useEffect, useState} from 'react'
 import {AriaAlert} from './AriaAlert'
 

--- a/packages/react/src/live-region/AriaStatus.features.stories.tsx
+++ b/packages/react/src/live-region/AriaStatus.features.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryObj} from '@storybook/react'
+import type {StoryObj} from '@storybook/react-vite'
 import {useEffect, useState} from 'react'
 import {AriaStatus} from './AriaStatus'
 import {VisuallyHidden} from '../VisuallyHidden'

--- a/packages/react/src/live-region/AriaStatus.stories.tsx
+++ b/packages/react/src/live-region/AriaStatus.stories.tsx
@@ -1,4 +1,4 @@
-import type {StoryObj} from '@storybook/react'
+import type {StoryObj} from '@storybook/react-vite'
 import {useEffect, useState} from 'react'
 import {AriaStatus} from './AriaStatus'
 

--- a/packages/react/src/stories/ThemeProvider.stories.tsx
+++ b/packages/react/src/stories/ThemeProvider.stories.tsx
@@ -1,4 +1,4 @@
-import type {Meta, StoryFn} from '@storybook/react'
+import type {Meta, StoryFn} from '@storybook/react-vite'
 
 import {ThemeProvider, BaseStyles, Box, useTheme} from '..'
 import type {ThemeProviderProps} from '../ThemeProvider'

--- a/packages/react/src/stories/deprecated/ActionList.stories.tsx
+++ b/packages/react/src/stories/deprecated/ActionList.stories.tsx
@@ -11,7 +11,7 @@ import {
   ArrowRightIcon,
   ArrowLeftIcon,
 } from '@primer/octicons-react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import React, {forwardRef} from 'react'
 import {Label, ThemeProvider} from '../..'
 import {ActionList as _ActionList} from '../../deprecated/ActionList'

--- a/packages/react/src/stories/deprecated/ActionMenu.stories.tsx
+++ b/packages/react/src/stories/deprecated/ActionMenu.stories.tsx
@@ -11,7 +11,7 @@ import {
   ArrowRightIcon,
   TriangleDownIcon,
 } from '@primer/octicons-react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type React from 'react'
 import {useCallback, useState, useRef} from 'react'
 import {ThemeProvider} from '../..'

--- a/packages/react/src/stories/deprecated/SideNav.dev.stories.tsx
+++ b/packages/react/src/stories/deprecated/SideNav.dev.stories.tsx
@@ -1,5 +1,5 @@
 import {Avatar, Box, CounterLabel, Heading, Label, SideNav, Text} from '../..'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../../utils/types'
 import Octicon from '../../Octicon'
 import {DotIcon, MailIcon, PersonIcon, SmileyIcon, ZapIcon} from '@primer/octicons-react'

--- a/packages/react/src/stories/useAnchoredPosition.stories.tsx
+++ b/packages/react/src/stories/useAnchoredPosition.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {BaseStyles, Box, ThemeProvider} from '..'
 import {useAnchoredPosition} from '../hooks'
 import type {AnchorSide} from '@primer/behaviors'

--- a/packages/react/src/stories/useFocusTrap.stories.tsx
+++ b/packages/react/src/stories/useFocusTrap.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 
 import {BaseStyles, Box, Button, Flash, Text, ThemeProvider} from '..'
 import {useFocusTrap} from '../hooks/useFocusTrap'

--- a/packages/react/src/stories/useFocusZone.stories.tsx
+++ b/packages/react/src/stories/useFocusZone.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useRef, useState} from 'react'
-import type {Meta} from '@storybook/react'
+import type {Meta} from '@storybook/react-vite'
 import {Box, BaseStyles, Flash, theme, ThemeProvider} from '..'
 import {Button} from '../Button'
 import Link from '../Link'


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update storybook's eslint plugin to v9. This should help land: https://github.com/primer/react/pull/6198

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Fix new lint errors where we need to import from `@storybook/react-vite` instead of `@storybook/react`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to our linting setup