### PR TITLE
Remove sx and BoxWithFallback from the `Spinner` component

### DIFF
--- a/.changeset/beige-shrimps-sleep.md
+++ b/.changeset/beige-shrimps-sleep.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': major
+---
+
+Remove sx prop support from the Spinner component.

--- a/packages/react/src/Spinner/Spinner.dev.stories.module.css
+++ b/packages/react/src/Spinner/Spinner.dev.stories.module.css
@@ -1,0 +1,3 @@
+.SpinnerBorder {
+  border: 1px solid red;
+}

--- a/packages/react/src/Spinner/Spinner.dev.stories.tsx
+++ b/packages/react/src/Spinner/Spinner.dev.stories.tsx
@@ -1,9 +1,10 @@
 import type {Meta} from '@storybook/react-vite'
 import Spinner from './Spinner'
+import classes from './Spinner.dev.stories.module.css'
 
 export default {
   title: 'Components/Spinner/Dev',
   component: Spinner,
 } as Meta<typeof Spinner>
 
-export const Default = () => <Spinner sx={{border: '1px solid red'}} size="small" />
+export const Default = () => <Spinner className={classes.SpinnerBorder} size="small" />

--- a/packages/react/src/Spinner/Spinner.docs.json
+++ b/packages/react/src/Spinner/Spinner.docs.json
@@ -45,11 +45,6 @@
     {
       "name": "data-*",
       "type": "string"
-    },
-    {
-      "name": "sx",
-      "type": "SystemStyleObject",
-      "deprecated": true
     }
   ],
   "subcomponents": []

--- a/packages/react/src/Spinner/Spinner.tsx
+++ b/packages/react/src/Spinner/Spinner.tsx
@@ -1,11 +1,9 @@
 import type React from 'react'
-import {type SxProp} from '../sx'
 import {VisuallyHidden} from '../VisuallyHidden'
 import type {HTMLDataAttributes} from '../internal/internal-types'
 import {useId} from '../hooks'
 import classes from './Spinner.module.css'
 import {clsx} from 'clsx'
-import {BoxWithFallback} from '../internal/components/BoxWithFallback'
 
 const sizeMap = {
   small: '16px',
@@ -22,8 +20,7 @@ export type SpinnerProps = {
   'aria-label'?: string
   className?: string
   style?: React.CSSProperties
-} & HTMLDataAttributes &
-  SxProp
+} & HTMLDataAttributes
 
 function Spinner({
   size: sizeKey = 'medium',
@@ -48,7 +45,7 @@ function Spinner({
         aria-hidden
         aria-label={ariaLabel ?? undefined}
         aria-labelledby={hasHiddenLabel ? labelId : undefined}
-        className={className}
+        className={clsx(className, classes.SpinnerAnimation)}
         style={style}
         {...props}
       >
@@ -74,10 +71,6 @@ function Spinner({
   )
 }
 
-function StyledSpinner({className, ...props}: SpinnerProps) {
-  return <BoxWithFallback as={Spinner} className={clsx(className, classes.SpinnerAnimation)} {...props} />
-}
+Spinner.displayName = 'Spinner'
 
-StyledSpinner.displayName = 'Spinner'
-
-export default StyledSpinner
+export default Spinner


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Remove `sx` and `BoxWithFallback` from the `Spinner` component
Closes [#5819](https://github.com/github/primer/issues/5819)

 [sx usage](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+name%3ASpinner+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x)

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->
 
- [X] Major release; if selected, include a written rollout or migration plan
 