### PR TITLE
refactor(Avatar): remove support for sx prop

### DIFF
--- a/.changeset/seven-cameras-act.md
+++ b/.changeset/seven-cameras-act.md
@@ -1,0 +1,6 @@
+---
+'@primer/react': major
+'@primer/styled-react': minor
+---
+
+Update Avatar component to no longer support sx, add sx wrapper to @primer/styled-react

--- a/packages/react/src/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/Avatar/Avatar.stories.tsx
@@ -62,10 +62,4 @@ Playground.argTypes = {
       disable: true,
     },
   },
-  sx: {
-    controls: false,
-    table: {
-      disable: true,
-    },
-  },
 }

--- a/packages/react/src/Avatar/Avatar.test.tsx
+++ b/packages/react/src/Avatar/Avatar.test.tsx
@@ -31,16 +31,6 @@ describe('Avatar', () => {
     expect(avatar).toHaveAttribute('src', 'primer.png')
   })
 
-  it('respects margin props', () => {
-    render(
-      <ThemeProvider theme={theme}>
-        <Avatar src="primer.png" alt="" sx={{m: 2}} data-testid="avatar" />
-      </ThemeProvider>,
-    )
-    const avatar = screen.getByTestId('avatar')
-    expect(avatar).toHaveStyle(`margin: 8px`)
-  })
-
   it('should support the `style` prop without overriding internal styles', () => {
     render(
       <Avatar

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -1,9 +1,7 @@
 import {clsx} from 'clsx'
 import React from 'react'
-import type {SxProp} from '../sx'
 import type {ResponsiveValue} from '../hooks/useResponsiveValue'
 import {isResponsiveValue} from '../hooks/useResponsiveValue'
-import {BoxWithFallback} from '../internal/components/BoxWithFallback'
 import classes from './Avatar.module.css'
 
 export const DEFAULT_AVATAR_SIZE = 20
@@ -19,11 +17,10 @@ export type AvatarProps = {
   alt?: string
   /** Additional class name. */
   className?: string
-} & SxProp &
-  React.ComponentPropsWithoutRef<'img'>
+} & React.ComponentPropsWithoutRef<'img'>
 
 const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(function Avatar(
-  {alt = '', size = DEFAULT_AVATAR_SIZE, square = false, sx: sxProp, className, style, ...rest},
+  {alt = '', size = DEFAULT_AVATAR_SIZE, square = false, className, style, ...rest},
   ref,
 ) {
   const isResponsive = isResponsiveValue(size)
@@ -38,8 +35,7 @@ const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(function Avatar(
   }
 
   return (
-    <BoxWithFallback
-      as="img"
+    <img
       data-component="Avatar"
       className={clsx(className, classes.Avatar)}
       ref={ref}
@@ -56,7 +52,6 @@ const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(function Avatar(
             }
           : (cssSizeVars as React.CSSProperties)
       }
-      sx={sxProp}
       {...rest}
     />
   )

--- a/packages/styled-react/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/styled-react/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`@primer/styled-react exports 1`] = `
 [
+  "Avatar",
   "ActionList",
   "ActionMenu",
   "Box",

--- a/packages/styled-react/src/index.ts
+++ b/packages/styled-react/src/index.ts
@@ -1,3 +1,9 @@
+import {Avatar as PrimerAvatar} from '@primer/react'
+import {createStyledComponent} from './utils/createStyledComponent'
+
+const Avatar = /*#__PURE__*/ createStyledComponent(PrimerAvatar)
+
+export {Avatar}
 export {
   ActionList,
   ActionMenu,


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5726

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

- Remove support for `sx` from the Avatar component

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Major release; if selected, include a written rollout or migration plan

We are using the `@primer/styled-react` component to mitigate removing `sx` usage. We will make sure usage is updated upstream before merging.