### PR TITLE
refactor(test): add explicit disabled animations to all screenshots

### DIFF
--- a/e2e/components/ActionList.test.ts
+++ b/e2e/components/ActionList.test.ts
@@ -126,7 +126,9 @@ test.describe('ActionList', () => {
           })
 
           // Default state
-          await expect(page).toHaveScreenshot(`ActionList.${story.title}.${theme}.png`)
+          await expect(page).toHaveScreenshot(`ActionList.${story.title}.${theme}.png`, {
+            animations: 'disabled',
+          })
         })
       }
     })

--- a/e2e/components/Autocomplete.test.ts
+++ b/e2e/components/Autocomplete.test.ts
@@ -121,7 +121,9 @@ test.describe('Autocomplete', () => {
 
             await story.setup(page)
 
-            await expect(page).toHaveScreenshot(`Autocomplete.${story.title}.${theme}.png`, {animations: 'disabled'})
+            await expect(page).toHaveScreenshot(`Autocomplete.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
 
           test('@aat', async ({page}) => {

--- a/e2e/components/Avatar.test.ts
+++ b/e2e/components/Avatar.test.ts
@@ -35,7 +35,9 @@ test.describe('Avatar', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Avatar.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Avatar.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/AvatarPair.test.ts
+++ b/e2e/components/AvatarPair.test.ts
@@ -2,39 +2,58 @@ import {test, expect} from '@playwright/test'
 import {visit} from '../test-helpers/storybook'
 import {themes} from '../test-helpers/themes'
 
-const stories = [
-  {
-    title: 'Default',
-    id: 'components-avatarpair--default',
-  },
-  {
-    title: 'Parent Circle',
-    id: 'components-avatarpair-features--parent-circle',
-  },
-  {
-    title: 'Parent Square',
-    id: 'components-avatarpair-features--parent-square',
-  },
-] as const
-
 test.describe('AvatarPair', () => {
-  for (const story of stories) {
-    test.describe(story.title, () => {
-      for (const theme of themes) {
-        test.describe(theme, () => {
-          test('default @vrt', async ({page}) => {
-            await visit(page, {
-              id: story.id,
-              globals: {
-                colorScheme: theme,
-              },
-            })
-
-            // Default state
-            await expect(page).toHaveScreenshot(`AvatarPair.${story.title}.${theme}.png`)
+  test.describe('Default', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-avatarpair--default',
+            globals: {
+              colorScheme: theme,
+            },
           })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`AvatarPair.Default.${theme}.png`)
         })
-      }
-    })
-  }
+      })
+    }
+  })
+
+  test.describe('Parent Circle', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-avatarpair-features--parent-circle',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`AvatarPair.Parent Circle.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Parent Square', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-avatarpair-features--parent-square',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`AvatarPair.Parent Square.${theme}.png`)
+        })
+      })
+    }
+  })
 })

--- a/e2e/components/AvatarStack.test.ts
+++ b/e2e/components/AvatarStack.test.ts
@@ -62,7 +62,9 @@ test.describe('AvatarStack', () => {
               },
             })
 
-            await expect(page).toHaveScreenshot(`AvatarStack.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`AvatarStack.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
 
           test('@aat', async ({page}) => {

--- a/e2e/components/Banner.test.ts
+++ b/e2e/components/Banner.test.ts
@@ -86,7 +86,9 @@ test.describe('Banner', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Banner.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Banner.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }
@@ -103,7 +105,9 @@ test.describe('Banner', () => {
               width,
               height: 667,
             })
-            await expect(page).toHaveScreenshot(`Banner.${story.title}.${name}.png`)
+            await expect(page).toHaveScreenshot(`Banner.${story.title}.${name}.png`, {
+              animations: 'disabled',
+            })
           })
         }
       }

--- a/e2e/components/Blankslate.test.ts
+++ b/e2e/components/Blankslate.test.ts
@@ -62,7 +62,9 @@ test.describe('Blankslate', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Blankslate.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Blankslate.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }
@@ -79,7 +81,9 @@ test.describe('Blankslate', () => {
               width,
               height: 667,
             })
-            await expect(page).toHaveScreenshot(`Blankslate.${story.title}.${name}.png`)
+            await expect(page).toHaveScreenshot(`Blankslate.${story.title}.${name}.png`, {
+              animations: 'disabled',
+            })
           })
         }
       }
@@ -97,7 +101,9 @@ test.describe('Blankslate', () => {
         })
 
         // Default state
-        await expect(page).toHaveScreenshot(`Blankslate.${id}.png`)
+        await expect(page).toHaveScreenshot(`Blankslate.${id}.png`, {
+          animations: 'disabled',
+        })
       })
     })
   }

--- a/e2e/components/BranchName.test.ts
+++ b/e2e/components/BranchName.test.ts
@@ -34,12 +34,16 @@ test.describe('BranchName', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`BranchName.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`BranchName.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
 
             // Focus state
             if (story.focus) {
               await page.keyboard.press('Tab')
-              await expect(page).toHaveScreenshot(`BranchName.${story.title}.${theme}.focus.png`)
+              await expect(page).toHaveScreenshot(`BranchName.${story.title}.${theme}.focus.png`, {
+                animations: 'disabled',
+              })
             }
           })
         })

--- a/e2e/components/Breadcrumbs.test.ts
+++ b/e2e/components/Breadcrumbs.test.ts
@@ -23,15 +23,21 @@ test.describe('Breadcrumbs', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Breadcrumbs.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Breadcrumbs.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
 
             // Hover state
             await page.getByRole('link', {name: 'Home'}).hover()
-            await expect(page).toHaveScreenshot(`Breadcrumbs.${story.title}.${theme}.hover.png`)
+            await expect(page).toHaveScreenshot(`Breadcrumbs.${story.title}.${theme}.hover.png`, {
+              animations: 'disabled',
+            })
 
             // Focus state
             await page.keyboard.press('Tab')
-            await expect(page).toHaveScreenshot(`Breadcrumbs.${story.title}.${theme}.focus.png`)
+            await expect(page).toHaveScreenshot(`Breadcrumbs.${story.title}.${theme}.focus.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Button.test.ts
+++ b/e2e/components/Button.test.ts
@@ -2,115 +2,405 @@ import {test, expect} from '@playwright/test'
 import {visit} from '../test-helpers/storybook'
 import {themes} from '../test-helpers/themes'
 
-const stories = [
-  {
-    title: 'Danger',
-    id: 'components-button-features--danger',
-  },
-  {
-    title: 'Default',
-    id: 'components-button--default',
-  },
-  {
-    title: 'Disabled',
-    id: 'components-button-features--disabled',
-  },
-  {
-    title: 'Invisible',
-    id: 'components-button-features--invisible',
-  },
-  {
-    title: 'Link',
-    id: 'components-button-features--link',
-  },
-  {
-    title: 'Leading Visual',
-    id: 'components-button-features--leading-visual',
-  },
-  {
-    title: 'Medium',
-    id: 'components-button-features--medium',
-  },
-  {
-    title: 'Primary',
-    id: 'components-button-features--primary',
-  },
-  {
-    title: 'Small',
-    id: 'components-button-features--small',
-  },
-  {
-    title: 'Trailing Action',
-    id: 'components-button-features--trailing-action',
-  },
-  {
-    title: 'Trailing Counter',
-    id: 'components-button-features--trailing-counter',
-  },
-  {
-    title: 'Trailing Visual',
-    id: 'components-button-features--trailing-visual',
-  },
-  {
-    title: 'Inactive',
-    id: 'components-button-features--inactive',
-  },
-  {
-    title: 'Loading',
-    id: 'components-button-features--loading',
-  },
-  {
-    title: 'Loading With Leading Visual',
-    id: 'components-button-features--loading-with-leading-visual',
-  },
-  {
-    title: 'Loading With Trailing Visual',
-    id: 'components-button-features--loading-with-trailing-visual',
-  },
-  {
-    title: 'Loading With Trailing Action',
-    id: 'components-button-features--loading-with-trailing-action',
-  },
-  {
-    title: 'Dev Invisible Variants',
-    id: 'components-button-dev--invisible-variants',
-  },
-  {
-    title: 'Dev Sx Prop',
-    id: 'components-button-dev--test-sx-prop',
-  },
-  {
-    title: 'Aria Expanded Buttons',
-    id: 'components-button-features--expanded-button',
-  },
-  {
-    title: 'Dev Disabled Variants',
-    id: 'components-button-dev--disabled-button-variants',
-  },
-  {
-    title: 'Trailing Counter No Text',
-    id: 'components-button-features--trailing-counter-with-no-text',
-  },
-] as const
-
 test.describe('Button', () => {
-  for (const story of stories) {
-    test.describe(story.title, () => {
-      for (const theme of themes) {
-        test.describe(theme, () => {
-          test('default @vrt', async ({page}) => {
-            await visit(page, {
-              id: story.id,
-              globals: {
-                colorScheme: theme,
-              },
-            })
-
-            // Default state
-            await expect(page).toHaveScreenshot(`Button.${story.title}.${theme}.png`)
+  test.describe('Danger', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--danger',
+            globals: {
+              colorScheme: theme,
+            },
           })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Danger.${theme}.png`)
         })
-      }
+      })
+    }
+  })
+
+  test.describe('Default', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button--default',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Default.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Disabled', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--disabled',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Disabled.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Invisible', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--invisible',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Invisible.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Link', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--link',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Link.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Large', () => {
+    test('default @vrt', async ({page}) => {
+      await visit(page, {
+        id: 'components-button-features--large',
+      })
+
+      // Default state
+      expect(await page.screenshot()).toMatchSnapshot(`Button.Large.png`)
     })
-  }
+  })
+
+  test.describe('Leading Visual', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--leading-visual',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Leading Visual.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Medium', () => {
+    test('default @vrt', async ({page}) => {
+      await visit(page, {
+        id: 'components-button-features--medium',
+      })
+
+      // Default state
+      expect(await page.screenshot()).toMatchSnapshot(`Button.Medium.png`)
+    })
+  })
+
+  test.describe('Primary', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--primary',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Primary.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Small', () => {
+    test('default @vrt', async ({page}) => {
+      await visit(page, {
+        id: 'components-button-features--small',
+      })
+
+      // Default state
+      expect(await page.screenshot()).toMatchSnapshot(`Button.Small.png`)
+    })
+  })
+
+  test.describe('Trailing Action', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--trailing-action',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Trailing Action.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Trailing Counter', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--trailing-counter',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Trailing Counter.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Trailing Visual', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--trailing-visual',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Trailing Visual.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Inactive', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--inactive',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Inactive.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Loading', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--loading',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot({animations: 'disabled'})).toMatchSnapshot(`Button.Loading.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Loading With Leading Visual', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--loading-with-leading-visual',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot({animations: 'disabled'})).toMatchSnapshot(
+            `Button.Loading With Leading Visual.${theme}.png`,
+          )
+        })
+      })
+    }
+  })
+
+  test.describe('Loading With Trailing Visual', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--loading-with-trailing-visual',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot({animations: 'disabled'})).toMatchSnapshot(
+            `Button.Loading With Trailing Visual.${theme}.png`,
+          )
+        })
+      })
+    }
+  })
+
+  test.describe('Loading With Trailing Action', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--loading-with-trailing-action',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot({animations: 'disabled'})).toMatchSnapshot(
+            `Button.Loading With Trailing Action.${theme}.png`,
+          )
+        })
+      })
+    }
+  })
+
+  test.describe('Dev: Invisible Variants', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-dev--invisible-variants',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Invisible Variants.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Dev: sx prop', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-dev--test-sx-prop',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.sx prop.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Aria expanded buttons', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--expanded-button',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot({animations: 'disabled'})).toMatchSnapshot(
+            `Button.Aria expanded buttons.${theme}.png`,
+          )
+        })
+      })
+    }
+  })
+
+  test.describe('Dev: Disabled variants', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-dev--disabled-button-variants',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Button.Disabled variants.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Trailing Counter No Text', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-button-features--trailing-counter-with-no-text',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`Trailing Counter No Text.${theme}.png`)
+        })
+      })
+    }
+  })
 })

--- a/e2e/components/ButtonGroup.test.ts
+++ b/e2e/components/ButtonGroup.test.ts
@@ -43,7 +43,9 @@ test.describe('ButtonGroup', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`ButtonGroup.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`ButtonGroup.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/CircleBadge.test.ts
+++ b/e2e/components/CircleBadge.test.ts
@@ -27,7 +27,9 @@ test.describe('CircleBadge', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`CircleBadge.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`CircleBadge.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/CircleOcticon.test.ts
+++ b/e2e/components/CircleOcticon.test.ts
@@ -27,7 +27,9 @@ test.describe('CircleOcticon', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`CircleOcticon.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`CircleOcticon.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/CounterLabel.test.ts
+++ b/e2e/components/CounterLabel.test.ts
@@ -31,7 +31,9 @@ test.describe('CounterLabel', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`CounterLabel.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`CounterLabel.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Details.test.ts
+++ b/e2e/components/Details.test.ts
@@ -27,12 +27,16 @@ test.describe('Details', () => {
             })
 
             // Default state - closed
-            await expect(page).toHaveScreenshot(`Details.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Details.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
             // Click the summary to open
             await page.getByText('See Details').click()
             await page.getByText('This is some content').waitFor()
             // Open state
-            await expect(page).toHaveScreenshot(`Details.${story.title}.${theme}.open.png`)
+            await expect(page).toHaveScreenshot(`Details.${story.title}.${theme}.open.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Flash.test.ts
+++ b/e2e/components/Flash.test.ts
@@ -39,7 +39,9 @@ test.describe('Flash', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Flash.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Flash.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Header.test.ts
+++ b/e2e/components/Header.test.ts
@@ -23,7 +23,9 @@ test.describe('Header', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Header.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Header.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Heading.test.ts
+++ b/e2e/components/Heading.test.ts
@@ -29,7 +29,9 @@ test.describe('Heading', () => {
         })
 
         // Default state
-        await expect(page).toHaveScreenshot(`Heading.${story.title}.png`)
+        await expect(page).toHaveScreenshot(`Heading.${story.title}.png`, {
+          animations: 'disabled',
+        })
       })
     })
   }

--- a/e2e/components/Hidden.test.ts
+++ b/e2e/components/Hidden.test.ts
@@ -28,19 +28,25 @@ test.describe('Hidden', () => {
             await page
               .getByText('The below content is visible when the viewport is regular or wide but hidden when narrow:')
               .waitFor()
-            await expect(page).toHaveScreenshot(`Hidden.${story.title}.medium.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Hidden.${story.title}.medium.${theme}.png`, {
+              animations: 'disabled',
+            })
             // Wide size viewport
             await page.setViewportSize({width: viewports['primer.breakpoint.lg'], height: 768})
             await page
               .getByText('The below content is visible when the viewport is regular or wide but hidden when narrow:')
               .waitFor()
-            await expect(page).toHaveScreenshot(`Hidden.${story.title}.wide.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Hidden.${story.title}.wide.${theme}.png`, {
+              animations: 'disabled',
+            })
             // Narrow size viewport
             await page.setViewportSize({width: viewports['primer.breakpoint.xs'], height: 768})
             await page
               .getByText('The below content is visible when the viewport is regular or wide but hidden when narrow:')
               .waitFor()
-            await expect(page).toHaveScreenshot(`Hidden.${story.title}.narrow.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Hidden.${story.title}.narrow.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/InlineMessage.test.ts
+++ b/e2e/components/InlineMessage.test.ts
@@ -37,7 +37,9 @@ test.describe('InlineMessage', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`InlineMessage.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`InlineMessage.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }
@@ -61,7 +63,9 @@ test.describe('InlineMessage', () => {
             await page.setViewportSize({width: 400, height: 200})
 
             // Default state
-            await expect(page).toHaveScreenshot(`InlineMessage.${id}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`InlineMessage.${id}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/IssueLabel.test.ts
+++ b/e2e/components/IssueLabel.test.ts
@@ -120,7 +120,9 @@ test.describe('IssueLabel', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`IssueLabel.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`IssueLabel.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Label.test.ts
+++ b/e2e/components/Label.test.ts
@@ -71,7 +71,9 @@ test.describe('Label', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Label.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Label.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Link.test.ts
+++ b/e2e/components/Link.test.ts
@@ -35,15 +35,21 @@ test.describe('Link', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Link.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Link.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
 
             // Hover state
             await page.getByRole('link').hover()
-            await expect(page).toHaveScreenshot(`Link.${story.title}.${theme}.hover.png`)
+            await expect(page).toHaveScreenshot(`Link.${story.title}.${theme}.hover.png`, {
+              animations: 'disabled',
+            })
 
             // Focus state
             await page.keyboard.press('Tab')
-            await expect(page).toHaveScreenshot(`Link.${story.title}.${theme}.focus.png`)
+            await expect(page).toHaveScreenshot(`Link.${story.title}.${theme}.focus.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }
@@ -62,7 +68,9 @@ test.describe('Link', () => {
           })
 
           // Default state
-          await expect(page).toHaveScreenshot(`Link.Dev Inline.${theme}.png`)
+          await expect(page).toHaveScreenshot(`Link.Dev Inline.${theme}.png`, {
+            animations: 'disabled',
+          })
         })
       })
     }

--- a/e2e/components/LinkButton.test.ts
+++ b/e2e/components/LinkButton.test.ts
@@ -63,7 +63,9 @@ test.describe('LinkButton', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`LinkButton.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`LinkButton.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Octicon.test.ts
+++ b/e2e/components/Octicon.test.ts
@@ -27,7 +27,9 @@ test.describe('Octicon', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Octicon.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Octicon.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Overlay.test.ts
+++ b/e2e/components/Overlay.test.ts
@@ -61,7 +61,9 @@ test.describe('Overlay ', () => {
               },
             })
 
-            await expect(page).toHaveScreenshot(`Overlay.${story.title}.${theme}.png`, {animations: 'disabled'})
+            await expect(page).toHaveScreenshot(`Overlay.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
 
           test('axe @aat', async ({page}) => {

--- a/e2e/components/PageLayout.test.ts
+++ b/e2e/components/PageLayout.test.ts
@@ -88,7 +88,9 @@ test.describe('PageLayout', () => {
           })
 
           // Default state
-          await expect(page).toHaveScreenshot(`PageLayout.StickyPane.${theme}.png`)
+          await expect(page).toHaveScreenshot(`PageLayout.StickyPane.${theme}.png`, {
+            animations: 'disabled',
+          })
 
           const content = page.getByTestId('content3')
           await content.scrollIntoViewIfNeeded()
@@ -113,7 +115,9 @@ test.describe('PageLayout', () => {
           })
 
           // Default state
-          await expect(page).toHaveScreenshot(`PageLayout.NonStickyPane.${theme}.png`)
+          await expect(page).toHaveScreenshot(`PageLayout.NonStickyPane.${theme}.png`, {
+            animations: 'disabled',
+          })
 
           const content3 = page.getByTestId('content3')
           await content3.scrollIntoViewIfNeeded()
@@ -140,7 +144,9 @@ test.describe('PageLayout', () => {
           })
 
           // Default state
-          await expect(page).toHaveScreenshot(`PageLayout.Custom Sticky Header.${theme}.png`)
+          await expect(page).toHaveScreenshot(`PageLayout.Custom Sticky Header.${theme}.png`, {
+            animations: 'disabled',
+          })
 
           const content = page.getByTestId('content3')
           await content.scrollIntoViewIfNeeded()

--- a/e2e/components/Pagehead.test.ts
+++ b/e2e/components/Pagehead.test.ts
@@ -23,7 +23,9 @@ test.describe('Pagehead', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Pagehead.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Pagehead.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Pagination.test.ts
+++ b/e2e/components/Pagination.test.ts
@@ -35,7 +35,9 @@ test.describe('Pagination', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Pagehead.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Pagehead.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Popover.test.ts
+++ b/e2e/components/Popover.test.ts
@@ -31,7 +31,9 @@ test.describe('Popover', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Popover.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Popover.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Radio.test.ts
+++ b/e2e/components/Radio.test.ts
@@ -35,7 +35,9 @@ test.describe('Radio', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Radio.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Radio.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }
@@ -57,7 +59,9 @@ test.describe('Radio', () => {
           })
 
           // Default state
-          await expect(page).toHaveScreenshot(`Radio.Checked.${theme}.png`)
+          await expect(page).toHaveScreenshot(`Radio.Checked.${theme}.png`, {
+            animations: 'disabled',
+          })
         })
       })
     }

--- a/e2e/components/SegmentedControl.test.ts
+++ b/e2e/components/SegmentedControl.test.ts
@@ -89,18 +89,27 @@ test.describe('SegmentedControl', () => {
             }
 
             // Default state
-            await expect(page).toHaveScreenshot(`SegmentedControl.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`SegmentedControl.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
 
             if (story.title === 'Default') {
               // Focus state
               await page.keyboard.press('Tab')
-              await expect(page).toHaveScreenshot(`SegmentedControl.${story.title}.${theme}.focus.png`)
+              await expect(page).toHaveScreenshot(`SegmentedControl.${story.title}.${theme}.focus.png`, {
+                animations: 'disabled',
+              })
 
               // Middle Button Focus state
               await page.keyboard.press('Tab')
               await page.keyboard.press('Enter')
               await page.keyboard.press('Shift+Tab')
-              await expect(page).toHaveScreenshot(`SegmentedControl.${story.title}.${theme}.middle.selected.focus.png`)
+              await expect(page).toHaveScreenshot(
+                `SegmentedControl.${story.title}.${theme}.middle.selected.focus.png`,
+                {
+                  animations: 'disabled',
+                },
+              )
             }
           })
         })

--- a/e2e/components/Stack.test.ts
+++ b/e2e/components/Stack.test.ts
@@ -20,7 +20,9 @@ test.describe('Stack', () => {
         id: 'components-stack--playground',
         args: scenario,
       })
-      await expect(page).toHaveScreenshot(`Stack.${id}.png`)
+      await expect(page).toHaveScreenshot(`Stack.${id}.png`, {
+        animations: 'disabled',
+      })
     })
   }
 })

--- a/e2e/components/StateLabel.test.ts
+++ b/e2e/components/StateLabel.test.ts
@@ -67,7 +67,9 @@ test.describe('StateLabel', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`StateLabel.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`StateLabel.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/TabNav.test.ts
+++ b/e2e/components/TabNav.test.ts
@@ -23,7 +23,9 @@ test.describe('TabNav', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`TabNav.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`TabNav.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Text.test.ts
+++ b/e2e/components/Text.test.ts
@@ -47,7 +47,9 @@ test.describe('Text', () => {
         })
 
         // Default state
-        await expect(page).toHaveScreenshot(`Text.${story.title}.png`)
+        await expect(page).toHaveScreenshot(`Text.${story.title}.png`, {
+          animations: 'disabled',
+        })
       })
     })
   }

--- a/e2e/components/TextInputWithTokens.test.ts
+++ b/e2e/components/TextInputWithTokens.test.ts
@@ -47,7 +47,9 @@ test.describe('TextInputWithTokens', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`TextInputWithTokens.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`TextInputWithTokens.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Timeline.test.ts
+++ b/e2e/components/Timeline.test.ts
@@ -39,7 +39,9 @@ test.describe('Timeline', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Timeline.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Timeline.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }
@@ -57,7 +59,9 @@ test.describe('Timeline', () => {
           })
 
           // Default state
-          await expect(page).toHaveScreenshot(`Timeline.With Inline Links.${theme}.png`)
+          await expect(page).toHaveScreenshot(`Timeline.With Inline Links.${theme}.png`, {
+            animations: 'disabled',
+          })
 
           // Hover state
           await page
@@ -65,11 +69,15 @@ test.describe('Timeline', () => {
               name: 'Monalisa',
             })
             .hover()
-          await expect(page).toHaveScreenshot(`Timeline.With Inline Links.${theme}.hover.png`)
+          await expect(page).toHaveScreenshot(`Timeline.With Inline Links.${theme}.hover.png`, {
+            animations: 'disabled',
+          })
 
           // Focus state
           await page.keyboard.press('Tab')
-          await expect(page).toHaveScreenshot(`Timeline.With Inline Links.${theme}.focus.png`)
+          await expect(page).toHaveScreenshot(`Timeline.With Inline Links.${theme}.focus.png`, {
+            animations: 'disabled',
+          })
         })
       })
     }

--- a/e2e/components/ToggleSwitch.test.ts
+++ b/e2e/components/ToggleSwitch.test.ts
@@ -2,62 +2,166 @@ import {test, expect} from '@playwright/test'
 import {visit} from '../test-helpers/storybook'
 import {themes} from '../test-helpers/themes'
 
-const stories = [
-  {
-    title: 'Default',
-    id: 'components-toggleswitch--default',
-  },
-  {
-    title: 'Checked',
-    id: 'components-toggleswitch-features--checked',
-  },
-  {
-    title: 'Checked Disabled',
-    id: 'components-toggleswitch-features--checked-disabled',
-  },
-  {
-    title: 'Controlled',
-    id: 'components-toggleswitch-features--controlled',
-  },
-  {
-    title: 'Disabled',
-    id: 'components-toggleswitch-features--disabled',
-  },
-  {
-    title: 'Label End',
-    id: 'components-toggleswitch-features--label-end',
-  },
-  {
-    title: 'Loading',
-    id: 'components-toggleswitch-features--loading',
-  },
-  {
-    title: 'Small',
-    id: 'components-toggleswitch-features--small',
-  },
-  {
-    title: 'With Caption',
-    id: 'components-toggleswitch-features--with-caption',
-  },
-] as const
-
 test.describe('ToggleSwitch', () => {
-  for (const story of stories) {
-    test.describe(story.title, () => {
-      for (const theme of themes) {
-        test.describe(theme, () => {
-          test('default @vrt', async ({page}) => {
-            await visit(page, {
-              id: story.id,
-              globals: {
-                colorScheme: theme,
-              },
-            })
-
-            await expect(page).toHaveScreenshot(`ToggleSwitch.${story.title}.${theme}.png`)
+  test.describe('Default', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-toggleswitch--default',
+            globals: {
+              colorScheme: theme,
+            },
           })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`ToggleSwitch.Default.${theme}.png`)
         })
-      }
-    })
-  }
+      })
+    }
+  })
+
+  test.describe('Checked', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-toggleswitch-features--checked',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`ToggleSwitch.Checked.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Checked Disabled', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-toggleswitch-features--checked-disabled',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`ToggleSwitch.Checked Disabled.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Controlled', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-toggleswitch-features--controlled',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`ToggleSwitch.Controlled.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Disabled', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-toggleswitch-features--disabled',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`ToggleSwitch.Disabled.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Label End', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-toggleswitch-features--label-end',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`ToggleSwitch.Label End.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Loading', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-toggleswitch-features--loading',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot({animations: 'disabled'})).toMatchSnapshot(`ToggleSwitch.Loading.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('Small', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-toggleswitch-features--small',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`ToggleSwitch.Small.${theme}.png`)
+        })
+      })
+    }
+  })
+
+  test.describe('With Caption', () => {
+    for (const theme of themes) {
+      test.describe(theme, () => {
+        test('default @vrt', async ({page}) => {
+          await visit(page, {
+            id: 'components-toggleswitch-features--with-caption',
+            globals: {
+              colorScheme: theme,
+            },
+          })
+
+          // Default state
+          expect(await page.screenshot()).toMatchSnapshot(`ToggleSwitch.With Caption.${theme}.png`)
+        })
+      })
+    }
+  })
 })

--- a/e2e/components/Token.test.ts
+++ b/e2e/components/Token.test.ts
@@ -67,7 +67,9 @@ test.describe('Token', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Token.Default.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Token.Default.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/Truncate.test.ts
+++ b/e2e/components/Truncate.test.ts
@@ -39,7 +39,9 @@ test.describe('Truncate', () => {
             })
 
             // Default state
-            await expect(page).toHaveScreenshot(`Truncate.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`Truncate.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }

--- a/e2e/components/UnderlinePanels.test.ts
+++ b/e2e/components/UnderlinePanels.test.ts
@@ -50,7 +50,9 @@ test.describe('UnderlinePanels', () => {
               },
             })
 
-            await expect(page).toHaveScreenshot(`UnderlinePanels.${story.title}.${theme}.png`)
+            await expect(page).toHaveScreenshot(`UnderlinePanels.${story.title}.${theme}.png`, {
+              animations: 'disabled',
+            })
           })
         })
       }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Add explicit disabled animations to all of our screenshots. This seemed to be the default but wanted to make it explicit to see if it changes anything 👀 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update all `toHaveScreenshot` calls to explicitly disable animations

#### Removed

<!-- List of things removed in this PR -->
