### PR TITLE
chore: remove loadsh in product dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9761,22 +9761,6 @@
         "@types/lodash": "*"
       }
     },
-    "node_modules/@types/lodash.isempty": {
-      "version": "4.4.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.isobject": {
-      "version": "3.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/lodash.keyby": {
       "version": "4.6.9",
       "resolved": "https://registry.npmjs.org/@types/lodash.keyby/-/lodash.keyby-4.6.9.tgz",
@@ -19223,14 +19207,6 @@
     "node_modules/lodash.groupby": {
       "version": "4.6.0",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isempty": {
-      "version": "4.4.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isobject": {
-      "version": "3.0.2",
       "license": "MIT"
     },
     "node_modules/lodash.iteratee": {
@@ -30350,7 +30326,7 @@
     },
     "packages/mcp": {
       "name": "@primer/mcp",
-      "version": "0.0.0",
+      "version": "0.0.2",
       "dependencies": {
         "@babel/runtime": "^7.27.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -30361,7 +30337,7 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "mcp": "dist/stdio.js"
+        "mcp": "bin/mcp.js"
       },
       "devDependencies": {
         "@babel/core": "^7.27.1",
@@ -30758,8 +30734,6 @@
         "focus-visible": "^5.2.1",
         "history": "^5.0.0",
         "hsluv": "1.0.1",
-        "lodash.isempty": "^4.4.0",
-        "lodash.isobject": "^3.0.2",
         "react-compiler-runtime": "^19.1.0-rc.2",
         "react-intersection-observer": "^9.16.0",
         "styled-system": "^5.1.5",
@@ -30796,8 +30770,6 @@
         "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/user-event": "^14.5.2",
         "@types/lodash.groupby": "4.6.9",
-        "@types/lodash.isempty": "4.4.9",
-        "@types/lodash.isobject": "3.0.9",
         "@types/lodash.keyby": "4.6.9",
         "@types/node": "20.12.11",
         "@types/react": "18.3.11",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -102,8 +102,6 @@
     "focus-visible": "^5.2.1",
     "history": "^5.0.0",
     "hsluv": "1.0.1",
-    "lodash.isempty": "^4.4.0",
-    "lodash.isobject": "^3.0.2",
     "react-compiler-runtime": "^19.1.0-rc.2",
     "react-intersection-observer": "^9.16.0",
     "styled-system": "^5.1.5",
@@ -140,8 +138,6 @@
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.5.2",
     "@types/lodash.groupby": "4.6.9",
-    "@types/lodash.isempty": "4.4.9",
-    "@types/lodash.isobject": "3.0.9",
     "@types/lodash.keyby": "4.6.9",
     "@types/node": "20.12.11",
     "@types/react": "18.3.11",
@@ -232,4 +228,3 @@
     }
   }
 }
-

--- a/packages/react/src/utils/theme.ts
+++ b/packages/react/src/utils/theme.ts
@@ -3,9 +3,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 
-import isEmpty from 'lodash.isempty'
-import isObject from 'lodash.isobject'
-
 function fontStack(fonts) {
   return fonts.map(font => (font.includes(' ') ? `"${font}"` : font)).join(', ')
 }
@@ -33,11 +30,14 @@ function filterObject(obj, predicate) {
   }
 
   return Object.entries(obj).reduce((acc, [key, value]) => {
-    if (isObject(value)) {
+    if (value !== null && typeof value === 'object') {
       const result = filterObject(value, predicate)
 
       // Don't include empty objects or arrays
-      if (!isEmpty(result)) {
+      if (
+        (Array.isArray(result) && result.length !== 0) ||
+        Object.entries(result).length !== 0
+      ) {
         acc[key] = result
       }
     } else if (predicate(value)) {


### PR DESCRIPTION
@hectahertz 

Following up on #6551, this PR removes only lodash from prod deps with easy to understand logic.