### PR TITLE
refactor(Avatar): remove sx prop support from Avatar component

### DIFF
--- a/.changeset/fifty-weeks-exist.md
+++ b/.changeset/fifty-weeks-exist.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': major
+---
+
+Remove sx prop support from the Avatar component.

--- a/packages/react/src/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/Avatar/Avatar.stories.tsx
@@ -62,10 +62,4 @@ Playground.argTypes = {
       disable: true,
     },
   },
-  sx: {
-    controls: false,
-    table: {
-      disable: true,
-    },
-  },
 }

--- a/packages/react/src/Avatar/Avatar.test.tsx
+++ b/packages/react/src/Avatar/Avatar.test.tsx
@@ -1,8 +1,6 @@
 import {describe, expect, it} from 'vitest'
 import {render, screen} from '@testing-library/react'
 import {Avatar} from '..'
-import {ThemeProvider} from '../ThemeProvider'
-import theme from '../theme'
 
 describe('Avatar', () => {
   it('should support `className` on the outermost element', () => {
@@ -29,16 +27,6 @@ describe('Avatar', () => {
     render(<Avatar src="primer.png" alt="" data-testid="avatar" />)
     const avatar = screen.getByTestId('avatar')
     expect(avatar).toHaveAttribute('src', 'primer.png')
-  })
-
-  it('respects margin props', () => {
-    render(
-      <ThemeProvider theme={theme}>
-        <Avatar src="primer.png" alt="" sx={{m: 2}} data-testid="avatar" />
-      </ThemeProvider>,
-    )
-    const avatar = screen.getByTestId('avatar')
-    expect(avatar).toHaveStyle(`margin: 8px`)
   })
 
   it('should support the `style` prop without overriding internal styles', () => {

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -1,9 +1,7 @@
 import {clsx} from 'clsx'
 import React from 'react'
-import type {SxProp} from '../sx'
 import type {ResponsiveValue} from '../hooks/useResponsiveValue'
 import {isResponsiveValue} from '../hooks/useResponsiveValue'
-import {BoxWithFallback} from '../internal/components/BoxWithFallback'
 import classes from './Avatar.module.css'
 
 export const DEFAULT_AVATAR_SIZE = 20
@@ -19,11 +17,10 @@ export type AvatarProps = {
   alt?: string
   /** Additional class name. */
   className?: string
-} & SxProp &
-  React.ComponentPropsWithoutRef<'img'>
+} & React.ComponentPropsWithoutRef<'img'>
 
 const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(function Avatar(
-  {alt = '', size = DEFAULT_AVATAR_SIZE, square = false, sx: sxProp, className, style, ...rest},
+  {alt = '', size = DEFAULT_AVATAR_SIZE, square = false, className, style, ...rest},
   ref,
 ) {
   const isResponsive = isResponsiveValue(size)
@@ -38,8 +35,7 @@ const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(function Avatar(
   }
 
   return (
-    <BoxWithFallback
-      as="img"
+    <img
       data-component="Avatar"
       className={clsx(className, classes.Avatar)}
       ref={ref}
@@ -56,7 +52,6 @@ const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(function Avatar(
             }
           : (cssSizeVars as React.CSSProperties)
       }
-      sx={sxProp}
       {...rest}
     />
   )

--- a/packages/react/src/Avatar/Avatar.types.test.tsx
+++ b/packages/react/src/Avatar/Avatar.types.test.tsx
@@ -3,8 +3,3 @@ import Avatar from '../Avatar'
 export function shouldAcceptCallWithNoProps() {
   return <Avatar src="https://avatars.githubusercontent.com/primer" />
 }
-
-export function shouldNotAcceptSystemProps() {
-  // @ts-expect-error system props should not be accepted
-  return <Avatar src="https://avatars.githubusercontent.com/primer" backgroundColor="thistle" />
-}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

remove sx prop support from Avatar component. To convert use className instead.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [x] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
