### PR TITLE
Update Radio stories to no longer use styled-components

### DIFF
--- a/packages/react/src/Radio/Radio.features.stories.tsx
+++ b/packages/react/src/Radio/Radio.features.stories.tsx
@@ -1,5 +1,5 @@
 import {MarkGithubIcon} from '@primer/octicons-react'
-import {Avatar, Box, FormControl, Radio} from '..'
+import {Avatar, FormControl, Radio} from '..'
 
 export default {
   title: 'Components/Radio/Features',
@@ -8,7 +8,7 @@ export default {
 
 export const WithLeadingVisual = () => {
   return (
-    <Box as="form">
+    <form>
       <FormControl>
         <FormControl.LeadingVisual>
           <MarkGithubIcon />
@@ -23,29 +23,29 @@ export const WithLeadingVisual = () => {
         <Radio value="default" name="default-radio-name" />
         <FormControl.Label>Default label</FormControl.Label>
       </FormControl>
-    </Box>
+    </form>
   )
 }
 
 export const Disabled = () => {
   return (
-    <Box as="form">
+    <form>
       <FormControl disabled>
         <Radio value="default" name="default-radio-name" />
         <FormControl.Label>Default label</FormControl.Label>
       </FormControl>
-    </Box>
+    </form>
   )
 }
 
 export const WithCaption = () => {
   return (
-    <Box as="form">
+    <form>
       <FormControl>
         <Radio value="default" name="default-radio-name" />
         <FormControl.Label>Default label</FormControl.Label>
         <FormControl.Caption>This is a caption</FormControl.Caption>
       </FormControl>
-    </Box>
+    </form>
   )
 }

--- a/packages/react/src/Radio/Radio.stories.tsx
+++ b/packages/react/src/Radio/Radio.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta} from '@storybook/react-vite'
 import type {RadioProps} from '..'
-import {Box, FormControl, Radio} from '..'
+import {FormControl, Radio} from '..'
 import type {FormControlArgs} from '../utils/form-story-helpers'
 import {
   formControlArgs,
@@ -20,13 +20,13 @@ export const Playground = ({value: _value, ...args}: FormControlArgs<RadioProps>
   const {parentArgs, labelArgs, captionArgs} = getFormControlArgsByChildComponent(args)
 
   return (
-    <Box as="form">
+    <form>
       <FormControl {...parentArgs}>
         <Radio name="default-radio-name" value="default" {...args} />
         <FormControl.Label {...labelArgs} />
         {captionArgs.children && <FormControl.Caption {...captionArgs} />}
       </FormControl>
-    </Box>
+    </form>
   )
 }
 Playground.argTypes = {
@@ -43,10 +43,10 @@ Playground.args = {
 }
 
 export const Default = () => (
-  <Box as="form">
+  <form>
     <FormControl>
       <Radio name="default-radio-name" value="default" />
       <FormControl.Label>Label</FormControl.Label>
     </FormControl>
-  </Box>
+  </form>
 )


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5620
Closes https://github.com/github/primer/issues/5621

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

Changed `Radio.stories.tsx` and `Radio.features.stories.tsx` to no longer use styled-components

#### Removed

Removed anything associated with styled-components

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
