### PR TITLE
fix: Fix typo in comment - "regarless" to "regardless"

### DIFF
--- a/packages/react/src/LabelGroup/LabelGroup.tsx
+++ b/packages/react/src/LabelGroup/LabelGroup.tsx
@@ -256,7 +256,7 @@ const LabelGroup: React.FC<React.PropsWithChildren<LabelGroupProps>> = ({
     }
 
     if (visibleChildCount === 'auto') {
-      // Instatiates the IntersectionObserver to track when children fit in the container.
+      // Instantiates the IntersectionObserver to track when children fit in the container.
       const observer = new IntersectionObserver(
         (entries: IntersectionObserverEntry[]) => {
           const updatedEntries: Record<string, boolean> = {}

--- a/packages/react/src/TreeView/useRovingTabIndex.ts
+++ b/packages/react/src/TreeView/useRovingTabIndex.ts
@@ -98,7 +98,7 @@ export function getNextFocusableElement(activeElement: HTMLElement, event: Keybo
       return getParentElement(activeElement)
   }
 
-  // ArrowUp, ArrowDown, Home, and End behavior are the same regarless of element state
+  // ArrowUp, ArrowDown, Home, and End behavior are the same regardless of element state
   switch (event.key) {
     case 'ArrowUp':
       // Focus previous visible element


### PR DESCRIPTION
Fix minor typo in TreeView component comment:
- Fix spelling of "regarless" to "regardless"
- No functional changes, only comment improvement
