### PR TITLE
CircleOcticon: Deprecate component

### DIFF
--- a/.changeset/cold-teams-buy.md
+++ b/.changeset/cold-teams-buy.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+CircleOcticon: Deprecate component

--- a/packages/react/src/CircleOcticon/CircleOcticon.docs.json
+++ b/packages/react/src/CircleOcticon/CircleOcticon.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "circle_octicon",
   "name": "CircleOcticon",
-  "status": "alpha",
+  "status": "deprecated",
   "a11yReviewed": "2025-01-08",
   "stories": [],
   "importPath": "@primer/react",

--- a/packages/react/src/CircleOcticon/CircleOcticon.stories.tsx
+++ b/packages/react/src/CircleOcticon/CircleOcticon.stories.tsx
@@ -6,7 +6,7 @@ import {CheckIcon} from '@primer/octicons-react'
 import * as Icons from '@primer/octicons-react'
 
 const meta: Meta<typeof CircleOcticon> = {
-  title: 'Components/CircleOcticon',
+  title: 'Deprecated/Components/CircleOcticon',
   component: CircleOcticon,
 }
 export default meta

--- a/packages/react/src/CircleOcticon/CircleOcticon.tsx
+++ b/packages/react/src/CircleOcticon/CircleOcticon.tsx
@@ -10,8 +10,7 @@ export type CircleOcticonProps = {
 } & BoxProps
 
 /**
- * @deprecated This component is deprecated.
- * Replace deprecated `CircleOcticon` component with specific icon imports from `@primer/octicons-react` and customized styling.)
+ * @deprecated This component is deprecated. Replace component with specific icon imports from `@primer/octicons-react` and customized styling.)
  */
 function CircleOcticon(props: CircleOcticonProps) {
   const {size = 32, as, icon: IconComponent, bg, 'aria-label': ariaLabel, ...rest} = props

--- a/packages/react/src/CircleOcticon/CircleOcticon.tsx
+++ b/packages/react/src/CircleOcticon/CircleOcticon.tsx
@@ -9,6 +9,10 @@ export type CircleOcticonProps = {
   icon: React.ComponentType<React.PropsWithChildren<{size?: IconProps['size']}>>
 } & BoxProps
 
+/**
+ * @deprecated This component is deprecated.
+ * Replace deprecated `CircleOcticon` component with specific icon imports from `@primer/octicons-react` and customized styling.)
+ */
 function CircleOcticon(props: CircleOcticonProps) {
   const {size = 32, as, icon: IconComponent, bg, 'aria-label': ariaLabel, ...rest} = props
   return (


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Part of https://github.com/github/primer/issues/5534

Deprecates the `CircleOcticon` component. Existing internal usage may utilize Primer recipe component (https://github.com/github/github/pull/395572).

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- List of things added in this PR -->

#### Changed

* Deprecates `CircleOcticon` component

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
