### PR TITLE
Add browser test script to styled-react package

### DIFF
--- a/packages/styled-react/package.json
+++ b/packages/styled-react/package.json
@@ -24,7 +24,8 @@
     "build": "script/build",
     "clean": "rimraf dist",
     "lint:npm": "publint --types",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "browser-test": "vitest --config vitest.config.browser.ts src/__tests__/primer-react*.browser.test.tsx"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.27.1",


### PR DESCRIPTION
Adds a `browser-test` npm script to the `@primer/styled-react` package to run browser tests

## Changes

- Added `"browser-test": "vitest --config vitest.config.browser.ts src/__tests__/primer-react*.browser.test.tsx --run"` script to `package.json`
 
 