### PR TITLE
Patch 37.28.1

### DIFF
--- a/.changeset/hungry-elephants-develop.md
+++ b/.changeset/hungry-elephants-develop.md
@@ -1,5 +1,0 @@
----
-"@primer/react": patch
----
-
-Fixing an issue where hovering the TabNav will give the tabs outlines. 

--- a/.changeset/hungry-elephants-develop.md
+++ b/.changeset/hungry-elephants-develop.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Fixing an issue where hovering the TabNav will give the tabs outlines. 

--- a/examples/codesandbox/package.json
+++ b/examples/codesandbox/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.3.1",
     "@vitejs/plugin-react": "^4.3.3",
-    "@primer/react": "37.28.0",
+    "@primer/react": "37.28.1",
     "eslint": "^9.30.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@primer/react": "37.28.0",
+    "@primer/react": "37.28.1",
     "next": "^15.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/theming/package.json
+++ b/examples/theming/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@primer/octicons-react": "^19.14.0",
-    "@primer/react": "37.28.0",
+    "@primer/react": "37.28.1",
     "clsx": "^2.1.1",
     "next": "^14.2.30",
     "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "37.27.0",
+        "@primer/react": "37.28.1",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
@@ -446,7 +446,7 @@
       "name": "example-nextjs",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "37.27.0",
+        "@primer/react": "37.28.1",
         "next": "^15.2.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -631,7 +631,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.14.0",
-        "@primer/react": "37.27.0",
+        "@primer/react": "37.28.1",
         "clsx": "^2.1.1",
         "next": "^14.2.30",
         "react": "^18.3.1",
@@ -31499,7 +31499,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "37.27.0",
+      "version": "37.28.1",
       "license": "MIT",
       "dependencies": {
         "@github/relative-time-element": "^4.4.5",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @primer/react
 
+## 37.28.1
+
+### Patch Changes
+
+- [`1d3aba0`](https://github.com/primer/react/commit/1d3aba0b1f93a880cc274e53d025ea2287b9fcd9) Thanks [@jonrohan](https://github.com/jonrohan)! - Fixing an issue where hovering the TabNav will give the tabs outlines.
+
 ## 37.28.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/react",
-  "version": "37.28.0",
+  "version": "37.28.1",
   "description": "An implementation of GitHub's Primer Design System using React",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",

--- a/packages/react/src/TabNav/TabNav.module.css
+++ b/packages/react/src/TabNav/TabNav.module.css
@@ -21,9 +21,12 @@
   border: var(--borderWidth-thin) solid transparent;
   border-bottom: 0;
 
-  &:hover,
-  &:focus {
+  &:hover {
     color: var(--fgColor-default);
+    text-decoration: none;
+  }
+
+  &:focus {
     text-decoration: none;
 
     @mixin focusOutline -6px;


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

v37.28.0 introduced some visual regressions to TabNav, this pulls [the fix](https://github.com/primer/react/pull/6315) into a new patch release,.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

#### New

<!-- List of things added in this PR -->
- v37.28.0 + new PR fix
- Update versions to v37.28.1


### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
