### PR TITLE
[ActionList] Prevent title="[object Object]" when Description has non-string children

### DIFF
--- a/.changeset/brown-rules-taste.md
+++ b/.changeset/brown-rules-taste.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fix ActionList.Description title attribute for non-string children with truncate

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "37.26.0",
+        "@primer/react": "37.27.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
@@ -445,7 +445,7 @@
       "name": "example-nextjs",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "37.26.0",
+        "@primer/react": "37.27.0",
         "next": "^15.2.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -630,7 +630,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.14.0",
-        "@primer/react": "37.26.0",
+        "@primer/react": "37.27.0",
         "clsx": "^2.1.1",
         "next": "^14.2.30",
         "react": "^18.3.1",
@@ -32661,7 +32661,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "37.26.0",
+      "version": "37.27.0",
       "license": "MIT",
       "dependencies": {
         "@github/relative-time-element": "^4.4.5",

--- a/packages/react/src/ActionList/ActionList.features.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.features.stories.tsx
@@ -591,6 +591,21 @@ export const TextWrapAndTruncation = () => (
         <ActionList.LeadingVisual>
           <ArrowRightIcon />
         </ActionList.LeadingVisual>
+        Description with truncation and complex children
+        <ActionList.Description
+          title="This is a long description with bold and italic text that should truncate"
+          truncate
+        >
+          With <strong>bold</strong> and <em>italic</em> text, and it should truncate if it is too long
+        </ActionList.Description>
+        <ActionList.TrailingVisual>
+          <ArrowLeftIcon />
+        </ActionList.TrailingVisual>
+      </ActionList.Item>
+      <ActionList.Item>
+        <ActionList.LeadingVisual>
+          <ArrowRightIcon />
+        </ActionList.LeadingVisual>
         Inline Description
         <ActionList.Description>This description wraps because it is inline without truncation</ActionList.Description>
         <ActionList.TrailingVisual>

--- a/packages/react/src/ActionList/ActionList.test.tsx
+++ b/packages/react/src/ActionList/ActionList.test.tsx
@@ -174,4 +174,39 @@ describe('ActionList', () => {
     expect(container.querySelector('li[aria-disabled="true"]')?.nextElementSibling).toHaveTextContent('Option 4')
     expect(container.querySelector('li[aria-disabled="true"]')?.nextElementSibling).toHaveAttribute('tabindex', '0')
   })
+
+  it('sets title correctly for Description component', () => {
+    const {container} = HTMLRender(
+      <ActionList>
+        <ActionList.Item>
+          Option 1<ActionList.Description truncate>Simple string description</ActionList.Description>
+        </ActionList.Item>
+        <ActionList.Item>
+          Option 2
+          <ActionList.Description truncate>
+            <span>Complex</span> content
+          </ActionList.Description>
+        </ActionList.Item>
+        <ActionList.Item>
+          Option 3
+          <ActionList.Description truncate title="Custom title">
+            <span>Complex</span> content
+          </ActionList.Description>
+        </ActionList.Item>
+        <ActionList.Item>
+          Option 4
+          <ActionList.Description>
+            <span>Non-truncated</span> content
+          </ActionList.Description>
+        </ActionList.Item>
+      </ActionList>,
+    )
+
+    const descriptions = container.querySelectorAll('[data-component="ActionList.Description"]')
+
+    expect(descriptions[0]).toHaveAttribute('title', 'Simple string description')
+    expect(descriptions[1]).not.toHaveAttribute('title')
+    expect(descriptions[2]).toHaveAttribute('title', 'Custom title')
+    expect(descriptions[3]).not.toHaveAttribute('title')
+  })
 })

--- a/packages/react/src/ActionList/Description.tsx
+++ b/packages/react/src/ActionList/Description.tsx
@@ -20,6 +20,11 @@ export type ActionListDescriptionProps = {
    * Whether the inline description should truncate the text on overflow.
    */
   truncate?: boolean
+  /**
+   * The title attribute for the truncated text tooltip.
+   * If not provided and children is a string, it will be set automatically.
+   */
+  title?: string
 } & SxProp
 
 export const Description: React.FC<React.PropsWithChildren<ActionListDescriptionProps>> = ({
@@ -27,9 +32,11 @@ export const Description: React.FC<React.PropsWithChildren<ActionListDescription
   sx = defaultSxProp,
   className,
   truncate,
+  title,
   ...props
 }) => {
   const {blockDescriptionId, inlineDescriptionId} = React.useContext(ItemContext)
+  const effectiveTitle = title || (typeof props.children === 'string' ? props.children : undefined)
 
   if (variant === 'block' || !truncate) {
     return (
@@ -49,7 +56,7 @@ export const Description: React.FC<React.PropsWithChildren<ActionListDescription
         id={inlineDescriptionId}
         className={clsx(className, classes.Description)}
         sx={sx}
-        title={props.children as string}
+        title={effectiveTitle}
         inline={true}
         maxWidth="100%"
         data-component="ActionList.Description"


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #4400

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API change
This pull request enhances the `ActionList` component in the `packages/react` library by introducing support for a `title` attribute in the `Description` subcomponent. This attribute provides better support for truncated text. -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
