### PR TITLE
Allow customizing 'On'/'Off' text in ToggleSwitch

### DIFF
--- a/.changeset/upset-flowers-yawn.md
+++ b/.changeset/upset-flowers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Add buttonLabelOn and buttonLabelOff to ToggleSwitch

--- a/e2e/components/ToggleSwitch.test.ts
+++ b/e2e/components/ToggleSwitch.test.ts
@@ -39,6 +39,10 @@ const stories = [
     title: 'With Caption',
     id: 'components-toggleswitch-features--with-caption',
   },
+  {
+    title: 'With Custom Labels',
+    id: 'components-toggleswitch-features--with-custom-labels',
+  },
 ] as const
 
 test.describe('ToggleSwitch', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "38.0.0-rc.1",
+        "@primer/react": "38.0.0-rc.2",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.3",
@@ -88,7 +88,7 @@
       "name": "example-nextjs",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "38.0.0-rc.1",
+        "@primer/react": "38.0.0-rc.2",
         "next": "^15.2.3",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -104,7 +104,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.14.0",
-        "@primer/react": "38.0.0-rc.1",
+        "@primer/react": "38.0.0-rc.2",
         "clsx": "^2.1.1",
         "next": "^15.2.3",
         "react": "18.3.1",
@@ -26008,7 +26008,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "38.0.0-rc.1",
+      "version": "38.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@github/mini-throttle": "^2.1.1",
@@ -26581,11 +26581,11 @@
     },
     "packages/styled-react": {
       "name": "@primer/styled-react",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0-rc.2",
       "devDependencies": {
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
-        "@primer/react": "^38.0.0-rc.1",
+        "@primer/react": "^38.0.0-rc.2",
         "@rollup/plugin-babel": "^6.0.4",
         "@types/react": "18.3.11",
         "@types/react-dom": "18.3.1",
@@ -26600,7 +26600,7 @@
         "typescript": "^5.9.2"
       },
       "peerDependencies": {
-        "@primer/react": "38.0.0-rc.1",
+        "@primer/react": "38.0.0-rc.2",
         "@types/react": "18.x || 19.x",
         "@types/react-dom": "18.x || 19.x",
         "@types/react-is": "18.x || 19.x",

--- a/packages/react/src/ToggleSwitch/ToggleSwitch.docs.json
+++ b/packages/react/src/ToggleSwitch/ToggleSwitch.docs.json
@@ -30,6 +30,9 @@
     },
     {
       "id": "components-toggleswitch-features--controlled"
+    },
+    {
+      "id": "components-toggleswitch-features--with-custom-labels"
     }
   ],
   "importPath": "@primer/react",
@@ -112,6 +115,18 @@
       "type": "'button' | 'submit' | 'reset'",
       "defaultValue": "'button'",
       "description": "As it’s part of form behavior, this controls whether the button is of type `button`, `submit`, or `reset`."
+    },
+    {
+      "name": "buttonLabelOn",
+      "type": "string",
+      "defaultValue": "'On'",
+      "description": "The text to display when the toggle switch is turned on."
+    },
+    {
+      "name": "buttonLabelOff",
+      "type": "string",
+      "defaultValue": "'Off'",
+      "description": "The text to display when the toggle switch is turned off."
     }
   ],
   "subcomponents": []

--- a/packages/react/src/ToggleSwitch/ToggleSwitch.features.stories.tsx
+++ b/packages/react/src/ToggleSwitch/ToggleSwitch.features.stories.tsx
@@ -160,3 +160,12 @@ export const Controlled = () => {
     </>
   )
 }
+
+export const WithCustomLabels = () => (
+  <ToggleSwitchStoryWrapper>
+    <span id="toggle" className={styles.ToggleLabel}>
+      Toggle label
+    </span>
+    <ToggleSwitch buttonLabelOn="Active" buttonLabelOff="Inactive" aria-labelledby="toggle" />
+  </ToggleSwitchStoryWrapper>
+)

--- a/packages/react/src/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/packages/react/src/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -51,6 +51,16 @@ Playground.argTypes = {
     },
     options: ['small', 'medium'],
   },
+  buttonLabelOn: {
+    control: {
+      type: 'text',
+    },
+  },
+  buttonLabelOff: {
+    control: {
+      type: 'text',
+    },
+  },
 }
 
 export const Default = () => (

--- a/packages/react/src/ToggleSwitch/ToggleSwitch.test.tsx
+++ b/packages/react/src/ToggleSwitch/ToggleSwitch.test.tsx
@@ -31,6 +31,26 @@ describe('ToggleSwitch', () => {
     expect(toggleSwitch).toHaveAttribute('aria-pressed', 'true')
   })
 
+  it('uses custom On text', () => {
+    const {getByText} = render(
+      <>
+        <div id="switchLabel">{SWITCH_LABEL_TEXT}</div>
+        <ToggleSwitch buttonLabelOn="Engaged" aria-labelledby="switchLabel" defaultChecked />
+      </>,
+    )
+    expect(getByText('Engaged')).toBeInTheDocument()
+  })
+
+  it('uses custom Off text', () => {
+    const {getByText} = render(
+      <>
+        <div id="switchLabel">{SWITCH_LABEL_TEXT}</div>
+        <ToggleSwitch buttonLabelOff="Deactivated" aria-labelledby="switchLabel" />
+      </>,
+    )
+    expect(getByText('Deactivated')).toBeInTheDocument()
+  })
+
   it('renders a switch that is disabled', async () => {
     const user = userEvent.setup()
     const {getByLabelText} = render(

--- a/packages/react/src/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/react/src/ToggleSwitch/ToggleSwitch.tsx
@@ -42,6 +42,10 @@ export interface ToggleSwitchProps extends Omit<React.HTMLAttributes<HTMLDivElem
   loadingLabel?: string
   /** type of button to account for behavior when added to a form*/
   buttonType?: 'button' | 'submit' | 'reset'
+  /** Text to display when the toggle switch is in the 'on' position. Defaults to 'On'. */
+  buttonLabelOn?: string
+  /** Text to display when the toggle switch is in the 'off' position. Defaults to 'Off'. */
+  buttonLabelOff?: string
 }
 
 type InnerIconProps = {size?: ToggleSwitchProps['size']}
@@ -88,6 +92,8 @@ const ToggleSwitch = React.forwardRef<HTMLButtonElement, ToggleSwitchProps>(func
     loadingLabelDelay = 2000,
     loadingLabel = 'Loading',
     className,
+    buttonLabelOn,
+    buttonLabelOff,
     ...rest
   } = props
   const isControlled = typeof checked !== 'undefined'
@@ -152,10 +158,10 @@ const ToggleSwitch = React.forwardRef<HTMLButtonElement, ToggleSwitchProps>(func
         onClick={handleToggleClick}
       >
         <span className={classes.StatusTextItem} data-hidden={!isOn}>
-          On
+          {buttonLabelOn ?? 'On'}
         </span>
         <span className={classes.StatusTextItem} data-hidden={isOn}>
-          Off
+          {buttonLabelOff ?? 'Off'}
         </span>
       </span>
 


### PR DESCRIPTION
This makes the 'On' and 'Off' text that appears next to a ToggleSwitch be customizable. The prop names I chose feel awkward, but I also thought it'd be confusing to have a name like 'onLabel' or 'onText' since it reads as if it's meant to be a function to act as a handler.

One thing I wondered about: was there any accessibility reason why the text was hard-coded to 'On' and 'Off'?

<img width="701" height="444" alt="screenshot of Storybook of ToggleSwitch component in off state with the word Inactive next to the switch" src="https://github.com/user-attachments/assets/4c67dea7-db63-4e6d-8a8a-686ab3f71a84" />

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

Adds the `buttonLabelOn` and `buttonLabelOff` props to ToggleSwitch to allow changing the 'On' and 'Off' text that appears next to the switch.

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
