### PR TITLE
Remove `sx` rom the `SideNav` component

### DIFF
--- a/.changeset/rich-walls-fold.md
+++ b/.changeset/rich-walls-fold.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': major
+---
+
+Update SideNav component to no longer support sx.

--- a/packages/react/src/SideNav.tsx
+++ b/packages/react/src/SideNav.tsx
@@ -4,9 +4,7 @@ import Link, {type LinkProps} from './Link'
 import type React from 'react'
 import {type PropsWithChildren} from 'react'
 import {clsx} from 'clsx'
-import type {SxProp} from './sx'
 import classes from './SideNav.module.css'
-import {BoxWithFallback} from './internal/components/BoxWithFallback'
 
 type SideNavBaseProps = {
   as?: React.ElementType
@@ -15,16 +13,15 @@ type SideNavBaseProps = {
   className?: string
   children?: React.ReactNode
   'aria-label'?: string
-} & SxProp
+}
 
 function SideNav({
-  as = 'nav',
+  as: Component = 'nav',
   variant = 'normal',
   className,
   bordered,
   children,
   'aria-label': ariaLabel,
-  sx: sxProp,
 }: SideNavBaseProps) {
   const variantClassName = variant === 'lightweight' ? 'lightweight' : 'normal'
   const newClassName = clsx(
@@ -39,9 +36,9 @@ function SideNav({
   )
 
   return (
-    <BoxWithFallback as={as} className={newClassName} aria-label={ariaLabel} sx={sxProp}>
+    <Component className={newClassName} aria-label={ariaLabel}>
       {children}
-    </BoxWithFallback>
+    </Component>
   )
 }
 
@@ -58,15 +55,9 @@ const SideNavLink = ({selected, to, variant, className, children, ...rest}: Styl
   // according to their docs, NavLink supports aria-current:
   // https://reacttraining.com/react-router/web/api/NavLink/aria-current-string
   return (
-    <BoxWithFallback
-      as={Link}
-      aria-current={isReactRouter || selected ? 'page' : undefined}
-      className={newClassName}
-      variant={variant}
-      {...rest}
-    >
+    <Link aria-current={isReactRouter || selected ? 'page' : undefined} className={newClassName} {...rest}>
       {children}
-    </BoxWithFallback>
+    </Link>
   )
 }
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes [#5832](https://github.com/github/primer/issues/5832)
- sx usage: [0](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+name%3ASideNav+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x) are still using `sx` props with `SideNav`.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

<!-- List of things removed in this PR -->
Removed `sx` props and `BoxWithFallback` from `SideNav`.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->
 
- [X] Major release; if selected, include a written rollout or migration plan
 