### PR TITLE
Remove sx props and Box from `Truncate`

### DIFF
--- a/.changeset/lucky-facts-obey.md
+++ b/.changeset/lucky-facts-obey.md
@@ -1,0 +1,6 @@
+---
+'@primer/react': major
+'@primer/styled-react': patch
+---
+
+Update Truncate component to no longer support sx, add sx wrapper to @primer/styled-react.

--- a/packages/react/src/Truncate/Truncate.docs.json
+++ b/packages/react/src/Truncate/Truncate.docs.json
@@ -21,7 +21,7 @@
   "props": [
     {
       "name": "maxWidth",
-      "type": "number",
+      "type": "number | string",
       "defaultValue": "125",
       "description": "Sets the max-width of the text."
     },
@@ -41,11 +41,6 @@
       "name": "as",
       "type": "React.ElementType",
       "defaultValue": "'div'"
-    },
-    {
-      "name": "sx",
-      "type": "SystemStyleObject",
-      "deprecated": true
     }
   ],
   "subcomponents": []

--- a/packages/react/src/Truncate/Truncate.stories.tsx
+++ b/packages/react/src/Truncate/Truncate.stories.tsx
@@ -41,12 +41,6 @@ Playground.argTypes = {
       disable: true,
     },
   },
-  sx: {
-    controls: false,
-    table: {
-      disable: true,
-    },
-  },
   theme: {
     controls: false,
     table: {

--- a/packages/react/src/Truncate/Truncate.tsx
+++ b/packages/react/src/Truncate/Truncate.tsx
@@ -1,27 +1,23 @@
 import React from 'react'
 import {clsx} from 'clsx'
-import type {MaxWidthProps} from 'styled-system'
-import type {SxProp} from '../sx'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
-import {BoxWithFallback} from '../internal/components/BoxWithFallback'
 import classes from './Truncate.module.css'
 
 type TruncateProps = React.HTMLAttributes<HTMLElement> & {
   title: string
   inline?: boolean
   expandable?: boolean
-} & MaxWidthProps &
-  SxProp
+  maxWidth?: number | string
+}
 
 const Truncate = React.forwardRef(function Truncate(
-  {as, children, className, title, inline, expandable, maxWidth = 125, style, sx, ...rest},
+  {as: Component = 'div', children, className, title, inline, expandable, maxWidth = 125, style, ...rest},
   ref,
 ) {
   return (
-    <BoxWithFallback
+    <Component
       {...rest}
       ref={ref}
-      as={as}
       className={clsx(className, classes.Truncate)}
       data-expandable={expandable}
       data-inline={inline}
@@ -33,10 +29,9 @@ const Truncate = React.forwardRef(function Truncate(
             typeof maxWidth === 'number' ? `${maxWidth}px` : typeof maxWidth === 'string' ? maxWidth : undefined,
         } as React.CSSProperties
       }
-      sx={sx}
     >
       {children}
-    </BoxWithFallback>
+    </Component>
   )
 }) as PolymorphicForwardRefComponent<'div', TruncateProps>
 

--- a/packages/styled-react/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/styled-react/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`@primer/styled-react exports 1`] = `
 [
+  "Truncate",
   "ActionList",
   "ActionMenu",
   "Box",
@@ -17,7 +18,6 @@ exports[`@primer/styled-react exports 1`] = `
   "PageLayout",
   "Text",
   "TextInput",
-  "Truncate",
   "sx",
 ]
 `;

--- a/packages/styled-react/src/index.ts
+++ b/packages/styled-react/src/index.ts
@@ -1,3 +1,9 @@
+import {Truncate as PrimerTruncate} from '@primer/react'
+import {createStyledComponent} from './utils/createStyledComponent'
+
+const Truncate: ReturnType<typeof createStyledComponent> = /*#__PURE__*/ createStyledComponent(PrimerTruncate)
+export {Truncate}
+
 export {
   ActionList,
   ActionMenu,
@@ -15,7 +21,6 @@ export {
   PageLayout,
   Text,
   TextInput,
-  Truncate,
 
   // Utilities for working with the `sx` prop
   sx,


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Migrates the `Truncate` component away from `BoxWithFallback` components and `sx` prop support to use CSS modules, Closes [#4822](https://github.com/github/primer/issues/4822)
 

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [X] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why
 