### PR TITLE
Remove support for `sx` from `PageLayout` component

### DIFF
--- a/.changeset/strange-steaks-burn.md
+++ b/.changeset/strange-steaks-burn.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": major
+---
+
+Update PageLayout component to no longer support sx

--- a/packages/react/src/PageLayout/PageLayout.dev.stories.module.css
+++ b/packages/react/src/PageLayout/PageLayout.dev.stories.module.css
@@ -1,4 +1,7 @@
-.PageLayout {
-  border: var(--borderWidth-default) solid red;
+.PageLayoutRedBorder {
+  border: var(--borderWidth-default) solid var(--borderColor-closed-emphasis);
+}
+
+.PageLayoutGreenText {
   color: var(--fgColor-success);
 }

--- a/packages/react/src/PageLayout/PageLayout.dev.stories.module.css
+++ b/packages/react/src/PageLayout/PageLayout.dev.stories.module.css
@@ -1,0 +1,4 @@
+.PageLayout {
+  border: var(--borderWidth-default) solid red;
+  color: var(--fgColor-success);
+}

--- a/packages/react/src/PageLayout/PageLayout.dev.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.dev.stories.tsx
@@ -1,6 +1,7 @@
 import type {Meta, StoryFn} from '@storybook/react-vite'
 import {Placeholder} from '../Placeholder'
 import {PageLayout} from './PageLayout'
+import classes from './PageLayout.examples.stories.module.css'
 
 const meta: Meta = {
   title: 'Components/PageLayout/Dev',
@@ -346,11 +347,10 @@ export const Default: StoryFn = args => (
     padding={args.padding}
     rowGap={args.rowGap}
     columnGap={args.columnGap}
-    sx={{border: '1px solid red'}}
+    className={classes.PageLayout}
   >
     <PageLayout.Header
       padding={args['Header.padding']}
-      sx={{color: 'var(--fgColor-success)'}}
       divider={{
         narrow: args['Header.divider.narrow'],
         regular: args['Header.divider.regular'],
@@ -365,7 +365,6 @@ export const Default: StoryFn = args => (
       <Placeholder height={args['Header placeholder height']} label="Header" />
     </PageLayout.Header>
     <PageLayout.Content
-      sx={{color: 'var(--fgColor-success)'}}
       width={args['Content.width']}
       padding={args['Content.padding']}
       hidden={{
@@ -377,7 +376,6 @@ export const Default: StoryFn = args => (
       <Placeholder height={args['Content placeholder height']} label="Content" />
     </PageLayout.Content>
     <PageLayout.Pane
-      sx={{color: 'var(--fgColor-success)'}}
       position={{
         narrow: args['Pane.position.narrow'],
         regular: args['Pane.position.regular'],
@@ -402,7 +400,6 @@ export const Default: StoryFn = args => (
       <Placeholder height={args['Pane placeholder height']} label="Pane" />
     </PageLayout.Pane>
     <PageLayout.Footer
-      sx={{color: 'var(--fgColor-success)'}}
       padding={args['Footer.padding']}
       divider={{
         narrow: args['Footer.divider.narrow'],

--- a/packages/react/src/PageLayout/PageLayout.dev.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.dev.stories.tsx
@@ -1,7 +1,6 @@
 import type {Meta, StoryFn} from '@storybook/react-vite'
 import {Placeholder} from '../Placeholder'
 import {PageLayout} from './PageLayout'
-import {clsx} from 'clsx'
 import classes from './PageLayout.dev.stories.module.css'
 
 const meta: Meta = {

--- a/packages/react/src/PageLayout/PageLayout.dev.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.dev.stories.tsx
@@ -1,7 +1,8 @@
 import type {Meta, StoryFn} from '@storybook/react-vite'
 import {Placeholder} from '../Placeholder'
 import {PageLayout} from './PageLayout'
-import classes from './PageLayout.examples.stories.module.css'
+import {clsx} from 'clsx'
+import classes from './PageLayout.dev.stories.module.css'
 
 const meta: Meta = {
   title: 'Components/PageLayout/Dev',
@@ -347,7 +348,7 @@ export const Default: StoryFn = args => (
     padding={args.padding}
     rowGap={args.rowGap}
     columnGap={args.columnGap}
-    className={classes.PageLayout}
+    className={classes.PageLayoutRedBorder}
   >
     <PageLayout.Header
       padding={args['Header.padding']}
@@ -361,6 +362,7 @@ export const Default: StoryFn = args => (
         regular: args['Header.hidden.regular'],
         wide: args['Header.hidden.wide'],
       }}
+      className={classes.PageLayoutGreenText}
     >
       <Placeholder height={args['Header placeholder height']} label="Header" />
     </PageLayout.Header>
@@ -372,6 +374,7 @@ export const Default: StoryFn = args => (
         regular: args['Content.hidden.regular'],
         wide: args['Content.hidden.wide'],
       }}
+      className={classes.PageLayoutGreenText}
     >
       <Placeholder height={args['Content placeholder height']} label="Content" />
     </PageLayout.Content>
@@ -396,6 +399,7 @@ export const Default: StoryFn = args => (
         regular: args['Pane.hidden.regular'],
         wide: args['Pane.hidden.wide'],
       }}
+      className={classes.PageLayoutGreenText}
     >
       <Placeholder height={args['Pane placeholder height']} label="Pane" />
     </PageLayout.Pane>
@@ -411,6 +415,7 @@ export const Default: StoryFn = args => (
         regular: args['Footer.hidden.regular'],
         wide: args['Footer.hidden.wide'],
       }}
+      className={classes.PageLayoutGreenText}
     >
       <Placeholder height={args['Footer placeholder height']} label="Footer" />
     </PageLayout.Footer>

--- a/packages/react/src/PageLayout/PageLayout.docs.json
+++ b/packages/react/src/PageLayout/PageLayout.docs.json
@@ -57,11 +57,6 @@
       "type": "| 'none' | 'condensed' | 'normal'",
       "defaultValue": "'normal'",
       "description": ""
-    },
-    {
-      "name": "sx",
-      "type": "SystemStyleObject",
-      "deprecated": true
     }
   ],
   "subcomponents": [
@@ -104,11 +99,6 @@
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",
           "description": "Whether the header is hidden."
-        },
-        {
-          "name": "sx",
-          "type": "SystemStyleObject",
-          "deprecated": true
         }
       ]
     },
@@ -144,11 +134,6 @@
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",
           "description": "Whether the content is hidden."
-        },
-        {
-          "name": "sx",
-          "type": "SystemStyleObject",
-          "deprecated": true
         }
       ]
     },
@@ -233,11 +218,6 @@
           "defaultValue": ""
         },
         {
-          "name": "sx",
-          "type": "SystemStyleObject",
-          "deprecated": true
-        },
-        {
           "name": "ref",
           "type": "React.RefObject<HTMLDivElement>"
         }
@@ -282,11 +262,6 @@
           "type": "| boolean | { narrow?: boolean regular?: boolean wide?: boolean }",
           "defaultValue": "false",
           "description": "Whether the footer is hidden."
-        },
-        {
-          "name": "sx",
-          "type": "SystemStyleObject",
-          "deprecated": true
         }
       ]
     }

--- a/packages/react/src/PageLayout/PageLayout.module.css
+++ b/packages/react/src/PageLayout/PageLayout.module.css
@@ -154,6 +154,24 @@ body[data-page-layout-dragging='true'] * {
   }
 }
 
+/* DRAG HANDLE STYLES */
+.PageLayoutPaneDragHandle {
+  position: absolute;
+  inset: 0 -2px;
+  cursor: col-resize;
+  transition: background 0.2s;
+  background: transparent;
+}
+
+.PageLayoutPaneDragHandle:hover {
+  background: var(--bgColor-neutral-muted);
+}
+
+.PageLayoutPaneDragHandle.IsDragging,
+.PageLayoutPaneDragHandle.IsDragging:hover {
+  background: var(--bgColor-accent-emphasis);
+}
+
 .Header {
   width: 100%;
   /* stylelint-disable-next-line primer/spacing */

--- a/packages/react/src/PageLayout/PageLayout.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.stories.tsx
@@ -349,7 +349,6 @@ export const Default: StoryFn = args => (
     padding={args.padding}
     rowGap={args.rowGap}
     columnGap={args.columnGap}
-    sx={args.sx}
   >
     {args['Render header?'] ? (
       <PageLayout.Header

--- a/packages/react/src/PageLayout/PageLayout.tsx
+++ b/packages/react/src/PageLayout/PageLayout.tsx
@@ -19,6 +19,7 @@ const REGION_ORDER = {
   footer: 4,
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SPACING_MAP = {
   none: 0,
   condensed: 3,
@@ -37,16 +38,23 @@ const PageLayoutContext = React.createContext<{
   paneRef: {current: null},
 })
 
+// ----------------------------------------------------------------------------
+// PageLayout
+
 export type PageLayoutProps = {
+  /** The maximum width of the page container */
   containerWidth?: keyof typeof containerWidths
+  /** The spacing between the outer edges of the page container and the viewport */
   padding?: keyof typeof SPACING_MAP
   rowGap?: keyof typeof SPACING_MAP
   columnGap?: keyof typeof SPACING_MAP
+  /** Private prop to allow SplitPageLayout to customize slot components */
   _slotsConfig?: Record<'header' | 'footer', React.ElementType>
   className?: string
   style?: React.CSSProperties
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const containerWidths = {
   full: '100%',
   medium: '768px',
@@ -54,6 +62,7 @@ const containerWidths = {
   xlarge: '1280px',
 }
 
+// TODO: refs
 const Root: React.FC<React.PropsWithChildren<PageLayoutProps>> = ({
   containerWidth = 'xlarge',
   padding = 'normal',
@@ -65,6 +74,7 @@ const Root: React.FC<React.PropsWithChildren<PageLayoutProps>> = ({
   _slotsConfig: slotsConfig,
 }) => {
   const paneRef = useRef<HTMLDivElement>(null)
+
   const [slots, rest] = useSlots(children, slotsConfig ?? {header: Header, footer: Footer})
 
   const memoizedContextValue = React.useMemo(() => {
@@ -80,10 +90,12 @@ const Root: React.FC<React.PropsWithChildren<PageLayoutProps>> = ({
     <PageLayoutContext.Provider value={memoizedContextValue}>
       <div
         className={clsx(classes.PageLayoutRoot, className)}
-        style={{
-          '--spacing': `var(--spacing-${padding})`,
-          ...style,
-        }}
+        style={
+          {
+            '--spacing': `var(--spacing-${padding})`,
+            ...style,
+          } as React.CSSProperties
+        }
       >
         <div className={classes.PageLayoutWrapper} data-width={containerWidth}>
           {slots.header}
@@ -121,10 +133,12 @@ const HorizontalDivider: React.FC<React.PropsWithChildren<DividerProps>> = ({
       className={clsx(classes.HorizontalDivider, className)}
       data-variant={responsiveVariant}
       data-position={position}
-      style={{
-        '--spacing-divider': `var(--spacing-${padding})`,
-        ...style,
-      }}
+      style={
+        {
+          '--spacing': `var(--spacing-${padding})`,
+          ...style,
+        } as React.CSSProperties
+      }
     />
   )
 }
@@ -199,6 +213,7 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
 
     function handleKeyDrag(event: KeyboardEvent) {
       let delta = 0
+      // https://github.com/github/accessibility/issues/5101#issuecomment-1822870655
       if ((event.key === 'ArrowLeft' || event.key === 'ArrowDown') && currentWidth > minWidth) {
         delta = -3
       } else if ((event.key === 'ArrowRight' || event.key === 'ArrowUp') && currentWidth < maxWidth) {
@@ -216,7 +231,7 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
       stableOnDragEnd.current?.()
       event.preventDefault()
     }
-
+    // TODO: Support touch events
     if (isDragging || isKeyboardDrag) {
       window.addEventListener('mousemove', handleDrag)
       window.addEventListener('keydown', handleKeyDrag)
@@ -251,6 +266,7 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
       style={style}
     >
       {draggable ? (
+        // Drag handle
         <div
           className={clsx(classes.PageLayoutPaneDragHandle, {
             [classes.IsDragging]: isDragging || isKeyboardDrag,
@@ -290,10 +306,31 @@ const VerticalDivider: React.FC<React.PropsWithChildren<DividerProps & Draggable
 // PageLayout.Header
 
 export type PageLayoutHeaderProps = {
+  /**
+   * A unique label for the rendered banner landmark
+   */
   'aria-label'?: React.AriaAttributes['aria-label']
+  /**
+   * An id to an element which uniquely labels the rendered banner landmark
+   */
   'aria-labelledby'?: React.AriaAttributes['aria-labelledby']
+
   padding?: keyof typeof SPACING_MAP
   divider?: 'none' | 'line' | ResponsiveValue<'none' | 'line', 'none' | 'line' | 'filled'>
+  /**
+   * @deprecated Use the `divider` prop with a responsive value instead.
+   *
+   * Before:
+   * ```
+   * divider="line"
+   * dividerWhenNarrow="filled"
+   * ```
+   *
+   * After:
+   * ```
+   * divider={{regular: 'line', narrow: 'filled'}}
+   * ```
+   */
   dividerWhenNarrow?: 'inherit' | 'none' | 'line' | 'filled'
   hidden?: boolean | ResponsiveValue<boolean>
   className?: string
@@ -310,6 +347,7 @@ const Header: React.FC<React.PropsWithChildren<PageLayoutHeaderProps>> = ({
   children,
   style,
   className,
+  // Combine divider and dividerWhenNarrow for backwards compatibility
 }) => {
   const dividerProp =
     !isResponsiveValue(divider) && dividerWhenNarrow !== 'inherit'
@@ -326,25 +364,31 @@ const Header: React.FC<React.PropsWithChildren<PageLayoutHeaderProps>> = ({
       aria-labelledby={labelledBy}
       hidden={isHidden}
       className={clsx(classes.Header, className)}
-      style={{
-        '--spacing': `var(--spacing-${rowGap})`,
-        ...style,
-      }}
+      style={
+        {
+          '--spacing': `var(--spacing-${rowGap})`,
+          ...style,
+        } as React.CSSProperties
+      }
     >
       <div
         className={classes.HeaderContent}
-        style={{
-          '--spacing': `var(--spacing-${padding})`,
-        }}
+        style={
+          {
+            '--spacing': `var(--spacing-${padding})`,
+          } as React.CSSProperties
+        }
       >
         {children}
       </div>
       <HorizontalDivider
         variant={dividerVariant}
         className={classes.HeaderHorizontalDivider}
-        style={{
-          '--spacing': `var(--spacing-${rowGap})`,
-        }}
+        style={
+          {
+            '--spacing': `var(--spacing-${rowGap})`,
+          } as React.CSSProperties
+        }
       />
     </header>
   )
@@ -356,8 +400,18 @@ Header.displayName = 'PageLayout.Header'
 // PageLayout.Content
 
 export type PageLayoutContentProps = {
+  /**
+   * Provide an optional element type for the outermost element rendered by the component.
+   * @default 'main'
+   */
   as?: React.ElementType
+  /**
+   * A unique label for the rendered main landmark
+   */
   'aria-label'?: React.AriaAttributes['aria-label']
+  /**
+   * An id to an element which uniquely labels the rendered main landmark
+   */
   'aria-labelledby'?: React.AriaAttributes['aria-labelledby']
   width?: keyof typeof contentWidths
   padding?: keyof typeof SPACING_MAP
@@ -366,6 +420,8 @@ export type PageLayoutContentProps = {
   style?: React.CSSProperties
 }
 
+// TODO: Account for pane width when centering content
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const contentWidths = {
   full: '100%',
   medium: '768px',
@@ -398,9 +454,11 @@ const Content: React.FC<React.PropsWithChildren<PageLayoutContentProps>> = ({
       <div
         className={classes.Content}
         data-width={width}
-        style={{
-          '--spacing': `var(--spacing-${padding})`,
-        }}
+        style={
+          {
+            '--spacing': `var(--spacing-${padding})`,
+          } as React.CSSProperties
+        }
       >
         {children}
       </div>
@@ -433,6 +491,20 @@ const isPaneWidth = (width: PaneWidth | CustomWidthOptions): width is PaneWidth 
 
 export type PageLayoutPaneProps = {
   position?: keyof typeof panePositions | ResponsiveValue<keyof typeof panePositions>
+  /**
+   * @deprecated Use the `position` prop with a responsive value instead.
+   *
+   * Before:
+   * ```
+   * position="start"
+   * positionWhenNarrow="end"
+   * ```
+   *
+   * After:
+   * ```
+   * position={{regular: 'start', narrow: 'end'}}
+   * ```
+   */
   positionWhenNarrow?: 'inherit' | keyof typeof panePositions
   'aria-labelledby'?: string
   'aria-label'?: string
@@ -442,6 +514,20 @@ export type PageLayoutPaneProps = {
   widthStorageKey?: string
   padding?: keyof typeof SPACING_MAP
   divider?: 'none' | 'line' | ResponsiveValue<'none' | 'line', 'none' | 'line' | 'filled'>
+  /**
+   * @deprecated Use the `divider` prop with a responsive value instead.
+   *
+   * Before:
+   * ```
+   * divider="line"
+   * dividerWhenNarrow="filled"
+   * ```
+   *
+   * After:
+   * ```
+   * divider={{regular: 'line', narrow: 'filled'}}
+   * ```
+   */
   dividerWhenNarrow?: 'inherit' | 'none' | 'line' | 'filled'
   sticky?: boolean
   offsetHeader?: string | number
@@ -451,11 +537,13 @@ export type PageLayoutPaneProps = {
   style?: React.CSSProperties
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const panePositions = {
   start: REGION_ORDER.paneStart,
   end: REGION_ORDER.paneEnd,
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const paneWidths = {
   small: ['100%', null, '240px', '256px'],
   medium: ['100%', null, '256px', '296px'],
@@ -490,6 +578,7 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
     },
     forwardRef,
   ) => {
+    // Combine position and positionWhenNarrow for backwards compatibility
     const positionProp =
       !isResponsiveValue(responsivePosition) && positionWhenNarrow !== 'inherit'
         ? {regular: responsivePosition, narrow: positionWhenNarrow}
@@ -497,6 +586,7 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
 
     const position = useResponsiveValue(positionProp, 'end')
 
+    // Combine divider and dividerWhenNarrow for backwards compatibility
     const dividerProp =
       !isResponsiveValue(responsiveDivider) && dividerWhenNarrow !== 'inherit'
         ? {regular: responsiveDivider, narrow: dividerWhenNarrow}
@@ -578,12 +668,15 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
         data-position={position}
         data-sticky={sticky || undefined}
       >
+        {/* Show a horizontal divider when viewport is narrow. Otherwise, show a vertical divider. */}
         <HorizontalDivider
           variant={{narrow: dividerVariant, regular: 'none'}}
           className={classes.PaneHorizontalDivider}
-          style={{
-            '--spacing': `var(--spacing-${rowGap})`,
-          }}
+          style={
+            {
+              '--spacing': `var(--spacing-${rowGap})`,
+            } as React.CSSProperties
+          }
           position={position}
         />
         <div
@@ -593,24 +686,29 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
           {...(id && {id: paneId})}
           className={classes.Pane}
           data-resizable={resizable || undefined}
-          style={{
-            '--spacing': `var(--spacing-${padding})`,
-            '--pane-min-width': isCustomWidthOptions(width) ? width.min : `${minWidth}px`,
-            '--pane-max-width': isCustomWidthOptions(width) ? width.max : `calc(100vw - var(--pane-max-width-diff))`,
-            '--pane-width-custom': isCustomWidthOptions(width) ? width.default : undefined,
-            '--pane-width-size': `var(--pane-width-${isPaneWidth(width) ? width : 'custom'})`,
-            '--pane-width': `${paneWidth}px`,
-          }}
+          style={
+            {
+              '--spacing': `var(--spacing-${padding})`,
+              '--pane-min-width': isCustomWidthOptions(width) ? width.min : `${minWidth}px`,
+              '--pane-max-width': isCustomWidthOptions(width) ? width.max : `calc(100vw - var(--pane-max-width-diff))`,
+              '--pane-width-custom': isCustomWidthOptions(width) ? width.default : undefined,
+              '--pane-width-size': `var(--pane-width-${isPaneWidth(width) ? width : 'custom'})`,
+              '--pane-width': `${paneWidth}px`,
+            } as React.CSSProperties
+          }
         >
           {children}
         </div>
         <VerticalDivider
           variant={{
             narrow: 'none',
+            // If pane is resizable, always show a vertical divider on regular viewports
             regular: resizable ? 'line' : dividerVariant,
           }}
+          // If pane is resizable, the divider should be draggable
           draggable={resizable}
           onDrag={(delta, isKeyboard = false) => {
+            // Get the number of pixels the divider was dragged
             let deltaWithDirection
             if (isKeyboard) {
               deltaWithDirection = delta
@@ -619,6 +717,7 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
             }
             updatePaneWidth(paneWidth + deltaWithDirection)
           }}
+          // Ensure `paneWidth` state and actual pane width are in sync when the drag ends
           onDragEnd={() => {
             const paneRect = paneRef.current?.getBoundingClientRect()
             if (!paneRect) return
@@ -627,9 +726,11 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
           position={position}
           onDoubleClick={() => updatePaneWidth(getDefaultPaneWidth(width))}
           className={classes.PaneVerticalDivider}
-          style={{
-            '--spacing': `var(--spacing-${columnGap})`,
-          }}
+          style={
+            {
+              '--spacing': `var(--spacing-${columnGap})`,
+            } as React.CSSProperties
+          }
         />
       </div>
     )
@@ -642,10 +743,31 @@ Pane.displayName = 'PageLayout.Pane'
 // PageLayout.Footer
 
 export type PageLayoutFooterProps = {
+  /**
+   * A unique label for the rendered contentinfo landmark
+   */
   'aria-label'?: React.AriaAttributes['aria-label']
+
+  /**
+   * An id to an element which uniquely labels the rendered contentinfo landmark
+   */
   'aria-labelledby'?: React.AriaAttributes['aria-labelledby']
   padding?: keyof typeof SPACING_MAP
   divider?: 'none' | 'line' | ResponsiveValue<'none' | 'line', 'none' | 'line' | 'filled'>
+  /**
+   * @deprecated Use the `divider` prop with a responsive value instead.
+   *
+   * Before:
+   * ```
+   * divider="line"
+   * dividerWhenNarrow="filled"
+   * ```
+   *
+   * After:
+   * ```
+   * divider={{regular: 'line', narrow: 'filled'}}
+   * ```
+   */
   dividerWhenNarrow?: 'inherit' | 'none' | 'line' | 'filled'
   hidden?: boolean | ResponsiveValue<boolean>
   className?: string
@@ -663,6 +785,7 @@ const Footer: React.FC<React.PropsWithChildren<PageLayoutFooterProps>> = ({
   className,
   style,
 }) => {
+  // Combine divider and dividerWhenNarrow for backwards compatibility
   const dividerProp =
     !isResponsiveValue(divider) && dividerWhenNarrow !== 'inherit'
       ? {regular: divider, narrow: dividerWhenNarrow}
@@ -678,23 +801,29 @@ const Footer: React.FC<React.PropsWithChildren<PageLayoutFooterProps>> = ({
       aria-labelledby={labelledBy}
       hidden={isHidden}
       className={clsx(classes.FooterWrapper, className)}
-      style={{
-        '--spacing': `var(--spacing-${rowGap})`,
-        ...style,
-      }}
+      style={
+        {
+          '--spacing': `var(--spacing-${rowGap})`,
+          ...style,
+        } as React.CSSProperties
+      }
     >
       <HorizontalDivider
         className={classes.FooterHorizontalDivider}
-        style={{
-          '--spacing': `var(--spacing-${rowGap})`,
-        }}
+        style={
+          {
+            '--spacing': `var(--spacing-${rowGap})`,
+          } as React.CSSProperties
+        }
         variant={dividerVariant}
       />
       <div
         className={classes.FooterContent}
-        style={{
-          '--spacing': `var(--spacing-${padding})`,
-        }}
+        style={
+          {
+            '--spacing': `var(--spacing-${padding})`,
+          } as React.CSSProperties
+        }
       >
         {children}
       </div>

--- a/packages/react/src/PageLayout/PageLayout.tsx
+++ b/packages/react/src/PageLayout/PageLayout.tsx
@@ -658,12 +658,14 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
     return (
       <div
         className={clsx(classes.PaneWrapper, className)}
-        style={{
-          '--offset-header': typeof offsetHeader === 'number' ? `${offsetHeader}px` : offsetHeader,
-          '--spacing-row': `var(--spacing-${rowGap})`,
-          '--spacing-column': `var(--spacing-${columnGap})`,
-          ...style,
-        }}
+        style={
+          {
+            '--offset-header': typeof offsetHeader === 'number' ? `${offsetHeader}px` : offsetHeader,
+            '--spacing-row': `var(--spacing-${rowGap})`,
+            '--spacing-column': `var(--spacing-${columnGap})`,
+            ...style,
+          } as React.CSSProperties
+        }
         data-is-hidden={isHidden}
         data-position={position}
         data-sticky={sticky || undefined}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5796
##  Current `sx` usage: [13](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x+name%3A%22PageLayout%22)
❌  Still need to separately update github-ui components to use @primer/styled-react

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

Remove support for `sx` from the `PageLayout` component, and any associated stories, docs, and tests

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Major release; if selected, include a written rollout or migration plan

We are using the `@primer/styled-react` component to mitigate removing `sx` usage. We will make sure usage is updated upstream before merging.

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->