### PR TITLE
Update Popover.dev.stories.tsx to no longer use styled-components

### DIFF
--- a/packages/react/src/Popover/Popover.dev.stories.tsx
+++ b/packages/react/src/Popover/Popover.dev.stories.tsx
@@ -9,33 +9,6 @@ export default {
   component: Popover,
 } as Meta<typeof Popover>
 
-export const SxProps = () => (
-  <Popover
-    relative
-    open={true}
-    caret="top-right"
-    sx={{
-      left: '50%',
-      transform: 'translateX(-50%)',
-      mt: 2,
-      color: 'var(--bgColor-danger-muted)',
-    }}
-    style={{padding: '16px'}}
-  >
-    <Popover.Content
-      sx={{
-        minWidth: '260px',
-        width: '40%',
-      }}
-      style={{padding: '32px'}}
-    >
-      <Heading sx={{fontSize: 2}}>Popover heading</Heading>
-      <Text as="p">Message about popovers</Text>
-      <Button>Got it!</Button>
-    </Popover.Content>
-  </Popover>
-)
-
 export const PopoverOverflow = () => (
   <Popover relative open={true}>
     <Popover.Content height={'small'}>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5619

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

Changed `Popover.dev.stories.tsx` to no longer use styled-components

#### Removed

Removed `Sx Props` story from `Popover.dev.stories.tsx` because it no longer has a purpose after removing `sx` prop

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
