### PR TITLE
Fix PageHeader context bar `font-weight`

### DIFF
--- a/.changeset/angry-boats-poke.md
+++ b/.changeset/angry-boats-poke.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Fix PageHeader context bar `font-weight`

--- a/packages/react/src/PageHeader/PageHeader.module.css
+++ b/packages/react/src/PageHeader/PageHeader.module.css
@@ -29,7 +29,7 @@
     'description description description description description'
     'navigation navigation navigation navigation navigation';
 
-  /* 
+  /*
     line-height is calculated with calc(height/font-size) and the below numbers are from @primer/primitives.
     --custom-font-size, --custom-line-height, --custom-font-weight are custom properties that can be used to override the below values.
     We don't want these values to be overridden but still want to allow consumers to override them if needed.
@@ -120,7 +120,7 @@
   display: flex;
   padding-bottom: var(--base-size-8);
   font-size: var(--text-body-size-medium, 0.875rem);
-  font-weight: var(--base-text-weight-light);
+  font-weight: var(--base-text-weight-normal);
   line-height: var(--text-body-lineHeight-medium, 1.4285);
   flex-direction: row;
   grid-row: var(--grid-row-order-context-area);
@@ -172,7 +172,7 @@
   display: flex;
   padding-right: var(--base-size-8);
   font-size: var(--text-body-size-medium, 0.875rem);
-  font-weight: var(--base-text-weight-light);
+  font-weight: var(--base-text-weight-normal);
   line-height: var(--text-body-lineHeight-medium, 1.4285);
   grid-row: var(--grid-row-order-breadcrumbs);
   grid-area: breadcrumbs;
@@ -242,7 +242,7 @@
   display: block;
   padding-top: var(--base-size-8);
   font-size: var(--text-body-size-medium, 0.875rem);
-  font-weight: var(--base-text-weight-light);
+  font-weight: var(--base-text-weight-normal);
   line-height: var(--text-body-lineHeight-medium, 1.4285);
   grid-row: var(--grid-row-order-navigation);
   grid-area: navigation;


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5382

I took a look at the prev. implementation before CSS Modules and best I can tell we didn't set the weight to `light`. I'm not sure if this was maybe an oversight? 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
