### PR TITLE
Remove support for `sx` from `AnchoredOverlay` component

### DIFF
--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.dev.stories.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.dev.stories.tsx
@@ -15,7 +15,6 @@ export default meta
 
 export const RepositionAfterContentGrows = () => {
   const [open, setOpen] = useState(false)
-
   const [loading, setLoading] = useState(true)
 
   React.useEffect(() => {
@@ -36,7 +35,7 @@ export const RepositionAfterContentGrows = () => {
       </div>
       <AnchoredOverlay
         renderAnchor={props => (
-          <Button {...props} sx={{width: 'fit-content'}}>
+          <Button {...props} style={{width: 'fit-content'}}>
             Button
           </Button>
         )}
@@ -62,7 +61,6 @@ export const RepositionAfterContentGrows = () => {
 
 export const RepositionAfterContentGrowsWithinDialog = () => {
   const [open, setOpen] = useState(false)
-
   const [loading, setLoading] = useState(true)
 
   React.useEffect(() => {
@@ -84,7 +82,7 @@ export const RepositionAfterContentGrowsWithinDialog = () => {
         </div>
         <AnchoredOverlay
           renderAnchor={props => (
-            <Button {...props} sx={{width: 'fit-content'}}>
+            <Button {...props} style={{width: 'fit-content'}}>
               Button
             </Button>
           )}

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.stories.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.stories.tsx
@@ -53,7 +53,7 @@ export const Default = () => {
       onOpen={() => setOpen(true)}
       onClose={() => setOpen(false)}
       renderAnchor={props => <Button {...props}>Button</Button>}
-      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'User Card Overlay', sx: {minWidth: '320px'}}}
+      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'User Card Overlay', style: {minWidth: '320px'}}}
       focusZoneSettings={{disabled: true}}
       preventOverflow={false}
     >
@@ -84,7 +84,7 @@ export const Playground = (args: Args) => {
         role: 'dialog',
         'aria-modal': true,
         'aria-label': 'User Card Overlay',
-        sx: {minWidth: '320px'},
+        style: {minWidth: '320px'},
       }}
       side={args.side}
       focusZoneSettings={{disabled: true}}

--- a/packages/styled-react/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/styled-react/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -4,7 +4,9 @@ exports[`@primer/styled-react exports 1`] = `
 [
   "ActionList",
   "ActionMenu",
+  "AnchoredOverlay",
   "Box",
+  "BranchName",
   "Breadcrumbs",
   "Button",
   "Flash",

--- a/packages/styled-react/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/styled-react/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -4,7 +4,6 @@ exports[`@primer/styled-react exports 1`] = `
 [
   "ActionList",
   "ActionMenu",
-  "AnchoredOverlay",
   "Box",
   "BranchName",
   "Breadcrumbs",

--- a/packages/styled-react/src/index.ts
+++ b/packages/styled-react/src/index.ts
@@ -1,7 +1,6 @@
 export {
   ActionList,
   ActionMenu,
-  AnchoredOverlay,
   Box,
   type BoxProps,
   Breadcrumbs,

--- a/packages/styled-react/src/index.ts
+++ b/packages/styled-react/src/index.ts
@@ -1,6 +1,7 @@
 export {
   ActionList,
   ActionMenu,
+  AnchoredOverlay,
   Box,
   type BoxProps,
   Breadcrumbs,


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5738

(sx: 0)

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

- Remove `sx` from AnchoredOverlay stories

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

No changeset needed since these changes only affect Storybook.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
