### PR TITLE
fix: Add an indicator for disabled ActionList items (e.g. in a SelectPanel)

### DIFF
--- a/.changeset/true-parents-watch.md
+++ b/.changeset/true-parents-watch.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Disabled ActionList items now have a visible indicator when hovered or selected.

--- a/packages/react/src/ActionList/ActionList.module.css
+++ b/packages/react/src/ActionList/ActionList.module.css
@@ -340,6 +340,21 @@
         }
       }
     }
+
+    &:where([data-active]),
+    &:where([data-is-active-descendant]) {
+      background: transparent;
+
+      /* provides a visual indication of the current item for Windows high-contrast mode */
+      outline: 2px solid var(--control-transparent-bgColor-selected);
+
+      /* gray accent line */
+      &::after {
+        @mixin activeIndicatorLine;
+        /* stylelint-disable-next-line primer/colors */
+        background: var(--fgColor-muted);
+      }
+    }
   }
 
   /* Make sure that the first visible item isn't a divider */

--- a/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
@@ -853,3 +853,38 @@ export const WithInactiveItems = () => {
     </FormControl>
   )
 }
+
+const itemsWithDisabled: Items[] = items.slice()
+itemsWithDisabled[4].disabled = true
+
+export const WithDisabledItems = () => {
+  const [selected, setSelected] = useState<ItemInput[]>(itemsWithDisabled.slice(1, 3))
+  const [filter, setFilter] = useState('')
+  const filteredItems = itemsWithDisabled.filter(item => item.text?.toLowerCase().startsWith(filter.toLowerCase()))
+
+  const [open, setOpen] = useState(false)
+
+  return (
+    <FormControl>
+      <FormControl.Label>Labels</FormControl.Label>
+      <SelectPanel
+        title="Select labels"
+        placeholder="Select labels" // button text when no items are selected
+        subtitle="Use labels to organize issues and pull requests"
+        renderAnchor={({children, ...anchorProps}) => (
+          <Button trailingAction={TriangleDownIcon} {...anchorProps} aria-haspopup="dialog">
+            {children}
+          </Button>
+        )}
+        open={open}
+        onOpenChange={setOpen}
+        items={filteredItems}
+        selected={selected}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
+        width="medium"
+        message={filteredItems.length === 0 ? NoResultsMessage(filter) : undefined}
+      />
+    </FormControl>
+  )
+}

--- a/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
@@ -854,10 +854,12 @@ export const WithInactiveItems = () => {
   )
 }
 
-const itemsWithDisabled: Items[] = items.slice()
-itemsWithDisabled[4].disabled = true
-
 export const WithDisabledItems = () => {
+  const itemsWithDisabled = items.map<Items>((item: Items, index: number) => ({
+    ...item,
+    disabled: index === 4 ? true : item.disabled,
+  }))
+
   const [selected, setSelected] = useState<ItemInput[]>(itemsWithDisabled.slice(1, 3))
   const [filter, setFilter] = useState('')
   const filteredItems = itemsWithDisabled.filter(item => item.text?.toLowerCase().startsWith(filter.toLowerCase()))


### PR DESCRIPTION
Part of https://github.com/github/accessibility-audits/issues/11962 (Hubber access only)

This PR adds new indicator styles for disabled ActionList items that are hovered or selected with arrow keys, and a new Storybook story to demo them: “SelectPanel > Features > With Disabled Items”.

Previously, there were no indicator styles at all, so focus would seem to “disappear” when moving past a disabled item.

> [!NOTE]
> The `primer_react_select_panel_with_modern_action_list` feature flag must be enabled.

**Before**

Screen recording, without audio, showing how focus “disappeared” before.

https://github.com/user-attachments/assets/2d3ed009-3a59-44a8-a0f2-71ae3d2de073

**After**

Screen recording, without audio, showing how focus indication is now preserved.

https://github.com/user-attachments/assets/ba4f277a-59e1-40f1-a66e-39a39ee9593f

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

- Disabled `ActionList` items now have a visible indicator when hovered or selected.

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Check out the newly-added Storybook story. I’ll update this PR body with a link once it’s available.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
