### PR TITLE
Add browser tests for polymorphic `as` prop behavior in styled-react components

### DIFF
--- a/packages/styled-react/src/__tests__/primer-react.browser.test.tsx
+++ b/packages/styled-react/src/__tests__/primer-react.browser.test.tsx
@@ -47,8 +47,9 @@ import {
 
 describe('@primer/react', () => {
   test('ActionList supports `sx` prop', () => {
-    render(<ActionList data-testid="component" sx={{background: 'red'}} />)
+    render(<ActionList as="ul" data-testid="component" sx={{background: 'red'}} variant="inset" />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByTestId('component')).toHaveAttribute('data-variant', 'inset')
   })
 
   test('ActionMenu.Button supports `sx` prop', () => {
@@ -109,7 +110,7 @@ describe('@primer/react', () => {
   })
 
   test('Box supports `sx` prop', () => {
-    render(<Box data-testid="component" sx={{background: 'red'}} />)
+    render(<Box as="div" data-testid="component" sx={{background: 'red'}} />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
   })
 
@@ -119,13 +120,15 @@ describe('@primer/react', () => {
   })
 
   test('Breadcrumbs.Item supports `sx` prop', () => {
-    render(<Breadcrumbs.Item data-testid="component" sx={{background: 'red'}} />)
+    render(<Breadcrumbs.Item as="li" data-testid="component" sx={{background: 'red'}} selected />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByTestId('component').className.includes('selected')).toBe(true)
   })
 
   test('Button supports `sx` prop', () => {
-    render(<Button data-testid="component" sx={{background: 'red'}} />)
+    render(<Button as="button" data-testid="component" sx={{background: 'red'}} size="medium" />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByTestId('component')).toHaveAttribute('data-size', 'medium')
   })
 
   test('Checkbox supports `sx` prop', () => {
@@ -156,8 +159,9 @@ describe('@primer/react', () => {
   })
 
   test('Flash supports `sx` prop', () => {
-    render(<Flash data-testid="component" sx={{background: 'red'}} />)
+    render(<Flash as="div" data-testid="component" sx={{background: 'red'}} variant="success" />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByTestId('component')).toHaveAttribute('data-variant', 'success')
   })
 
   test('FormControl supports `sx` prop', () => {
@@ -170,7 +174,7 @@ describe('@primer/react', () => {
   })
 
   test('Header supports `sx` prop', () => {
-    render(<Header data-testid="component" sx={{background: 'red'}} />)
+    render(<Header as="header" data-testid="component" sx={{background: 'red'}} />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
   })
 
@@ -180,23 +184,40 @@ describe('@primer/react', () => {
   })
 
   test('IconButton supports `sx` prop', () => {
-    render(<IconButton aria-label="test" data-testid="component" sx={{background: 'red'}} icon={() => <svg />} />)
+    render(
+      <IconButton
+        as="button"
+        aria-label="test"
+        data-testid="component"
+        sx={{background: 'red'}}
+        icon={() => <svg />}
+      />,
+    )
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+
+    // Test that IconButton renders the icon component (SVG) in its children
+    const iconButton = screen.getByTestId('component')
+    const svgElement = iconButton.querySelector('svg')
+    expect(svgElement).toBeInTheDocument()
+    expect(iconButton.children.length).toBeGreaterThan(0)
   })
 
   test('Label supports `sx` prop', () => {
-    render(<Label data-testid="component" sx={{background: 'red'}} />)
+    render(<Label as="span" data-testid="component" sx={{background: 'red'}} size="large" />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByTestId('component')).toHaveAttribute('data-size', 'large')
   })
 
   test('Link supports `sx` prop', () => {
-    render(<Link data-testid="component" sx={{background: 'red'}} />)
+    render(<Link as="a" data-testid="component" sx={{background: 'red'}} inline />)
+    expect(screen.getByTestId('component')).toHaveAttribute('data-inline', 'true')
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
   })
 
   test('LinkButton supports `sx` prop', () => {
-    render(<LinkButton data-testid="component" sx={{background: 'red'}} />)
+    render(<LinkButton as="a" data-testid="component" sx={{background: 'red'}} size="medium" />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByTestId('component')).toHaveAttribute('data-size', 'medium')
   })
 
   test('NavList supports `sx` prop', () => {
@@ -234,19 +255,23 @@ describe('@primer/react', () => {
     render(
       <ThemeProvider>
         <Overlay
+          as="div"
           data-testid="component"
           sx={{background: 'red'}}
           onClickOutside={() => {}}
           onEscape={() => {}}
           returnFocusRef={ref}
+          role="dialog"
         />
       </ThemeProvider>,
     )
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByTestId('component')).toHaveAttribute('role', 'dialog')
   })
 
   test('PageHeader supports `sx` prop', () => {
-    const {container} = render(<PageHeader data-testid="component" sx={{background: 'red'}} />)
+    const {container} = render(<PageHeader as="div" data-testid="component" sx={{background: 'red'}} role="article" />)
+    expect(screen.getByTestId('component')).toHaveAttribute('role', 'article')
     expect(window.getComputedStyle(container.firstElementChild!).backgroundColor).toBe('rgb(255, 0, 0)')
   })
 
@@ -271,8 +296,13 @@ describe('@primer/react', () => {
   })
 
   test('PageLayout.Content supports `sx` prop', () => {
-    const {container} = render(<PageLayout.Content data-testid="component" sx={{background: 'red'}} />)
-    expect(window.getComputedStyle(container.firstElementChild!).backgroundColor).toBe('rgb(255, 0, 0)')
+    const {container} = render(
+      <PageLayout.Content as="div" data-testid="component" sx={{background: 'red'}} aria-labelledby="normal" />,
+    )
+
+    const outerElement = container.firstElementChild! as HTMLElement
+    expect(window.getComputedStyle(outerElement).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(outerElement).toHaveAttribute('aria-labelledby', 'normal')
   })
 
   test('PageLayout.Pane supports `sx` prop', () => {
@@ -334,8 +364,9 @@ describe('@primer/react', () => {
   })
 
   test.skip('Select supports `sx` prop', () => {
-    render(<Select data-testid="component" sx={{background: 'red'}} />)
+    render(<Select as="select" data-testid="component" sx={{background: 'red'}} required />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByTestId('component')).toHaveAttribute('required')
   })
 
   test('Spinner supports `sx` prop', () => {
@@ -359,13 +390,15 @@ describe('@primer/react', () => {
   })
 
   test('Text supports `sx` prop', () => {
-    render(<Text data-testid="component" sx={{background: 'red'}} />)
+    render(<Text as="span" data-testid="component" sx={{background: 'red'}} size="small" />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByTestId('component')).toHaveAttribute('data-size', 'small')
   })
 
   test('TextInput supports `sx` prop', () => {
-    const {container} = render(<TextInput sx={{background: 'red'}} />)
+    const {container} = render(<TextInput as="input" sx={{background: 'red'}} loading />)
     expect(window.getComputedStyle(container.firstElementChild!).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(container.firstElementChild).toHaveAttribute('data-trailing-visual', 'true')
   })
 
   test('TextInput.Action supports `sx` prop', () => {
@@ -404,8 +437,9 @@ describe('@primer/react', () => {
   })
 
   test('Token supports `sx` prop', () => {
-    render(<Token data-testid="component" sx={{background: 'red'}} text="test" />)
+    render(<Token as="button" data-testid="component" sx={{background: 'red'}} text="test" />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByTestId('component')).toHaveTextContent('test')
   })
 
   test.todo('Tooltip supports `sx` prop', () => {
@@ -418,25 +452,30 @@ describe('@primer/react', () => {
   })
 
   test('Truncate supports `sx` prop', () => {
-    render(<Truncate data-testid="component" sx={{background: 'red'}} title="test" />)
+    render(<Truncate as="div" data-testid="component" sx={{background: 'red'}} title="test" />)
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByTestId('component')).toHaveAttribute('title', 'test')
   })
 
   test('UnderlineNav supports `sx` prop', () => {
     render(
-      <UnderlineNav aria-label="navigation" data-testid="component" sx={{background: 'red'}}>
+      <UnderlineNav as="nav" aria-label="navigation" data-testid="component" sx={{background: 'red'}} variant="inset">
         <UnderlineNav.Item>test</UnderlineNav.Item>
       </UnderlineNav>,
     )
+    console.log(screen.getByLabelText('navigation').attributes)
     expect(window.getComputedStyle(screen.getByLabelText('navigation')).backgroundColor).toBe('rgb(255, 0, 0)')
+    expect(screen.getByLabelText('navigation')).toHaveAttribute('data-variant', 'inset')
   })
 
   test('UnderlineNav.Item supports `sx` prop', () => {
     render(
-      <UnderlineNav.Item data-testid="component" sx={{background: 'red'}}>
+      <UnderlineNav.Item as="a" data-testid="component" sx={{background: 'red'}} icon={<svg />}>
         test
       </UnderlineNav.Item>,
     )
     expect(window.getComputedStyle(screen.getByTestId('component')).backgroundColor).toBe('rgb(255, 0, 0)')
+    const svgElement = screen.getByTestId('component').querySelector('svg')
+    expect(svgElement).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Adds browser tests to verify that `styled-react` components correctly handle the polymorphic `as` prop. Ensures styled-components wrappers maintain component behavior when rendering and provides test coverage for component-specific props preservation.

## Current State
Tests currently fail for several components, reproducing the existing `as` prop forwarding issues in styled-react wrappers. PR #6910 should fix these test failures.