### PR TITLE
Update vitest config and TreeView tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31892,6 +31892,33 @@
         }
       }
     },
+    "node_modules/vitest-fail-on-console": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/vitest-fail-on-console/-/vitest-fail-on-console-0.7.1.tgz",
+      "integrity": "sha512-/PjuonFu7CwUVrKaiQPIGXOtiEv2/Gz3o8MbLmovX9TGDxoRCctRC8CA9zJMRUd6AvwGu/V5a3znObTmlPNTgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.3.0"
+      },
+      "peerDependencies": {
+        "vite": ">=4.5.2",
+        "vitest": ">=0.26.2"
+      }
+    },
+    "node_modules/vitest-fail-on-console/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/expect": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.0.tgz",
@@ -32814,6 +32841,7 @@
         "unist-util-find": "3.0.0",
         "unist-util-find-before": "4.0.0",
         "unist-util-flat-filter": "2.0.0",
+        "vitest-fail-on-console": "^0.7.1",
         "yaml": "2.7.0"
       },
       "engines": {

--- a/packages/react/config/vitest/browser/global.css
+++ b/packages/react/config/vitest/browser/global.css
@@ -1,0 +1,53 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+table {
+  /* stylelint-disable-next-line primer/borders */
+  border-collapse: collapse;
+}
+
+[data-color-mode='light'] input {
+  color-scheme: light;
+}
+
+[data-color-mode='dark'] input {
+  color-scheme: dark;
+}
+
+@media (prefers-color-scheme: light) {
+  [data-color-mode='auto'][data-light-theme*='light'] {
+    color-scheme: light;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  [data-color-mode='auto'][data-dark-theme*='dark'] {
+    color-scheme: dark;
+  }
+}
+
+[role='button']:focus:not(:focus-visible):not(:global(.focus-visible)),
+[role='tabpanel'][tabindex='0']:focus:not(:focus-visible):not(:global(.focus-visible)),
+button:focus:not(:focus-visible):not(:global(.focus-visible)),
+summary:focus:not(:focus-visible):not(:global(.focus-visible)),
+a:focus:not(:focus-visible):not(:global(.focus-visible)) {
+  outline: none;
+  box-shadow: none;
+}
+
+[tabindex='0']:focus:not(:focus-visible):not(:global(.focus-visible)),
+details-dialog:focus:not(:focus-visible):not(:global(.focus-visible)) {
+  outline: none;
+}
+
+body {
+  color: var(--fgColor-default);
+  background-color: var(--bgColor-default);
+  font-family: var(--fontStack-system);
+  line-height: 1.5;
+}

--- a/packages/react/config/vitest/browser/setup.ts
+++ b/packages/react/config/vitest/browser/setup.ts
@@ -1,0 +1,36 @@
+import '@primer/primitives/dist/css/base/motion/motion.css'
+import '@primer/primitives/dist/css/base/size/size.css'
+import '@primer/primitives/dist/css/base/typography/typography.css'
+import '@primer/primitives/dist/css/functional/size/border.css'
+import '@primer/primitives/dist/css/functional/size/breakpoints.css'
+import '@primer/primitives/dist/css/functional/size/size-coarse.css'
+import '@primer/primitives/dist/css/functional/size/size-fine.css'
+import '@primer/primitives/dist/css/functional/size/size.css'
+import '@primer/primitives/dist/css/functional/size/viewport.css'
+import '@primer/primitives/dist/css/functional/themes/dark-colorblind.css'
+import '@primer/primitives/dist/css/functional/themes/dark-dimmed.css'
+import '@primer/primitives/dist/css/functional/themes/dark-high-contrast.css'
+import '@primer/primitives/dist/css/functional/themes/dark-tritanopia.css'
+import '@primer/primitives/dist/css/functional/themes/dark.css'
+import '@primer/primitives/dist/css/functional/themes/light-colorblind.css'
+import '@primer/primitives/dist/css/functional/themes/light-high-contrast.css'
+import '@primer/primitives/dist/css/functional/themes/light-tritanopia.css'
+import '@primer/primitives/dist/css/functional/themes/light.css'
+import '@primer/primitives/dist/css/functional/typography/typography.css'
+import './global.css'
+
+import {beforeEach} from 'vitest'
+import {cleanup} from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+beforeEach(() => {
+  cleanup()
+})
+
+// @ts-expect-error this is needed for act() from React
+// @see https://react.dev/reference/react/act#error-the-current-testing-environment-is-not-configured-to-support-act
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+document.documentElement.setAttribute('data-color-mode', 'auto')
+document.documentElement.setAttribute('data-light-theme', 'light')
+document.documentElement.setAttribute('data-dark-theme', 'dark')

--- a/packages/react/config/vitest/setup.ts
+++ b/packages/react/config/vitest/setup.ts
@@ -1,11 +1,12 @@
-import {afterEach} from 'vitest'
-import {cleanup} from '@testing-library/react'
-import '@testing-library/jest-dom/vitest'
+import failOnConsole from 'vitest-fail-on-console'
 
-afterEach(() => {
-  cleanup()
+const failConsoleMessages = process.env.CI === 'true'
+
+failOnConsole({
+  shouldFailOnAssert: failConsoleMessages,
+  shouldFailOnDebug: failConsoleMessages,
+  shouldFailOnError: failConsoleMessages,
+  shouldFailOnInfo: failConsoleMessages,
+  shouldFailOnLog: failConsoleMessages,
+  shouldFailOnWarn: failConsoleMessages,
 })
-
-// @ts-expect-error this is needed for act() from React
-// @see https://react.dev/reference/react/act#error-the-current-testing-environment-is-not-configured-to-support-act
-globalThis.IS_REACT_ACT_ENVIRONMENT = true

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -73,6 +73,7 @@ module.exports = {
     '<rootDir>/src/internal/utils/',
     '<rootDir>/src/live-region/',
     '<rootDir>/src/utils/',
+    '<rootDir>/src/TreeView/',
   ],
   transformIgnorePatterns: ['node_modules/(?!@github/[a-z-]+-element|@lit-labs/react|@oddbird/popover-polyfill)'],
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -212,6 +212,7 @@
     "unist-util-find": "3.0.0",
     "unist-util-find-before": "4.0.0",
     "unist-util-flat-filter": "2.0.0",
+    "vitest-fail-on-console": "^0.7.1",
     "yaml": "2.7.0"
   },
   "peerDependencies": {

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
@@ -1,6 +1,7 @@
-import {useCallback, useState} from 'react'
+import {act, useCallback, useState} from 'react'
 import {describe, expect, it, vi} from 'vitest'
 import {render, fireEvent} from '@testing-library/react'
+import {userEvent} from '@vitest/browser/context'
 import {AnchoredOverlay} from '../AnchoredOverlay'
 import {Button} from '../Button'
 import theme from '../theme'
@@ -53,35 +54,39 @@ const AnchoredOverlayTestComponent = ({
 }
 
 describe('AnchoredOverlay', () => {
-  it('should call onOpen when the anchor is clicked', () => {
+  it('should call onOpen when the anchor is clicked', async () => {
     const mockOpenCallback = vi.fn()
     const mockCloseCallback = vi.fn()
     const anchoredOverlay = render(
       <AnchoredOverlayTestComponent onOpenCallback={mockOpenCallback} onCloseCallback={mockCloseCallback} />,
     )
     const anchor = anchoredOverlay.baseElement.querySelector('[aria-haspopup="true"]')!
-    fireEvent.click(anchor)
+    await act(async () => {
+      await userEvent.click(anchor)
+    })
 
     expect(mockOpenCallback).toHaveBeenCalledTimes(1)
     expect(mockOpenCallback).toHaveBeenCalledWith('anchor-click')
     expect(mockCloseCallback).toHaveBeenCalledTimes(0)
   })
 
-  it('should call onOpen when the anchor activated by a key press', () => {
+  it('should call onOpen when the anchor activated by a key press', async () => {
     const mockOpenCallback = vi.fn()
     const mockCloseCallback = vi.fn()
     const anchoredOverlay = render(
       <AnchoredOverlayTestComponent onOpenCallback={mockOpenCallback} onCloseCallback={mockCloseCallback} />,
     )
     const anchor = anchoredOverlay.baseElement.querySelector('[aria-haspopup="true"]')!
-    fireEvent.keyDown(anchor, {key: ' '})
+    await act(async () => {
+      await userEvent.type(anchor, '{Space}')
+    })
 
     expect(mockOpenCallback).toHaveBeenCalledTimes(1)
     expect(mockOpenCallback).toHaveBeenCalledWith('anchor-key-press')
     expect(mockCloseCallback).toHaveBeenCalledTimes(0)
   })
 
-  it('should call onClose when the user clicks off of the overlay', () => {
+  it('should call onClose when the user clicks off of the overlay', async () => {
     const mockOpenCallback = vi.fn()
     const mockCloseCallback = vi.fn()
     const anchoredOverlay = render(
@@ -91,7 +96,9 @@ describe('AnchoredOverlay', () => {
         onCloseCallback={mockCloseCallback}
       />,
     )
-    fireEvent.mouseDown(anchoredOverlay.baseElement)
+    await act(async () => {
+      await userEvent.click(anchoredOverlay.baseElement)
+    })
 
     expect(mockOpenCallback).toHaveBeenCalledTimes(0)
     expect(mockCloseCallback).toHaveBeenCalledTimes(1)
@@ -101,15 +108,18 @@ describe('AnchoredOverlay', () => {
   it('should call onClose when the escape key is pressed', async () => {
     const mockOpenCallback = vi.fn()
     const mockCloseCallback = vi.fn()
-    const anchoredOverlay = render(
+
+    render(
       <AnchoredOverlayTestComponent
         initiallyOpen={true}
         onOpenCallback={mockOpenCallback}
         onCloseCallback={mockCloseCallback}
       />,
     )
-    const overlay = await anchoredOverlay.findByRole('none')
-    fireEvent.keyDown(overlay, {key: 'Escape'})
+
+    await act(async () => {
+      await userEvent.keyboard('{Escape}')
+    })
 
     expect(mockOpenCallback).toHaveBeenCalledTimes(0)
     expect(mockCloseCallback).toHaveBeenCalledTimes(1)
@@ -121,21 +131,23 @@ describe('AnchoredOverlay', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('should call onPositionChange when provided', () => {
+  it('should call onPositionChange when provided', async () => {
     const mockPositionChangeCallback = vi.fn(({position}: {position: AnchorPosition}) => position)
     const anchoredOverlay = render(
       <AnchoredOverlayTestComponent initiallyOpen={true} onPositionChange={mockPositionChangeCallback} />,
     )
-    const overlay = anchoredOverlay.baseElement.querySelector('[role="none"]')!
-    fireEvent.keyDown(overlay, {key: 'Escape'})
 
-    expect(mockPositionChangeCallback).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      await userEvent.keyboard('{Escape}')
+    })
+
+    expect(mockPositionChangeCallback).toHaveBeenCalled()
     expect(mockPositionChangeCallback).toHaveBeenCalledWith({
       position: {
         anchorAlign: 'start',
         anchorSide: 'outside-bottom',
         left: 0,
-        top: 26.84375,
+        top: 36,
       },
     })
   })

--- a/packages/react/src/AnchoredOverlay/__snapshots__/AnchoredOverlay.test.tsx.snap
+++ b/packages/react/src/AnchoredOverlay/__snapshots__/AnchoredOverlay.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AnchoredOverlay > should render consistently when open 1`] = `
 <div>
   <div
-    class="_BaseStyles_1n09d_56"
+    class="prc-src-BaseStyles-9LBd2"
     data-color-mode="light"
     data-dark-theme="dark"
     data-light-theme="light"
@@ -13,7 +13,7 @@ exports[`AnchoredOverlay > should render consistently when open 1`] = `
       aria-describedby=":rd:-loading-announcement"
       aria-expanded="true"
       aria-haspopup="true"
-      class="_ButtonBase_1h0a3_2"
+      class="prc-Button-ButtonBase-Eb8-K"
       data-loading="false"
       data-no-visuals="true"
       data-size="medium"
@@ -23,12 +23,12 @@ exports[`AnchoredOverlay > should render consistently when open 1`] = `
       type="button"
     >
       <span
-        class="_ButtonContent_1h0a3_101"
+        class="prc-Button-ButtonContent-KZ5Bz"
         data-align="center"
         data-component="buttonContent"
       >
         <span
-          class="_Label_1h0a3_128"
+          class="prc-Button-Label-B1e2-"
           data-component="text"
         >
           Anchor Button
@@ -43,14 +43,14 @@ exports[`AnchoredOverlay > should render consistently when open 1`] = `
         style="position: relative; z-index: 1;"
       >
         <div
-          class="_Overlay_1a2ug_11"
+          class="prc-Overlay-Overlay-ViJgm"
           data-focus-trap="active"
           data-height-auto=""
           data-variant="anchored"
           data-visibility-visible=""
           data-width-auto=""
           role="none"
-          style="left: 0px; top: 26.8438px;"
+          style="left: 0px; top: 36px;"
         >
           <span
             aria-hidden="true"

--- a/packages/react/src/Breadcrumbs/__tests__/__snapshots__/BreadcrumbsItem.test.tsx.snap
+++ b/packages/react/src/Breadcrumbs/__tests__/__snapshots__/BreadcrumbsItem.test.tsx.snap
@@ -3,6 +3,6 @@
 exports[`Breadcrumbs.Item > respects the "selected" prop 1`] = `
 <a
   aria-current="page"
-  class="_Item_tg8iv_12 selected _ItemSelected_tg8iv_53"
+  class="prc-Breadcrumbs-Item-V05wG selected prc-Breadcrumbs-ItemSelected-gKthY"
 />
 `;

--- a/packages/react/src/NavList/__snapshots__/NavList.test.tsx.snap
+++ b/packages/react/src/NavList/__snapshots__/NavList.test.tsx.snap
@@ -4,98 +4,98 @@ exports[`NavList > renders a simple list 1`] = `
 <div>
   <nav>
     <ul
-      class="_ActionList_1kphf_3"
+      class="prc-ActionList-ActionList--dkHj"
       data-dividers="false"
       data-variant="inset"
     >
       <li
-        class="_ActionListItem_1kphf_20"
+        class="prc-ActionList-ActionListItem-jXerx"
         data-active="true"
       >
         <a
           aria-current="page"
           aria-labelledby=":r1:--label  "
-          class="_ActionListContent_1kphf_282 _Link_u1kmx_1"
+          class="prc-ActionList-ActionListContent-Q8eQr prc-Link-Link-O33ci"
           href="/"
           id=":r1:"
           style="--subitem-depth: 0;"
           tabindex="0"
         >
           <span
-            class="_Spacer_1kphf_297"
+            class="prc-ActionList-Spacer-vgXtU"
           />
           <span
-            class="_ActionListSubContent_1kphf_31"
+            class="prc-ActionList-ActionListSubContent-Zcjdz"
             data-component="ActionList.Item--DividerContainer"
           >
             <span
-              class="_ItemLabel_1kphf_188"
+              class="prc-ActionList-ItemLabel-hYyH7"
               id=":r1:--label"
             >
               Home
             </span>
             <span
-              class="_InactiveWarning_1kphf_236"
+              class="prc-ActionList-InactiveWarning--0rPr"
             />
           </span>
         </a>
       </li>
       <li
-        class="_ActionListItem_1kphf_20"
+        class="prc-ActionList-ActionListItem-jXerx"
       >
         <a
           aria-labelledby=":r2:--label  "
-          class="_ActionListContent_1kphf_282 _Link_u1kmx_1"
+          class="prc-ActionList-ActionListContent-Q8eQr prc-Link-Link-O33ci"
           href="/about"
           id=":r2:"
           style="--subitem-depth: 0;"
           tabindex="0"
         >
           <span
-            class="_Spacer_1kphf_297"
+            class="prc-ActionList-Spacer-vgXtU"
           />
           <span
-            class="_ActionListSubContent_1kphf_31"
+            class="prc-ActionList-ActionListSubContent-Zcjdz"
             data-component="ActionList.Item--DividerContainer"
           >
             <span
-              class="_ItemLabel_1kphf_188"
+              class="prc-ActionList-ItemLabel-hYyH7"
               id=":r2:--label"
             >
               About
             </span>
             <span
-              class="_InactiveWarning_1kphf_236"
+              class="prc-ActionList-InactiveWarning--0rPr"
             />
           </span>
         </a>
       </li>
       <li
-        class="_ActionListItem_1kphf_20"
+        class="prc-ActionList-ActionListItem-jXerx"
       >
         <a
           aria-labelledby=":r3:--label  "
-          class="_ActionListContent_1kphf_282 _Link_u1kmx_1"
+          class="prc-ActionList-ActionListContent-Q8eQr prc-Link-Link-O33ci"
           href="/contact"
           id=":r3:"
           style="--subitem-depth: 0;"
           tabindex="0"
         >
           <span
-            class="_Spacer_1kphf_297"
+            class="prc-ActionList-Spacer-vgXtU"
           />
           <span
-            class="_ActionListSubContent_1kphf_31"
+            class="prc-ActionList-ActionListSubContent-Zcjdz"
             data-component="ActionList.Item--DividerContainer"
           >
             <span
-              class="_ItemLabel_1kphf_188"
+              class="prc-ActionList-ItemLabel-hYyH7"
               id=":r3:--label"
             >
               Contact
             </span>
             <span
-              class="_InactiveWarning_1kphf_236"
+              class="prc-ActionList-InactiveWarning--0rPr"
             />
           </span>
         </a>
@@ -109,25 +109,25 @@ exports[`NavList > renders with groups 1`] = `
 <div>
   <nav>
     <ul
-      class="_ActionList_1kphf_3"
+      class="prc-ActionList-ActionList--dkHj"
       data-dividers="false"
       data-variant="inset"
     >
       <li
         aria-hidden="true"
-        class="_Divider_1kphf_73"
+        class="prc-ActionList-Divider-eZxO8"
         data-component="ActionList.Divider"
       />
       <li
-        class="_Group_1rejt_1"
+        class="prc-ActionList-Group-42hnW"
       >
         <div
-          class="_GroupHeadingWrap_1rejt_9"
+          class="prc-ActionList-GroupHeadingWrap-CL7FP"
           data-component="GroupHeadingWrap"
           data-variant="subtle"
         >
           <h3
-            class="_GroupHeading_1rejt_7"
+            class="prc-ActionList-GroupHeading-w2osB"
             data-component="ActionList.GroupHeading"
             id=":r5:"
           >
@@ -136,36 +136,36 @@ exports[`NavList > renders with groups 1`] = `
         </div>
         <ul
           aria-labelledby=":r5:"
-          class="_GroupList_1rejt_18"
+          class="prc-ActionList-GroupList-kpPZc"
         >
           <li
-            class="_ActionListItem_1kphf_20"
+            class="prc-ActionList-ActionListItem-jXerx"
             data-active="true"
           >
             <a
               aria-current="page"
               aria-labelledby=":r6:--label  "
-              class="_ActionListContent_1kphf_282 _Link_u1kmx_1"
+              class="prc-ActionList-ActionListContent-Q8eQr prc-Link-Link-O33ci"
               href="/getting-started"
               id=":r6:"
               style="--subitem-depth: 0;"
               tabindex="0"
             >
               <span
-                class="_Spacer_1kphf_297"
+                class="prc-ActionList-Spacer-vgXtU"
               />
               <span
-                class="_ActionListSubContent_1kphf_31"
+                class="prc-ActionList-ActionListSubContent-Zcjdz"
                 data-component="ActionList.Item--DividerContainer"
               >
                 <span
-                  class="_ItemLabel_1kphf_188"
+                  class="prc-ActionList-ItemLabel-hYyH7"
                   id=":r6:--label"
                 >
                   Getting started
                 </span>
                 <span
-                  class="_InactiveWarning_1kphf_236"
+                  class="prc-ActionList-InactiveWarning--0rPr"
                 />
               </span>
             </a>
@@ -174,19 +174,19 @@ exports[`NavList > renders with groups 1`] = `
       </li>
       <li
         aria-hidden="true"
-        class="_Divider_1kphf_73"
+        class="prc-ActionList-Divider-eZxO8"
         data-component="ActionList.Divider"
       />
       <li
-        class="_Group_1rejt_1"
+        class="prc-ActionList-Group-42hnW"
       >
         <div
-          class="_GroupHeadingWrap_1rejt_9"
+          class="prc-ActionList-GroupHeadingWrap-CL7FP"
           data-component="GroupHeadingWrap"
           data-variant="subtle"
         >
           <h3
-            class="_GroupHeading_1rejt_7"
+            class="prc-ActionList-GroupHeading-w2osB"
             data-component="ActionList.GroupHeading"
             id=":r7:"
           >
@@ -195,34 +195,34 @@ exports[`NavList > renders with groups 1`] = `
         </div>
         <ul
           aria-labelledby=":r7:"
-          class="_GroupList_1rejt_18"
+          class="prc-ActionList-GroupList-kpPZc"
         >
           <li
-            class="_ActionListItem_1kphf_20"
+            class="prc-ActionList-ActionListItem-jXerx"
           >
             <a
               aria-labelledby=":r8:--label  "
-              class="_ActionListContent_1kphf_282 _Link_u1kmx_1"
+              class="prc-ActionList-ActionListContent-Q8eQr prc-Link-Link-O33ci"
               href="/Avatar"
               id=":r8:"
               style="--subitem-depth: 0;"
               tabindex="0"
             >
               <span
-                class="_Spacer_1kphf_297"
+                class="prc-ActionList-Spacer-vgXtU"
               />
               <span
-                class="_ActionListSubContent_1kphf_31"
+                class="prc-ActionList-ActionListSubContent-Zcjdz"
                 data-component="ActionList.Item--DividerContainer"
               >
                 <span
-                  class="_ItemLabel_1kphf_188"
+                  class="prc-ActionList-ItemLabel-hYyH7"
                   id=":r8:--label"
                 >
                   Avatar
                 </span>
                 <span
-                  class="_InactiveWarning_1kphf_236"
+                  class="prc-ActionList-InactiveWarning--0rPr"
                 />
               </span>
             </a>
@@ -238,44 +238,44 @@ exports[`NavList.Item with NavList.SubNav > does not have active styles if SubNa
 <div>
   <nav>
     <ul
-      class="_ActionList_1kphf_3"
+      class="prc-ActionList-ActionList--dkHj"
       data-dividers="false"
       data-variant="inset"
     >
       <li
-        class="_ActionListItem_1kphf_20"
+        class="prc-ActionList-ActionListItem-jXerx"
         data-has-subitem="true"
       >
         <button
           aria-controls=":r23:"
           aria-expanded="true"
           aria-labelledby=":r22:--label :r22:--trailing-visual "
-          class="_ActionListContent_1kphf_282"
+          class="prc-ActionList-ActionListContent-Q8eQr"
           id=":r22:"
           style="--subitem-depth: 0;"
           tabindex="0"
           type="button"
         >
           <span
-            class="_Spacer_1kphf_297"
+            class="prc-ActionList-Spacer-vgXtU"
           />
           <span
-            class="_ActionListSubContent_1kphf_31"
+            class="prc-ActionList-ActionListSubContent-Zcjdz"
             data-component="ActionList.Item--DividerContainer"
           >
             <span
-              class="_ItemLabel_1kphf_188"
+              class="prc-ActionList-ItemLabel-hYyH7"
               id=":r22:--label"
             >
               Item
             </span>
             <span
-              class="_TrailingVisual_1kphf_158 _VisualWrap_1kphf_615"
+              class="prc-ActionList-TrailingVisual-8LMjP prc-ActionList-VisualWrap-MGVnU"
               id=":r22:--trailing-visual"
             >
               <svg
                 aria-hidden="true"
-                class="octicon octicon-chevron-down _ExpandIcon_1kphf_484"
+                class="octicon octicon-chevron-down prc-ActionList-ExpandIcon-6JuzS"
                 display="inline-block"
                 fill="currentColor"
                 focusable="false"
@@ -291,43 +291,43 @@ exports[`NavList.Item with NavList.SubNav > does not have active styles if SubNa
               </svg>
             </span>
             <span
-              class="_InactiveWarning_1kphf_236"
+              class="prc-ActionList-InactiveWarning--0rPr"
             />
           </span>
         </button>
         <ul
           aria-labelledby=":r22:"
-          class="_SubGroup_1kphf_494"
+          class="prc-ActionList-SubGroup-4pVPh"
           id=":r23:"
         >
           <li
-            class="_ActionListItem_1kphf_20"
+            class="prc-ActionList-ActionListItem-jXerx"
             data-active="true"
           >
             <a
               aria-current="page"
               aria-labelledby=":r25:--label  "
-              class="_ActionListContent_1kphf_282 _Link_u1kmx_1"
+              class="prc-ActionList-ActionListContent-Q8eQr prc-Link-Link-O33ci"
               href="#"
               id=":r25:"
               style="--subitem-depth: 1;"
               tabindex="0"
             >
               <span
-                class="_Spacer_1kphf_297"
+                class="prc-ActionList-Spacer-vgXtU"
               />
               <span
-                class="_ActionListSubContent_1kphf_31"
+                class="prc-ActionList-ActionListSubContent-Zcjdz"
                 data-component="ActionList.Item--DividerContainer"
               >
                 <span
-                  class="_ItemLabel_1kphf_188"
+                  class="prc-ActionList-ItemLabel-hYyH7"
                   id=":r25:--label"
                 >
                   Sub Item
                 </span>
                 <span
-                  class="_InactiveWarning_1kphf_236"
+                  class="prc-ActionList-InactiveWarning--0rPr"
                 />
               </span>
             </a>
@@ -343,12 +343,12 @@ exports[`NavList.Item with NavList.SubNav > has active styles if SubNav contains
 <div>
   <nav>
     <ul
-      class="_ActionList_1kphf_3"
+      class="prc-ActionList-ActionList--dkHj"
       data-dividers="false"
       data-variant="inset"
     >
       <li
-        class="_ActionListItem_1kphf_20"
+        class="prc-ActionList-ActionListItem-jXerx"
         data-active="true"
         data-has-subitem="true"
       >
@@ -356,32 +356,32 @@ exports[`NavList.Item with NavList.SubNav > has active styles if SubNav contains
           aria-controls=":r1u:"
           aria-expanded="false"
           aria-labelledby=":r1t:--label :r1t:--trailing-visual "
-          class="_ActionListContent_1kphf_282"
+          class="prc-ActionList-ActionListContent-Q8eQr"
           id=":r1t:"
           style="--subitem-depth: 0;"
           tabindex="0"
           type="button"
         >
           <span
-            class="_Spacer_1kphf_297"
+            class="prc-ActionList-Spacer-vgXtU"
           />
           <span
-            class="_ActionListSubContent_1kphf_31"
+            class="prc-ActionList-ActionListSubContent-Zcjdz"
             data-component="ActionList.Item--DividerContainer"
           >
             <span
-              class="_ItemLabel_1kphf_188"
+              class="prc-ActionList-ItemLabel-hYyH7"
               id=":r1t:--label"
             >
               Item
             </span>
             <span
-              class="_TrailingVisual_1kphf_158 _VisualWrap_1kphf_615"
+              class="prc-ActionList-TrailingVisual-8LMjP prc-ActionList-VisualWrap-MGVnU"
               id=":r1t:--trailing-visual"
             >
               <svg
                 aria-hidden="true"
-                class="octicon octicon-chevron-down _ExpandIcon_1kphf_484"
+                class="octicon octicon-chevron-down prc-ActionList-ExpandIcon-6JuzS"
                 display="inline-block"
                 fill="currentColor"
                 focusable="false"
@@ -397,43 +397,43 @@ exports[`NavList.Item with NavList.SubNav > has active styles if SubNav contains
               </svg>
             </span>
             <span
-              class="_InactiveWarning_1kphf_236"
+              class="prc-ActionList-InactiveWarning--0rPr"
             />
           </span>
         </button>
         <ul
           aria-labelledby=":r1t:"
-          class="_SubGroup_1kphf_494"
+          class="prc-ActionList-SubGroup-4pVPh"
           id=":r1u:"
         >
           <li
-            class="_ActionListItem_1kphf_20"
+            class="prc-ActionList-ActionListItem-jXerx"
             data-active="true"
           >
             <a
               aria-current="page"
               aria-labelledby=":r20:--label  "
-              class="_ActionListContent_1kphf_282 _Link_u1kmx_1"
+              class="prc-ActionList-ActionListContent-Q8eQr prc-Link-Link-O33ci"
               href="#"
               id=":r20:"
               style="--subitem-depth: 1;"
               tabindex="0"
             >
               <span
-                class="_Spacer_1kphf_297"
+                class="prc-ActionList-Spacer-vgXtU"
               />
               <span
-                class="_ActionListSubContent_1kphf_31"
+                class="prc-ActionList-ActionListSubContent-Zcjdz"
                 data-component="ActionList.Item--DividerContainer"
               >
                 <span
-                  class="_ItemLabel_1kphf_188"
+                  class="prc-ActionList-ItemLabel-hYyH7"
                   id=":r20:--label"
                 >
                   Sub Item
                 </span>
                 <span
-                  class="_InactiveWarning_1kphf_236"
+                  class="prc-ActionList-InactiveWarning--0rPr"
                 />
               </span>
             </a>

--- a/packages/react/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/react/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ProgressBar > respects the "progress" prop 1`] = `
 
     <div>
       <span
-        class="_ProgressBarContainer_1bos7_27"
+        class="prc-ProgressBar-ProgressBarContainer-VJMc2"
         data-progress-bar-size="default"
         data-progress-display="block"
       >
@@ -19,7 +19,7 @@ exports[`ProgressBar > respects the "progress" prop 1`] = `
           aria-valuemax="100"
           aria-valuemin="0"
           aria-valuenow="80"
-          class="sc-aXZVg lfjCwU _ProgressBarItem_1bos7_11"
+          class="sc-aXZVg lfjCwU prc-ProgressBar-ProgressBarItem-NPfsV"
           role="progressbar"
           style="--progress-width: 80%; --progress-bg: var(--bgColor-success-emphasis);"
         />
@@ -28,7 +28,7 @@ exports[`ProgressBar > respects the "progress" prop 1`] = `
   </body>,
   "container": <div>
     <span
-      class="_ProgressBarContainer_1bos7_27"
+      class="prc-ProgressBar-ProgressBarContainer-VJMc2"
       data-progress-bar-size="default"
       data-progress-display="block"
     >
@@ -37,7 +37,7 @@ exports[`ProgressBar > respects the "progress" prop 1`] = `
         aria-valuemax="100"
         aria-valuemin="0"
         aria-valuenow="80"
-        class="sc-aXZVg lfjCwU _ProgressBarItem_1bos7_11"
+        class="sc-aXZVg lfjCwU prc-ProgressBar-ProgressBarItem-NPfsV"
         role="progressbar"
         style="--progress-width: 80%; --progress-bg: var(--bgColor-success-emphasis);"
       />

--- a/packages/react/src/TextInputWithTokens/__snapshots__/TextInputWithTokens.test.tsx.snap
+++ b/packages/react/src/TextInputWithTokens/__snapshots__/TextInputWithTokens.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-leading-visual="true"
         data-size="medium"
         data-trailing-visual="true"
@@ -37,21 +37,21 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </svg>
         </span>
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -61,7 +61,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -72,7 +72,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -96,7 +96,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -106,7 +106,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -117,7 +117,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -141,7 +141,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -151,7 +151,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -162,7 +162,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -186,7 +186,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -196,7 +196,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -207,7 +207,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -231,7 +231,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -241,7 +241,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -252,7 +252,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -276,7 +276,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -286,7 +286,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -297,7 +297,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -321,7 +321,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -331,7 +331,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -342,7 +342,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -366,7 +366,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -376,7 +376,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -387,7 +387,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -437,7 +437,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-leading-visual="true"
       data-size="medium"
       data-trailing-visual="true"
@@ -464,21 +464,21 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
         </svg>
       </span>
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -488,7 +488,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -499,7 +499,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -523,7 +523,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -533,7 +533,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -544,7 +544,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -568,7 +568,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -578,7 +578,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -589,7 +589,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -613,7 +613,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -623,7 +623,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -634,7 +634,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -658,7 +658,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -668,7 +668,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -679,7 +679,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -703,7 +703,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -713,7 +713,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -724,7 +724,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -748,7 +748,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -758,7 +758,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -769,7 +769,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -793,7 +793,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -803,7 +803,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -814,7 +814,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -925,25 +925,25 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -953,7 +953,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -964,7 +964,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -988,7 +988,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -998,7 +998,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -1009,7 +1009,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -1033,7 +1033,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
             </span>
           </span>
           <span
-            class="sc-aXZVg eKNwWh _Text_140xm_1"
+            class="sc-aXZVg eKNwWh prc-Text-Text-jAl-N"
             color="fg.muted"
             font-size="2"
           >
@@ -1046,25 +1046,25 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -1074,7 +1074,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -1085,7 +1085,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -1109,7 +1109,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -1119,7 +1119,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -1130,7 +1130,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -1154,7 +1154,7 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
           </span>
         </span>
         <span
-          class="sc-aXZVg eKNwWh _Text_140xm_1"
+          class="sc-aXZVg eKNwWh prc-Text-Text-jAl-N"
           color="fg.muted"
           font-size="2"
         >
@@ -1228,20 +1228,20 @@ exports[`TextInputWithTokens > renders as block layout 1`] = `
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-block="true"
         data-size="medium"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
@@ -1252,20 +1252,20 @@ exports[`TextInputWithTokens > renders as block layout 1`] = `
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-block="true"
       data-size="medium"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
@@ -1337,27 +1337,27 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
         data-token-wrapping="true"
         style="max-height: 20px;"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -1367,7 +1367,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -1378,7 +1378,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -1402,7 +1402,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -1412,7 +1412,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -1423,7 +1423,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -1447,7 +1447,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -1457,7 +1457,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -1468,7 +1468,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -1492,7 +1492,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -1502,7 +1502,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -1513,7 +1513,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -1537,7 +1537,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -1547,7 +1547,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -1558,7 +1558,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -1582,7 +1582,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -1592,7 +1592,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -1603,7 +1603,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -1627,7 +1627,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -1637,7 +1637,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -1648,7 +1648,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -1672,7 +1672,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -1682,7 +1682,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -1693,7 +1693,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -1722,27 +1722,27 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
       data-token-wrapping="true"
       style="max-height: 20px;"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -1752,7 +1752,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -1763,7 +1763,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -1787,7 +1787,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -1797,7 +1797,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -1808,7 +1808,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -1832,7 +1832,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -1842,7 +1842,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -1853,7 +1853,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -1877,7 +1877,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -1887,7 +1887,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -1898,7 +1898,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -1922,7 +1922,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -1932,7 +1932,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -1943,7 +1943,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -1967,7 +1967,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -1977,7 +1977,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -1988,7 +1988,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -2012,7 +2012,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -2022,7 +2022,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -2033,7 +2033,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -2057,7 +2057,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -2067,7 +2067,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -2078,7 +2078,7 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -2168,25 +2168,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="small"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -2196,7 +2196,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -2207,7 +2207,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -2231,7 +2231,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -2241,7 +2241,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -2252,7 +2252,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -2276,7 +2276,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -2286,7 +2286,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -2297,7 +2297,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -2321,7 +2321,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -2331,7 +2331,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -2342,7 +2342,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -2366,7 +2366,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -2376,7 +2376,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -2387,7 +2387,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -2411,7 +2411,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -2421,7 +2421,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -2432,7 +2432,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -2456,7 +2456,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -2466,7 +2466,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -2477,7 +2477,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -2501,7 +2501,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -2511,7 +2511,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -2522,7 +2522,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -2551,25 +2551,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="small"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -2579,7 +2579,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -2590,7 +2590,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -2614,7 +2614,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -2624,7 +2624,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -2635,7 +2635,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -2659,7 +2659,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -2669,7 +2669,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -2680,7 +2680,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -2704,7 +2704,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -2714,7 +2714,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -2725,7 +2725,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -2749,7 +2749,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -2759,7 +2759,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -2770,7 +2770,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -2794,7 +2794,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -2804,7 +2804,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -2815,7 +2815,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -2839,7 +2839,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -2849,7 +2849,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -2860,7 +2860,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -2884,7 +2884,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -2894,7 +2894,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -2905,7 +2905,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -2995,25 +2995,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="small"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3023,7 +3023,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -3034,7 +3034,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3058,7 +3058,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3068,7 +3068,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -3079,7 +3079,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3103,7 +3103,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3113,7 +3113,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -3124,7 +3124,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3148,7 +3148,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3158,7 +3158,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -3169,7 +3169,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3193,7 +3193,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3203,7 +3203,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -3214,7 +3214,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3238,7 +3238,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3248,7 +3248,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -3259,7 +3259,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3283,7 +3283,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3293,7 +3293,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -3304,7 +3304,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3328,7 +3328,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3338,7 +3338,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -3349,7 +3349,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3377,25 +3377,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
     </div>
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="small"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3405,7 +3405,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -3416,7 +3416,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3440,7 +3440,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3450,7 +3450,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -3461,7 +3461,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3485,7 +3485,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3495,7 +3495,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -3506,7 +3506,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3530,7 +3530,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3540,7 +3540,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -3551,7 +3551,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3575,7 +3575,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3585,7 +3585,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -3596,7 +3596,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3620,7 +3620,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3630,7 +3630,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -3641,7 +3641,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3665,7 +3665,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3675,7 +3675,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -3686,7 +3686,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3710,7 +3710,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -3720,7 +3720,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -3731,7 +3731,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -3760,25 +3760,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="small"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -3788,7 +3788,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -3799,7 +3799,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="medium"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -3823,7 +3823,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -3833,7 +3833,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -3844,7 +3844,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="medium"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -3868,7 +3868,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -3878,7 +3878,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -3889,7 +3889,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="medium"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -3913,7 +3913,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -3923,7 +3923,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -3934,7 +3934,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="medium"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -3958,7 +3958,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -3968,7 +3968,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -3979,7 +3979,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="medium"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -4003,7 +4003,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -4013,7 +4013,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -4024,7 +4024,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="medium"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -4048,7 +4048,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -4058,7 +4058,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -4069,7 +4069,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="medium"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -4093,7 +4093,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -4103,7 +4103,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -4114,7 +4114,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="medium"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -4204,25 +4204,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="small"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4232,7 +4232,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -4243,7 +4243,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4267,7 +4267,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4277,7 +4277,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -4288,7 +4288,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4312,7 +4312,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4322,7 +4322,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -4333,7 +4333,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4357,7 +4357,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4367,7 +4367,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -4378,7 +4378,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4402,7 +4402,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4412,7 +4412,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -4423,7 +4423,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4447,7 +4447,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4457,7 +4457,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -4468,7 +4468,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4492,7 +4492,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4502,7 +4502,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -4513,7 +4513,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4537,7 +4537,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4547,7 +4547,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -4558,7 +4558,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4586,25 +4586,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
     </div>
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="small"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4614,7 +4614,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -4625,7 +4625,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4649,7 +4649,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4659,7 +4659,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -4670,7 +4670,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4694,7 +4694,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4704,7 +4704,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -4715,7 +4715,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4739,7 +4739,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4749,7 +4749,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -4760,7 +4760,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4784,7 +4784,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4794,7 +4794,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -4805,7 +4805,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4829,7 +4829,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4839,7 +4839,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -4850,7 +4850,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4874,7 +4874,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4884,7 +4884,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -4895,7 +4895,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4919,7 +4919,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4929,7 +4929,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -4940,7 +4940,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -4968,25 +4968,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
     </div>
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -4996,7 +4996,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -5007,7 +5007,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5031,7 +5031,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -5041,7 +5041,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -5052,7 +5052,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5076,7 +5076,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -5086,7 +5086,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -5097,7 +5097,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5121,7 +5121,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -5131,7 +5131,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -5142,7 +5142,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5166,7 +5166,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -5176,7 +5176,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -5187,7 +5187,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5211,7 +5211,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -5221,7 +5221,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -5232,7 +5232,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5256,7 +5256,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -5266,7 +5266,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -5277,7 +5277,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5301,7 +5301,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -5311,7 +5311,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -5322,7 +5322,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5351,25 +5351,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -5379,7 +5379,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -5390,7 +5390,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -5414,7 +5414,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -5424,7 +5424,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -5435,7 +5435,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -5459,7 +5459,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -5469,7 +5469,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -5480,7 +5480,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -5504,7 +5504,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -5514,7 +5514,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -5525,7 +5525,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -5549,7 +5549,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -5559,7 +5559,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -5570,7 +5570,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -5594,7 +5594,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -5604,7 +5604,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -5615,7 +5615,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -5639,7 +5639,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -5649,7 +5649,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -5660,7 +5660,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -5684,7 +5684,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -5694,7 +5694,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -5705,7 +5705,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -5795,25 +5795,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="small"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -5823,7 +5823,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -5834,7 +5834,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5858,7 +5858,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -5868,7 +5868,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -5879,7 +5879,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5903,7 +5903,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -5913,7 +5913,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -5924,7 +5924,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5948,7 +5948,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -5958,7 +5958,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -5969,7 +5969,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -5993,7 +5993,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6003,7 +6003,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -6014,7 +6014,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6038,7 +6038,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6048,7 +6048,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -6059,7 +6059,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6083,7 +6083,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6093,7 +6093,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -6104,7 +6104,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6128,7 +6128,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6138,7 +6138,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -6149,7 +6149,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6177,25 +6177,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
     </div>
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="small"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6205,7 +6205,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -6216,7 +6216,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6240,7 +6240,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6250,7 +6250,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -6261,7 +6261,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6285,7 +6285,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6295,7 +6295,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -6306,7 +6306,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6330,7 +6330,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6340,7 +6340,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -6351,7 +6351,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6375,7 +6375,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6385,7 +6385,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -6396,7 +6396,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6420,7 +6420,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6430,7 +6430,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -6441,7 +6441,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6465,7 +6465,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6475,7 +6475,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -6486,7 +6486,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6510,7 +6510,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6520,7 +6520,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -6531,7 +6531,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="medium"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6559,25 +6559,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
     </div>
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6587,7 +6587,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -6598,7 +6598,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6622,7 +6622,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6632,7 +6632,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -6643,7 +6643,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6667,7 +6667,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6677,7 +6677,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -6688,7 +6688,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6712,7 +6712,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6722,7 +6722,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -6733,7 +6733,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6757,7 +6757,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6767,7 +6767,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -6778,7 +6778,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6802,7 +6802,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6812,7 +6812,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -6823,7 +6823,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6847,7 +6847,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6857,7 +6857,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -6868,7 +6868,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6892,7 +6892,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6902,7 +6902,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -6913,7 +6913,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -6941,25 +6941,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
     </div>
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -6969,7 +6969,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -6980,7 +6980,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7004,7 +7004,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7014,7 +7014,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -7025,7 +7025,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7049,7 +7049,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7059,7 +7059,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -7070,7 +7070,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7094,7 +7094,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7104,7 +7104,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -7115,7 +7115,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7139,7 +7139,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7149,7 +7149,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -7160,7 +7160,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7184,7 +7184,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7194,7 +7194,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -7205,7 +7205,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7229,7 +7229,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7239,7 +7239,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -7250,7 +7250,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7274,7 +7274,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7284,7 +7284,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -7295,7 +7295,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7324,25 +7324,25 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -7352,7 +7352,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -7363,7 +7363,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -7387,7 +7387,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -7397,7 +7397,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -7408,7 +7408,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -7432,7 +7432,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -7442,7 +7442,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -7453,7 +7453,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -7477,7 +7477,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -7487,7 +7487,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -7498,7 +7498,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -7522,7 +7522,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -7532,7 +7532,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -7543,7 +7543,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -7567,7 +7567,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -7577,7 +7577,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -7588,7 +7588,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -7612,7 +7612,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -7622,7 +7622,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -7633,7 +7633,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -7657,7 +7657,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -7667,7 +7667,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -7678,7 +7678,7 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -7768,26 +7768,26 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
         data-token-wrapping="true"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="true"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7797,7 +7797,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -7808,7 +7808,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7832,7 +7832,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7842,7 +7842,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -7853,7 +7853,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7877,7 +7877,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7887,7 +7887,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -7898,7 +7898,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7922,7 +7922,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7932,7 +7932,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -7943,7 +7943,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -7967,7 +7967,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -7977,7 +7977,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -7988,7 +7988,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -8012,7 +8012,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -8022,7 +8022,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -8033,7 +8033,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -8057,7 +8057,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -8067,7 +8067,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -8078,7 +8078,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -8102,7 +8102,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -8112,7 +8112,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -8123,7 +8123,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -8152,26 +8152,26 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
       data-token-wrapping="true"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="true"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -8181,7 +8181,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -8192,7 +8192,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -8216,7 +8216,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -8226,7 +8226,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -8237,7 +8237,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -8261,7 +8261,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -8271,7 +8271,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -8282,7 +8282,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -8306,7 +8306,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -8316,7 +8316,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -8327,7 +8327,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -8351,7 +8351,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -8361,7 +8361,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -8372,7 +8372,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -8396,7 +8396,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -8406,7 +8406,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -8417,7 +8417,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -8441,7 +8441,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -8451,7 +8451,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -8462,7 +8462,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -8486,7 +8486,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -8496,7 +8496,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -8507,7 +8507,7 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -8597,25 +8597,25 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="false"
             data-is-selected="false"
@@ -8625,7 +8625,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             text="zero"
           >
             <span
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -8636,7 +8636,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="false"
             data-is-selected="false"
@@ -8646,7 +8646,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             text="one"
           >
             <span
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -8657,7 +8657,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="false"
             data-is-selected="false"
@@ -8667,7 +8667,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             text="two"
           >
             <span
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -8678,7 +8678,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="false"
             data-is-selected="false"
@@ -8688,7 +8688,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             text="three"
           >
             <span
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -8699,7 +8699,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="false"
             data-is-selected="false"
@@ -8709,7 +8709,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             text="four"
           >
             <span
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -8720,7 +8720,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="false"
             data-is-selected="false"
@@ -8730,7 +8730,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             text="five"
           >
             <span
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -8741,7 +8741,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="false"
             data-is-selected="false"
@@ -8751,7 +8751,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             text="six"
           >
             <span
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -8762,7 +8762,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="false"
             data-is-selected="false"
@@ -8772,7 +8772,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
             text="seven"
           >
             <span
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -8788,25 +8788,25 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="false"
           data-is-selected="false"
@@ -8816,7 +8816,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           text="zero"
         >
           <span
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -8827,7 +8827,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="false"
           data-is-selected="false"
@@ -8837,7 +8837,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           text="one"
         >
           <span
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -8848,7 +8848,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="false"
           data-is-selected="false"
@@ -8858,7 +8858,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           text="two"
         >
           <span
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -8869,7 +8869,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="false"
           data-is-selected="false"
@@ -8879,7 +8879,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           text="three"
         >
           <span
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -8890,7 +8890,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="false"
           data-is-selected="false"
@@ -8900,7 +8900,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           text="four"
         >
           <span
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -8911,7 +8911,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="false"
           data-is-selected="false"
@@ -8921,7 +8921,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           text="five"
         >
           <span
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -8932,7 +8932,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="false"
           data-is-selected="false"
@@ -8942,7 +8942,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           text="six"
         >
           <span
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -8953,7 +8953,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="false"
           data-is-selected="false"
@@ -8963,7 +8963,7 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
           text="seven"
         >
           <span
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -9040,26 +9040,26 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
         data-trailing-visual="true"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9069,7 +9069,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -9080,7 +9080,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9104,7 +9104,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9114,7 +9114,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -9125,7 +9125,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9149,7 +9149,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9159,7 +9159,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -9170,7 +9170,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9194,7 +9194,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9204,7 +9204,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -9215,7 +9215,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9239,7 +9239,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9249,7 +9249,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -9260,7 +9260,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9284,7 +9284,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9294,7 +9294,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -9305,7 +9305,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9329,7 +9329,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9339,7 +9339,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -9350,7 +9350,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9374,7 +9374,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9384,7 +9384,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -9395,7 +9395,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9423,14 +9423,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerVisible-FH5pT prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="16px"
                 viewBox="0 0 16 16"
@@ -9458,7 +9458,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </span>
       </span>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-leading-visual="true"
         data-size="medium"
       >
@@ -9466,14 +9466,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerVisible-FH5pT prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="16px"
                 viewBox="0 0 16 16"
@@ -9500,21 +9500,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
         </span>
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9524,7 +9524,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -9535,7 +9535,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9559,7 +9559,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9569,7 +9569,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -9580,7 +9580,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9604,7 +9604,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9614,7 +9614,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -9625,7 +9625,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9649,7 +9649,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9659,7 +9659,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -9670,7 +9670,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9694,7 +9694,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9704,7 +9704,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -9715,7 +9715,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9739,7 +9739,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9749,7 +9749,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -9760,7 +9760,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9784,7 +9784,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9794,7 +9794,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -9805,7 +9805,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9829,7 +9829,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9839,7 +9839,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -9850,7 +9850,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9878,14 +9878,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerHidden_1x9o3_13 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerHidden-c-Wb6 prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="16px"
                 viewBox="0 0 16 16"
@@ -9913,26 +9913,26 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </span>
       </span>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
         data-trailing-visual="true"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9942,7 +9942,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -9953,7 +9953,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -9977,7 +9977,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -9987,7 +9987,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -9998,7 +9998,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10022,7 +10022,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10032,7 +10032,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -10043,7 +10043,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10067,7 +10067,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10077,7 +10077,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -10088,7 +10088,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10112,7 +10112,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10122,7 +10122,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -10133,7 +10133,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10157,7 +10157,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10167,7 +10167,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -10178,7 +10178,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10202,7 +10202,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10212,7 +10212,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -10223,7 +10223,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10247,7 +10247,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10257,7 +10257,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -10268,7 +10268,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10296,14 +10296,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerVisible-FH5pT prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="16px"
                 viewBox="0 0 16 16"
@@ -10331,7 +10331,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </span>
       </span>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-leading-visual="true"
         data-size="medium"
       >
@@ -10339,10 +10339,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <div
-              class="_SpinnerHidden_1x9o3_13"
+              class="prc-components-SpinnerHidden-c-Wb6"
             >
               <svg
                 aria-hidden="true"
@@ -10362,11 +10362,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
               </svg>
             </div>
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="32px"
                 viewBox="0 0 16 16"
@@ -10393,21 +10393,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
         </span>
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10417,7 +10417,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -10428,7 +10428,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10452,7 +10452,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10462,7 +10462,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -10473,7 +10473,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10497,7 +10497,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10507,7 +10507,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -10518,7 +10518,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10542,7 +10542,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10552,7 +10552,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -10563,7 +10563,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10587,7 +10587,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10597,7 +10597,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -10608,7 +10608,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10632,7 +10632,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10642,7 +10642,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -10653,7 +10653,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10677,7 +10677,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10687,7 +10687,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -10698,7 +10698,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10722,7 +10722,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10732,7 +10732,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -10743,7 +10743,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10771,14 +10771,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerHidden_1x9o3_13 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerHidden-c-Wb6 prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="16px"
                 viewBox="0 0 16 16"
@@ -10806,7 +10806,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </span>
       </span>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-leading-visual="true"
         data-size="medium"
       >
@@ -10814,10 +10814,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <div
-              class="_SpinnerHidden_1x9o3_13"
+              class="prc-components-SpinnerHidden-c-Wb6"
             >
               <svg
                 aria-hidden="true"
@@ -10837,11 +10837,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
               </svg>
             </div>
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="32px"
                 viewBox="0 0 16 16"
@@ -10868,21 +10868,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
         </span>
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10892,7 +10892,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -10903,7 +10903,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10927,7 +10927,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10937,7 +10937,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -10948,7 +10948,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -10972,7 +10972,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -10982,7 +10982,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -10993,7 +10993,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -11017,7 +11017,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -11027,7 +11027,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -11038,7 +11038,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -11062,7 +11062,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -11072,7 +11072,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -11083,7 +11083,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -11107,7 +11107,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -11117,7 +11117,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -11128,7 +11128,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -11152,7 +11152,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -11162,7 +11162,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -11173,7 +11173,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -11197,7 +11197,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -11207,7 +11207,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -11218,7 +11218,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -11246,14 +11246,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerHidden_1x9o3_13 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerHidden-c-Wb6 prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="16px"
                 viewBox="0 0 16 16"
@@ -11281,921 +11281,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </span>
       </span>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
-        data-leading-visual="true"
-        data-size="medium"
-        data-trailing-visual="true"
-      >
-        <span
-          class="TextInput-icon"
-        >
-          <div
-            class="_Box_1x9o3_21"
-          >
-            <div
-              class="_SpinnerVisible_1x9o3_17"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-mark-github"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="16"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 16 16"
-                width="16"
-              >
-                <path
-                  d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"
-                />
-              </svg>
-            </div>
-            <span
-              class="_Box_sy9es_1"
-            >
-              <svg
-                aria-hidden="true"
-                class="_SpinnerHidden_1x9o3_13 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
-                fill="none"
-                height="32px"
-                viewBox="0 0 16 16"
-                width="32px"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  r="7"
-                  stroke="currentColor"
-                  stroke-opacity="0.25"
-                  stroke-width="2"
-                  vector-effect="non-scaling-stroke"
-                />
-                <path
-                  d="M15 8a7.002 7.002 0 00-7-7"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-width="2"
-                  vector-effect="non-scaling-stroke"
-                />
-              </svg>
-            </span>
-          </div>
-        </span>
-        <div
-          class="_Container_1ef6o_25"
-          data-prevent-token-wrapping="false"
-        >
-          <div
-            class="_InputWrapper_1ef6o_20"
-          >
-            <input
-              aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
-              tabindex="0"
-              type="text"
-            />
-          </div>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="zero"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              zero
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="one"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              one
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="two"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              two
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="three"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              three
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="four"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              four
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="five"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              five
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="six"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              six
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="seven"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              seven
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-        <span
-          class="TextInput-icon"
-        >
-          <div
-            class="_Box_1x9o3_21"
-          >
-            <span
-              class="_Box_sy9es_1"
-            >
-              <svg
-                aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _SpinnerAnimation_sy9es_11"
-                fill="none"
-                height="16px"
-                viewBox="0 0 16 16"
-                width="16px"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  r="7"
-                  stroke="currentColor"
-                  stroke-opacity="0.25"
-                  stroke-width="2"
-                  vector-effect="non-scaling-stroke"
-                />
-                <path
-                  d="M15 8a7.002 7.002 0 00-7-7"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-width="2"
-                  vector-effect="non-scaling-stroke"
-                />
-              </svg>
-            </span>
-          </div>
-        </span>
-      </span>
-      <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
-        data-size="medium"
-        data-trailing-visual="true"
-      >
-        <div
-          class="_Container_1ef6o_25"
-          data-prevent-token-wrapping="false"
-        >
-          <div
-            class="_InputWrapper_1ef6o_20"
-          >
-            <input
-              aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
-              tabindex="0"
-              type="text"
-            />
-          </div>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="zero"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              zero
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="one"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              one
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="two"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              two
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="three"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              three
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="four"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              four
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="five"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              five
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="six"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              six
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
-            data-cursor-is-interactive="true"
-            data-is-remove-btn="true"
-            data-is-selected="false"
-            data-size="xlarge"
-            style="border-width: 1px;"
-            tabindex="-1"
-            text="seven"
-          >
-            <div
-              class="_TokenTextContainer_p11sb_1"
-            >
-              seven
-              <span
-                class="sc-gEvEer jFikVR"
-              >
-                 (press backspace or delete to remove)
-              </span>
-            </div>
-            <span
-              aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
-              data-size="xlarge"
-              style="transform: translate(1px, -1px);"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-x"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="24"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-        <span
-          class="TextInput-icon"
-        >
-          <div
-            class="_Box_1x9o3_21"
-          >
-            <div
-              class="_SpinnerHidden_1x9o3_13"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-mark-github"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="16"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 16 16"
-                width="16"
-              >
-                <path
-                  d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"
-                />
-              </svg>
-            </div>
-            <span
-              class="_Box_sy9es_1"
-            >
-              <svg
-                aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
-                fill="none"
-                height="32px"
-                viewBox="0 0 16 16"
-                width="32px"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  r="7"
-                  stroke="currentColor"
-                  stroke-opacity="0.25"
-                  stroke-width="2"
-                  vector-effect="non-scaling-stroke"
-                />
-                <path
-                  d="M15 8a7.002 7.002 0 00-7-7"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-width="2"
-                  vector-effect="non-scaling-stroke"
-                />
-              </svg>
-            </span>
-          </div>
-        </span>
-      </span>
-      <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-leading-visual="true"
         data-size="medium"
         data-trailing-visual="true"
@@ -12204,14 +11290,928 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
-            <span
-              class="_Box_sy9es_1"
+            <div
+              class="prc-components-SpinnerVisible-FH5pT"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _SpinnerAnimation_sy9es_11"
+                class="octicon octicon-mark-github"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="16"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <path
+                  d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"
+                />
+              </svg>
+            </div>
+            <span
+              class="prc-Spinner-Box-yUhAo"
+            >
+              <svg
+                aria-hidden="true"
+                class="prc-components-SpinnerHidden-c-Wb6 prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
+                fill="none"
+                height="32px"
+                viewBox="0 0 16 16"
+                width="32px"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  r="7"
+                  stroke="currentColor"
+                  stroke-opacity="0.25"
+                  stroke-width="2"
+                  vector-effect="non-scaling-stroke"
+                />
+                <path
+                  d="M15 8a7.002 7.002 0 00-7-7"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-width="2"
+                  vector-effect="non-scaling-stroke"
+                />
+              </svg>
+            </span>
+          </div>
+        </span>
+        <div
+          class="prc-TextInputWithTokens-Container-ccL44"
+          data-prevent-token-wrapping="false"
+        >
+          <div
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
+          >
+            <input
+              aria-invalid="false"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
+              tabindex="0"
+              type="text"
+            />
+          </div>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="zero"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              zero
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="one"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              one
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="two"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              two
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="three"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              three
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="four"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              four
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="five"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              five
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="six"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              six
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="seven"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              seven
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <span
+          class="TextInput-icon"
+        >
+          <div
+            class="prc-components-Box-kkr8W"
+          >
+            <span
+              class="prc-Spinner-Box-yUhAo"
+            >
+              <svg
+                aria-hidden="true"
+                class="prc-components-SpinnerVisible-FH5pT prc-Spinner-SpinnerAnimation-KWCu3"
+                fill="none"
+                height="16px"
+                viewBox="0 0 16 16"
+                width="16px"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  r="7"
+                  stroke="currentColor"
+                  stroke-opacity="0.25"
+                  stroke-width="2"
+                  vector-effect="non-scaling-stroke"
+                />
+                <path
+                  d="M15 8a7.002 7.002 0 00-7-7"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-width="2"
+                  vector-effect="non-scaling-stroke"
+                />
+              </svg>
+            </span>
+          </div>
+        </span>
+      </span>
+      <span
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
+        data-size="medium"
+        data-trailing-visual="true"
+      >
+        <div
+          class="prc-TextInputWithTokens-Container-ccL44"
+          data-prevent-token-wrapping="false"
+        >
+          <div
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
+          >
+            <input
+              aria-invalid="false"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
+              tabindex="0"
+              type="text"
+            />
+          </div>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="zero"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              zero
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="one"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              one
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="two"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              two
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="three"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              three
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="four"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              four
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="five"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              five
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="six"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              six
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+            data-cursor-is-interactive="true"
+            data-is-remove-btn="true"
+            data-is-selected="false"
+            data-size="xlarge"
+            style="border-width: 1px;"
+            tabindex="-1"
+            text="seven"
+          >
+            <div
+              class="prc-Token-TokenTextContainer-DBGXC"
+            >
+              seven
+              <span
+                class="sc-gEvEer jFikVR"
+              >
+                 (press backspace or delete to remove)
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="prc-Token-TokenButton-LXZrO"
+              data-size="xlarge"
+              style="transform: translate(1px, -1px);"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-x"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="24"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <span
+          class="TextInput-icon"
+        >
+          <div
+            class="prc-components-Box-kkr8W"
+          >
+            <div
+              class="prc-components-SpinnerHidden-c-Wb6"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-mark-github"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="16"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <path
+                  d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"
+                />
+              </svg>
+            </div>
+            <span
+              class="prc-Spinner-Box-yUhAo"
+            >
+              <svg
+                aria-hidden="true"
+                class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
+                fill="none"
+                height="32px"
+                viewBox="0 0 16 16"
+                width="32px"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  r="7"
+                  stroke="currentColor"
+                  stroke-opacity="0.25"
+                  stroke-width="2"
+                  vector-effect="non-scaling-stroke"
+                />
+                <path
+                  d="M15 8a7.002 7.002 0 00-7-7"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-width="2"
+                  vector-effect="non-scaling-stroke"
+                />
+              </svg>
+            </span>
+          </div>
+        </span>
+      </span>
+      <span
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
+        data-leading-visual="true"
+        data-size="medium"
+        data-trailing-visual="true"
+      >
+        <span
+          class="TextInput-icon"
+        >
+          <div
+            class="prc-components-Box-kkr8W"
+          >
+            <span
+              class="prc-Spinner-Box-yUhAo"
+            >
+              <svg
+                aria-hidden="true"
+                class="prc-components-SpinnerVisible-FH5pT prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="16px"
                 viewBox="0 0 16 16"
@@ -12238,21 +12238,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
         </span>
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12262,7 +12262,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -12273,7 +12273,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12297,7 +12297,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12307,7 +12307,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -12318,7 +12318,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12342,7 +12342,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12352,7 +12352,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -12363,7 +12363,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12387,7 +12387,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12397,7 +12397,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -12408,7 +12408,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12432,7 +12432,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12442,7 +12442,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -12453,7 +12453,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12477,7 +12477,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12487,7 +12487,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -12498,7 +12498,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12522,7 +12522,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12532,7 +12532,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -12543,7 +12543,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12567,7 +12567,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12577,7 +12577,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -12588,7 +12588,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12616,10 +12616,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <div
-              class="_SpinnerVisible_1x9o3_17"
+              class="prc-components-SpinnerVisible-FH5pT"
             >
               <svg
                 aria-hidden="true"
@@ -12639,11 +12639,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
               </svg>
             </div>
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerHidden_1x9o3_13 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerHidden-c-Wb6 prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="32px"
                 viewBox="0 0 16 16"
@@ -12671,26 +12671,26 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </span>
       </span>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
         data-trailing-visual="true"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12700,7 +12700,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -12711,7 +12711,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12735,7 +12735,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12745,7 +12745,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -12756,7 +12756,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12780,7 +12780,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12790,7 +12790,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -12801,7 +12801,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12825,7 +12825,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12835,7 +12835,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -12846,7 +12846,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12870,7 +12870,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12880,7 +12880,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -12891,7 +12891,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12915,7 +12915,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12925,7 +12925,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -12936,7 +12936,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -12960,7 +12960,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -12970,7 +12970,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -12981,7 +12981,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13005,7 +13005,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13015,7 +13015,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -13026,7 +13026,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13054,10 +13054,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <div
-              class="_SpinnerHidden_1x9o3_13"
+              class="prc-components-SpinnerHidden-c-Wb6"
             >
               <svg
                 aria-hidden="true"
@@ -13077,11 +13077,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
               </svg>
             </div>
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="32px"
                 viewBox="0 0 16 16"
@@ -13109,7 +13109,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </span>
       </span>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-leading-visual="true"
         data-size="small"
         data-trailing-visual="true"
@@ -13118,10 +13118,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <div
-              class="_SpinnerHidden_1x9o3_13"
+              class="prc-components-SpinnerHidden-c-Wb6"
             >
               <svg
                 aria-hidden="true"
@@ -13141,11 +13141,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
               </svg>
             </div>
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="32px"
                 viewBox="0 0 16 16"
@@ -13172,21 +13172,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
         </span>
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13196,7 +13196,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -13207,7 +13207,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13231,7 +13231,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13241,7 +13241,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -13252,7 +13252,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13276,7 +13276,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13286,7 +13286,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -13297,7 +13297,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13321,7 +13321,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13331,7 +13331,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -13342,7 +13342,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13366,7 +13366,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13376,7 +13376,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -13387,7 +13387,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13411,7 +13411,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13421,7 +13421,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -13432,7 +13432,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13456,7 +13456,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13466,7 +13466,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -13477,7 +13477,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13501,7 +13501,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13511,7 +13511,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -13522,7 +13522,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="small"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13550,10 +13550,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <div
-              class="_SpinnerVisible_1x9o3_17"
+              class="prc-components-SpinnerVisible-FH5pT"
             >
               <svg
                 aria-hidden="true"
@@ -13573,11 +13573,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
               </svg>
             </div>
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerHidden_1x9o3_13 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerHidden-c-Wb6 prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="32px"
                 viewBox="0 0 16 16"
@@ -13605,7 +13605,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </span>
       </span>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-leading-visual="true"
         data-size="medium"
         data-trailing-visual="true"
@@ -13614,10 +13614,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <div
-              class="_SpinnerHidden_1x9o3_13"
+              class="prc-components-SpinnerHidden-c-Wb6"
             >
               <svg
                 aria-hidden="true"
@@ -13637,11 +13637,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
               </svg>
             </div>
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="32px"
                 viewBox="0 0 16 16"
@@ -13668,21 +13668,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
         </span>
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13692,7 +13692,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -13703,7 +13703,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13727,7 +13727,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13737,7 +13737,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -13748,7 +13748,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13772,7 +13772,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13782,7 +13782,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -13793,7 +13793,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13817,7 +13817,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13827,7 +13827,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -13838,7 +13838,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13862,7 +13862,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13872,7 +13872,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -13883,7 +13883,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13907,7 +13907,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13917,7 +13917,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -13928,7 +13928,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13952,7 +13952,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -13962,7 +13962,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -13973,7 +13973,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -13997,7 +13997,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -14007,7 +14007,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -14018,7 +14018,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -14046,10 +14046,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <div
-              class="_SpinnerVisible_1x9o3_17"
+              class="prc-components-SpinnerVisible-FH5pT"
             >
               <svg
                 aria-hidden="true"
@@ -14069,11 +14069,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
               </svg>
             </div>
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerHidden_1x9o3_13 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerHidden-c-Wb6 prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="32px"
                 viewBox="0 0 16 16"
@@ -14101,7 +14101,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </span>
       </span>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-leading-visual="true"
         data-size="medium"
         data-trailing-visual="true"
@@ -14110,10 +14110,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <div
-              class="_SpinnerVisible_1x9o3_17"
+              class="prc-components-SpinnerVisible-FH5pT"
             >
               <svg
                 aria-hidden="true"
@@ -14133,11 +14133,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
               </svg>
             </div>
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerHidden_1x9o3_13 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerHidden-c-Wb6 prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="32px"
                 viewBox="0 0 16 16"
@@ -14164,21 +14164,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
         </span>
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -14188,7 +14188,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -14199,7 +14199,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -14223,7 +14223,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -14233,7 +14233,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -14244,7 +14244,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -14268,7 +14268,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -14278,7 +14278,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -14289,7 +14289,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -14313,7 +14313,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -14323,7 +14323,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -14334,7 +14334,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -14358,7 +14358,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -14368,7 +14368,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -14379,7 +14379,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -14403,7 +14403,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -14413,7 +14413,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -14424,7 +14424,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -14448,7 +14448,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -14458,7 +14458,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -14469,7 +14469,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -14493,7 +14493,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -14503,7 +14503,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -14514,7 +14514,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="large"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -14542,10 +14542,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           class="TextInput-icon"
         >
           <div
-            class="_Box_1x9o3_21"
+            class="prc-components-Box-kkr8W"
           >
             <div
-              class="_SpinnerHidden_1x9o3_13"
+              class="prc-components-SpinnerHidden-c-Wb6"
             >
               <svg
                 aria-hidden="true"
@@ -14565,11 +14565,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
               </svg>
             </div>
             <span
-              class="_Box_sy9es_1"
+              class="prc-Spinner-Box-yUhAo"
             >
               <svg
                 aria-hidden="true"
-                class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
+                class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
                 fill="none"
                 height="32px"
                 viewBox="0 0 16 16"
@@ -14600,26 +14600,26 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
       data-trailing-visual="true"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -14629,7 +14629,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -14640,7 +14640,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -14664,7 +14664,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -14674,7 +14674,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -14685,7 +14685,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -14709,7 +14709,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -14719,7 +14719,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -14730,7 +14730,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -14754,7 +14754,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -14764,7 +14764,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -14775,7 +14775,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -14799,7 +14799,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -14809,7 +14809,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -14820,7 +14820,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -14844,7 +14844,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -14854,7 +14854,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -14865,7 +14865,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -14889,7 +14889,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -14899,7 +14899,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -14910,7 +14910,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -14934,7 +14934,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -14944,7 +14944,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -14955,7 +14955,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -14983,14 +14983,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerVisible-FH5pT prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="16px"
               viewBox="0 0 16 16"
@@ -15018,7 +15018,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       </span>
     </span>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-leading-visual="true"
       data-size="medium"
     >
@@ -15026,14 +15026,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerVisible-FH5pT prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="16px"
               viewBox="0 0 16 16"
@@ -15060,21 +15060,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </div>
       </span>
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15084,7 +15084,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -15095,7 +15095,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15119,7 +15119,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15129,7 +15129,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -15140,7 +15140,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15164,7 +15164,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15174,7 +15174,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -15185,7 +15185,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15209,7 +15209,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15219,7 +15219,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -15230,7 +15230,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15254,7 +15254,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15264,7 +15264,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -15275,7 +15275,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15299,7 +15299,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15309,7 +15309,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -15320,7 +15320,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15344,7 +15344,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15354,7 +15354,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -15365,7 +15365,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15389,7 +15389,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15399,7 +15399,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -15410,7 +15410,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15438,14 +15438,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerHidden_1x9o3_13 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerHidden-c-Wb6 prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="16px"
               viewBox="0 0 16 16"
@@ -15473,26 +15473,26 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       </span>
     </span>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
       data-trailing-visual="true"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15502,7 +15502,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -15513,7 +15513,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15537,7 +15537,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15547,7 +15547,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -15558,7 +15558,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15582,7 +15582,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15592,7 +15592,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -15603,7 +15603,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15627,7 +15627,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15637,7 +15637,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -15648,7 +15648,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15672,7 +15672,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15682,7 +15682,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -15693,7 +15693,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15717,7 +15717,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15727,7 +15727,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -15738,7 +15738,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15762,7 +15762,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15772,7 +15772,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -15783,7 +15783,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15807,7 +15807,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15817,7 +15817,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -15828,7 +15828,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -15856,14 +15856,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerVisible-FH5pT prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="16px"
               viewBox="0 0 16 16"
@@ -15891,7 +15891,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       </span>
     </span>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-leading-visual="true"
       data-size="medium"
     >
@@ -15899,10 +15899,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <div
-            class="_SpinnerHidden_1x9o3_13"
+            class="prc-components-SpinnerHidden-c-Wb6"
           >
             <svg
               aria-hidden="true"
@@ -15922,11 +15922,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </svg>
           </div>
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="32px"
               viewBox="0 0 16 16"
@@ -15953,21 +15953,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </div>
       </span>
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -15977,7 +15977,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -15988,7 +15988,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16012,7 +16012,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16022,7 +16022,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -16033,7 +16033,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16057,7 +16057,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16067,7 +16067,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -16078,7 +16078,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16102,7 +16102,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16112,7 +16112,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -16123,7 +16123,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16147,7 +16147,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16157,7 +16157,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -16168,7 +16168,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16192,7 +16192,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16202,7 +16202,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -16213,7 +16213,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16237,7 +16237,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16247,7 +16247,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -16258,7 +16258,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16282,7 +16282,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16292,7 +16292,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -16303,7 +16303,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16331,14 +16331,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerHidden_1x9o3_13 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerHidden-c-Wb6 prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="16px"
               viewBox="0 0 16 16"
@@ -16366,7 +16366,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       </span>
     </span>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-leading-visual="true"
       data-size="medium"
     >
@@ -16374,10 +16374,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <div
-            class="_SpinnerHidden_1x9o3_13"
+            class="prc-components-SpinnerHidden-c-Wb6"
           >
             <svg
               aria-hidden="true"
@@ -16397,11 +16397,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </svg>
           </div>
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="32px"
               viewBox="0 0 16 16"
@@ -16428,21 +16428,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </div>
       </span>
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16452,7 +16452,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -16463,7 +16463,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16487,7 +16487,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16497,7 +16497,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -16508,7 +16508,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16532,7 +16532,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16542,7 +16542,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -16553,7 +16553,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16577,7 +16577,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16587,7 +16587,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -16598,7 +16598,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16622,7 +16622,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16632,7 +16632,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -16643,7 +16643,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16667,7 +16667,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16677,7 +16677,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -16688,7 +16688,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16712,7 +16712,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16722,7 +16722,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -16733,7 +16733,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16757,7 +16757,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -16767,7 +16767,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -16778,7 +16778,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -16806,14 +16806,14 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerHidden_1x9o3_13 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerHidden-c-Wb6 prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="16px"
               viewBox="0 0 16 16"
@@ -16841,921 +16841,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       </span>
     </span>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
-      data-leading-visual="true"
-      data-size="medium"
-      data-trailing-visual="true"
-    >
-      <span
-        class="TextInput-icon"
-      >
-        <div
-          class="_Box_1x9o3_21"
-        >
-          <div
-            class="_SpinnerVisible_1x9o3_17"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-mark-github"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="16"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 16 16"
-              width="16"
-            >
-              <path
-                d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"
-              />
-            </svg>
-          </div>
-          <span
-            class="_Box_sy9es_1"
-          >
-            <svg
-              aria-hidden="true"
-              class="_SpinnerHidden_1x9o3_13 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
-              fill="none"
-              height="32px"
-              viewBox="0 0 16 16"
-              width="32px"
-            >
-              <circle
-                cx="8"
-                cy="8"
-                r="7"
-                stroke="currentColor"
-                stroke-opacity="0.25"
-                stroke-width="2"
-                vector-effect="non-scaling-stroke"
-              />
-              <path
-                d="M15 8a7.002 7.002 0 00-7-7"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-width="2"
-                vector-effect="non-scaling-stroke"
-              />
-            </svg>
-          </span>
-        </div>
-      </span>
-      <div
-        class="_Container_1ef6o_25"
-        data-prevent-token-wrapping="false"
-      >
-        <div
-          class="_InputWrapper_1ef6o_20"
-        >
-          <input
-            aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
-            tabindex="0"
-            type="text"
-          />
-        </div>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="zero"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            zero
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="one"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            one
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="two"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            two
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="three"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            three
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="four"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            four
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="five"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            five
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="six"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            six
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="seven"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            seven
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-      <span
-        class="TextInput-icon"
-      >
-        <div
-          class="_Box_1x9o3_21"
-        >
-          <span
-            class="_Box_sy9es_1"
-          >
-            <svg
-              aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _SpinnerAnimation_sy9es_11"
-              fill="none"
-              height="16px"
-              viewBox="0 0 16 16"
-              width="16px"
-            >
-              <circle
-                cx="8"
-                cy="8"
-                r="7"
-                stroke="currentColor"
-                stroke-opacity="0.25"
-                stroke-width="2"
-                vector-effect="non-scaling-stroke"
-              />
-              <path
-                d="M15 8a7.002 7.002 0 00-7-7"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-width="2"
-                vector-effect="non-scaling-stroke"
-              />
-            </svg>
-          </span>
-        </div>
-      </span>
-    </span>
-    <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
-      data-size="medium"
-      data-trailing-visual="true"
-    >
-      <div
-        class="_Container_1ef6o_25"
-        data-prevent-token-wrapping="false"
-      >
-        <div
-          class="_InputWrapper_1ef6o_20"
-        >
-          <input
-            aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
-            tabindex="0"
-            type="text"
-          />
-        </div>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="zero"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            zero
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="one"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            one
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="two"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            two
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="three"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            three
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="four"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            four
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="five"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            five
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="six"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            six
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
-          data-cursor-is-interactive="true"
-          data-is-remove-btn="true"
-          data-is-selected="false"
-          data-size="xlarge"
-          style="border-width: 1px;"
-          tabindex="-1"
-          text="seven"
-        >
-          <div
-            class="_TokenTextContainer_p11sb_1"
-          >
-            seven
-            <span
-              class="sc-gEvEer jFikVR"
-            >
-               (press backspace or delete to remove)
-            </span>
-          </div>
-          <span
-            aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
-            data-size="xlarge"
-            style="transform: translate(1px, -1px);"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-x"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-      <span
-        class="TextInput-icon"
-      >
-        <div
-          class="_Box_1x9o3_21"
-        >
-          <div
-            class="_SpinnerHidden_1x9o3_13"
-          >
-            <svg
-              aria-hidden="true"
-              class="octicon octicon-mark-github"
-              display="inline-block"
-              fill="currentColor"
-              focusable="false"
-              height="16"
-              overflow="visible"
-              style="vertical-align: text-bottom;"
-              viewBox="0 0 16 16"
-              width="16"
-            >
-              <path
-                d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"
-              />
-            </svg>
-          </div>
-          <span
-            class="_Box_sy9es_1"
-          >
-            <svg
-              aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
-              fill="none"
-              height="32px"
-              viewBox="0 0 16 16"
-              width="32px"
-            >
-              <circle
-                cx="8"
-                cy="8"
-                r="7"
-                stroke="currentColor"
-                stroke-opacity="0.25"
-                stroke-width="2"
-                vector-effect="non-scaling-stroke"
-              />
-              <path
-                d="M15 8a7.002 7.002 0 00-7-7"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-width="2"
-                vector-effect="non-scaling-stroke"
-              />
-            </svg>
-          </span>
-        </div>
-      </span>
-    </span>
-    <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-leading-visual="true"
       data-size="medium"
       data-trailing-visual="true"
@@ -17764,14 +16850,928 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
-          <span
-            class="_Box_sy9es_1"
+          <div
+            class="prc-components-SpinnerVisible-FH5pT"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _SpinnerAnimation_sy9es_11"
+              class="octicon octicon-mark-github"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <path
+                d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"
+              />
+            </svg>
+          </div>
+          <span
+            class="prc-Spinner-Box-yUhAo"
+          >
+            <svg
+              aria-hidden="true"
+              class="prc-components-SpinnerHidden-c-Wb6 prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
+              fill="none"
+              height="32px"
+              viewBox="0 0 16 16"
+              width="32px"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="7"
+                stroke="currentColor"
+                stroke-opacity="0.25"
+                stroke-width="2"
+                vector-effect="non-scaling-stroke"
+              />
+              <path
+                d="M15 8a7.002 7.002 0 00-7-7"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-width="2"
+                vector-effect="non-scaling-stroke"
+              />
+            </svg>
+          </span>
+        </div>
+      </span>
+      <div
+        class="prc-TextInputWithTokens-Container-ccL44"
+        data-prevent-token-wrapping="false"
+      >
+        <div
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
+        >
+          <input
+            aria-invalid="false"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
+            tabindex="0"
+            type="text"
+          />
+        </div>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="zero"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            zero
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="one"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            one
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="two"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            two
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="three"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            three
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="four"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            four
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="five"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            five
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="six"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            six
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="seven"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            seven
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <span
+        class="TextInput-icon"
+      >
+        <div
+          class="prc-components-Box-kkr8W"
+        >
+          <span
+            class="prc-Spinner-Box-yUhAo"
+          >
+            <svg
+              aria-hidden="true"
+              class="prc-components-SpinnerVisible-FH5pT prc-Spinner-SpinnerAnimation-KWCu3"
+              fill="none"
+              height="16px"
+              viewBox="0 0 16 16"
+              width="16px"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="7"
+                stroke="currentColor"
+                stroke-opacity="0.25"
+                stroke-width="2"
+                vector-effect="non-scaling-stroke"
+              />
+              <path
+                d="M15 8a7.002 7.002 0 00-7-7"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-width="2"
+                vector-effect="non-scaling-stroke"
+              />
+            </svg>
+          </span>
+        </div>
+      </span>
+    </span>
+    <span
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
+      data-size="medium"
+      data-trailing-visual="true"
+    >
+      <div
+        class="prc-TextInputWithTokens-Container-ccL44"
+        data-prevent-token-wrapping="false"
+      >
+        <div
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
+        >
+          <input
+            aria-invalid="false"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
+            tabindex="0"
+            type="text"
+          />
+        </div>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="zero"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            zero
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="one"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            one
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="two"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            two
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="three"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            three
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="four"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            four
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="five"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            five
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="six"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            six
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
+          data-cursor-is-interactive="true"
+          data-is-remove-btn="true"
+          data-is-selected="false"
+          data-size="xlarge"
+          style="border-width: 1px;"
+          tabindex="-1"
+          text="seven"
+        >
+          <div
+            class="prc-Token-TokenTextContainer-DBGXC"
+          >
+            seven
+            <span
+              class="sc-gEvEer jFikVR"
+            >
+               (press backspace or delete to remove)
+            </span>
+          </div>
+          <span
+            aria-hidden="true"
+            class="prc-Token-TokenButton-LXZrO"
+            data-size="xlarge"
+            style="transform: translate(1px, -1px);"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-x"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="24"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M5.72 5.72a.75.75 0 0 1 1.06 0L12 10.94l5.22-5.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L13.06 12l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L12 13.06l-5.22 5.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.94 12 5.72 6.78a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+      <span
+        class="TextInput-icon"
+      >
+        <div
+          class="prc-components-Box-kkr8W"
+        >
+          <div
+            class="prc-components-SpinnerHidden-c-Wb6"
+          >
+            <svg
+              aria-hidden="true"
+              class="octicon octicon-mark-github"
+              display="inline-block"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              overflow="visible"
+              style="vertical-align: text-bottom;"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <path
+                d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"
+              />
+            </svg>
+          </div>
+          <span
+            class="prc-Spinner-Box-yUhAo"
+          >
+            <svg
+              aria-hidden="true"
+              class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
+              fill="none"
+              height="32px"
+              viewBox="0 0 16 16"
+              width="32px"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="7"
+                stroke="currentColor"
+                stroke-opacity="0.25"
+                stroke-width="2"
+                vector-effect="non-scaling-stroke"
+              />
+              <path
+                d="M15 8a7.002 7.002 0 00-7-7"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-width="2"
+                vector-effect="non-scaling-stroke"
+              />
+            </svg>
+          </span>
+        </div>
+      </span>
+    </span>
+    <span
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
+      data-leading-visual="true"
+      data-size="medium"
+      data-trailing-visual="true"
+    >
+      <span
+        class="TextInput-icon"
+      >
+        <div
+          class="prc-components-Box-kkr8W"
+        >
+          <span
+            class="prc-Spinner-Box-yUhAo"
+          >
+            <svg
+              aria-hidden="true"
+              class="prc-components-SpinnerVisible-FH5pT prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="16px"
               viewBox="0 0 16 16"
@@ -17798,21 +17798,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </div>
       </span>
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -17822,7 +17822,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -17833,7 +17833,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -17857,7 +17857,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -17867,7 +17867,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -17878,7 +17878,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -17902,7 +17902,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -17912,7 +17912,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -17923,7 +17923,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -17947,7 +17947,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -17957,7 +17957,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -17968,7 +17968,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -17992,7 +17992,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18002,7 +18002,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -18013,7 +18013,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18037,7 +18037,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18047,7 +18047,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -18058,7 +18058,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18082,7 +18082,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18092,7 +18092,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -18103,7 +18103,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18127,7 +18127,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18137,7 +18137,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -18148,7 +18148,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18176,10 +18176,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <div
-            class="_SpinnerVisible_1x9o3_17"
+            class="prc-components-SpinnerVisible-FH5pT"
           >
             <svg
               aria-hidden="true"
@@ -18199,11 +18199,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </svg>
           </div>
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerHidden_1x9o3_13 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerHidden-c-Wb6 prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="32px"
               viewBox="0 0 16 16"
@@ -18231,26 +18231,26 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       </span>
     </span>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
       data-trailing-visual="true"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18260,7 +18260,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -18271,7 +18271,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18295,7 +18295,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18305,7 +18305,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -18316,7 +18316,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18340,7 +18340,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18350,7 +18350,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -18361,7 +18361,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18385,7 +18385,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18395,7 +18395,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -18406,7 +18406,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18430,7 +18430,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18440,7 +18440,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -18451,7 +18451,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18475,7 +18475,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18485,7 +18485,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -18496,7 +18496,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18520,7 +18520,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18530,7 +18530,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -18541,7 +18541,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18565,7 +18565,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18575,7 +18575,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -18586,7 +18586,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18614,10 +18614,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <div
-            class="_SpinnerHidden_1x9o3_13"
+            class="prc-components-SpinnerHidden-c-Wb6"
           >
             <svg
               aria-hidden="true"
@@ -18637,11 +18637,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </svg>
           </div>
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="32px"
               viewBox="0 0 16 16"
@@ -18669,7 +18669,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       </span>
     </span>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-leading-visual="true"
       data-size="small"
       data-trailing-visual="true"
@@ -18678,10 +18678,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <div
-            class="_SpinnerHidden_1x9o3_13"
+            class="prc-components-SpinnerHidden-c-Wb6"
           >
             <svg
               aria-hidden="true"
@@ -18701,11 +18701,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </svg>
           </div>
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="32px"
               viewBox="0 0 16 16"
@@ -18732,21 +18732,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </div>
       </span>
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18756,7 +18756,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -18767,7 +18767,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18791,7 +18791,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18801,7 +18801,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -18812,7 +18812,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18836,7 +18836,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18846,7 +18846,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -18857,7 +18857,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18881,7 +18881,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18891,7 +18891,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -18902,7 +18902,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18926,7 +18926,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18936,7 +18936,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -18947,7 +18947,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -18971,7 +18971,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -18981,7 +18981,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -18992,7 +18992,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19016,7 +19016,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19026,7 +19026,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -19037,7 +19037,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19061,7 +19061,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19071,7 +19071,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -19082,7 +19082,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="small"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19110,10 +19110,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <div
-            class="_SpinnerVisible_1x9o3_17"
+            class="prc-components-SpinnerVisible-FH5pT"
           >
             <svg
               aria-hidden="true"
@@ -19133,11 +19133,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </svg>
           </div>
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerHidden_1x9o3_13 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerHidden-c-Wb6 prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="32px"
               viewBox="0 0 16 16"
@@ -19165,7 +19165,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       </span>
     </span>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-leading-visual="true"
       data-size="medium"
       data-trailing-visual="true"
@@ -19174,10 +19174,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <div
-            class="_SpinnerHidden_1x9o3_13"
+            class="prc-components-SpinnerHidden-c-Wb6"
           >
             <svg
               aria-hidden="true"
@@ -19197,11 +19197,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </svg>
           </div>
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="32px"
               viewBox="0 0 16 16"
@@ -19228,21 +19228,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </div>
       </span>
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19252,7 +19252,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -19263,7 +19263,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19287,7 +19287,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19297,7 +19297,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -19308,7 +19308,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19332,7 +19332,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19342,7 +19342,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -19353,7 +19353,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19377,7 +19377,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19387,7 +19387,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -19398,7 +19398,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19422,7 +19422,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19432,7 +19432,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -19443,7 +19443,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19467,7 +19467,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19477,7 +19477,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -19488,7 +19488,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19512,7 +19512,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19522,7 +19522,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -19533,7 +19533,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19557,7 +19557,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19567,7 +19567,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -19578,7 +19578,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19606,10 +19606,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <div
-            class="_SpinnerVisible_1x9o3_17"
+            class="prc-components-SpinnerVisible-FH5pT"
           >
             <svg
               aria-hidden="true"
@@ -19629,11 +19629,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </svg>
           </div>
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerHidden_1x9o3_13 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerHidden-c-Wb6 prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="32px"
               viewBox="0 0 16 16"
@@ -19661,7 +19661,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       </span>
     </span>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-leading-visual="true"
       data-size="medium"
       data-trailing-visual="true"
@@ -19670,10 +19670,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <div
-            class="_SpinnerVisible_1x9o3_17"
+            class="prc-components-SpinnerVisible-FH5pT"
           >
             <svg
               aria-hidden="true"
@@ -19693,11 +19693,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </svg>
           </div>
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerHidden_1x9o3_13 _Spinner_1x9o3_1 _SpinnerLeading_1x9o3_9 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerHidden-c-Wb6 prc-components-Spinner-80CNt prc-components-SpinnerLeading-kUwx3 prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="32px"
               viewBox="0 0 16 16"
@@ -19724,21 +19724,21 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         </div>
       </span>
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19748,7 +19748,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -19759,7 +19759,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19783,7 +19783,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19793,7 +19793,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -19804,7 +19804,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19828,7 +19828,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19838,7 +19838,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -19849,7 +19849,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19873,7 +19873,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19883,7 +19883,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -19894,7 +19894,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19918,7 +19918,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19928,7 +19928,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -19939,7 +19939,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -19963,7 +19963,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -19973,7 +19973,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -19984,7 +19984,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -20008,7 +20008,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -20018,7 +20018,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -20029,7 +20029,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -20053,7 +20053,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -20063,7 +20063,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -20074,7 +20074,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="large"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -20102,10 +20102,10 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="TextInput-icon"
       >
         <div
-          class="_Box_1x9o3_21"
+          class="prc-components-Box-kkr8W"
         >
           <div
-            class="_SpinnerHidden_1x9o3_13"
+            class="prc-components-SpinnerHidden-c-Wb6"
           >
             <svg
               aria-hidden="true"
@@ -20125,11 +20125,11 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
             </svg>
           </div>
           <span
-            class="_Box_sy9es_1"
+            class="prc-Spinner-Box-yUhAo"
           >
             <svg
               aria-hidden="true"
-              class="_SpinnerVisible_1x9o3_17 _Spinner_1x9o3_1 _SpinnerAnimation_sy9es_11"
+              class="prc-components-SpinnerVisible-FH5pT prc-components-Spinner-80CNt prc-Spinner-SpinnerAnimation-KWCu3"
               fill="none"
               height="32px"
               viewBox="0 0 16 16"
@@ -20221,25 +20221,25 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -20249,7 +20249,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
               <span
@@ -20260,7 +20260,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -20284,7 +20284,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -20294,7 +20294,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
               <span
@@ -20305,7 +20305,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -20329,7 +20329,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -20339,7 +20339,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
               <span
@@ -20350,7 +20350,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -20374,7 +20374,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -20384,7 +20384,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
               <span
@@ -20395,7 +20395,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -20419,7 +20419,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -20429,7 +20429,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
               <span
@@ -20440,7 +20440,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -20464,7 +20464,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -20474,7 +20474,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
               <span
@@ -20485,7 +20485,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -20509,7 +20509,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -20519,7 +20519,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
               <span
@@ -20530,7 +20530,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -20554,7 +20554,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _Token_t9wai_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
             data-cursor-is-interactive="true"
             data-is-remove-btn="true"
             data-is-selected="false"
@@ -20564,7 +20564,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
               <span
@@ -20575,7 +20575,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1"
+              class="prc-Token-TokenButton-LXZrO"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
               tabindex="-1"
@@ -20604,25 +20604,25 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -20632,7 +20632,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
             <span
@@ -20643,7 +20643,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -20667,7 +20667,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -20677,7 +20677,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
             <span
@@ -20688,7 +20688,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -20712,7 +20712,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -20722,7 +20722,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
             <span
@@ -20733,7 +20733,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -20757,7 +20757,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -20767,7 +20767,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
             <span
@@ -20778,7 +20778,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -20802,7 +20802,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -20812,7 +20812,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
             <span
@@ -20823,7 +20823,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -20847,7 +20847,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -20857,7 +20857,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
             <span
@@ -20868,7 +20868,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -20892,7 +20892,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -20902,7 +20902,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
             <span
@@ -20913,7 +20913,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -20937,7 +20937,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _Token_t9wai_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-Token-HwPm6"
           data-cursor-is-interactive="true"
           data-is-remove-btn="true"
           data-is-selected="false"
@@ -20947,7 +20947,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
             <span
@@ -20958,7 +20958,7 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1"
+            class="prc-Token-TokenButton-LXZrO"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
             tabindex="-1"
@@ -21048,25 +21048,25 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
           </div>
           <span
-            class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
             data-cursor-is-interactive="true"
             data-has-remove-button="true"
             data-size="xlarge"
@@ -21075,13 +21075,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             text="zero"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               zero
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+              class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
               data-has-multiple-action-targets="true"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
@@ -21106,7 +21106,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
             data-cursor-is-interactive="true"
             data-has-remove-button="true"
             data-size="xlarge"
@@ -21115,13 +21115,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             text="one"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               one
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+              class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
               data-has-multiple-action-targets="true"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
@@ -21146,7 +21146,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
             data-cursor-is-interactive="true"
             data-has-remove-button="true"
             data-size="xlarge"
@@ -21155,13 +21155,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             text="two"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               two
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+              class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
               data-has-multiple-action-targets="true"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
@@ -21186,7 +21186,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
             data-cursor-is-interactive="true"
             data-has-remove-button="true"
             data-size="xlarge"
@@ -21195,13 +21195,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             text="three"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               three
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+              class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
               data-has-multiple-action-targets="true"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
@@ -21226,7 +21226,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
             data-cursor-is-interactive="true"
             data-has-remove-button="true"
             data-size="xlarge"
@@ -21235,13 +21235,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             text="four"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               four
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+              class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
               data-has-multiple-action-targets="true"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
@@ -21266,7 +21266,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
             data-cursor-is-interactive="true"
             data-has-remove-button="true"
             data-size="xlarge"
@@ -21275,13 +21275,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             text="five"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               five
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+              class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
               data-has-multiple-action-targets="true"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
@@ -21306,7 +21306,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
             data-cursor-is-interactive="true"
             data-has-remove-button="true"
             data-size="xlarge"
@@ -21315,13 +21315,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             text="six"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               six
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+              class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
               data-has-multiple-action-targets="true"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
@@ -21346,7 +21346,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             </span>
           </span>
           <span
-            class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+            class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
             data-cursor-is-interactive="true"
             data-has-remove-button="true"
             data-size="xlarge"
@@ -21355,13 +21355,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
             text="seven"
           >
             <div
-              class="_TokenTextContainer_p11sb_1"
+              class="prc-Token-TokenTextContainer-DBGXC"
             >
               seven
             </div>
             <span
               aria-hidden="true"
-              class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+              class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
               data-has-multiple-action-targets="true"
               data-size="xlarge"
               style="transform: translate(1px, -1px);"
@@ -21391,25 +21391,25 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />
         </div>
         <span
-          class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
           data-cursor-is-interactive="true"
           data-has-remove-button="true"
           data-size="xlarge"
@@ -21418,13 +21418,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           text="zero"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             zero
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+            class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
             data-has-multiple-action-targets="true"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
@@ -21449,7 +21449,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
           data-cursor-is-interactive="true"
           data-has-remove-button="true"
           data-size="xlarge"
@@ -21458,13 +21458,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           text="one"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             one
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+            class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
             data-has-multiple-action-targets="true"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
@@ -21489,7 +21489,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
           data-cursor-is-interactive="true"
           data-has-remove-button="true"
           data-size="xlarge"
@@ -21498,13 +21498,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           text="two"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             two
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+            class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
             data-has-multiple-action-targets="true"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
@@ -21529,7 +21529,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
           data-cursor-is-interactive="true"
           data-has-remove-button="true"
           data-size="xlarge"
@@ -21538,13 +21538,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           text="three"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             three
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+            class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
             data-has-multiple-action-targets="true"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
@@ -21569,7 +21569,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
           data-cursor-is-interactive="true"
           data-has-remove-button="true"
           data-size="xlarge"
@@ -21578,13 +21578,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           text="four"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             four
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+            class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
             data-has-multiple-action-targets="true"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
@@ -21609,7 +21609,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
           data-cursor-is-interactive="true"
           data-has-remove-button="true"
           data-size="xlarge"
@@ -21618,13 +21618,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           text="five"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             five
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+            class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
             data-has-multiple-action-targets="true"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
@@ -21649,7 +21649,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
           data-cursor-is-interactive="true"
           data-has-remove-button="true"
           data-size="xlarge"
@@ -21658,13 +21658,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           text="six"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             six
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+            class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
             data-has-multiple-action-targets="true"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
@@ -21689,7 +21689,7 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           </span>
         </span>
         <span
-          class="_TokenBase_12d14_1 _IssueLabel_1nwpc_1"
+          class="prc-Token-TokenBase-MtVGQ prc-Token-IssueLabel-ACoKj"
           data-cursor-is-interactive="true"
           data-has-remove-button="true"
           data-size="xlarge"
@@ -21698,13 +21698,13 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
           text="seven"
         >
           <div
-            class="_TokenTextContainer_p11sb_1"
+            class="prc-Token-TokenTextContainer-DBGXC"
           >
             seven
           </div>
           <span
             aria-hidden="true"
-            class="_TokenButton_gq6x5_1 _RemoveButton_1nwpc_5"
+            class="prc-Token-TokenButton-LXZrO prc-Token-RemoveButton-VhwCm"
             data-has-multiple-action-targets="true"
             data-size="xlarge"
             style="transform: translate(1px, -1px);"
@@ -21795,19 +21795,19 @@ exports[`TextInputWithTokens > renders without tokens 1`] = `
 
     <div>
       <span
-        class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+        class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-size="medium"
       >
         <div
-          class="_Container_1ef6o_25"
+          class="prc-TextInputWithTokens-Container-ccL44"
           data-prevent-token-wrapping="false"
         >
           <div
-            class="_InputWrapper_1ef6o_20"
+            class="prc-TextInputWithTokens-InputWrapper-fdtPL"
           >
             <input
               aria-invalid="false"
-              class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+              class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
               tabindex="0"
               type="text"
             />
@@ -21818,19 +21818,19 @@ exports[`TextInputWithTokens > renders without tokens 1`] = `
   </body>,
   "container": <div>
     <span
-      class="_TextInputWrapper_1ef6o_1 _TextInputWrapper_12w30_150 _TextInputBaseWrapper_12w30_1"
+      class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-size="medium"
     >
       <div
-        class="_Container_1ef6o_25"
+        class="prc-TextInputWithTokens-Container-ccL44"
         data-prevent-token-wrapping="false"
       >
         <div
-          class="_InputWrapper_1ef6o_20"
+          class="prc-TextInputWithTokens-InputWrapper-fdtPL"
         >
           <input
             aria-invalid="false"
-            class="_UnstyledTextInput_1ef6o_16 _Input_19mun_1"
+            class="prc-TextInputWithTokens-UnstyledTextInput-NJSW7 prc-components-Input-sKHcw"
             tabindex="0"
             type="text"
           />

--- a/packages/react/src/Timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
+++ b/packages/react/src/Timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Timeline > renders with clipSidebar prop 1`] = `
 <div>
   <div
-    class="_Timeline_5d0zw_1"
+    class="prc-Timeline-Timeline-T476g"
     data-clip-sidebar=""
   />
 </div>
@@ -12,7 +12,7 @@ exports[`Timeline > renders with clipSidebar prop 1`] = `
 exports[`Timeline.Item > renders with condensed prop 1`] = `
 <div>
   <div
-    class="Timeline-Item _TimelineItem_5d0zw_6"
+    class="Timeline-Item prc-Timeline-TimelineItem-yUFAS"
     data-condensed=""
   />
 </div>

--- a/packages/react/src/__tests__/__snapshots__/BaseStyles.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/BaseStyles.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`BaseStyles > has default styles 1`] = `
 <div>
   <div
-    class="_BaseStyles_1n09d_56"
+    class="prc-src-BaseStyles-9LBd2"
     data-color-mode="light"
     data-portal-root="true"
   >

--- a/packages/react/src/__tests__/__snapshots__/SubNavLink.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/SubNavLink.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`SubNav.Link > respects the "selected" prop 1`] = `
     <div>
       <a
         aria-current="true"
-        class="_Link_tvhmi_24"
+        class="prc-SubNav-Link-zaEfe"
         data-selected="true"
       />
     </div>
@@ -19,7 +19,7 @@ exports[`SubNav.Link > respects the "selected" prop 1`] = `
   "container": <div>
     <a
       aria-current="true"
-      class="_Link_tvhmi_24"
+      class="prc-SubNav-Link-zaEfe"
       data-selected="true"
     />
   </div>,

--- a/packages/react/src/__tests__/__snapshots__/ThemeProvider.test.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/ThemeProvider.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`has default theme 1`] = `
 <span
-  class="sc-aXZVg hPmBIl _Text_140xm_1"
+  class="sc-aXZVg hPmBIl prc-Text-Text-jAl-N"
   color="fg.default"
 >
   Hello

--- a/packages/react/src/hooks/__tests__/useAnchoredPosition.test.tsx
+++ b/packages/react/src/hooks/__tests__/useAnchoredPosition.test.tsx
@@ -1,4 +1,4 @@
-import {render} from '@testing-library/react'
+import {render, waitFor} from '@testing-library/react'
 import {it, expect, vi} from 'vitest'
 import React from 'react'
 import {useAnchoredPosition} from '../../hooks/useAnchoredPosition'
@@ -18,11 +18,13 @@ const Component = ({callback}: {callback: (hookReturnValue: ReturnType<typeof us
   )
 }
 
-it('should should return a position', () => {
+it('should should return a position', async () => {
   const cb = vi.fn()
   render(<Component callback={cb} />)
-  expect(cb).toHaveBeenCalledTimes(2)
-  expect(cb.mock.calls[1][0]['position']).toMatchInlineSnapshot(`
+
+  await waitFor(() => {
+    expect(cb).toHaveBeenCalledTimes(2)
+    expect(cb.mock.calls[1][0]['position']).toMatchInlineSnapshot(`
     {
       "anchorAlign": "start",
       "anchorSide": "outside-bottom",
@@ -30,4 +32,5 @@ it('should should return a position', () => {
       "top": 4,
     }
   `)
+  })
 })

--- a/packages/react/vitest.config.browser.mts
+++ b/packages/react/vitest.config.browser.mts
@@ -1,10 +1,20 @@
-import {defineConfig} from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import {defineConfig} from 'vitest/config'
+import postcssPresetPrimer from 'postcss-preset-primer'
 
 export default defineConfig({
+  css: {
+    modules: {
+      generateScopedName: 'prc-[folder]-[local]-[hash:base64:5]',
+    },
+    postcss: {
+      plugins: [postcssPresetPrimer()],
+    },
+  },
   plugins: [react()],
   define: {
     __DEV__: true,
+    'process.env.CI': JSON.stringify(process.env.CI),
   },
   test: {
     name: '@primer/react',
@@ -73,8 +83,9 @@ export default defineConfig({
       'src/internal/utils/**/*.test.?(c|m)[jt]s?(x)',
       'src/live-region/**/*.test.?(c|m)[jt]s?(x)',
       'src/utils/**/*.test.?(c|m)[jt]s?(x)',
+      'src/TreeView/**/*.test.?(c|m)[jt]s?(x)',
     ],
-    setupFiles: ['config/vitest/setup.ts'],
+    setupFiles: ['config/vitest/setup.ts', 'config/vitest/browser/setup.ts'],
     css: {
       include: [/.+/],
     },

--- a/packages/react/vitest.config.mts
+++ b/packages/react/vitest.config.mts
@@ -25,5 +25,6 @@ export default defineConfig({
     name: '@primer/react (node)',
     include: ['src/__tests__/exports.test.ts', 'src/__tests__/storybook.test.tsx'],
     environment: 'node',
+    setupFiles: ['./config/vitest/setup.ts'],
   },
 })


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Updates our TreeView tests from Jest to Vitest. This PR also includes some changes I needed to land in order to convert the tests, namely:

- The vitest browser environment is now set up so that our styles should match how they appear in storybook
- Our test suite will now fail in CI if a `console.*` method is logged (helps to prevent `act()` warnings from sneaking in)

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update TreeView tests from Jest to Vitest
- Update vitest setup files
  - Split browser-config into specific setup file
  - Use shared setup config across Node.js and browser tests
- Use postcss preset for transforming CSS files in vitest

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to our internal test setup and does not impact our public API.