### PR TITLE
fix: add mini-throttle as dep to packages/react

### DIFF
--- a/.changeset/stale-wasps-smell.md
+++ b/.changeset/stale-wasps-smell.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Add @github/mini-throttle as dependency to project to help with bundle output

--- a/package-lock.json
+++ b/package-lock.json
@@ -5547,7 +5547,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@github/mini-throttle/-/mini-throttle-2.1.1.tgz",
       "integrity": "sha512-KtOPaB+FiKJ6jcKm9UKyaM5fPURHGf+xcp+b4Mzoi81hOc6M1sIGpMZMAVbNzfa2lW5+RPGKq888Px0j76OZ/A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@github/prettier-config": {
@@ -30269,14 +30268,15 @@
       "version": "37.31.0",
       "license": "MIT",
       "dependencies": {
+        "@github/mini-throttle": "^2.1.1",
         "@github/relative-time-element": "^4.4.5",
-        "@github/tab-container-element": "4.8.2",
+        "@github/tab-container-element": "^4.8.2",
         "@lit-labs/react": "1.2.1",
         "@oddbird/popover-polyfill": "^0.5.2",
         "@primer/behaviors": "^1.8.0",
         "@primer/live-region-element": "^0.7.1",
         "@primer/octicons-react": "^19.13.0",
-        "@primer/primitives": "11.1.0",
+        "@primer/primitives": "10.x || 11.x",
         "@styled-system/css": "^5.1.5",
         "@styled-system/props": "^5.1.5",
         "@styled-system/theme-get": "^5.1.2",
@@ -30890,7 +30890,6 @@
         "@babel/preset-typescript": "^7.27.1",
         "@primer/react": "^37.31.0",
         "@rollup/plugin-babel": "^6.0.4",
-        "@testing-library/jest-dom": "^6.6.4",
         "@types/react": "18.3.11",
         "@types/react-dom": "18.3.1",
         "@vitejs/plugin-react": "^4.3.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -82,8 +82,9 @@
     "npm": ">=7"
   },
   "dependencies": {
+    "@github/mini-throttle": "^2.1.1",
     "@github/relative-time-element": "^4.4.5",
-    "@github/tab-container-element": "4.8.2",
+    "@github/tab-container-element": "^4.8.2",
     "@lit-labs/react": "1.2.1",
     "@oddbird/popover-polyfill": "^0.5.2",
     "@primer/behaviors": "^1.8.0",


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

This came up in Slack that certain bundler setups fail to resolve the `@github/mini-throttle` dependency. It turned out that this dependency was used in `@primer/react` but was not included in `package.json` which meant that our rollup config did not treat it as external. As a result, it was included in `lib-esm/node_modules`.

This PR adds the dependency to primer/react and also adjusts some of the github-ui ranges to be more inclusive of versions

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add `@github/mini-throttle` to deps
- Adjust ranges of github packages to be more inclusive of. versions

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release