### PR TITLE
fix: remove min height calc logic for SelectPanel

### DIFF
--- a/packages/react/src/SelectPanel/SelectPanel.module.css
+++ b/packages/react/src/SelectPanel/SelectPanel.module.css
@@ -93,7 +93,6 @@
 .Message {
   display: flex;
   height: 100%;
-  min-height: min(calc(var(--max-height) - 150px), 324px); /* maxHeight of dialog - (header & footer) */
   padding: var(--base-size-24);
   text-align: center;
   flex-direction: column;

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -23,7 +23,6 @@ import {useFeatureFlag} from '../FeatureFlags'
 import {announce, announceFromElement} from '@primer/live-region-element'
 import classes from './SelectPanel.module.css'
 import {clsx} from 'clsx'
-import {heightMap} from '../Overlay/Overlay'
 import {debounce} from '@github/mini-throttle'
 import {useResponsiveValue} from '../hooks/useResponsiveValue'
 import type {ButtonProps, LinkButtonProps} from '../Button/types'
@@ -721,7 +720,6 @@ function Panel({
               }
             : {}),
           style: {
-            '--max-height': overlayProps?.maxHeight ? heightMap[overlayProps.maxHeight] : heightMap['large'],
             /* override AnchoredOverlay position */
             transform: variant === 'modal' ? 'translate(-50%, -50%)' : undefined,
             // set maxHeight based on calculated availablePanelHeight when keyboard is visible


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #6220 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->
* Min height calculation logic for `SelectPanel`

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [X] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

<img width="603" alt="Screenshot 2025-06-20 at 1 13 13 PM" src="https://github.com/user-attachments/assets/a2b3237a-f1c0-4761-afd0-1b0119ecf959" />
<img width="603" alt="Screenshot 2025-06-20 at 1 13 19 PM" src="https://github.com/user-attachments/assets/46f74b6a-f6d4-4d7c-87e7-7b5837b5b595" />
<img width="603" alt="Screenshot 2025-06-20 at 1 15 20 PM" src="https://github.com/user-attachments/assets/07d48dc3-f7df-4bd5-8d0f-2a38bf7f8fdf" />
<img width="603" alt="Screenshot 2025-06-20 at 1 16 12 PM" src="https://github.com/user-attachments/assets/fbc81a9e-1c3b-4b50-a936-9e75039b5aa4" />


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [X] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
