### PR TITLE
fix: update PR selection criteria in lock-release workflow to look for PRs that are BEHIND instead of mergable

### DIFF
--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -78,7 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Update all PRs that are toggled merge when ready
         run: |
-            PR_NUMBERS=$(gh pr list -L 100 -R primer/react --state open --json number,baseRefName,autoMergeRequest,mergeStateStatus,reviewDecision -q '.[] | select(.autoMergeRequest != null) | select(.baseRefName == "main") | select(.mergeStateStatus == "BEHIND") | select(.reviewDecision == "APPROVED") | .number')
+          PR_NUMBERS=$(gh pr list -L 100 -R primer/react --state open --json number,baseRefName,autoMergeRequest,mergeStateStatus,reviewDecision -q '.[] | select(.autoMergeRequest != null) | select(.baseRefName == "main") | select(.mergeStateStatus == "BEHIND") | select(.reviewDecision == "APPROVED") | .number')
           if [ -n "$PR_NUMBERS" ]; then
             echo "Updating $PR_NUMBERS"
             echo "$PR_NUMBERS" | xargs -I {} gh pr update-branch -R primer/react {}

--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -78,7 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Update all PRs that are toggled merge when ready
         run: |
-          PR_NUMBERS=$(gh pr list -L 100 -R primer/react --state open --json number,baseRefName,autoMergeRequest,mergeStateStatus -q '.[] | select(.autoMergeRequest != null) | select(.baseRefName == "main") | select(.mergeStateStatus == "BEHIND") | .number')
+            PR_NUMBERS=$(gh pr list -L 100 -R primer/react --state open --json number,baseRefName,autoMergeRequest,mergeStateStatus,reviewDecision -q '.[] | select(.autoMergeRequest != null) | select(.baseRefName == "main") | select(.mergeStateStatus == "BEHIND") | select(.reviewDecision == "APPROVED") | .number')
           if [ -n "$PR_NUMBERS" ]; then
             echo "Updating $PR_NUMBERS"
             echo "$PR_NUMBERS" | xargs -I {} gh pr update-branch -R primer/react {}

--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -78,7 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Update all PRs that are toggled merge when ready
         run: |
-          PR_NUMBERS=$(gh pr list -L 100 -R primer/react --state open --json number,mergeable,baseRefName,autoMergeRequest -q '.[] | select(.autoMergeRequest != null) | select(.mergeable == "MERGEABLE") | select(.baseRefName == "main") | .number')
+          PR_NUMBERS=$(gh pr list -L 100 -R primer/react --state open --json number,baseRefName,autoMergeRequest,mergeStateStatus -q '.[] | select(.autoMergeRequest != null) | select(.baseRefName == "main") | select(.mergeStateStatus == "BEHIND") | .number')
           if [ -n "$PR_NUMBERS" ]; then
             echo "Updating $PR_NUMBERS"
             echo "$PR_NUMBERS" | xargs -I {} gh pr update-branch -R primer/react {}


### PR DESCRIPTION
This changes the `toggle-lock` workflow logic when looking for PRs to update the branch of. I think there might be an issue with using the "MERGABLE" status so instead just checking if it's Open, Auto-merge enabled, Approved, and behind main.