### PR TITLE
fix(mcp): add component slug for better docs lookup

### DIFF
--- a/packages/mcp/src/primer.ts
+++ b/packages/mcp/src/primer.ts
@@ -4,6 +4,7 @@ type Component = {
   id: string
   name: string
   importPath: string
+  slug: string
 }
 
 const components: Array<Component> = Object.entries(componentsMetadata.components).map(([id, component]) => {
@@ -11,6 +12,7 @@ const components: Array<Component> = Object.entries(componentsMetadata.component
     id,
     name: component.name,
     importPath: component.importPath,
+    slug: id.replace('_', '-'),
   }
 })
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -43,7 +43,7 @@ server.tool(
   async ({name}) => {
     const components = listComponents()
     const match = components.find(component => {
-      return component.name === name
+      return component.name === name || component.name.toLowerCase() === name.toLowerCase()
     })
     if (!match) {
       return {
@@ -56,7 +56,7 @@ server.tool(
       }
     }
 
-    const url = new URL(`/product/components/${match.id}`, 'https://primer.style')
+    const url = new URL(`/product/components/${match.slug}`, 'https://primer.style')
     const response = await fetch(url)
     if (!response.ok) {
       throw new Error(`Failed to fetch ${url}: ${response.statusText}`)


### PR DESCRIPTION
Update our `@primer/mcp` package so that components now have a `slug` property. This makes it easier to match a component id like `action_list` to the docs url (`/product/components/action-list`)

This also makes it easier to match on component names by getting rid of case sensitivity