### PR TITLE
Set the disable scroll class after the scrollbar width is calculated

### DIFF
--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -288,7 +288,12 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
   )
 
   React.useEffect(() => {
-    document.body.style.setProperty('--dialog-scrollgutter', `${window.innerWidth - document.body.clientWidth}px`)
+    const scrollbarWidth = window.innerWidth - document.body.clientWidth
+    // If the dialog is rendered, we add a class to the dialog element to disable
+    dialogRef.current?.classList.add(classes.DisableScroll)
+    // and set a CSS variable to the scrollbar width so that the dialog can
+    // account for the scrollbar width when calculating its width.
+    document.body.style.setProperty('--dialog-scrollgutter', `${scrollbarWidth}px`)
   }, [])
 
   const header = (renderHeader ?? DefaultHeader)(defaultedProps)
@@ -327,7 +332,7 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
             data-width={width}
             data-height={height}
             sx={sx}
-            className={clsx(className, classes.Dialog, classes.DisableScroll)}
+            className={clsx(className, classes.Dialog)}
           >
             {header}
             <ScrollableRegion aria-labelledby={dialogLabelId} className={classes.DialogOverflowWrapper}>


### PR DESCRIPTION
follow up to https://github.com/primer/react/pull/6266

The fix wasn't working because it was calculating the scrollbar width after it had already been disabled which was giving `0px`. I'm going to skip the changeset since this is meant to be part of the other change.
