### PR TITLE
fix: prepend `/react/storybook` to point to the correct location for TooltipV2

### DIFF
--- a/packages/react/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/Tooltip/Tooltip.stories.tsx
@@ -32,7 +32,7 @@ export const Default = () => (
         description={
           <div data-a11y-link-underlines="true">
             There are plans to deprecate this component in a future release. We recommend using{' '}
-            <Link inline={true} href="/?path=/story/components-tooltipv2--default">
+            <Link inline={true} href="/react/storybook/?path=/story/components-tooltipv2--default">
               Tooltip
             </Link>{' '}
             instead.


### PR DESCRIPTION
## Summary


<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5164

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

Not applicable.

#### Changed

<!-- List of things changed in this PR -->

Tooltip Version 1's deprecation notice pointed to the wrong storybook URL. This PR updates the URL to point to the correct location.

- Correct Location (this PR): https://primer.style/react/storybook/?path=/story/components-tooltipv2--default
- Incorrect location (previous): https://primer.style/?path=/story/components-tooltipv2--default

#### Removed

<!-- List of things removed in this PR -->

Not applicable.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Verify this is the link we want
- Consider abstracting this out in a separate PR so we're pointing to the correct URL without having to re-remember this prefix

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
