### PR TITLE
fix(styled-react): update types output

### DIFF
--- a/.changeset/salty-geese-own.md
+++ b/.changeset/salty-geese-own.md
@@ -1,0 +1,5 @@
+---
+'@primer/styled-react': patch
+---
+
+Update the types output for the `@primer/style-react` package so that the paths resolve correctly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
         run: npm run lint:css
       - name: Lint markdown
         run: npm run lint:md
+      - name: Lint npm packages
+        run: npx turbo lint:npm
 
   test:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "37.31.0",
+        "@primer/react": "38.0.0-rc.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
@@ -444,7 +444,7 @@
       "name": "example-nextjs",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "37.31.0",
+        "@primer/react": "38.0.0-rc.0",
         "next": "^15.2.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -629,7 +629,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.14.0",
-        "@primer/react": "37.31.0",
+        "@primer/react": "38.0.0-rc.0",
         "clsx": "^2.1.1",
         "next": "^14.2.30",
         "react": "^18.3.1",
@@ -8584,6 +8584,19 @@
       },
       "peerDependencies": {
         "@primer/primitives": "9.x || 10.x"
+      }
+    },
+    "node_modules/@publint/pack": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.2.tgz",
+      "integrity": "sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -26060,6 +26073,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/publint": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.12.tgz",
+      "integrity": "sha512-1w3MMtL9iotBjm1mmXtG3Nk06wnq9UhGNRpQ2j6n1Zq7YAD6gnxMMZMIxlRPAydVjVbjSm+n0lhwqsD1m4LD5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@publint/pack": "^0.1.2",
+        "package-manager-detector": "^1.1.0",
+        "picocolors": "^1.1.1",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "publint": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      }
+    },
+    "node_modules/publint/node_modules/package-manager-detector": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.3.0.tgz",
+      "integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -32439,13 +32481,13 @@
     },
     "packages/mcp": {
       "name": "@primer/mcp",
-      "version": "0.0.3",
+      "version": "0.0.4-rc.0",
       "dependencies": {
         "@babel/runtime": "^7.28.3",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@primer/octicons": "^19.15.5",
         "@primer/primitives": "10.x || 11.x",
-        "@primer/react": "^37.24.0",
+        "@primer/react": "^38.0.0-rc.0",
         "cheerio": "^1.0.0",
         "turndown": "^7.2.0",
         "zod": "^3.23.8"
@@ -32730,7 +32772,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "37.31.0",
+      "version": "38.0.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "@github/mini-throttle": "^2.1.1",
@@ -33350,14 +33392,15 @@
     },
     "packages/styled-react": {
       "name": "@primer/styled-react",
-      "version": "0.1.0",
+      "version": "1.0.0-rc.0",
       "devDependencies": {
         "@babel/preset-typescript": "^7.27.1",
-        "@primer/react": "^37.31.0",
+        "@primer/react": "^38.0.0-rc.0",
         "@rollup/plugin-babel": "^6.0.4",
         "@types/react": "18.3.11",
         "@types/react-dom": "18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
+        "publint": "^0.3.12",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "rimraf": "^6.0.1",
@@ -33367,7 +33410,7 @@
         "typescript": "^5.8.2"
       },
       "peerDependencies": {
-        "@primer/react": "37.x",
+        "@primer/react": "38.0.0-rc.0",
         "@types/react": "18.x || 19.x",
         "@types/react-dom": "18.x || 19.x",
         "@types/react-is": "18.x || 19.x",

--- a/packages/styled-react/package.json
+++ b/packages/styled-react/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "script/build",
     "clean": "rimraf dist",
+    "lint:npm": "publint --types",
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
@@ -32,6 +33,7 @@
     "@types/react": "18.3.11",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
+    "publint": "^0.3.12",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "rimraf": "^6.0.1",

--- a/packages/styled-react/tsconfig.build.json
+++ b/packages/styled-react/tsconfig.build.json
@@ -5,5 +5,5 @@
     "declaration": true,
     "emitDeclarationOnly": true
   },
-  "exclude": ["vitest.config.ts", "vitest.config.browser.ts"]
+  "exclude": ["vitest.config.ts", "vitest.config.browser.ts", "config", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,10 @@
       "dependsOn": [],
       "outputs": ["storybook-static/**"]
     },
+    "lint:npm": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "type-check": {
       "dependsOn": ["^build"],
       "outputs": []


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update the `tsconfig.build.json` exclude list so that our types are generated in the correct location for `@primer/styled-react`. This also adds a new task, `lint:npm`, to hopefully avoid these types of issues with publishing in the future 😅 

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add `lint:npm` task to turbo and to `packages/styled-react`
- Update `tsconfig.build.json` so types are emitted to correct paths in `dist` folder

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
