### PR TITLE
Update PageHeader.dev.stories.tsx to no longer use styled-components

### DIFF
--- a/packages/react/src/PageHeader/PageHeader.dev.stories.module.css
+++ b/packages/react/src/PageHeader/PageHeader.dev.stories.module.css
@@ -1,0 +1,7 @@
+.PaddingContainer {
+  padding: var(--base-size-16);
+}
+
+.LargeTitle {
+  font-size: var(--text-display-size);
+}

--- a/packages/react/src/PageHeader/PageHeader.dev.stories.tsx
+++ b/packages/react/src/PageHeader/PageHeader.dev.stories.tsx
@@ -1,9 +1,9 @@
 import type {Meta} from '@storybook/react-vite'
-import {Button, IconButton, Box} from '..'
+import {Button, IconButton} from '..'
 import Label from '../Label'
 import {GitBranchIcon, PencilIcon, SidebarExpandIcon} from '@primer/octicons-react'
-
 import {PageHeader} from './PageHeader'
+import classes from './PageHeader.dev.stories.module.css'
 
 const meta: Meta<typeof PageHeader> = {
   title: 'Components/PageHeader/Dev',
@@ -16,7 +16,7 @@ const meta: Meta<typeof PageHeader> = {
 export default meta
 
 export const LargeVariantWithMultilineTitle = () => (
-  <Box sx={{padding: 3}}>
+  <div className={classes.PaddingContainer}>
     <PageHeader
       role="banner"
       aria-label="Title long title some extra loooong looong words here some extra loooong looong words here some extra loooong
@@ -44,55 +44,15 @@ export const LargeVariantWithMultilineTitle = () => (
         <Button variant="primary">Add Item</Button>
       </PageHeader.Actions>
     </PageHeader>
-  </Box>
+  </div>
 )
 
-export const ArrayTypeFontSizeOnTitle = () => (
-  <Box sx={{padding: 3}}>
+export const FontSizeOnTitle = () => (
+  <div className={classes.PaddingContainer}>
     <PageHeader role="banner" aria-label="Issue Title">
       <PageHeader.TitleArea>
-        <PageHeader.Title
-          sx={{
-            lineHeight: '1.25',
-            fontWeight: 'normal',
-            fontSize: ['26px', '26px', 'var(--text-title-size-large, 32px)', 'var(--text-title-size-large, 32px)'], // it doesn't support this format right now.
-          }}
-        >
-          Issue Title
-        </PageHeader.Title>
+        <PageHeader.Title className={classes.LargeTitle}>Issue Title</PageHeader.Title>
       </PageHeader.TitleArea>
     </PageHeader>
-  </Box>
-)
-
-export const ThemeBaseFontSizeOnTitle = () => (
-  <Box sx={{padding: 3}}>
-    <PageHeader role="banner" aria-label="Issue Title">
-      <PageHeader.TitleArea>
-        <PageHeader.Title
-          sx={{
-            fontSize: 8,
-          }}
-        >
-          Issue Title
-        </PageHeader.Title>
-      </PageHeader.TitleArea>
-    </PageHeader>
-  </Box>
-)
-
-export const StringTypeFontSizeOnTitle = () => (
-  <Box sx={{padding: 3}}>
-    <PageHeader role="banner" aria-label="Issue Title">
-      <PageHeader.TitleArea>
-        <PageHeader.Title
-          sx={{
-            fontSize: '56px',
-          }}
-        >
-          Issue Title
-        </PageHeader.Title>
-      </PageHeader.TitleArea>
-    </PageHeader>
-  </Box>
+  </div>
 )


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5609

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

Added new CSS module

#### Changed

Changed `PageHeader.dev.stories.tsx` to no longer use styled-components

#### Removed

Removed a couple of stories that only had a purpose when `sx` prop was being used

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
