### PR TITLE
Update Button.dev.stories.tsx to no longer use styled-components

### DIFF
--- a/e2e/components/Button.test.ts
+++ b/e2e/components/Button.test.ts
@@ -76,10 +76,6 @@ const stories = [
     id: 'components-button-dev--invisible-variants',
   },
   {
-    title: 'Dev Sx Prop',
-    id: 'components-button-dev--test-sx-prop',
-  },
-  {
     title: 'Aria Expanded Buttons',
     id: 'components-button-features--expanded-button',
   },

--- a/packages/react/src/Button/Button.dev.stories.module.css
+++ b/packages/react/src/Button/Button.dev.stories.module.css
@@ -1,0 +1,5 @@
+.FlexRow {
+  display: flex;
+  flex-direction: row;
+  gap: var(--base-size-16);
+}

--- a/packages/react/src/Button/Button.dev.stories.tsx
+++ b/packages/react/src/Button/Button.dev.stories.tsx
@@ -2,6 +2,7 @@ import {SearchIcon, TriangleDownIcon, EyeIcon, IssueClosedIcon, HeartFillIcon} f
 import {Button, IconButton} from '.'
 import {default as Text} from '../Text'
 import {Stack} from '../Stack'
+import classes from './Button.dev.stories.module.css'
 
 export default {
   title: 'Components/Button/Dev',
@@ -10,7 +11,7 @@ export default {
 export const InvisibleVariants = () => {
   const count = 4
   return (
-    <div style={{display: 'flex', flexDirection: 'row', gap: '1rem'}}>
+    <div className={classes.FlexRow}>
       <Button variant="invisible">Button</Button>
       <Button variant="invisible" leadingVisual={SearchIcon}>
         Button
@@ -28,69 +29,6 @@ export const InvisibleVariants = () => {
         Button
       </Button>
       <IconButton icon={TriangleDownIcon} variant="invisible" aria-label="Invisible" />
-    </div>
-  )
-}
-
-export const TestSxProp = () => {
-  const count = 4
-  return (
-    <div style={{display: 'flex', flexDirection: 'row', gap: '1rem'}}>
-      <Button
-        size="medium"
-        sx={{
-          color: 'firebrick',
-          backgroundColor: '#F6F8FA',
-        }}
-      >
-        Medium Red
-      </Button>
-      <Button
-        size="small"
-        sx={{
-          ':hover': {
-            color: 'deepskyblue',
-          },
-          [`@media screen and (max-width: 768px)`]: {
-            color: 'maroon',
-            backgroundColor: '#F6F8FA',
-          },
-          '@media (min-width: 1440)': {
-            color: 'firebrick',
-            backgroundColor: '#F6F8FA',
-          },
-        }}
-      >
-        Red
-      </Button>
-      <Button variant="invisible" sx={{color: 'firebrick', backgroundColor: '#F6F8FA'}}>
-        Invariant color overridden
-      </Button>
-      <Button leadingVisual={IssueClosedIcon} sx={{color: 'done.fg'}}>
-        <Text sx={{color: 'fg.default'}}>Close issue</Text>
-      </Button>
-      <Button
-        size="small"
-        variant="invisible"
-        sx={{
-          width: 32,
-          height: 32,
-          '&:focus': {
-            outline: 0,
-            '& > span': {
-              boxShadow: `inset 0 0 0 2px deeppink`,
-            },
-          },
-        }}
-      >
-        Custom size
-      </Button>
-      <Button size="small" block variant="invisible" sx={{width: 320}}>
-        Overridden Block
-      </Button>
-      <Button sx={{fontSize: 32}} count={count}>
-        Watch
-      </Button>
     </div>
   )
 }

--- a/packages/react/src/Button/Button.dev.stories.tsx
+++ b/packages/react/src/Button/Button.dev.stories.tsx
@@ -1,6 +1,5 @@
-import {SearchIcon, TriangleDownIcon, EyeIcon, IssueClosedIcon, HeartFillIcon} from '@primer/octicons-react'
+import {SearchIcon, TriangleDownIcon, EyeIcon, HeartFillIcon} from '@primer/octicons-react'
 import {Button, IconButton} from '.'
-import {default as Text} from '../Text'
 import {Stack} from '../Stack'
 import classes from './Button.dev.stories.module.css'
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5594

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

Changed `Button.dev.stories.tsx` to no longer use styled-components

#### Removed

Removed the `Test Sx Prop` story for `Button` because it no longer has a purpose after removal of `sx` prop

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
