### PR TITLE
Remove support for sx from `SubNav`, `Text`, `Textarea`, `TextInput`, `TextInputWithTokens` components

### DIFF
--- a/.changeset/quick-guests-ask.md
+++ b/.changeset/quick-guests-ask.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': major
+---
+
+Remove support for sx from the SubNav, Text, Textarea, TextInput, TextInputWithTokens component.

--- a/e2e/components/TextInput.test.ts
+++ b/e2e/components/TextInput.test.ts
@@ -219,24 +219,6 @@ test.describe('TextInput', () => {
     }
   })
 
-  test.describe('Dev: With Sx', () => {
-    for (const theme of themes) {
-      test.describe(theme, () => {
-        test('default @vrt', async ({page}) => {
-          await visit(page, {
-            id: 'components-textinput-dev--with-sx',
-            globals: {
-              colorScheme: theme,
-            },
-          })
-
-          // Default state
-          expect(await page.screenshot()).toMatchSnapshot(`TextInput.Dev.WithSx.${theme}.png`)
-        })
-      })
-    }
-  })
-
   test.describe('Dev: With CSS', () => {
     for (const theme of themes) {
       test.describe(theme, () => {
@@ -250,24 +232,6 @@ test.describe('TextInput', () => {
 
           // Default state
           expect(await page.screenshot()).toMatchSnapshot(`TextInput.Dev.WithCSS.${theme}.png`)
-        })
-      })
-    }
-  })
-
-  test.describe('Dev: With Sx and CSS', () => {
-    for (const theme of themes) {
-      test.describe(theme, () => {
-        test('default @vrt', async ({page}) => {
-          await visit(page, {
-            id: 'components-textinput-dev--with-sx-and-css',
-            globals: {
-              colorScheme: theme,
-            },
-          })
-
-          // Default state
-          expect(await page.screenshot()).toMatchSnapshot(`TextInput.Dev.WithSxAndCSS.${theme}.png`)
         })
       })
     }

--- a/packages/react/src/SubNav/SubNav.docs.json
+++ b/packages/react/src/SubNav/SubNav.docs.json
@@ -38,11 +38,6 @@
       "name": "aria-label",
       "type": "string",
       "description": "Used to set the `aria-label` on the top level `<nav>` element."
-    },
-    {
-      "name": "sx",
-      "type": "SystemStyleObject",
-      "deprecated": true
     }
   ],
   "subcomponents": [
@@ -67,23 +62,12 @@
           "name": "to",
           "type": "string | Partial<Path>",
           "description": "Used when the item is rendered using a component like React Router's `Link`. The path to navigate to."
-        },
-        {
-          "name": "sx",
-          "type": "SystemStyleObject",
-          "deprecated": true
         }
       ]
     },
     {
       "name": "SubNav.Links",
-      "props": [
-        {
-          "name": "sx",
-          "type": "SystemStyleObject",
-          "deprecated": true
-        }
-      ]
+      "props": []
     }
   ]
 }

--- a/packages/react/src/Text/Text.docs.json
+++ b/packages/react/src/Text/Text.docs.json
@@ -43,11 +43,6 @@
       "type": "React.ElementType"
     },
     {
-      "name": "sx",
-      "type": "SystemStyleObject",
-      "deprecated": true
-    },
-    {
       "name": "size",
       "type": "'large' | 'medium' | 'small'"
     },

--- a/packages/react/src/Text/Text.stories.tsx
+++ b/packages/react/src/Text/Text.stories.tsx
@@ -20,12 +20,6 @@ Playground.argTypes = {
   as: {
     type: 'string',
   },
-  sx: {
-    controls: false,
-    table: {
-      disable: true,
-    },
-  },
   ref: {
     controls: false,
     table: {

--- a/packages/react/src/Text/Text.tsx
+++ b/packages/react/src/Text/Text.tsx
@@ -1,11 +1,9 @@
 import {clsx} from 'clsx'
-import {type StyledComponent} from 'styled-components'
 import React, {forwardRef} from 'react'
 import type {SystemCommonProps, SystemTypographyProps} from '../constants'
-import type {SxProp} from '../sx'
 import {useRefObjectAsForwardedRef} from '../hooks'
+import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 import classes from './Text.module.css'
-import {BoxWithFallback} from '../internal/components/BoxWithFallback'
 
 type StyledTextProps = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -14,27 +12,24 @@ type StyledTextProps = {
   weight?: 'light' | 'normal' | 'medium' | 'semibold'
 } & SystemTypographyProps &
   SystemCommonProps &
-  SxProp &
   React.HTMLAttributes<HTMLSpanElement>
 
-const Text = forwardRef(({as: Component = 'span', className, size, weight, ...props}, forwardedRef) => {
-  const innerRef = React.useRef<HTMLElement>(null)
-  useRefObjectAsForwardedRef(forwardedRef, innerRef)
+const Text = forwardRef<HTMLElement, StyledTextProps>(
+  ({as: Component = 'span', className, size, weight, ...props}, forwardedRef) => {
+    const innerRef = React.useRef<HTMLElement>(null)
+    useRefObjectAsForwardedRef(forwardedRef, innerRef)
 
-  return (
-    <BoxWithFallback
-      as={Component}
-      className={clsx(className, classes.Text)}
-      data-size={size}
-      data-weight={weight}
-      {...props}
-      // @ts-ignore shh
-      ref={innerRef}
-    />
-  )
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-}) as StyledComponent<'span', any, StyledTextProps, never>
+    return (
+      <Component
+        className={clsx(className, classes.Text)}
+        data-size={size}
+        data-weight={weight}
+        {...props}
+        ref={innerRef}
+      />
+    )
+  },
+) as PolymorphicForwardRefComponent<'span', StyledTextProps>
 
 Text.displayName = 'Text'
 

--- a/packages/react/src/TextInput/TextInput.dev.stories.tsx
+++ b/packages/react/src/TextInput/TextInput.dev.stories.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import type {Meta} from '@storybook/react-vite'
-import {Box, FormControl} from '..'
+import {FormControl} from '..'
 import TextInput from '.'
 import {textInputExcludedControlKeys} from '../utils/story-helpers'
 
@@ -11,28 +11,10 @@ export default {
 } as Meta<React.ComponentProps<typeof TextInput>>
 
 export const WithCSS = () => (
-  <Box as="form">
+  <form>
     <FormControl>
       <FormControl.Label>Default label</FormControl.Label>
       <TextInput className="testCustomClassnameBorderColor" />
     </FormControl>
-  </Box>
-)
-
-export const WithSx = () => (
-  <Box as="form">
-    <FormControl>
-      <FormControl.Label>Default label</FormControl.Label>
-      <TextInput sx={{borderColor: 'red'}} />
-    </FormControl>
-  </Box>
-)
-
-export const WithSxAndCSS = () => (
-  <Box as="form">
-    <FormControl>
-      <FormControl.Label>Default label</FormControl.Label>
-      <TextInput sx={{borderColor: 'red'}} className="testCustomClassnameBorderColor" />
-    </FormControl>
-  </Box>
+  </form>
 )

--- a/packages/react/src/TextInput/TextInput.tsx
+++ b/packages/react/src/TextInput/TextInput.tsx
@@ -46,7 +46,6 @@ export type TextInputNonPassthroughProps = {
     | 'contrast'
     | 'disabled'
     | 'monospace'
-    | 'sx'
     | 'width'
     | 'maxWidth'
     | 'minWidth'
@@ -75,7 +74,6 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
       loaderText = 'Loading',
       monospace,
       validationStatus,
-      sx: sxProp,
       size: sizeProp,
       onFocus,
       onBlur,
@@ -137,7 +135,6 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
         contrast={contrast}
         disabled={disabled}
         monospace={monospace}
-        sx={sxProp}
         size={sizeProp}
         width={widthProp}
         minWidth={minWidthProp}

--- a/packages/react/src/TextInputWithTokens/TextInputWithTokens.tsx
+++ b/packages/react/src/TextInputWithTokens/TextInputWithTokens.tsx
@@ -80,7 +80,6 @@ function TextInputWithTokensInnerComponent<TokenComponentType extends AnyReactCo
     className,
     block,
     disabled,
-    sx: sxProp,
     tokens,
     onTokenRemove,
     tokenComponent: TokenComponent = Token,
@@ -269,7 +268,6 @@ function TextInputWithTokensInnerComponent<TokenComponentType extends AnyReactCo
       data-token-wrapping={Boolean(preventTokenWrapping || maxHeight) || undefined}
       className={clsx(className, styles.TextInputWrapper)}
       style={maxHeight ? {maxHeight, ...style} : style}
-      sx={sxProp}
     >
       {IconComponent && !LeadingVisual && <IconComponent className="TextInput-icon" />}
       <TextInputInnerVisualSlot

--- a/packages/react/src/Textarea/Textarea.docs.json
+++ b/packages/react/src/Textarea/Textarea.docs.json
@@ -89,11 +89,6 @@
       "defaultValue": "\"input\""
     },
     {
-      "name": "sx",
-      "type": "SystemStyleObject",
-      "deprecated": true
-    },
-    {
       "name": "className",
       "type": "string | undefined",
       "description": "The className to apply to the wrapper element"

--- a/packages/react/src/Textarea/Textarea.stories.tsx
+++ b/packages/react/src/Textarea/Textarea.stories.tsx
@@ -55,11 +55,6 @@ Playground.argTypes = {
   rows: {
     control: {type: 'number'},
   },
-  sx: {
-    table: {
-      disable: true,
-    },
-  },
   validationStatus: {
     options: ['error', 'success'],
     control: {type: 'radio'},

--- a/packages/react/src/Textarea/Textarea.tsx
+++ b/packages/react/src/Textarea/Textarea.tsx
@@ -2,7 +2,6 @@ import type {TextareaHTMLAttributes, ReactElement} from 'react'
 import React from 'react'
 import {TextInputBaseWrapper} from '../internal/components/TextInputWrapper'
 import type {FormValidationStatus} from '../utils/types/FormValidationStatus'
-import type {SxProp} from '../sx'
 import classes from './TextArea.module.css'
 
 export const DEFAULT_TEXTAREA_ROWS = 7
@@ -46,8 +45,7 @@ export type TextareaProps = {
    * CSS styles to apply to the Textarea
    */
   style?: React.CSSProperties
-} & TextareaHTMLAttributes<HTMLTextAreaElement> &
-  SxProp
+} & TextareaHTMLAttributes<HTMLTextAreaElement>
 
 /**
  * An accessible, native textarea component that supports validation states.
@@ -58,7 +56,6 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     {
       value,
       disabled,
-      sx: sxProp,
       required,
       validationStatus,
       rows = DEFAULT_TEXTAREA_ROWS,
@@ -76,7 +73,6 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ): ReactElement => {
     return (
       <TextInputBaseWrapper
-        sx={sxProp}
         validationStatus={validationStatus}
         disabled={disabled}
         block={block}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Remove support for `sx` from the `SubNav`, `Text`, `Textarea`, `TextInput`, `TextInputWithTokens` component. 
Closes [#5817](https://github.com/github/primer/issues/5817)

- [ ] `sx` usage: 
  - [ ] [`SubNav`](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+name%3ASubNav+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x)
  - [ ] [`Text`](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+name%3AText+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x)
  - [ ] [`Textarea`](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+name%3ATextarea+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x)
  - [ ] [`TextInput`](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+name%3ATextInput+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x)
  - [ ] `TextInputWithTokens`: [no usage](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+name%3ATextInputWithTokens+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x)
  
<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->
 
- [X] Major release; if selected, include a written rollout or migration plan
 
