### PR TITLE
chore(mcp): update package to be private

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29975,7 +29975,7 @@
     },
     "packages/mcp": {
       "name": "@primer/mcp",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@babel/runtime": "^7.28.2",
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -30276,7 +30276,7 @@
         "@primer/behaviors": "^1.8.0",
         "@primer/live-region-element": "^0.7.1",
         "@primer/octicons-react": "^19.13.0",
-        "@primer/primitives": "11.1.0",
+        "@primer/primitives": "10.x || 11.x",
         "@styled-system/css": "^5.1.5",
         "@styled-system/props": "^5.1.5",
         "@styled-system/theme-get": "^5.1.2",
@@ -30890,7 +30890,6 @@
         "@babel/preset-typescript": "^7.27.1",
         "@primer/react": "^37.31.0",
         "@rollup/plugin-babel": "^6.0.4",
-        "@testing-library/jest-dom": "^6.6.4",
         "@types/react": "18.3.11",
         "@types/react-dom": "18.3.1",
         "@vitejs/plugin-react": "^4.3.3",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@primer/mcp",
+  "private": true,
   "description": "An MCP server that connects AI tools to the Primer Design System",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "bin": {
     "mcp": "./bin/mcp.js"


### PR DESCRIPTION
We currently manually publish this package and do not want to include this as a part of our regular release cadence.