### PR TITLE
Migrate Label.test.tsx from Jest to Vitest

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -33,6 +33,7 @@ module.exports = {
     '<rootDir>/src/Flash/',
     '<rootDir>/src/FormControl/__tests__/FormControl.Validation.test.tsx',
     '<rootDir>/src/InlineMessage/',
+    '<rootDir>/src/Label/',
     '<rootDir>/src/NavList/',
     '<rootDir>/src/Octicon/',
     '<rootDir>/src/Pagehead/',

--- a/packages/react/src/Label/Label.test.tsx
+++ b/packages/react/src/Label/Label.test.tsx
@@ -1,7 +1,6 @@
+import {describe, expect, it} from 'vitest'
 import {render} from '@testing-library/react'
-import axe from 'axe-core'
-import type {LabelColorOptions} from '../Label'
-import Label, {variants} from '../Label'
+import Label from '../Label'
 
 describe('Label', () => {
   it('should support `className` on the outermost element', () => {
@@ -9,9 +8,8 @@ describe('Label', () => {
     expect(render(<Element />).container.firstChild).toHaveClass('test-class-name')
   })
   it('renders text node child', () => {
-    const container = render(<Label>Default</Label>)
-    const label = container.baseElement
-    expect(label.textContent).toEqual('Default')
+    const rendered = render(<Label>Default</Label>)
+    expect(rendered.container.textContent).toEqual('Default')
   })
   it('default size is rendered as "small"', () => {
     const {getByText} = render(<Label>Default</Label>)
@@ -23,12 +21,5 @@ describe('Label', () => {
     const {getByText} = render(<Label>Default</Label>)
 
     expect(getByText('Default')).toHaveAttribute('data-variant', 'default')
-  })
-  it('should have no axe violations', async () => {
-    for (const variant in variants) {
-      const {container} = render(<Label variant={variant as LabelColorOptions}>Default</Label>)
-      const results = await axe.run(container)
-      expect(results).toHaveNoViolations()
-    }
   })
 })

--- a/packages/react/vitest.config.browser.mts
+++ b/packages/react/vitest.config.browser.mts
@@ -46,6 +46,7 @@ export default defineConfig({
       'src/Flash/**/*.test.?(c|m)[jt]s?(x)',
       'src/FormControl/__tests__/FormControl.Validation.test.tsx',
       'src/InlineMessage/**/*.test.?(c|m)[jt]s?(x)',
+      'src/Label/**/*.test.?(c|m)[jt]s?(x)',
       'src/NavList/**/*.test.?(c|m)[jt]s?(x)',
       'src/Octicon/**/*.test.?(c|m)[jt]s?(x)',
       'src/Pagehead/**/*.test.?(c|m)[jt]s?(x)',


### PR DESCRIPTION
This PR migrates the `Label.test.tsx` file from Jest to Vitest.

