### PR TITLE
Remove support for `sx` from `CircleOcticon` component

### DIFF
--- a/.changeset/serious-grapes-buy.md
+++ b/.changeset/serious-grapes-buy.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': major
+---
+
+Update CircleOcticon component to no longer support sx

--- a/packages/react/src/CircleOcticon/CircleOcticon.docs.json
+++ b/packages/react/src/CircleOcticon/CircleOcticon.docs.json
@@ -15,11 +15,6 @@
       "defaultValue": "32",
       "type": "number",
       "description": "Set the width and height of the icon in pixels."
-    },
-    {
-      "name": "sx",
-      "type": "SystemStyleObject",
-      "deprecated": true
     }
   ],
   "subcomponents": []

--- a/packages/react/src/CircleOcticon/CircleOcticon.module.css
+++ b/packages/react/src/CircleOcticon/CircleOcticon.module.css
@@ -1,0 +1,8 @@
+.CircleOcticon {
+  overflow: hidden;
+  border-radius: 50%;
+  border: solid 0 var(--borderColor-default);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/packages/react/src/CircleOcticon/CircleOcticon.stories.module.css
+++ b/packages/react/src/CircleOcticon/CircleOcticon.stories.module.css
@@ -1,0 +1,4 @@
+.CircleOcticon {
+  background-color: var(--bgColor-success-emphasis);
+  color: var(--fgColor-onEmphasis);
+}

--- a/packages/react/src/CircleOcticon/CircleOcticon.stories.tsx
+++ b/packages/react/src/CircleOcticon/CircleOcticon.stories.tsx
@@ -4,6 +4,7 @@ import type {CircleOcticonProps} from './CircleOcticon'
 import {CheckIcon} from '@primer/octicons-react'
 // eslint-disable-next-line import/no-namespace
 import * as Icons from '@primer/octicons-react'
+import classes from './CircleOcticon.stories.module.css'
 
 const meta: Meta<typeof CircleOcticon> = {
   title: 'Deprecated/Components/CircleOcticon',
@@ -12,12 +13,7 @@ const meta: Meta<typeof CircleOcticon> = {
 export default meta
 
 export const Default = () => (
-  <CircleOcticon
-    icon={CheckIcon}
-    size={32}
-    sx={{backgroundColor: 'success.emphasis', color: 'fg.onEmphasis'}}
-    aria-label="Changes approved"
-  />
+  <CircleOcticon icon={CheckIcon} size={32} className={classes.CircleOcticon} aria-label="Changes approved" />
 )
 
 type PlaygroundTypes = Omit<CircleOcticonProps, 'icon'> & {icon: keyof typeof Icons}
@@ -25,13 +21,19 @@ export const Playground: StoryFn<PlaygroundTypes> = ({
   icon: iconName,
   'aria-label': ariaLabel = 'Changes approved',
   ...args
-}) => <CircleOcticon icon={Icons[iconName]} aria-label={ariaLabel ? ariaLabel : undefined} {...args} />
+}) => (
+  <CircleOcticon
+    icon={Icons[iconName]}
+    aria-label={ariaLabel ? ariaLabel : undefined}
+    className={classes.CircleOcticon}
+    {...args}
+  />
+)
 
 Playground.args = {
   size: 32,
   icon: 'CheckIcon',
   'aria-label': undefined,
-  sx: {backgroundColor: 'success.emphasis', color: 'fg.onEmphasis'},
 }
 
 Playground.argTypes = {
@@ -48,8 +50,5 @@ Playground.argTypes = {
   },
   'aria-label': {
     type: 'string',
-  },
-  sx: {
-    controls: false,
   },
 }

--- a/packages/react/src/CircleOcticon/CircleOcticon.tsx
+++ b/packages/react/src/CircleOcticon/CircleOcticon.tsx
@@ -1,34 +1,42 @@
 import type {IconProps} from '@primer/octicons-react'
 import type React from 'react'
-import type {BoxProps} from '../Box'
-import Box from '../Box'
+import styles from './CircleOcticon.module.css'
 
 export type CircleOcticonProps = {
   as?: React.ElementType
   size?: number
   icon: React.ComponentType<React.PropsWithChildren<{size?: IconProps['size']}>>
-} & BoxProps
+  bg?: string
+  'aria-label'?: string
+  className?: string
+} & React.HTMLAttributes<HTMLElement>
 
 /**
  * @deprecated This component is deprecated. Replace component with specific icon imports from `@primer/octicons-react` and customized styling.)
  */
 function CircleOcticon(props: CircleOcticonProps) {
-  const {size = 32, as, icon: IconComponent, bg, 'aria-label': ariaLabel, ...rest} = props
+  const {
+    size = 32,
+    as: Component = 'div',
+    icon: IconComponent,
+    bg,
+    'aria-label': ariaLabel,
+    className,
+    style,
+    ...rest
+  } = props
+
+  const wrapperStyle: React.CSSProperties = {
+    backgroundColor: bg,
+    width: size,
+    height: size,
+    ...style,
+  }
+
   return (
-    <Box
-      as={as}
-      bg={bg}
-      overflow="hidden"
-      borderWidth={0}
-      size={size}
-      borderRadius="50%"
-      borderStyle="solid"
-      borderColor="border.default"
-    >
-      <Box display="flex" as={as} size={size} {...rest} alignItems="center" justifyContent="center">
-        <IconComponent size={size} aria-label={ariaLabel} />
-      </Box>
-    </Box>
+    <Component className={`${styles.CircleOcticon}${className ? ` ${className}` : ''}`} style={wrapperStyle} {...rest}>
+      <IconComponent size={size} aria-label={ariaLabel} />
+    </Component>
   )
 }
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5781
##  Current `sx` usage: [1](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x+name%3A%22CircleOcticon%22)
❌  Still need to separately update github-ui components to use @primer/styled-react

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

Remove support for `sx` from the `CircleOcticon` component, and associated stories, docs, and tests

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Major release; if selected, include a written rollout or migration plan

We are using the `@primer/styled-react` component to mitigate removing `sx` usage. We will make sure usage is updated upstream before merging.

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
