### PR TITLE
refactor: move typed-css-modules to build step in react package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
         "rimraf": "5.0.5",
         "size-limit": "11.2.0",
         "stylelint": "16.20.0",
-        "typed-css-modules": "0.9.1",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.33.0",
         "vitest": "^3.2.0"
@@ -31680,6 +31679,7 @@
         "terser": "5.36.0",
         "ts-toolbelt": "9.6.0",
         "tsx": "4.20.3",
+        "typed-css-modules": "^0.9.1",
         "typescript": "^5.8.2",
         "typescript-plugin-css-modules": "5.1.0",
         "unist-util-find": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,9 @@
     "test:update": "npm run test -- --updateSnapshot",
     "test:watch": "npm run test -- --watch",
     "test:coverage": "npm run test -- --coverage",
-    "test:type-check": "npm run type-css-modules && tsc --noEmit",
+    "test:type-check": "tsc --noEmit",
     "vitest:update": "vitest -u",
-    "type-check": "npm run type-css-modules && tsc --noEmit && npm run type-check -ws --if-present",
-    "type-css-modules": "tcm -p **/packages/react/src/**/*.module.css",
+    "type-check": "tsc --noEmit && npm run type-check -ws --if-present",
     "release": "npm run build && changeset publish",
     "reset": "script/reset",
     "size": "size-limit"
@@ -88,7 +87,6 @@
     "rimraf": "5.0.5",
     "size-limit": "11.2.0",
     "stylelint": "16.20.0",
-    "typed-css-modules": "0.9.1",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.33.0",
     "vitest": "^3.2.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,7 +48,8 @@
     "build:hooks.json": "tsx script/hooks-json/build.ts",
     "build:precompile-color-schemes": "tsx script/precompile-color-schemes.ts",
     "storybook": "storybook",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "type-css-modules": "tcm -p **/packages/react/src/**/*.module.css"
   },
   "repository": "primer/react",
   "keywords": [
@@ -205,6 +206,7 @@
     "terser": "5.36.0",
     "ts-toolbelt": "9.6.0",
     "tsx": "4.20.3",
+    "typed-css-modules": "^0.9.1",
     "typescript": "^5.8.2",
     "typescript-plugin-css-modules": "5.1.0",
     "unist-util-find": "3.0.0",
@@ -233,3 +235,4 @@
     }
   }
 }
+

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,7 +49,7 @@
     "build:precompile-color-schemes": "tsx script/precompile-color-schemes.ts",
     "storybook": "storybook",
     "type-check": "tsc --noEmit",
-    "type-css-modules": "tcm -p **/packages/react/src/**/*.module.css"
+    "type-css-modules": "tcm -p src/**/*.module.css"
   },
   "repository": "primer/react",
   "keywords": [

--- a/packages/react/script/build
+++ b/packages/react/script/build
@@ -8,6 +8,9 @@ npm run clean
 # Generate color schemes
 npm run build:precompile-color-schemes
 
+# Generate types for CSS Modules
+npm run type-css-modules
+
 # Bundle
 npx rollup -c
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Small update so that the `typed-css-modules` dependency is added to the build step of `packages/react` so that things like our reset script work as expected.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Move `typed-css-modules` to `packages/react`
- Add `type-css-modules` script to build step of `packages/react` 

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why
