### PR TITLE
ci: add upload-versions to release candidate workflow

### DIFF
--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -68,3 +68,4 @@ jobs:
               description: package.version,
               target_url: `https://unpkg.com/${package.name}@${package.version}/`
             })
+      - uses: ./.github/actions/upload-versions


### PR DESCRIPTION
Add the `upload-versions` shared action to our release candidate workflow to update our Primer Release workflow