### PR TITLE
Remove support for `sx` from `BaseStyles` component

### DIFF
--- a/packages/react/src/BaseStyles.dev.stories.tsx
+++ b/packages/react/src/BaseStyles.dev.stories.tsx
@@ -9,19 +9,6 @@ export default {
 
 export const Default = () => 'Hello'
 
-export const WithSxProps = () => (
-  <BaseStyles
-    sx={{
-      color: 'red',
-      backgroundColor: 'blue',
-      fontFamily: 'Arial',
-      lineHeight: '1.5',
-    }}
-  >
-    Hello
-  </BaseStyles>
-)
-
 export const WithSystemProps = () => (
   <BaseStyles color="red" backgroundColor="blue" fontFamily="Arial" fontSize="14px" lineHeight="1.5" display="flex">
     Hello

--- a/packages/react/src/BaseStyles.tsx
+++ b/packages/react/src/BaseStyles.tsx
@@ -3,12 +3,10 @@ import {type CSSProperties, type PropsWithChildren} from 'react'
 import {clsx} from 'clsx'
 import type {SystemCommonProps, SystemTypographyProps} from './constants'
 import {useTheme} from './ThemeProvider'
-import type {SxProp} from './sx'
 
 import classes from './BaseStyles.module.css'
 
 import 'focus-visible'
-import {BoxWithFallback} from './internal/components/BoxWithFallback'
 
 export type BaseStylesProps = PropsWithChildren & {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -17,8 +15,7 @@ export type BaseStylesProps = PropsWithChildren & {
   style?: CSSProperties
   color?: string // Fixes `color` ts-error
 } & SystemTypographyProps &
-  SystemCommonProps &
-  SxProp
+  SystemCommonProps
 
 function BaseStyles({
   children,
@@ -40,8 +37,7 @@ function BaseStyles({
   }
 
   return (
-    <BoxWithFallback
-      as={Component}
+    <Component
       className={newClassName}
       data-portal-root
       /**
@@ -59,7 +55,7 @@ function BaseStyles({
       {...rest}
     >
       {children}
-    </BoxWithFallback>
+    </Component>
   )
 }
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/6758
###  Current `sx` usage: [0](https://primer-query.githubapp.com/?query=attribute%3A%22sx%22+package%3A%22%40primer%2Freact%22+version%3A%3E%3D37.x+name%3A%22BaseStyles%22)
✅   Don't need to separately update github-ui components to use @primer/styled-react

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

Remove support for `sx` from the `BaseStyles` component, and any associated stories, docs, and tests

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Major release; if selected, include a written rollout or migration plan

This component currently has 0 `sx` usage in dotcom, and therefore does not need the @primer/styled-react wrapper. this will be confirmed again before merging.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
