### PR TITLE
Update ConfirmationDialog.features.stories.tsx to no longer use styled-components

### DIFF
--- a/packages/react/src/ConfirmationDialog/ConfirmationDialog.features.stories.module.css
+++ b/packages/react/src/ConfirmationDialog/ConfirmationDialog.features.stories.module.css
@@ -1,0 +1,9 @@
+.ButtonContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.TurnGreenButton {
+  margin-bottom: var(--base-size-8);
+}

--- a/packages/react/src/ConfirmationDialog/ConfirmationDialog.features.stories.tsx
+++ b/packages/react/src/ConfirmationDialog/ConfirmationDialog.features.stories.tsx
@@ -1,11 +1,12 @@
 import type React from 'react'
 import {useState, useCallback} from 'react'
 import type {Meta} from '@storybook/react-vite'
-import {Box, useTheme} from '..'
+import {useTheme} from '..'
 import {Button} from '../Button'
 import {ActionMenu} from '../ActionMenu'
 import {ActionList} from '../ActionList'
 import {ConfirmationDialog, useConfirm} from './ConfirmationDialog'
+import classes from './ConfirmationDialog.features.stories.module.css'
 
 export default {
   title: 'Components/ConfirmationDialog/Features',
@@ -28,20 +29,20 @@ export const ShorthandHook = () => {
     [confirm, theme],
   )
   return (
-    <Box display="flex" flexDirection="column" alignItems="flex-start">
-      <Button onClick={onButtonClick} sx={{mb: 2}}>
+    <div className={classes.ButtonContainer}>
+      <Button onClick={onButtonClick} className={classes.TurnGreenButton}>
         Turn me green!
       </Button>
-      <Button onClick={onButtonClick} sx={{mb: 2}}>
+      <Button onClick={onButtonClick} className={classes.TurnGreenButton}>
         Turn me green!
       </Button>
-      <Button onClick={onButtonClick} sx={{mb: 2}}>
+      <Button onClick={onButtonClick} className={classes.TurnGreenButton}>
         Turn me green!
       </Button>
-      <Button onClick={onButtonClick} sx={{mb: 2}}>
+      <Button onClick={onButtonClick} className={classes.TurnGreenButton}>
         Turn me green!
       </Button>
-    </Box>
+    </div>
   )
 }
 
@@ -55,16 +56,15 @@ export const ShorthandHookFromActionMenu = () => {
   }, [confirm])
 
   return (
-    <Box display="flex" flexDirection="column" alignItems="flex-start">
+    <div className={classes.ButtonContainer}>
       <ActionMenu>
         <ActionMenu.Button>{text}</ActionMenu.Button>
-
         <ActionMenu.Overlay>
           <ActionList>
             <ActionList.Item onSelect={onButtonClick}>Do a trick!</ActionList.Item>
           </ActionList>
         </ActionMenu.Overlay>
       </ActionMenu>
-    </Box>
+    </div>
   )
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5600

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

Added new CSS module

#### Changed

Changed `ConfirmationDialog.features.stories.tsx` to no longer use styled-components

#### Removed

Removed anything associated with styled-components

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
