### PR TITLE
chore(FilteredActionList): fix className override

### DIFF
--- a/.changeset/giant-impalas-occur.md
+++ b/.changeset/giant-impalas-occur.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+chore(FilteredActionList): fix className override

--- a/packages/react/src/FilteredActionList/FilteredActionList.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionList.tsx
@@ -348,6 +348,8 @@ export function FilteredActionList({
     }
   }
 
+  const {className: textInputClassName, ...restTextInputProps} = textInputProps || {}
+
   return (
     <BoxWithFallback
       ref={inputAndListContainerRef}
@@ -374,8 +376,8 @@ export function FilteredActionList({
           aria-describedby={inputDescriptionTextId}
           loaderPosition={'leading'}
           loading={loading && !loadingType.appearsInBody}
-          className={clsx(textInputProps?.className, fullScreenOnNarrow && classes.FullScreenTextInput)}
-          {...textInputProps}
+          className={clsx(textInputClassName, {[classes.FullScreenTextInput]: fullScreenOnNarrow})}
+          {...restTextInputProps}
         />
       </StyledHeader>
       <VisuallyHidden id={inputDescriptionTextId}>Items will be filtered as you type</VisuallyHidden>


### PR DESCRIPTION
**Component prop handling improvements:**

* In `FilteredActionList.tsx`, destructured `className` from `textInputProps` and renamed the remainder to `restTextInputProps` for clearer prop management.
* Updated the `TextInput` element to use the separated `textInputClassName` and conditionally apply the `FullScreenTextInput` class, while spreading only the remaining props. This prevents `className` from being overridden and ensures correct class application.