### PR TITLE
Fix/update navlist group divider

### DIFF
--- a/.changeset/kind-pants-march.md
+++ b/.changeset/kind-pants-march.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Update NavList.Group to render divider when `sx` is provided

--- a/packages/react/src/NavList/NavList.tsx
+++ b/packages/react/src/NavList/NavList.tsx
@@ -285,20 +285,11 @@ export type NavListGroupProps = React.HTMLAttributes<HTMLLIElement> & {
   title?: string
 } & SxProp
 
-const defaultSx = {}
-const Group: React.FC<NavListGroupProps> = ({title, children, sx: sxProp = defaultSx, ...props}) => {
-  if (sxProp !== defaultSx) {
-    return (
-      <Box sx={sxProp} as="li" data-component="ActionList.Group">
-        {title ? <ActionList.GroupHeading>{title}</ActionList.GroupHeading> : null}
-        {children}
-      </Box>
-    )
-  }
+function Group({title, children, sx, ...rest}: NavListGroupProps) {
   return (
     <>
       <ActionList.Divider />
-      <ActionList.Group {...props}>
+      <BoxWithFallback as={ActionList.Group} {...rest} sx={sx}>
         {/* Setting up the default value for the heading level. TODO: API update to give flexibility to NavList.Group title's heading level */}
         {title ? (
           <ActionList.GroupHeading as="h3" data-component="ActionList.GroupHeading">
@@ -306,10 +297,11 @@ const Group: React.FC<NavListGroupProps> = ({title, children, sx: sxProp = defau
           </ActionList.GroupHeading>
         ) : null}
         {children}
-      </ActionList.Group>
+      </BoxWithFallback>
     </>
   )
 }
+
 // ----------------------------------------------------------------------------
 // NavList.GroupExpand
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5391

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Update the `NavList.Group` component to have the same result when both `sx` and no `sx` prop is provided. This change has an unintended side-effect which is that in the `sx` case no divider was being rendered 😅 

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Consolidate `sx` and no-`sx` scenarios into single return for `NavList.Group`

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
