### PR TITLE
Update RadioGroup.features.stories.tsx to no longer use styled-components

### DIFF
--- a/packages/react/src/RadioGroup/RadioGroup.features.stories.module.css
+++ b/packages/react/src/RadioGroup/RadioGroup.features.stories.module.css
@@ -1,0 +1,6 @@
+.ExternalLabel {
+  border-bottom: var(--borderWidth-default) solid var(--borderColor-default);
+  padding-bottom: var(--base-size-8);
+  margin-bottom: var(--base-size-16);
+  font-size: var(--text-title-size-medium);
+}

--- a/packages/react/src/RadioGroup/RadioGroup.features.stories.tsx
+++ b/packages/react/src/RadioGroup/RadioGroup.features.stories.tsx
@@ -1,4 +1,5 @@
-import {Radio, RadioGroup, FormControl, Box} from '..'
+import {Radio, RadioGroup, FormControl} from '..'
+import classes from './RadioGroup.features.stories.module.css'
 
 export default {
   title: 'Components/RadioGroup/Features',
@@ -24,17 +25,9 @@ export const VisuallyHiddenLabel = () => (
 
 export const WithExternalLabel = () => (
   <>
-    <Box
-      id="choiceHeading"
-      borderBottomWidth="1px"
-      borderBottomStyle="solid"
-      borderBottomColor="border.default"
-      pb={2}
-      mb={3}
-      fontSize={3}
-    >
+    <div id="choiceHeading" className={classes.ExternalLabel}>
       External label
-    </Box>
+    </div>
     <RadioGroup aria-labelledby="choiceHeading" name="defaultRadioGroup">
       <FormControl>
         <Radio value="one" />


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5623

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

Changed `RadioGroup.features.stories.tsx` to no longer use styled-components

#### Removed

Removed anything associated with styled-components

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
