### PR TITLE
ci: add status-checks workflow for overriding github-ui status check

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -1,0 +1,22 @@
+name: status-check
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  github-ui:
+    runs-on: ubuntu-latest
+    if: "${{ contains(github.event.pull_request.labels.*.name, 'integration-tests: skipped manually') }}"
+    steps:
+      - name: Create passing status check when override label is present
+        run: |
+          gh api -X POST "/repos/primer/react/statuses/$SHA" \
+            -f state='success' \
+            -f context='github-ui/ci' \
+            -f description='Checked manually' }}' \
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -16,7 +16,7 @@ jobs:
           gh api -X POST "/repos/primer/react/statuses/$SHA" \
             -f state='success' \
             -f context='github-ui/ci' \
-            -f description='Checked manually' }}' \
+            -f description='Checked manually' \
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Create a workflow that sets the `github-ui/ci` status check to passing if the skip label for integration checks is present

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add new status check workflow for overriding status checks

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->


- [x] None; if selected, include a brief description as to why
