### PR TITLE
Add 'prereleased' condition to unlock step in the toggle release lock workflow

### DIFF
--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -50,7 +50,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   unlock:
-    if: ${{ github.event.inputs.action == 'unlock' || github.event.action == 'released' }}
+    if: ${{ github.event.inputs.action == 'unlock' || github.event.action == 'released' || github.event.action == 'prereleased' }}
     name: Unlock the release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I noticed with the last unlock it skipped running because the event name wasn't 'released'