### PR TITLE
Add action and icon prop to `SelectPanel` message

### DIFF
--- a/.changeset/sharp-buckets-study.md
+++ b/.changeset/sharp-buckets-study.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Adds `icon` and `action` props to `SelectPanelMessage` to improve UX and accessibility.

--- a/packages/react/src/SelectPanel/SelectPanel.docs.json
+++ b/packages/react/src/SelectPanel/SelectPanel.docs.json
@@ -163,7 +163,7 @@
     },
     {
       "name": "message",
-      "type": "{title: string | React.ReactElement; variant: 'empty' | 'error' | 'warning';  body: React.ReactNode;}",
+      "type": "{title: string | React.ReactElement; variant: 'empty' | 'error' | 'warning';  body: React.ReactNode; icon?:React.ComponentType<IconProps>;action?: React.ReactElement;}",
       "defaultValue": "A default empty message is provided by default if this option is not supplied",
       "description": "Message to display in the panel in case of error or empty results"
     },

--- a/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useRef} from 'react'
+import React, {useState, useRef, useEffect} from 'react'
 import type {Meta, StoryObj} from '@storybook/react-vite'
 import Box from '../Box'
 import {Button} from '../Button'
@@ -11,12 +11,15 @@ import {
   GearIcon,
   InfoIcon,
   NoteIcon,
+  PlusIcon,
   ProjectIcon,
   SearchIcon,
   StopIcon,
+  TagIcon,
   TriangleDownIcon,
   TypographyIcon,
   VersionsIcon,
+  type IconProps,
 } from '@primer/octicons-react'
 import useSafeTimeout from '../hooks/useSafeTimeout'
 import ToggleSwitch from '../ToggleSwitch'
@@ -24,6 +27,7 @@ import Text from '../Text'
 import FormControl from '../FormControl'
 import {SegmentedControl} from '../SegmentedControl'
 import {Stack} from '../Stack'
+import {FeatureFlags} from '../FeatureFlags'
 
 const meta: Meta<typeof SelectPanel> = {
   title: 'Components/SelectPanel/Features',
@@ -882,5 +886,102 @@ export const WithInactiveItems = () => {
         message={filteredItems.length === 0 ? NoResultsMessage(filter) : undefined}
       />
     </FormControl>
+  )
+}
+
+export const WithMessage = () => {
+  const [selected, setSelected] = useState<ItemInput[]>([])
+  const [filter, setFilter] = useState('')
+  const [open, setOpen] = useState(false)
+  const [messageVariant, setMessageVariant] = useState(0)
+
+  const messageVariants: Array<
+    | undefined
+    | {
+        title: string
+        body: string | React.ReactElement
+        variant: 'empty' | 'error' | 'warning'
+        icon?: React.ComponentType<IconProps>
+        action?: React.ReactElement
+      }
+  > = [
+    undefined, // Default message
+    {
+      variant: 'empty',
+      title: 'No labels found',
+      body: 'Try adjusting your search or create a new label',
+      icon: TagIcon,
+      action: (
+        <Button variant="default" size="small" leadingVisual={PlusIcon} onClick={() => {}}>
+          Create new label
+        </Button>
+      ),
+    },
+    {
+      variant: 'error',
+      title: 'Failed to load labels',
+      body: (
+        <>
+          Check your network connection and try again or <Link href="/support">contact support</Link>
+        </>
+      ),
+    },
+    {
+      variant: 'warning',
+      title: 'Some labels may be outdated',
+      body: 'Consider refreshing to get the latest data',
+    },
+  ]
+
+  const itemsToShow = messageVariant === 0 ? items.slice(0, 3) : []
+  const filteredItems = itemsToShow.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
+
+  useEffect(() => {
+    setFilter('')
+  }, [messageVariant])
+
+  return (
+    <FeatureFlags flags={{primer_react_select_panel_with_modern_action_list: true}}>
+      <Stack align="start">
+        <FormControl>
+          <FormControl.Label>Message variant</FormControl.Label>
+          <SegmentedControl aria-label="Message variant" onChange={setMessageVariant}>
+            <SegmentedControl.Button defaultSelected aria-label="default message">
+              Default message
+            </SegmentedControl.Button>
+            <SegmentedControl.Button aria-label="Empty" leadingIcon={SearchIcon}>
+              Empty
+            </SegmentedControl.Button>
+            <SegmentedControl.Button aria-label="Error" leadingIcon={StopIcon}>
+              Error
+            </SegmentedControl.Button>
+            <SegmentedControl.Button aria-label="Warning" leadingIcon={AlertIcon}>
+              Warning
+            </SegmentedControl.Button>
+          </SegmentedControl>
+        </FormControl>
+        <FormControl>
+          <FormControl.Label>SelectPanel with message</FormControl.Label>
+          <SelectPanel
+            renderAnchor={({children, ...anchorProps}) => (
+              <Button trailingAction={TriangleDownIcon} {...anchorProps}>
+                {children}
+              </Button>
+            )}
+            placeholder="Select labels"
+            open={open}
+            onOpenChange={setOpen}
+            items={filteredItems}
+            selected={selected}
+            onSelectedChange={setSelected}
+            onFilterChange={setFilter}
+            overlayProps={{width: 'small', height: 'medium'}}
+            width="medium"
+            message={messageVariants[messageVariant]}
+            filterValue={filter}
+          />
+        </FormControl>
+      </Stack>
+    </FeatureFlags>
   )
 }

--- a/packages/react/src/SelectPanel/SelectPanel.module.css
+++ b/packages/react/src/SelectPanel/SelectPanel.module.css
@@ -30,7 +30,8 @@
 }
 
 .Wrapper[data-variant='modal'] .Title {
-  margin-top: var(--base-size-8); /* styling specific to the modal variant */
+  margin-top: var(--base-size-8);
+  /* styling specific to the modal variant */
 }
 
 .Subtitle {
@@ -126,6 +127,10 @@
   &:where([data-variant='error']) {
     color: var(--fgColor-danger);
   }
+}
+
+.MessageAction {
+  margin-top: var(--base-size-8);
 }
 
 .ResponsiveCloseButton {

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -1,4 +1,12 @@
-import {AlertIcon, InfoIcon, SearchIcon, StopIcon, TriangleDownIcon, XIcon} from '@primer/octicons-react'
+import {
+  AlertIcon,
+  InfoIcon,
+  SearchIcon,
+  StopIcon,
+  TriangleDownIcon,
+  XIcon,
+  type IconProps,
+} from '@primer/octicons-react'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import type {AnchoredOverlayProps} from '../AnchoredOverlay'
 import {AnchoredOverlay} from '../AnchoredOverlay'
@@ -94,6 +102,8 @@ interface SelectPanelBaseProps {
     title: string
     body: string | React.ReactElement
     variant: 'empty' | 'error' | 'warning'
+    icon?: React.ComponentType<IconProps>
+    action?: React.ReactElement
   }
   /**
    * @deprecated Use `secondaryAction` instead.
@@ -640,7 +650,7 @@ function Panel({
       return DefaultEmptyMessage
     } else if (message) {
       return (
-        <SelectPanelMessage title={message.title} variant={message.variant}>
+        <SelectPanelMessage title={message.title} variant={message.variant} icon={message.icon} action={message.action}>
           {message.body}
         </SelectPanelMessage>
       )

--- a/packages/react/src/SelectPanel/SelectPanelMessage.tsx
+++ b/packages/react/src/SelectPanel/SelectPanelMessage.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import Text from '../Text'
 import Octicon from '../Octicon'
-import {AlertIcon} from '@primer/octicons-react'
+import {AlertIcon, NoEntryIcon, type IconProps} from '@primer/octicons-react'
 import classes from './SelectPanel.module.css'
 import {clsx} from 'clsx'
 
@@ -10,14 +10,30 @@ export type SelectPanelMessageProps = {
   title: string
   variant: 'empty' | 'error' | 'warning'
   className?: string
+  /**
+   * Custom icon to display above the title.
+   * When not provided, uses NoEntryIcon for empty states and AlertIcon for error/warning states.
+   */
+  icon?: React.ComponentType<IconProps>
+  action?: React.ReactElement
 }
 
-export const SelectPanelMessage: React.FC<SelectPanelMessageProps> = ({variant, title, children, className}) => {
+export const SelectPanelMessage: React.FC<SelectPanelMessageProps> = ({
+  variant,
+  title,
+  children,
+  className,
+  icon: CustomIcon,
+  action,
+}) => {
+  const IconComponent = CustomIcon || (variant === 'empty' ? NoEntryIcon : AlertIcon)
+
   return (
     <div className={clsx(classes.Message, className)}>
-      {variant !== 'empty' ? <Octicon icon={AlertIcon} className={classes.MessageIcon} data-variant={variant} /> : null}
+      <Octicon icon={IconComponent} className={classes.MessageIcon} data-variant={variant} />
       <Text className={classes.MessageTitle}>{title}</Text>
       <Text className={classes.MessageBody}>{children}</Text>
+      {action && <div className={classes.MessageAction}>{action}</div>}
     </div>
   )
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes [#5362](https://github.com/github/primer/issues/5362)

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

Adds optional `icon` and `action` props to `SelectPanelMessage` to improve UX and accessibility. The `icon` prop allows custom icons for all message variants, the icon will be above the title. The `action` prop addresses the accessibility issue where "Create new item" actions were being rendered as `ActionList.Item` components, causing screen readers to announce them as selectable list items.

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->
 
- `SelectPanelMessage` now accepts `icon?: React.ComponentType<IconProps>` prop for custom icons above the title
- `SelectPanelMessage` now accepts `action?: React.ReactElement` prop for action buttons
 
#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [X] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [X] Added/updated tests
- [X] Added/updated documentation
- [X] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
