### PR TITLE
Fix SelectPanel storybook text truncation 

### DIFF
--- a/packages/react/src/SelectPanel/SelectPanel.examples.stories.module.css
+++ b/packages/react/src/SelectPanel/SelectPanel.examples.stories.module.css
@@ -19,9 +19,3 @@
   outline: 2px solid var(--focus-outlineColor, var(--color-accent-emphasis));
   outline-offset: -2px;
 }
-
-.TruncatedText {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}

--- a/packages/react/src/SelectPanel/SelectPanel.examples.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.examples.stories.tsx
@@ -298,7 +298,7 @@ export const CustomItemRenderer = () => {
         overlayProps={{width: 'medium'}}
         renderItem={item => (
           <ActionList.Item id={item.id?.toString()} className={styles.CustomActionListItem}>
-            <div className={styles.TruncatedText}>{item.text}</div>
+            <ActionList.Description truncate>{item.text}</ActionList.Description>
           </ActionList.Item>
         )}
         message={filteredItems.length === 0 ? NoResultsMessage(filter) : undefined}


### PR DESCRIPTION
The Storybook examples were importing `ActionList.Item` from deprecated `ActionList` components. The `.TruncatedText` CSS was not working properly because the deprecated `Item` doesn't have proper width constraints. Updated to use current `ActionList` components.

Closes [#5773](https://github.com/github/primer/issues/5773)

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->
 
- [X] None, a storybook issue.

 
