### PR TITLE
Remove support for `sx` from `FilteredActionList` component

### DIFF
--- a/.changeset/mighty-lizards-lick.md
+++ b/.changeset/mighty-lizards-lick.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": major
+---
+
+Update FilteredActionList and FilteredActionListLoaders components to no longer support sx

--- a/packages/react/src/FilteredActionList/FilteredActionList.module.css
+++ b/packages/react/src/FilteredActionList/FilteredActionList.module.css
@@ -11,6 +11,10 @@
   flex-grow: 1;
 }
 
+.ActionList {
+  flex-grow: 1;
+}
+
 .ActionListItem:focus {
   background: var(--control-transparent-bgColor-selected);
 

--- a/packages/react/src/FilteredActionList/FilteredActionList.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionList.tsx
@@ -15,7 +15,6 @@ import {useProvidedRefOrCreate} from '../hooks/useProvidedRefOrCreate'
 import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
 import useScrollFlash from '../hooks/useScrollFlash'
 import {VisuallyHidden} from '../VisuallyHidden'
-import type {SxProp} from '../sx'
 import type {FilteredActionListLoadingType} from './FilteredActionListLoaders'
 import {FilteredActionListLoadingTypes, FilteredActionListBodyLoader} from './FilteredActionListLoaders'
 import classes from './FilteredActionList.module.css'
@@ -26,14 +25,10 @@ import {isValidElementType} from 'react-is'
 import {useAnnouncements} from './useAnnouncements'
 import {clsx} from 'clsx'
 import {useFeatureFlag} from '../FeatureFlags'
-import {BoxWithFallback} from '../internal/components/BoxWithFallback'
 
 const menuScrollMargins: ScrollIntoViewOptions = {startMargin: 0, endMargin: 8}
 
-export interface FilteredActionListProps
-  extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>,
-    ListPropsBase,
-    SxProp {
+export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
   loading?: boolean
   loadingType?: FilteredActionListLoadingType
   placeholderText?: string
@@ -70,7 +65,6 @@ export function FilteredActionList({
   items,
   textInputProps,
   inputRef: providedInputRef,
-  sx,
   groupMetadata,
   showItemDividers,
   message,
@@ -284,7 +278,7 @@ export function FilteredActionList({
         {...listProps}
         role="listbox"
         id={listId}
-        sx={{flexGrow: 1}}
+        className={classes.ActionList}
       >
         {groupMetadata?.length
           ? groupMetadata.map((group, index) => {
@@ -349,12 +343,7 @@ export function FilteredActionList({
   }
 
   return (
-    <BoxWithFallback
-      ref={inputAndListContainerRef}
-      sx={sx}
-      className={clsx(className, classes.Root)}
-      data-testid="filtered-action-list"
-    >
+    <div ref={inputAndListContainerRef} className={clsx(className, classes.Root)} data-testid="filtered-action-list">
       <StyledHeader>
         <TextInput
           ref={inputRef}
@@ -396,7 +385,7 @@ export function FilteredActionList({
       <div ref={scrollContainerRef} className={classes.Container}>
         {getBodyContent()}
       </div>
-    </BoxWithFallback>
+    </div>
   )
 }
 

--- a/packages/react/src/FilteredActionList/FilteredActionListLoaders.module.css
+++ b/packages/react/src/FilteredActionList/FilteredActionListLoaders.module.css
@@ -2,3 +2,18 @@
   /* stylelint-disable-next-line primer/borders */
   border-radius: 4px;
 }
+
+.LoadingSpinner {
+  padding: var(--base-size-16);
+  flex-grow: 1;
+  align-content: center;
+  text-align: center;
+  height: 100%;
+}
+
+.LoadingSkeletonContainer {
+  padding: var(--base-size-8);
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+}

--- a/packages/react/src/FilteredActionList/FilteredActionListLoaders.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionListLoaders.tsx
@@ -1,4 +1,3 @@
-import Box from '../Box'
 import Spinner from '../Spinner'
 import {Stack} from '../Stack/Stack'
 import {SkeletonBox} from '../Skeleton/SkeletonBox'
@@ -44,15 +43,15 @@ export function FilteredActionListBodyLoader({
 
 function LoadingSpinner({...props}): JSX.Element {
   return (
-    <Box p={3} flexGrow={1} sx={{alignContent: 'center', textAlign: 'center', height: '100%'}}>
+    <div className={classes.LoadingSpinner}>
       <Spinner {...props} />
-    </Box>
+    </div>
   )
 }
 
 function LoadingSkeleton({rows = 10, ...props}: {rows: number}): JSX.Element {
   return (
-    <Box p={2} display="flex" flexGrow={1} flexDirection="column">
+    <div className={classes.LoadingSkeletonContainer}>
       <Stack direction="vertical" justify="center" gap="condensed" {...props}>
         {Array.from({length: rows}, (_, i) => (
           <Stack key={i} direction="horizontal" gap="condensed" align="center">
@@ -61,6 +60,6 @@ function LoadingSkeleton({rows = 10, ...props}: {rows: number}): JSX.Element {
           </Stack>
         ))}
       </Stack>
-    </Box>
+    </div>
   )
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/6789
###  Current `sx` usage: [0](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x+name%3A%22FilteredActionList%22)
✅   Don't need to separately update github-ui components to use @primer/styled-react

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

Remove support for `sx` from the `FilteredActionList` component, and any associated stories, docs, and tests

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Major release; if selected, include a written rollout or migration plan

This component currently has 0 `sx` usage in dotcom, and therefore does not need the @primer/styled-react wrapper. this will be confirmed again before merging.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
