### PR TITLE
chore(release): enter pre-release mode for v38

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "exit",
+  "mode": "pre",
   "tag": "rc",
   "initialVersions": {
     "codesandbox": "0.0.0",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,15 @@
+{
+  "mode": "exit",
+  "tag": "rc",
+  "initialVersions": {
+    "codesandbox": "0.0.0",
+    "example-nextjs": "0.0.0",
+    "example-theming": "0.0.0",
+    "@primer/mcp": "0.0.2",
+    "postcss-preset-primer": "0.0.0",
+    "@primer/react": "37.31.0",
+    "rollup-plugin-import-css": "0.0.0",
+    "@primer/styled-react": "0.1.0"
+  },
+  "changesets": []
+}

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -41,6 +41,10 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
       - name: Publish canary release
         run: |
+          if [[ -f '.changeset/pre.json' ]]; then
+            npx changeset pre exit
+          fi
+
           echo -e "---\n$( jq .name packages/react/package.json ): patch\n---\n\nFake entry to force publishing" > .changeset/force-snapshot-release.md
           npx changeset version --snapshot
           npx changeset publish --tag canary


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Enter the project into pre-release mode for v38.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add `pre.json` through `npx changeset pre enter rc`

#### Changed

<!-- List of things changed in this PR -->

- Update release canary workflow to work while project is in pre mode

#### Removed

<!-- List of things removed in this PR -->
