### PR TITLE
Add workflow_dispatch trigger to release_canary.yml

### DIFF
--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -5,6 +5,7 @@ on:
       - 'main'
       - 'next-major'
       - 'changeset-release/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Add `workflow_dispatch` to our canary release workflow. This should make it easier to test releases on PRs from forks or if we want to manually run this workflow against a specific branch.