### PR TITLE
chore: remove react-compiler-runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24082,15 +24082,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-compiler-runtime": {
-      "version": "19.1.0-rc.2",
-      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.1.0-rc.2.tgz",
-      "integrity": "sha512-852AwyIsbWJ5o1LkQVAZsVK3iLjMxOfKZuxqeGd/RfD+j1GqHb6j3DSHLtpu4HhFbQHsP2DzxjJyKR6luv4D8w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
-      }
-    },
     "node_modules/react-docgen": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.0.tgz",
@@ -30350,7 +30341,7 @@
     },
     "packages/mcp": {
       "name": "@primer/mcp",
-      "version": "0.0.0",
+      "version": "0.0.2",
       "dependencies": {
         "@babel/runtime": "^7.27.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -30361,7 +30352,7 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "mcp": "dist/stdio.js"
+        "mcp": "bin/mcp.js"
       },
       "devDependencies": {
         "@babel/core": "^7.27.1",
@@ -30760,7 +30751,6 @@
         "hsluv": "1.0.1",
         "lodash.isempty": "^4.4.0",
         "lodash.isobject": "^3.0.2",
-        "react-compiler-runtime": "^19.1.0-rc.2",
         "react-intersection-observer": "^9.16.0",
         "styled-system": "^5.1.5",
         "type-check": "0.4.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -104,7 +104,6 @@
     "hsluv": "1.0.1",
     "lodash.isempty": "^4.4.0",
     "lodash.isobject": "^3.0.2",
-    "react-compiler-runtime": "^19.1.0-rc.2",
     "react-intersection-observer": "^9.16.0",
     "styled-system": "^5.1.5",
     "type-check": "0.4.0"
@@ -232,4 +231,3 @@
     }
   }
 }
-


### PR DESCRIPTION
This package was introduced in #6211 but is not used anywhere in the codebase.