### PR TITLE
Update AvatarStack.dev.stories.tsx to no longer use styled-components

### DIFF
--- a/e2e/components/AvatarStack.test.ts
+++ b/e2e/components/AvatarStack.test.ts
@@ -40,10 +40,6 @@ const stories: Array<{title: string; id: string}> = [
     id: 'components-avatarstack-features--custom-size-on-children-responsive',
   },
   {
-    title: 'SX Prop',
-    id: 'components-avatarstack-dev--sx-prop',
-  },
-  {
     title: 'With Link Wrappers',
     id: 'components-avatarstack-dev--with-link-wrappers',
   },

--- a/packages/react/src/AvatarStack/AvatarStack.dev.stories.tsx
+++ b/packages/react/src/AvatarStack/AvatarStack.dev.stories.tsx
@@ -8,20 +8,6 @@ export default {
   component: AvatarStack,
 } as Meta<typeof AvatarStack>
 
-export const SxProp = () => (
-  <AvatarStack
-    alignRight
-    sx={{
-      backgroundColor: 'red',
-    }}
-  >
-    <Avatar alt="Primer logo" src="https://avatars.githubusercontent.com/primer" />
-    <Avatar alt="GitHub logo" src="https://avatars.githubusercontent.com/github" />
-    <Avatar alt="Atom logo" src="https://avatars.githubusercontent.com/atom" />
-    <Avatar alt="GitHub Desktop logo" src="https://avatars.githubusercontent.com/desktop" />
-  </AvatarStack>
-)
-
 export const WithLinkWrappers = () => (
   <AvatarStack>
     <Link aria-label="Primer is assigned" href="#" className="pc-AvatarItem" data-hovercard-url="/primer">


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes [https://github.com/github/primer/issues/5561](https://github.com/github/primer/issues/5590)](https://github.com/github/primer/issues/5591)

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

Changed `AvatarStack.dev.stories.tsx` to no longer use styled-components

#### Removed

Removed the `Sx Prop` story for `AvatarStack` because it no longer has a purpose after removal of `sx` prop

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
