### PR TITLE
Update AnchoredOverlay.features.stories.tsx stories to no longer use styled-components

### DIFF
--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.module.css
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.module.css
@@ -1,0 +1,60 @@
+.HeaderAndLayout {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: var(--base-size-24);
+  width: 100%;
+}
+
+.ScrollingRegion {
+  position: absolute;
+  inset: 96px 24px 24px;
+  overflow: scroll;
+  /* stylelint-disable-next-line color-named */
+  background-color: powderblue;
+}
+
+.PortalRootRegion {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.FlexColFill {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.PlaygroundCell {
+  margin: var(--base-size-8);
+}
+
+.Overlay {
+  min-width: 320px;
+}
+
+.UserName {
+  font-weight: var(--base-text-weight-medium, 500);
+  color: var(--fgColor-default);
+}
+
+.UserMeta {
+  color: var(--fgColor-muted);
+  margin-left: var(--base-size-4);
+}
+
+.Bio {
+  font-size: var(--text-body-size-medium);
+  line-height: var(--text-body-lineHeight-medium);
+}
+
+.MetaMuted {
+  font-size: var(--text-body-size-small);
+  line-height: var(--text-body-lineHeight-small);
+  color: var(--fgColor-muted);
+  margin-left: var(--base-size-4);
+}

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
@@ -11,7 +11,7 @@ import {Playground} from './AnchoredOverlay.stories'
 import {LocationIcon, RepoIcon} from '@primer/octicons-react'
 import {Stack} from '../Stack/Stack'
 import classes from './AnchoredOverlay.features.stories.module.css'
-import clsx from 'clsx'
+import {clsx} from 'clsx'
 
 export default {
   title: 'Components/AnchoredOverlay/Features',

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
@@ -333,7 +333,7 @@ export const OverlayPropsOverrides = () => {
         role: 'dialog',
         'aria-modal': true,
         'aria-label': 'User Card Overlay',
-        className: clsx(classes.Overlay, classes.OverlayAutoScroll),
+        className: classes.Overlay,
       }}
       focusZoneSettings={{disabled: true}}
       preventOverflow={false}

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
@@ -1,8 +1,7 @@
 import {useEffect, useRef, useState} from 'react'
 import type {Args, Meta} from '@storybook/react-vite'
 import {FocusKeys} from '@primer/behaviors'
-
-import {Avatar, Box, Link, Text} from '..'
+import {Avatar, Link} from '..'
 import {AnchoredOverlay} from '../AnchoredOverlay'
 import Heading from '../Heading'
 import Octicon from '../Octicon'
@@ -11,6 +10,8 @@ import {registerPortalRoot} from '../Portal'
 import {Playground} from './AnchoredOverlay.stories'
 import {LocationIcon, RepoIcon} from '@primer/octicons-react'
 import {Stack} from '../Stack/Stack'
+import classes from './AnchoredOverlay.features.stories.module.css'
+import clsx from 'clsx'
 
 export default {
   title: 'Components/AnchoredOverlay/Features',
@@ -24,25 +25,23 @@ const hoverCard = (
       <Button size="small">Follow</Button>
     </Stack>
     <Stack direction="horizontal" gap="none">
-      <Text weight="medium">monalisa</Text>
-      <Text color={'var(--fgColor-muted)'} ml={1}>
+      <span className={classes.UserName}>monalisa</span>
+      <span className={classes.UserMeta}>
         <Link inline muted href="#">
           Monalisa Octocat
         </Link>
-      </Text>
+      </span>
     </Stack>
-    <Text size="medium">Former beach cat and champion swimmer. Now your friendly octapus with a normal face.</Text>
+    <span className={classes.Bio}>
+      Former beach cat and champion swimmer. Now your friendly octopus with a normal face.
+    </span>
     <Stack direction="horizontal" gap="none">
       <Octicon color={'var(--fgColor-muted)'} icon={LocationIcon} />
-      <Text size="small" color={'var(--fgColor-muted)'} ml={1}>
-        Interwebs
-      </Text>
+      <span className={classes.MetaMuted}>Interwebs</span>
     </Stack>
     <Stack direction="horizontal" gap="none">
       <Octicon color={'var(--fgColor-muted)'} icon={RepoIcon} />
-      <Text size="small" color={'var(--fgColor-muted)'} ml={1}>
-        Owns this repository
-      </Text>
+      <span className={classes.MetaMuted}>Owns this repository</span>
     </Stack>
   </Stack>
 )
@@ -55,13 +54,13 @@ const HeaderAndLayout = ({children}: {children: JSX.Element}) => {
     }
   }, [scrollingElementRef])
   return (
-    <Box position="absolute" top={0} right={0} bottom={0} left={0} padding={4}>
+    <div className={classes.HeaderAndLayout}>
       <Heading>Header or some such</Heading>
-      <Box position="absolute" top={10} right={4} bottom={4} left={4} overflow="scroll" backgroundColor="powderblue">
+      <div className={classes.ScrollingRegion}>
         {children}
-        <Box ref={scrollingElementRef} position="absolute" top={0} left={0} />
-      </Box>
-    </Box>
+        <div ref={scrollingElementRef} className={classes.PortalRootRegion} />
+      </div>
+    </div>
   )
 }
 
@@ -80,9 +79,9 @@ export const PortalInsideScrollingElement = (args: Args) => {
                   .fill(null)
                   .map((_1, j) => (
                     <td key={`${i}${j}`}>
-                      <Box m={2}>
+                      <div className={classes.PlaygroundCell}>
                         <Playground {...{...args, portalContainerName: 'scrollingPortal'}} />
-                      </Box>
+                      </div>
                     </td>
                   ))}
               </tr>
@@ -103,11 +102,16 @@ export const CustomAnchorId = () => {
       onClose={() => setOpen(false)}
       renderAnchor={props => <Button {...props}>Button</Button>}
       anchorId="my-custom-anchor-id"
-      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'User Card Overlay', sx: {minWidth: '320px'}}}
+      overlayProps={{
+        role: 'dialog',
+        'aria-modal': true,
+        'aria-label': 'User Card Overlay',
+        className: classes.Overlay,
+      }}
       focusZoneSettings={{disabled: true}}
       preventOverflow={false}
     >
-      <Box sx={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column'}}>{hoverCard}</Box>
+      <div className={classes.FlexColFill}>{hoverCard}</div>
     </AnchoredOverlay>
   )
 }
@@ -122,11 +126,16 @@ export const Height = () => {
       onClose={() => setOpen(false)}
       renderAnchor={props => <Button {...props}>Button</Button>}
       height="large"
-      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'User Card Overlay', sx: {minWidth: '320px'}}}
+      overlayProps={{
+        role: 'dialog',
+        'aria-modal': true,
+        'aria-label': 'User Card Overlay',
+        className: classes.Overlay,
+      }}
       focusZoneSettings={{disabled: true}}
       preventOverflow={false}
     >
-      <Box sx={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column'}}>{hoverCard}</Box>
+      <div className={classes.FlexColFill}>{hoverCard}</div>
     </AnchoredOverlay>
   )
 }
@@ -141,20 +150,16 @@ export const Width = () => {
       onClose={() => setOpen(false)}
       renderAnchor={props => <Button {...props}>Button</Button>}
       width="large"
-      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'User Card Overlay', sx: {minWidth: '320px'}}}
+      overlayProps={{
+        role: 'dialog',
+        'aria-modal': true,
+        'aria-label': 'User Card Overlay',
+        className: classes.Overlay,
+      }}
       focusZoneSettings={{disabled: true}}
       preventOverflow={false}
     >
-      <Box
-        sx={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-        }}
-      >
-        {hoverCard}
-      </Box>
+      <div className={classes.FlexColFill}>{hoverCard}</div>
     </AnchoredOverlay>
   )
 }
@@ -173,11 +178,16 @@ export const AnchorAlignment = () => {
         </Button>
       )}
       align="center"
-      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'User Card Overlay', sx: {minWidth: '320px'}}}
+      overlayProps={{
+        role: 'dialog',
+        'aria-modal': true,
+        'aria-label': 'User Card Overlay',
+        className: classes.Overlay,
+      }}
       focusZoneSettings={{disabled: true}}
       preventOverflow={false}
     >
-      <Box sx={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column'}}>{hoverCard}</Box>
+      <div className={classes.FlexColFill}>{hoverCard}</div>
     </AnchoredOverlay>
   )
 }
@@ -192,11 +202,16 @@ export const AnchorSide = () => {
       onClose={() => setOpen(false)}
       renderAnchor={props => <Button {...props}>Button</Button>}
       side="outside-right"
-      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'User Card Overlay', sx: {minWidth: '320px'}}}
+      overlayProps={{
+        role: 'dialog',
+        'aria-modal': true,
+        'aria-label': 'User Card Overlay',
+        className: classes.Overlay,
+      }}
       focusZoneSettings={{disabled: true}}
       preventOverflow={false}
     >
-      <Box sx={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column'}}>{hoverCard}</Box>
+      <div className={classes.FlexColFill}>{hoverCard}</div>
     </AnchoredOverlay>
   )
 }
@@ -211,11 +226,16 @@ export const OffsetPositionFromAnchor = () => {
       onClose={() => setOpen(false)}
       renderAnchor={props => <Button {...props}>Button</Button>}
       anchorOffset={100}
-      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'User Card Overlay', sx: {minWidth: '320px'}}}
+      overlayProps={{
+        role: 'dialog',
+        'aria-modal': true,
+        'aria-label': 'User Card Overlay',
+        className: classes.Overlay,
+      }}
       focusZoneSettings={{disabled: true}}
       preventOverflow={false}
     >
-      <Box sx={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column'}}>{hoverCard}</Box>
+      <div className={classes.FlexColFill}>{hoverCard}</div>
     </AnchoredOverlay>
   )
 }
@@ -230,11 +250,16 @@ export const OffsetAlignmentFromAnchor = () => {
       onClose={() => setOpen(false)}
       renderAnchor={props => <Button {...props}>Button</Button>}
       alignmentOffset={100}
-      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'User Card Overlay', sx: {minWidth: '320px'}}}
+      overlayProps={{
+        role: 'dialog',
+        'aria-modal': true,
+        'aria-label': 'User Card Overlay',
+        className: classes.Overlay,
+      }}
       focusZoneSettings={{disabled: true}}
       preventOverflow={false}
     >
-      <Box sx={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column'}}>{hoverCard}</Box>
+      <div className={classes.FlexColFill}>{hoverCard}</div>
     </AnchoredOverlay>
   )
 }
@@ -250,7 +275,12 @@ export const FocusTrapOverrides = () => {
       onClose={() => setOpen(false)}
       renderAnchor={props => <Button {...props}>Button</Button>}
       focusTrapSettings={{initialFocusRef}}
-      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'Focus Trap Demo Overlay'}}
+      overlayProps={{
+        role: 'dialog',
+        'aria-modal': true,
+        'aria-label': 'Focus Trap Demo Overlay',
+        className: classes.Overlay,
+      }}
       focusZoneSettings={{disabled: true}}
       preventOverflow={false}
     >
@@ -270,7 +300,12 @@ export const FocusZoneOverrides = () => {
       onClose={() => setOpen(false)}
       renderAnchor={props => <Button {...props}>Button</Button>}
       focusZoneSettings={{bindKeys: FocusKeys.JK}}
-      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'Focus Zone Demo Overlay'}}
+      overlayProps={{
+        role: 'dialog',
+        'aria-modal': true,
+        'aria-label': 'Focus Zone Demo Overlay',
+        className: classes.Overlay,
+      }}
       preventOverflow={false}
     >
       <p>
@@ -298,7 +333,7 @@ export const OverlayPropsOverrides = () => {
         role: 'dialog',
         'aria-modal': true,
         'aria-label': 'User Card Overlay',
-        sx: {minWidth: '320px'},
+        className: clsx(classes.Overlay, classes.OverlayAutoScroll),
       }}
       focusZoneSettings={{disabled: true}}
       preventOverflow={false}
@@ -308,7 +343,7 @@ export const OverlayPropsOverrides = () => {
         <li>overflow: `auto`</li>
         <li>maxHeight: `xsmall`</li>
       </pre>
-      <Box sx={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column'}}>{hoverCard}</Box>
+      <div className={classes.FlexColFill}>{hoverCard}</div>
     </AnchoredOverlay>
   )
 }

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.features.stories.tsx
@@ -11,7 +11,6 @@ import {Playground} from './AnchoredOverlay.stories'
 import {LocationIcon, RepoIcon} from '@primer/octicons-react'
 import {Stack} from '../Stack/Stack'
 import classes from './AnchoredOverlay.features.stories.module.css'
-import {clsx} from 'clsx'
 
 export default {
   title: 'Components/AnchoredOverlay/Features',


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5585

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

Added new CSS module

#### Changed

Changed `AnchoredOverlay.features.stories.tsx` to no longer use styled-components

#### Removed

Removed anything associated with styled-components

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
