### PR TITLE
Remove support for `sx` and `Box` usage from the `UnderlineNav` component

### DIFF
--- a/.changeset/hot-mirrors-feel.md
+++ b/.changeset/hot-mirrors-feel.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': major
+---
+
+Update UnderlineNav component to no longer support sx and remove Box usage from it.

--- a/packages/react/src/UnderlineNav/UnderlineNav.docs.json
+++ b/packages/react/src/UnderlineNav/UnderlineNav.docs.json
@@ -55,11 +55,6 @@
       "type": "'inset' | 'flush'",
       "defaultValue": "'inset'",
       "description": "`inset` children are offset horizontally from container edges. `flush` children are flush horizontally with container edges"
-    },
-    {
-      "name": "sx",
-      "type": "SystemStyleObject",
-      "deprecated": true
     }
   ],
   "subcomponents": [
@@ -100,11 +95,6 @@
           "name": "as",
           "type": "React.ElementType",
           "defaultValue": "\"a\""
-        },
-        {
-          "name": "sx",
-          "type": "SystemStyleObject",
-          "deprecated": true
         }
       ],
       "passthrough": {

--- a/packages/react/src/UnderlineNav/UnderlineNav.module.css
+++ b/packages/react/src/UnderlineNav/UnderlineNav.module.css
@@ -1,0 +1,5 @@
+.menuItemContent {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}

--- a/packages/react/src/UnderlineNav/UnderlineNav.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNav.tsx
@@ -1,8 +1,5 @@
 import type {MutableRefObject, RefObject} from 'react'
 import React, {useRef, forwardRef, useCallback, useState, useEffect} from 'react'
-import Box from '../Box'
-import type {SxProp} from '../sx'
-import sx from '../sx'
 import {UnderlineNavContext} from './UnderlineNavContext'
 import type {ResizeObserverEntry} from '../hooks/useResizeObserver'
 import {useResizeObserver} from '../hooks/useResizeObserver'
@@ -18,16 +15,15 @@ import {useOnEscapePress} from '../hooks/useOnEscapePress'
 import {useOnOutsideClick} from '../hooks/useOnOutsideClick'
 import {useId} from '../hooks/useId'
 import {ActionList} from '../ActionList'
-import {defaultSxProp} from '../utils/defaultSxProp'
 import CounterLabel from '../CounterLabel'
 import {invariant} from '../utils/invariant'
+import classes from './UnderlineNav.module.css'
 
 export type UnderlineNavProps = {
   children: React.ReactNode
   'aria-label'?: React.AriaAttributes['aria-label']
   as?: React.ElementType
   className?: string
-  sx?: SxProp['sx']
   /**
    * loading state for all counters. It displays loading animation for individual counters (UnderlineNav.Item) until all are resolved. It is needed to prevent multiple layout shift.
    */
@@ -45,10 +41,8 @@ export const MORE_BTN_WIDTH = 86
 // The height is needed to make sure we don't have a layout shift when the more button is the only item in the nav.
 const MORE_BTN_HEIGHT = 45
 
-// Needed this because passing a ref using HTMLULListElement to `Box` causes a type error
-export const NavigationList = styled.ul`
-  ${sx};
-`
+// Needed for typing the ref with HTMLULListElement
+export const NavigationList = styled.ul``
 
 export const MoreMenuListItem = styled.li`
   display: flex;
@@ -145,7 +139,6 @@ export const UnderlineNav = forwardRef(
     {
       as = 'nav',
       'aria-label': ariaLabel,
-      sx: sxProp = defaultSxProp,
       loadingCounters = false,
       variant = 'inset',
       className,
@@ -316,19 +309,12 @@ export const UnderlineNav = forwardRef(
         }}
       >
         {ariaLabel && <VisuallyHidden as="h2">{`${ariaLabel} navigation`}</VisuallyHidden>}
-        <UnderlineWrapper
-          as={as}
-          aria-label={ariaLabel}
-          className={className}
-          ref={navRef}
-          sx={sxProp}
-          data-variant={variant}
-        >
+        <UnderlineWrapper as={as} aria-label={ariaLabel} className={className} ref={navRef} data-variant={variant}>
           <UnderlineItemList ref={listRef} role="list">
             {listItems}
             {menuItems.length > 0 && (
               <MoreMenuListItem ref={moreMenuRef}>
-                {!onlyMenuVisible && <Box sx={getDividerStyle(theme)}></Box>}
+                {!onlyMenuVisible && <div style={getDividerStyle(theme)}></div>}
                 <Button
                   ref={moreMenuBtnRef}
                   sx={moreBtnStyles}
@@ -337,7 +323,7 @@ export const UnderlineNav = forwardRef(
                   onClick={onAnchorClick}
                   trailingAction={TriangleDownIcon}
                 >
-                  <Box as="span">
+                  <span>
                     {onlyMenuVisible ? (
                       <>
                         <VisuallyHidden as="span">{`${ariaLabel}`}&nbsp;</VisuallyHidden>Menu
@@ -347,7 +333,7 @@ export const UnderlineNav = forwardRef(
                         More<VisuallyHidden as="span">&nbsp;{`${ariaLabel} items`}</VisuallyHidden>
                       </>
                     )}
-                  </Box>
+                  </span>
                 </Button>
                 <ActionList
                   selectionVariant="single"
@@ -398,18 +384,18 @@ export const UnderlineNav = forwardRef(
                         }}
                         {...menuItemProps}
                       >
-                        <Box as="span" sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
+                        <span className={classes.menuItemContent}>
                           {menuItemChildren}
                           {loadingCounters ? (
                             <LoadingCounter />
                           ) : (
                             counter !== undefined && (
-                              <Box as="span" data-component="counter">
+                              <span data-component="counter">
                                 <CounterLabel>{counter}</CounterLabel>
-                              </Box>
+                              </span>
                             )
                           )}
-                        </Box>
+                        </span>
                       </ActionList.LinkItem>
                     )
                   })}

--- a/packages/react/src/UnderlineNav/UnderlineNavItem.module.css
+++ b/packages/react/src/UnderlineNav/UnderlineNavItem.module.css
@@ -1,0 +1,5 @@
+.UnderlineNavItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/packages/react/src/UnderlineNav/UnderlineNavItem.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNavItem.tsx
@@ -1,13 +1,11 @@
 import type {MutableRefObject, RefObject} from 'react'
 import React, {forwardRef, useRef, useContext} from 'react'
-import Box from '../Box'
-import type {SxProp} from '../sx'
 import type {IconProps} from '@primer/octicons-react'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 import {UnderlineNavContext} from './UnderlineNavContext'
 import useLayoutEffect from '../utils/useIsomorphicLayoutEffect'
-import {defaultSxProp} from '../utils/defaultSxProp'
 import {UnderlineItem} from '../internal/components/UnderlineTabbedInterface'
+import classes from './UnderlineNavItem.module.css'
 
 // adopted from React.AnchorHTMLAttributes
 export type LinkProps = {
@@ -47,22 +45,11 @@ export type UnderlineNavItemProps = {
    * Counter
    */
   counter?: number | string
-} & SxProp &
-  LinkProps
+} & LinkProps
 
 export const UnderlineNavItem = forwardRef(
   (
-    {
-      sx: sxProp = defaultSxProp,
-      as: Component = 'a',
-      href = '#',
-      children,
-      counter,
-      onSelect,
-      'aria-current': ariaCurrent,
-      icon: Icon,
-      ...props
-    },
+    {as: Component = 'a', href = '#', children, counter, onSelect, 'aria-current': ariaCurrent, icon: Icon, ...props},
     forwardedRef,
   ) => {
     const backupRef = useRef<HTMLElement>(null)
@@ -111,7 +98,7 @@ export const UnderlineNavItem = forwardRef(
     )
 
     return (
-      <Box as="li" sx={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
+      <li className={classes.UnderlineNavItem}>
         <UnderlineItem
           ref={ref}
           as={Component}
@@ -123,12 +110,11 @@ export const UnderlineNavItem = forwardRef(
           icon={Icon}
           loadingCounters={loadingCounters}
           iconsVisible={iconsVisible}
-          sx={sxProp}
           {...props}
         >
           {children}
         </UnderlineItem>
-      </Box>
+      </li>
     )
   },
 ) as PolymorphicForwardRefComponent<'a', UnderlineNavItemProps>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes [#5770](https://github.com/github/primer/issues/5770)

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

<!-- List of things removed in this PR -->
Removed `sx` props and `Box` from `UnderlineNav`.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->
 
- [X] Major release; if selected, include a written rollout or migration plan
 