### PR TITLE
Update AvatarToken.stories.tsx to no longer use styled-components

### DIFF
--- a/packages/react/src/Token/AvatarToken.stories.module.css
+++ b/packages/react/src/Token/AvatarToken.stories.module.css
@@ -1,0 +1,19 @@
+.SingleExampleContainer {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 0;
+}
+
+.ExampleCollectionContainer {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: var(--base-size-40);
+}
+
+.InteractiveRow {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--base-size-8);
+}

--- a/packages/react/src/Token/AvatarToken.stories.tsx
+++ b/packages/react/src/Token/AvatarToken.stories.tsx
@@ -1,13 +1,11 @@
 import type React from 'react'
 import type {Meta} from '@storybook/react-vite'
 import {action} from 'storybook/actions'
-
-import {get} from '../constants'
 import {BaseStyles, ThemeProvider} from '..'
-import Box from '../Box'
-import type {AvatarTokenProps} from './AvatarToken'
 import AvatarToken from './AvatarToken'
+import type {AvatarTokenProps} from './AvatarToken'
 import Text from '../Text'
+import classes from './AvatarToken.stories.module.css'
 
 export default {
   title: 'Components/AvatarToken',
@@ -32,37 +30,23 @@ export default {
 const excludedControlKeys = ['id', 'as', 'tabIndex', 'onRemove']
 
 const SingleExampleContainer: React.FC<React.PropsWithChildren<{label?: string}>> = ({children, label}) => (
-  <Box
-    display="flex"
-    sx={{
-      alignItems: 'start',
-      flexDirection: 'column',
-      gap: get('space.0'),
-    }}
-  >
+  <div className={classes.SingleExampleContainer}>
     {label ? (
       <Text fontSize={0} color="fg.muted">
         {label}
       </Text>
     ) : null}
     {children}
-  </Box>
+  </div>
 )
 
 const ExampleCollectionContainer: React.FC<React.PropsWithChildren<unknown>> = ({children}) => (
-  <Box
-    display="flex"
-    sx={{
-      alignItems: 'start',
-      flexDirection: 'column',
-      gap: get('space.6'),
-    }}
-  >
+  <div className={classes.ExampleCollectionContainer}>
     <Text fontSize={1} color="fg.subtle">
       Hint: use the &quot;Controls&quot; tab in the Addons panel to change the token properties
     </Text>
     {children}
-  </Box>
+  </div>
 )
 
 export const DefaultToken = (args: Omit<AvatarTokenProps, 'ref'>) => {
@@ -78,17 +62,11 @@ DefaultToken.parameters = {controls: {exclude: [...excludedControlKeys, 'hideRem
 export const Interactive = (args: Omit<AvatarTokenProps, 'ref' | 'text'>) => {
   return (
     <ExampleCollectionContainer>
-      <Box
-        display="flex"
-        sx={{
-          alignItems: 'start',
-          gap: get('space.2'),
-        }}
-      >
+      <div className={classes.InteractiveRow}>
         <AvatarToken as="a" href="http://google.com/" {...args} text="Link" />
         <AvatarToken as="button" onClick={action('clicked')} {...args} text="Button" />
         <AvatarToken as="span" tabIndex={0} onFocus={action('focused')} {...args} text="Focusable Span" />
-      </Box>
+      </div>
     </ExampleCollectionContainer>
   )
 }
@@ -101,13 +79,7 @@ export const WithOnRemoveFn = (args: Omit<AvatarTokenProps, 'ref'>) => {
         <AvatarToken onRemove={action('remove me')} {...args} />
       </SingleExampleContainer>
       <SingleExampleContainer label="w/ onRemove passed and the token is interactive">
-        <Box
-          display="flex"
-          sx={{
-            alignItems: 'start',
-            gap: get('space.2'),
-          }}
-        >
+        <div className={classes.InteractiveRow}>
           <AvatarToken as="a" href="http://google.com/" onRemove={action('remove me')} {...args} text="Link" />
           <AvatarToken as="button" onClick={action('clicked')} onRemove={action('remove me')} {...args} text="Button" />
           <AvatarToken
@@ -118,7 +90,7 @@ export const WithOnRemoveFn = (args: Omit<AvatarTokenProps, 'ref'>) => {
             {...args}
             text="Focusable Span"
           />
-        </Box>
+        </div>
       </SingleExampleContainer>
     </ExampleCollectionContainer>
   )


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5593

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

Added new CSS module

#### Changed

Changed `AvatarToken.stories.tsx` to no longer use styled-components

#### Removed

Removed anything associated with styled-components

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
