### PR TITLE
docs(styled-react): update architecture for polymorphic components

### DIFF
--- a/packages/styled-react/ARCHITECTURE.md
+++ b/packages/styled-react/ARCHITECTURE.md
@@ -61,17 +61,19 @@ import {
   type ExampleComponentProps as PrimerExampleComponentProps,
 } from '@primer/react'
 import {forwardRef} from 'react'
-import {PolymorphicForwardRef as ForwardRefComponent} from '../polymorphic'
+import {ForwardRefComponent} from '../polymorphic'
+import {sx} from '../sx'
 
 type ExampleComponentProps = PrimerExampleComponentProps & SxProp
 
-const ExampleComponent = forwardRef(function ExampleComponent(props, ref) {
-  // @ts-expect-error the polymorphic component type is not inferred
-  // correctly
-  return <Box ref={ref} as={PrimerExampleComponent} {...props} />
-}) as ForwardRefComponent<'div', ExampleComponentProps>
+const ExampleComponent: ForwardRefComponent<'div', ExampleComponentProps> = styled(ExampleComponent).withConfig({
+  shouldForwardProp: prop => prop !== 'sx',
+})`
+  ${sx}
+`
 
 export {ExampleComponent}
+export type {ExampleComponentProps}
 ```
 
 ## Sub-components


### PR DESCRIPTION
Updates our architecture docs for polymorphic components based on our mob pair today 👀 

This helps to address a couple of problems:

- When using the `as` prop, the base component will not get overriden
- For `sx` being applied to nested components, this approach should correctly transform `sx` into `className` and pass it along
- This will also prevent `sx` from being passed to the wrapped component