### PR TITLE
chore: remove type-check from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23718,6 +23718,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -28272,6 +28273,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -30350,7 +30352,7 @@
     },
     "packages/mcp": {
       "name": "@primer/mcp",
-      "version": "0.0.0",
+      "version": "0.0.2",
       "dependencies": {
         "@babel/runtime": "^7.27.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -30361,7 +30363,7 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "mcp": "dist/stdio.js"
+        "mcp": "bin/mcp.js"
       },
       "devDependencies": {
         "@babel/core": "^7.27.1",
@@ -30762,8 +30764,7 @@
         "lodash.isobject": "^3.0.2",
         "react-compiler-runtime": "^19.1.0-rc.2",
         "react-intersection-observer": "^9.16.0",
-        "styled-system": "^5.1.5",
-        "type-check": "0.4.0"
+        "styled-system": "^5.1.5"
       },
       "devDependencies": {
         "@actions/core": "1.11.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -106,8 +106,7 @@
     "lodash.isobject": "^3.0.2",
     "react-compiler-runtime": "^19.1.0-rc.2",
     "react-intersection-observer": "^9.16.0",
-    "styled-system": "^5.1.5",
-    "type-check": "0.4.0"
+    "styled-system": "^5.1.5"
   },
   "devDependencies": {
     "@actions/core": "1.11.1",


### PR DESCRIPTION
This removes the dependency type-check from @primer/react, which was introduced in #5739

I think, it was accidently introduced by @lukasoppermann, when he was running mistakingly `npm i type-check` instead of `npm run type-check`.