### PR TITLE
chore: sync with v37.28.1

### DIFF
--- a/.changeset/hungry-elephants-develop.md
+++ b/.changeset/hungry-elephants-develop.md
@@ -1,5 +1,0 @@
----
-"@primer/react": patch
----
-
-Fixing an issue where hovering the TabNav will give the tabs outlines. 

--- a/examples/codesandbox/package.json
+++ b/examples/codesandbox/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.3.1",
     "@vitejs/plugin-react": "^4.3.3",
-    "@primer/react": "37.28.0",
+    "@primer/react": "37.28.1",
     "eslint": "^9.30.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@primer/react": "37.28.0",
+    "@primer/react": "37.28.1",
     "next": "^15.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/theming/package.json
+++ b/examples/theming/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@primer/octicons-react": "^19.14.0",
-    "@primer/react": "37.28.0",
+    "@primer/react": "37.28.1",
     "clsx": "^2.1.1",
     "next": "^14.2.30",
     "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "37.27.0",
+        "@primer/react": "37.28.1",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
@@ -446,7 +446,7 @@
       "name": "example-nextjs",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "37.27.0",
+        "@primer/react": "37.28.1",
         "next": "^15.2.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -631,7 +631,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.14.0",
-        "@primer/react": "37.27.0",
+        "@primer/react": "37.28.1",
         "clsx": "^2.1.1",
         "next": "^14.2.30",
         "react": "^18.3.1",
@@ -31499,7 +31499,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "37.27.0",
+      "version": "37.28.1",
       "license": "MIT",
       "dependencies": {
         "@github/relative-time-element": "^4.4.5",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @primer/react
 
+## 37.28.1
+
+### Patch Changes
+
+- [`1d3aba0`](https://github.com/primer/react/commit/1d3aba0b1f93a880cc274e53d025ea2287b9fcd9) Thanks [@jonrohan](https://github.com/jonrohan)! - Fixing an issue where hovering the TabNav will give the tabs outlines.
+
 ## 37.28.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/react",
-  "version": "37.28.0",
+  "version": "37.28.1",
   "description": "An implementation of GitHub's Primer Design System using React",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",


### PR DESCRIPTION
[Manually released v37.28.1](https://github.com/primer/react/pull/6316), submitting version changes to main