### PR TITLE
Remove support for `sx` from `PointerBox` component

### DIFF
--- a/.changeset/shy-bees-hug.md
+++ b/.changeset/shy-bees-hug.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": major
+---
+
+Update PointerBox component to no longer support sx

--- a/packages/react/src/Pagination/Pagination.docs.json
+++ b/packages/react/src/Pagination/Pagination.docs.json
@@ -71,11 +71,6 @@
       "type": "function",
       "defaultValue": "(props: PageProps) => ReactNode",
       "description": "Provide a custom component or render prop to render each page link within the component."
-    },
-    {
-      "name": "sx",
-      "type": "SystemStyleObject",
-      "deprecated": true
     }
   ],
   "subcomponents": []

--- a/packages/react/src/PointerBox/PointerBox.tsx
+++ b/packages/react/src/PointerBox/PointerBox.tsx
@@ -1,64 +1,53 @@
 import React from 'react'
 import {ThemeContext} from 'styled-components'
 import type {BoxProps} from '../Box'
-import Box from '../Box'
 import type {CaretProps} from '../internal/components/Caret'
 import Caret from '../internal/components/Caret'
-import {get} from '../constants'
-import type {SxProp} from '../sx'
-
-// FIXME: Make this work with BetterStyledSystem types
-type MutatedSxProps = {
-  sx?: {
-    bg?: string
-    backgroundColor?: string
-    borderColor?: string
-  }
-} & SxProp
 
 export type PointerBoxProps = {
   caret?: CaretProps['location']
   bg?: CaretProps['bg']
   borderColor?: CaretProps['borderColor']
   border?: CaretProps['borderWidth']
-} & BoxProps &
-  MutatedSxProps
+} & BoxProps
 
 function PointerBox(props: PointerBoxProps) {
   // don't destructure these, just grab them
   const themeContext = React.useContext(ThemeContext)
-  const {bg, border, borderColor, theme: themeProp, sx} = props
-  const {caret, children, ...boxProps} = props
-  const {bg: sxBg, backgroundColor, ...sxRest} = sx || {}
+  const {bg, border, borderColor, theme: themeProp, caret, children, ...boxProps} = props
   const theme = themeProp || themeContext
-  const customBackground = bg || sxBg || backgroundColor
+
+  const customBackground = bg ?? 'var(--bgColor-default)'
+  const customBorderColor = borderColor ?? 'var(--borderColor-default)'
+  const customBorderWidth = border ?? 'var(--borderWidth-default)'
 
   const caretProps = {
-    bg: bg || sx?.bg || sx?.backgroundColor,
-    borderColor: borderColor || sx?.borderColor,
+    bg,
+    borderColor,
     borderWidth: border,
     location: caret,
     theme,
   }
 
-  const defaultBoxProps = {borderWidth: '1px', borderStyle: 'solid', borderColor: 'border.default', borderRadius: 2}
-
   return (
-    <Box
-      {...defaultBoxProps}
-      {...boxProps}
-      sx={{
-        ...sxRest,
-        '--custom-bg': get(`colors.${customBackground}`)({theme}),
+    <div
+      style={{
+        borderWidth: customBorderWidth,
+        borderStyle: 'solid',
+        borderColor: customBorderColor,
+        borderRadius: 'var(--borderRadius-medium)',
+        position: 'relative',
+        background: customBackground,
+        ...(boxProps.style ?? {}),
         backgroundImage: customBackground
           ? `linear-gradient(var(--custom-bg), var(--custom-bg)), linear-gradient(${theme.colors.canvas.default}, ${theme.colors.canvas.default})`
           : undefined,
-        position: 'relative',
       }}
+      {...boxProps}
     >
       {children}
       <Caret {...caretProps} />
-    </Box>
+    </div>
   )
 }
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/5798
##  Current `sx` usage: [0](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x+name%3A%22PointerBox%22)
✅   Don't need to separately update github-ui components to use @primer/styled-react

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

Remove support for `sx` from the `PointerBox` component, and any associated stories, docs, and tests

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Major release; if selected, include a written rollout or migration plan

This component currently has 0 `sx` usage in dotcom, and therefore does not need the @primer/styled-react wrapper. this will be confirmed again before merging.

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
