### PR TITLE
Add CSS variable to `contrast` `TextInput`

### DIFF
--- a/packages/react/src/internal/components/TextInputWrapper.module.css
+++ b/packages/react/src/internal/components/TextInputWrapper.module.css
@@ -44,7 +44,9 @@
   }
 
   &:where([data-contrast]) {
-    background-color: var(--bgColor-inset);
+    /* this variable is available behind a feature flag in gh/gh */
+    /* stylelint-disable-next-line primer/colors */
+    background-color: var(--control-bgColor-contrast, var(--bgColor-inset));
   }
 
   &:where([data-disabled]) {


### PR DESCRIPTION
This adds a new CSS variable that we're adding behind a feature flag in gh/gh to test a color change to the contrast prop in order to eventually deprecate it.