### PR TITLE
feat(ActionList): Combine Item and LinkItem into unified Item component

### DIFF
--- a/.changeset/full-berries-work.md
+++ b/.changeset/full-berries-work.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': major
+---
+
+Combines `ActionList.Item` and `ActionList.LinkItem` into a unified `ActionList.Item` component

--- a/packages/react/src/ActionList/ActionList.dev.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.dev.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import type {Meta} from '@storybook/react-vite'
 import {ActionList} from '.'
 import {Item} from './Item'
-import {LinkItem} from './LinkItem'
 import {Group} from './Group'
 import {Divider} from './Divider'
 import {Description} from './Description'
@@ -14,7 +13,7 @@ import {AnchoredOverlay} from '../AnchoredOverlay'
 export default {
   title: 'Components/ActionList/Dev',
   component: ActionList,
-  subcomponents: {Item, LinkItem, Group, Divider, Description},
+  subcomponents: {Item, Group, Divider, Description},
 } as Meta<typeof ActionList>
 
 const users = [
@@ -257,19 +256,19 @@ export const ItemLabelStylesWithMixedDescriptions = () => (
           <ActionList.Heading as="h2" size="small">
             Some link items have block description
           </ActionList.Heading>
-          <ActionList.LinkItem>
+          <ActionList.Item>
             Item with inline description
             <ActionList.Description variant="block">Block description</ActionList.Description>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem>
+          </ActionList.Item>
+          <ActionList.Item>
             Item with inline description
             <ActionList.Description variant="block">Block description</ActionList.Description>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem>Item with no description</ActionList.LinkItem>
-          <ActionList.LinkItem>
+          </ActionList.Item>
+          <ActionList.Item>Item with no description</ActionList.Item>
+          <ActionList.Item>
             Item with inline description
             <ActionList.Description variant="block">Block description</ActionList.Description>
-          </ActionList.LinkItem>
+          </ActionList.Item>
         </ActionList>
       </Stack.Item>
     </Stack>

--- a/packages/react/src/ActionList/ActionList.docs.json
+++ b/packages/react/src/ActionList/ActionList.docs.json
@@ -8,7 +8,7 @@
   "props": [
     {
       "name": "children",
-      "type": "ActionList.Item[] | ActionList.LinkItem[] | ActionList.Group[]",
+      "type": "ActionList.Item[] | ActionList.Group[]",
       "defaultValue": "",
       "required": true,
       "description": ""
@@ -70,7 +70,7 @@
           "name": "onSelect",
           "type": "(event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>) => void",
           "defaultValue": "",
-          "description": "Callback that is called when the item is selected using either the mouse or keyboard. `event.preventDefault()` will prevent a menu from closing when within an `<ActionMenu />`. This is not called for disabled or inactive items."
+          "description": "Callback that is called when the item is selected using either the mouse or keyboard. `event.preventDefault()` will prevent a menu from closing when within an `<ActionMenu />`. This is not called for disabled or inactive items. When link props are provided, this may not be called as the default link behavior takes precedence."
         },
         {
           "name": "selected",
@@ -118,8 +118,28 @@
           "name": "sx",
           "type": "SystemStyleObject",
           "deprecated": true
+        },
+        {
+          "name": "as",
+          "type": "React.ElementType",
+          "defaultValue": "\"button\"",
+          "description": "The component or element type to render as. When href, to, or other link props are provided, this defaults to \"a\"."
+        },
+        {
+          "name": "href",
+          "type": "string",
+          "description": "URL to navigate to when item is clicked. When provided, the item will render as a link using LinkItem internally."
+        },
+        {
+          "name": "to",
+          "type": "string",
+          "description": "React Router destination to navigate to when item is clicked. When provided, the item will render as a link using LinkItem internally."
         }
-      ]
+      ],
+      "passthrough": {
+        "element": "button | a",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Attributes"
+      }
     },
     {
       "name": "ActionList.Heading",
@@ -151,49 +171,6 @@
           "deprecated": true
         }
       ]
-    },
-    {
-      "name": "ActionList.LinkItem",
-      "props": [
-        {
-          "name": "children",
-          "type": "React.ReactNode | ActionList.LeadingVisual | ActionList.Description | ActionList.TrailingVisual",
-          "defaultValue": "",
-          "required": true,
-          "description": ""
-        },
-        {
-          "name": "active",
-          "type": "boolean",
-          "defaultValue": "false",
-          "description": "Indicate whether the item is active. There should never be more than one active item."
-        },
-        {
-          "name": "ref",
-          "type": "React.RefObject<HTMLAnchorElement>"
-        },
-        {
-          "name": "as",
-          "type": "React.ElementType",
-          "defaultValue": "\"a\""
-        },
-        {
-          "name": "inactiveText",
-          "type": "string",
-          "required": false,
-          "description": "Text describing why the item is inactive. This may be used when an item's usual functionality\nis unavailable due to a system error such as a database outage.",
-          "defaultValue": ""
-        },
-        {
-          "name": "sx",
-          "type": "SystemStyleObject",
-          "deprecated": true
-        }
-      ],
-      "passthrough": {
-        "element": "a",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Attributes"
-      }
     },
     {
       "name": "ActionList.LeadingVisual",
@@ -350,7 +327,7 @@
       "props": [
         {
           "name": "children",
-          "type": "ActionList.Item[] | ActionList.LinkItem[]",
+          "type": "ActionList.Item[]",
           "defaultValue": "",
           "required": true,
           "description": ""

--- a/packages/react/src/ActionList/ActionList.examples.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.examples.stories.tsx
@@ -51,53 +51,53 @@ export const ListLinkItem = () => (
       </ActionList.LeadingVisual>
       not a link, just an Item for comparison
     </ActionList.Item>
-    <ActionList.LinkItem href="https://github.com/primer" aria-keyshortcuts="g">
+    <ActionList.Item href="https://github.com/primer" aria-keyshortcuts="g">
       <ActionList.LeadingVisual>
         <LinkIcon />
       </ActionList.LeadingVisual>
-      ActionList.LinkItem
-    </ActionList.LinkItem>
-    <ActionList.LinkItem href="https://github.com/primer" target="_blank" rel="noopener noreferrer">
+      ActionList.Item
+    </ActionList.Item>
+    <ActionList.Item href="https://github.com/primer" target="_blank" rel="noopener noreferrer">
       <ActionList.LeadingVisual>
         <LinkIcon />
       </ActionList.LeadingVisual>
-      ActionList.LinkItem with anchor attributes
-    </ActionList.LinkItem>
-    <ActionList.LinkItem as={ReactRouterLikeLink} to="?path=/story/components-actionlist--default">
+      ActionList.Item with anchor attributes
+    </ActionList.Item>
+    <ActionList.Item as={ReactRouterLikeLink} to="?path=/story/components-actionlist--default">
       <ActionList.LeadingVisual>
         <LinkIcon />
       </ActionList.LeadingVisual>
       as ReactRouterLink
-    </ActionList.LinkItem>
+    </ActionList.Item>
     <NextJSLikeLink href="?path=/story/components-actionlist--default">
-      <ActionList.LinkItem>
+      <ActionList.Item>
         <ActionList.LeadingVisual>
           <LinkIcon />
         </ActionList.LeadingVisual>
         NextJS style Link
-      </ActionList.LinkItem>
+      </ActionList.Item>
     </NextJSLikeLink>
-    <ActionList.LinkItem href="?path=/story/components-actionlist--default">
+    <ActionList.Item href="?path=/story/components-actionlist--default">
       <ActionList.LeadingVisual>
         <LinkIcon />
       </ActionList.LeadingVisual>
       With inline description
       <ActionList.Description variant="inline">inline description</ActionList.Description>
-    </ActionList.LinkItem>
-    <ActionList.LinkItem href="?path=/story/components-actionlist--default">
+    </ActionList.Item>
+    <ActionList.Item href="?path=/story/components-actionlist--default">
       <ActionList.LeadingVisual>
         <LinkIcon />
       </ActionList.LeadingVisual>
       With block description
       <ActionList.Description variant="block">Block description</ActionList.Description>
-    </ActionList.LinkItem>
-    <ActionList.LinkItem href="?path=/story/components-actionlist--default">
+    </ActionList.Item>
+    <ActionList.Item href="?path=/story/components-actionlist--default">
       <ActionList.LeadingVisual>
         <LinkIcon />
       </ActionList.LeadingVisual>
       Trailing visual
       <ActionList.TrailingVisual>⌘ + L</ActionList.TrailingVisual>
-    </ActionList.LinkItem>
+    </ActionList.Item>
   </ActionList>
 )
 ListLinkItem.storyName = 'Link Item'

--- a/packages/react/src/ActionList/ActionList.features.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.features.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import type {Meta} from '@storybook/react-vite'
 import {ActionList} from '.'
 import {Item} from './Item'
-import {LinkItem} from './LinkItem'
 import {Group} from './Group'
 import {Divider} from './Divider'
 import {Description} from './Description'
@@ -35,7 +34,7 @@ import classes from './ActionList.features.stories.module.css'
 export default {
   title: 'Components/ActionList/Features',
   component: ActionList,
-  subcomponents: {Item, LinkItem, Group, Divider, Description},
+  subcomponents: {Item, Group, Divider, Description},
 } as Meta<typeof ActionList>
 
 export const SimpleList = () => (
@@ -111,36 +110,36 @@ export const WithCustomHeading = () => (
       Details
     </Heading>
     <ActionList aria-labelledby="list-heading">
-      <ActionList.LinkItem href="https://github.com/primer/react#readme">
+      <ActionList.Item href="https://github.com/primer/react#readme">
         <ActionList.LeadingVisual>
           <BookIcon />
         </ActionList.LeadingVisual>
         Readme
-      </ActionList.LinkItem>
-      <ActionList.LinkItem href="https://github.com/primer/react/blob/main/LICENSE">
+      </ActionList.Item>
+      <ActionList.Item href="https://github.com/primer/react/blob/main/LICENSE">
         <ActionList.LeadingVisual>
           <LawIcon />
         </ActionList.LeadingVisual>
         MIT License
-      </ActionList.LinkItem>
-      <ActionList.LinkItem href="https://github.com/primer/react/stargazers">
+      </ActionList.Item>
+      <ActionList.Item href="https://github.com/primer/react/stargazers">
         <ActionList.LeadingVisual>
           <StarIcon />
         </ActionList.LeadingVisual>
         <strong>1.5k</strong> stars
-      </ActionList.LinkItem>
-      <ActionList.LinkItem href="https://github.com/primer/react/watchers">
+      </ActionList.Item>
+      <ActionList.Item href="https://github.com/primer/react/watchers">
         <ActionList.LeadingVisual>
           <EyeIcon />
         </ActionList.LeadingVisual>
         <strong>21</strong> watching
-      </ActionList.LinkItem>
-      <ActionList.LinkItem href="https://github.com/primer/react/network/members">
+      </ActionList.Item>
+      <ActionList.Item href="https://github.com/primer/react/network/members">
         <ActionList.LeadingVisual>
           <RepoForkedIcon />
         </ActionList.LeadingVisual>
         <strong>225</strong> forks
-      </ActionList.LinkItem>
+      </ActionList.Item>
     </ActionList>
   </>
 )
@@ -513,36 +512,36 @@ export const Links = () => (
     <ActionList.Heading as="h1" className={classes.HeadingSmall}>
       Details
     </ActionList.Heading>
-    <ActionList.LinkItem href="https://github.com/primer/react#readme">
+    <ActionList.Item href="https://github.com/primer/react#readme">
       <ActionList.LeadingVisual>
         <BookIcon />
       </ActionList.LeadingVisual>
       Readme
-    </ActionList.LinkItem>
-    <ActionList.LinkItem href="https://github.com/primer/react/blob/main/LICENSE">
+    </ActionList.Item>
+    <ActionList.Item href="https://github.com/primer/react/blob/main/LICENSE">
       <ActionList.LeadingVisual>
         <LawIcon />
       </ActionList.LeadingVisual>
       MIT License
-    </ActionList.LinkItem>
-    <ActionList.LinkItem href="https://github.com/primer/react/stargazers">
+    </ActionList.Item>
+    <ActionList.Item href="https://github.com/primer/react/stargazers">
       <ActionList.LeadingVisual>
         <StarIcon />
       </ActionList.LeadingVisual>
       <strong>1.5k</strong> stars
-    </ActionList.LinkItem>
-    <ActionList.LinkItem href="https://github.com/primer/react/watchers">
+    </ActionList.Item>
+    <ActionList.Item href="https://github.com/primer/react/watchers">
       <ActionList.LeadingVisual>
         <EyeIcon />
       </ActionList.LeadingVisual>
       <strong>21</strong> watching
-    </ActionList.LinkItem>
-    <ActionList.LinkItem href="https://github.com/primer/react/network/members">
+    </ActionList.Item>
+    <ActionList.Item href="https://github.com/primer/react/network/members">
       <ActionList.LeadingVisual>
         <RepoForkedIcon />
       </ActionList.LeadingVisual>
       <strong>225</strong> forks
-    </ActionList.LinkItem>
+    </ActionList.Item>
   </ActionList>
 )
 
@@ -909,15 +908,15 @@ export const WithTrailingAction = () => {
           </ActionList.Description>
           <ActionList.TrailingAction label="Apply settings" loading={loadingState} />
         </ActionList.Item>
-        <ActionList.LinkItem href="#">
+        <ActionList.Item href="#">
           LinkItem 1
           <ActionList.Description>
             with TrailingAction this is a long description and should not cause horizontal scroll on smaller screen
             sizes
           </ActionList.Description>
           <ActionList.TrailingAction label="Another action" />
-        </ActionList.LinkItem>
-        <ActionList.LinkItem href="#">
+        </ActionList.Item>
+        <ActionList.Item href="#">
           LinkItem 2
           <ActionList.Description>
             with TrailingVisual this is a long description and should not cause horizontal scroll on smaller screen
@@ -926,7 +925,7 @@ export const WithTrailingAction = () => {
           <ActionList.TrailingVisual>
             <TableIcon />
           </ActionList.TrailingVisual>
-        </ActionList.LinkItem>
+        </ActionList.Item>
         <ActionList.Item inactiveText="Unavailable due to an outage">
           Inactive Item<ActionList.Description>With TrailingAction</ActionList.Description>
           <ActionList.TrailingAction as="a" href="#" label="Some action 8" icon={ArrowRightIcon} />

--- a/packages/react/src/ActionList/ActionList.stories.tsx
+++ b/packages/react/src/ActionList/ActionList.stories.tsx
@@ -2,7 +2,6 @@ import type {StoryFn, Meta} from '@storybook/react-vite'
 import type {ActionListProps, ActionListGroupProps} from '.'
 import {ActionList} from '.'
 import {Item} from './Item'
-import {LinkItem} from './LinkItem'
 import {Group} from './Group'
 import {Divider} from './Divider'
 import {Description} from './Description'
@@ -11,7 +10,7 @@ import {TypographyIcon, VersionsIcon, SearchIcon, ArrowRightIcon, ArrowLeftIcon}
 export default {
   title: 'Components/ActionList',
   component: ActionList,
-  subcomponents: {Item, LinkItem, Group, Divider, Description},
+  subcomponents: {Item, Group, Divider, Description},
 } as Meta<typeof ActionList>
 
 export const Default = () => (
@@ -214,11 +213,11 @@ export const LinkItemPlayground = args => {
 
   return (
     <ActionList>
-      <ActionList.LinkItem {...args}>
+      <ActionList.Item {...args}>
         {leadingVisual && <ActionList.LeadingVisual>{leadingVisual}</ActionList.LeadingVisual>}
         Action list item
         {trailingVisual && <ActionList.TrailingVisual>{trailingVisual}</ActionList.TrailingVisual>}
-      </ActionList.LinkItem>
+      </ActionList.Item>
     </ActionList>
   )
 }

--- a/packages/react/src/ActionList/ActionList.test.tsx
+++ b/packages/react/src/ActionList/ActionList.test.tsx
@@ -95,9 +95,9 @@ describe('ActionList', () => {
           </ActionList.TrailingAction>
         </ActionList.Item>
         <ActionList.Divider className="divider" />
-        <ActionList.LinkItem className="link" href="//github.com" title="anchor" aria-keyshortcuts="d">
+        <ActionList.Item className="link" href="//github.com" title="anchor" aria-keyshortcuts="d">
           Link Item
-        </ActionList.LinkItem>
+        </ActionList.Item>
         <ActionList.Group className="group">
           <ActionList.GroupHeading as="h2" className="group_heading">
             Group Heading
@@ -180,13 +180,13 @@ describe('ActionList', () => {
   it('should support size prop on LinkItem', () => {
     const {container} = HTMLRender(
       <ActionList>
-        <ActionList.LinkItem href="//github.com" size="large">
+        <ActionList.Item href="//github.com" size="large">
           Large Link Item
-        </ActionList.LinkItem>
-        <ActionList.LinkItem href="//github.com" size="medium">
+        </ActionList.Item>
+        <ActionList.Item href="//github.com" size="medium">
           Medium Link Item
-        </ActionList.LinkItem>
-        <ActionList.LinkItem href="//github.com">Default Link Item</ActionList.LinkItem>
+        </ActionList.Item>
+        <ActionList.Item href="//github.com">Default Link Item</ActionList.Item>
       </ActionList>,
     )
 

--- a/packages/react/src/ActionList/BaseItem.tsx
+++ b/packages/react/src/ActionList/BaseItem.tsx
@@ -1,0 +1,325 @@
+import React from 'react'
+
+import {useId} from '../hooks/useId'
+import {useSlots} from '../hooks/useSlots'
+import {ActionListContainerContext} from './ActionListContainerContext'
+import {Description} from './Description'
+import {GroupContext} from './Group'
+import type {ActionListItemProps, ActionListProps} from './shared'
+import {Selection} from './Selection'
+import {LeadingVisual, TrailingVisual, VisualOrIndicator} from './Visuals'
+import {ItemContext, ListContext} from './shared'
+import {TrailingAction} from './TrailingAction'
+import {ConditionalWrapper} from '../internal/components/ConditionalWrapper'
+import {invariant} from '../utils/invariant'
+import VisuallyHidden from '../_VisuallyHidden'
+import classes from './ActionList.module.css'
+import {clsx} from 'clsx'
+import {BoxWithFallback} from '../internal/components/BoxWithFallback'
+import {fixedForwardRef} from '../utils/modern-polymorphic'
+
+type ActionListSubItemProps = {
+  children?: React.ReactNode
+}
+
+export const SubItem: React.FC<ActionListSubItemProps> = ({children}) => {
+  return <>{children}</>
+}
+
+SubItem.displayName = 'ActionList.SubItem'
+
+const ButtonItemContainerNoBox = React.forwardRef<HTMLButtonElement, React.HTMLAttributes<HTMLButtonElement>>(
+  ({children, style, ...props}, forwardedRef) => {
+    return (
+      <button type="button" ref={forwardedRef as React.Ref<HTMLButtonElement>} style={style} {...props}>
+        {children}
+      </button>
+    )
+  },
+)
+
+const DivItemContainerNoBox = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({children, ...props}, forwardedRef) => {
+    return (
+      <div ref={forwardedRef as React.Ref<HTMLDivElement>} {...props}>
+        {children}
+      </div>
+    )
+  },
+)
+
+const UnwrappedItem = <As extends React.ElementType = 'li'>(
+  {
+    variant = 'default',
+    size = 'medium',
+    disabled = false,
+    inactiveText,
+    selected = undefined,
+    active = false,
+    onSelect: onSelectUser,
+    sx: sxProp,
+    id,
+    role,
+    loading,
+    _PrivateItemWrapper,
+    className,
+    groupId: _groupId,
+    renderItem: _renderItem,
+    handleAddItem: _handleAddItem,
+    ...props
+  }: ActionListItemProps<As>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  forwardedRef: React.Ref<any>,
+): JSX.Element => {
+  const baseSlots = {
+    leadingVisual: LeadingVisual,
+    trailingVisual: TrailingVisual,
+    trailingAction: TrailingAction,
+    subItem: SubItem,
+  }
+
+  const [partialSlots, childrenWithoutSlots] = useSlots(props.children, {...baseSlots, description: Description})
+
+  const slots = {description: undefined, ...partialSlots}
+
+  const {container, afterSelect, selectionAttribute, defaultTrailingVisual} =
+    React.useContext(ActionListContainerContext)
+
+  // Be sure to avoid rendering the container unless there is a default
+  const wrappedDefaultTrailingVisual = defaultTrailingVisual ? (
+    <TrailingVisual>{defaultTrailingVisual}</TrailingVisual>
+  ) : null
+  const trailingVisual = slots.trailingVisual ?? wrappedDefaultTrailingVisual
+
+  const {role: listRole, selectionVariant: listSelectionVariant} = React.useContext(ListContext)
+  const {selectionVariant: groupSelectionVariant} = React.useContext(GroupContext)
+  const inactive = Boolean(inactiveText)
+  // TODO change `menuContext` check to ```listRole !== undefined && ['menu', 'listbox'].includes(listRole)```
+  // once we have a better way to handle existing usage in dotcom that incorrectly use ActionList.TrailingAction
+  const menuContext = container === 'ActionMenu' || container === 'SelectPanel' || container === 'FilteredActionList'
+  // TODO: when we change `menuContext` to check `listRole` instead of `container`
+  const showInactiveIndicator = inactive && !(listRole !== undefined && ['menu', 'listbox'].includes(listRole))
+
+  const onSelect = React.useCallback(
+    (
+      event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+      afterSelect?: Function,
+    ) => {
+      if (typeof onSelectUser === 'function') onSelectUser(event)
+      if (event.defaultPrevented) return
+      if (typeof afterSelect === 'function') afterSelect(event)
+    },
+    [onSelectUser],
+  )
+
+  const selectionVariant: ActionListProps['selectionVariant'] = groupSelectionVariant
+    ? groupSelectionVariant
+    : listSelectionVariant
+
+  /** Infer item role based on the container */
+  let inferredItemRole: ActionListItemProps['role']
+  if (container === 'ActionMenu') {
+    if (selectionVariant === 'single') inferredItemRole = 'menuitemradio'
+    else if (selectionVariant === 'multiple') inferredItemRole = 'menuitemcheckbox'
+    else inferredItemRole = 'menuitem'
+  } else if (listRole === 'listbox') {
+    if (selectionVariant !== undefined && !role) inferredItemRole = 'option'
+  }
+
+  const itemRole = role || inferredItemRole
+
+  if (slots.trailingAction) {
+    invariant(
+      !menuContext,
+      `ActionList.TrailingAction can not be used within a list with an ARIA role of "menu" or "listbox".`,
+    )
+  }
+
+  /** Infer the proper selection attribute based on the item's role */
+  let inferredSelectionAttribute: 'aria-selected' | 'aria-checked' | undefined
+  if (itemRole === 'menuitemradio' || itemRole === 'menuitemcheckbox') inferredSelectionAttribute = 'aria-checked'
+  else if (itemRole === 'option') inferredSelectionAttribute = 'aria-selected'
+
+  const itemSelectionAttribute = selectionAttribute || inferredSelectionAttribute
+  // Ensures ActionList.Item retains list item semantics if a valid ARIA role is applied, or if item is inactive
+  const listItemSemantics =
+    role === 'option' || role === 'menuitem' || role === 'menuitemradio' || role === 'menuitemcheckbox'
+
+  const listRoleTypes = ['listbox', 'menu', 'list']
+  const listSemantics = (listRole && listRoleTypes.includes(listRole)) || inactive || listItemSemantics
+  const buttonSemantics = !listSemantics && !_PrivateItemWrapper
+
+  const clickHandler = React.useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      if (disabled || inactive || loading) return
+      onSelect(event, afterSelect)
+    },
+    [onSelect, disabled, inactive, afterSelect, loading],
+  )
+
+  const keyPressHandler = React.useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (disabled || inactive || loading) return
+      if ([' ', 'Enter'].includes(event.key)) {
+        if (event.key === ' ') {
+          event.preventDefault() // prevent scrolling on Space
+          // immediately reset defaultPrevented once its job is done
+          // so as to not disturb the functions that use that event after this
+          event.defaultPrevented = false
+        }
+        onSelect(event, afterSelect)
+      }
+    },
+    [onSelect, disabled, loading, inactive, afterSelect],
+  )
+
+  const itemId = useId(id)
+  const labelId = `${itemId}--label`
+  const inlineDescriptionId = `${itemId}--inline-description`
+  const blockDescriptionId = `${itemId}--block-description`
+  const trailingVisualId = `${itemId}--trailing-visual`
+  const inactiveWarningId = inactive && !showInactiveIndicator ? `${itemId}--warning-message` : undefined
+
+  const DefaultItemWrapper = listSemantics ? DivItemContainerNoBox : ButtonItemContainerNoBox
+
+  const ItemWrapper = _PrivateItemWrapper || DefaultItemWrapper
+
+  // only apply aria-selected and aria-checked to selectable items
+  const selectableRoles = ['menuitemradio', 'menuitemcheckbox', 'option']
+  const includeSelectionAttribute = itemSelectionAttribute && itemRole && selectableRoles.includes(itemRole)
+
+  let focusable
+
+  if (showInactiveIndicator) {
+    focusable = true
+  }
+
+  // Extract the variant prop value from the description slot component
+  const descriptionVariant = slots.description?.props.variant ?? 'inline'
+
+  const menuItemProps = {
+    onClick: clickHandler,
+    onKeyPress: !buttonSemantics ? keyPressHandler : undefined,
+    'aria-disabled': disabled ? true : undefined,
+    'data-inactive': inactive ? true : undefined,
+    'data-loading': loading && !inactive ? true : undefined,
+    tabIndex: focusable ? undefined : 0,
+    'aria-labelledby': `${labelId} ${slots.trailingVisual ? trailingVisualId : ''} ${
+      slots.description && descriptionVariant === 'inline' ? inlineDescriptionId : ''
+    }`,
+    'aria-describedby':
+      [
+        slots.description && descriptionVariant === 'block' ? blockDescriptionId : undefined,
+        inactiveWarningId ?? undefined,
+      ]
+        .filter(String)
+        .join(' ')
+        .trim() || undefined,
+    ...(includeSelectionAttribute && {[itemSelectionAttribute]: selected}),
+    role: itemRole,
+    id: itemId,
+  }
+
+  const containerProps = _PrivateItemWrapper
+    ? {role: itemRole ? 'none' : undefined, ...props}
+    : // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      (listSemantics && {...menuItemProps, ...props, ref: forwardedRef}) || {}
+
+  const wrapperProps = _PrivateItemWrapper
+    ? menuItemProps
+    : !listSemantics && {
+        ...menuItemProps,
+        ...props,
+        ref: forwardedRef,
+      }
+
+  return (
+    <ItemContext.Provider
+      value={{
+        variant,
+        size,
+        disabled,
+        inactive: Boolean(inactiveText),
+        inlineDescriptionId,
+        blockDescriptionId,
+        trailingVisualId,
+      }}
+    >
+      <BoxWithFallback
+        {...containerProps}
+        as="li"
+        sx={sxProp}
+        ref={listSemantics ? forwardedRef : null}
+        data-variant={variant === 'danger' ? variant : undefined}
+        data-active={active ? true : undefined}
+        data-inactive={inactiveText ? true : undefined}
+        data-has-subitem={slots.subItem ? true : undefined}
+        data-has-description={slots.description ? true : false}
+        className={clsx(classes.ActionListItem, className)}
+      >
+        <ItemWrapper
+          {...wrapperProps}
+          className={classes.ActionListContent}
+          data-size={size}
+          // @ts-ignore: ItemWrapper is polymorphic and the ref type depends on the rendered element ('button' or 'li')
+          ref={forwardedRef}
+        >
+          <span className={classes.Spacer} />
+          <Selection selected={selected} className={classes.LeadingAction} />
+          <VisualOrIndicator
+            inactiveText={showInactiveIndicator ? inactiveText : undefined}
+            itemHasLeadingVisual={Boolean(slots.leadingVisual)}
+            labelId={labelId}
+            loading={loading}
+            position="leading"
+          >
+            {slots.leadingVisual}
+          </VisualOrIndicator>
+          <span className={classes.ActionListSubContent} data-component="ActionList.Item--DividerContainer">
+            <ConditionalWrapper
+              if={!!slots.description}
+              className={classes.ItemDescriptionWrap}
+              data-description-variant={descriptionVariant}
+            >
+              <span id={labelId} className={classes.ItemLabel}>
+                {childrenWithoutSlots}
+                {/* Loading message needs to be in here so it is read with the label */}
+                {/* If the item is inactive, we do not simultaneously announce that it is loading */}
+                {loading === true && !inactive && <VisuallyHidden>Loading</VisuallyHidden>}
+              </span>
+              {slots.description}
+            </ConditionalWrapper>
+            <VisualOrIndicator
+              inactiveText={showInactiveIndicator ? inactiveText : undefined}
+              itemHasLeadingVisual={Boolean(slots.leadingVisual)}
+              labelId={labelId}
+              loading={loading}
+              position="trailing"
+            >
+              {trailingVisual}
+            </VisualOrIndicator>
+
+            {
+              // If the item is inactive, but it's not in an overlay (e.g. ActionMenu, SelectPanel),
+              // render the inactive warning message directly in the item.
+              !showInactiveIndicator && inactiveText ? (
+                <span className={classes.InactiveWarning} id={inactiveWarningId}>
+                  {inactiveText}
+                </span>
+              ) : null
+            }
+          </span>
+        </ItemWrapper>
+        {!inactive && !loading && !menuContext && Boolean(slots.trailingAction) && slots.trailingAction}
+        {slots.subItem}
+      </BoxWithFallback>
+    </ItemContext.Provider>
+  )
+}
+
+const BaseItem = fixedForwardRef(UnwrappedItem)
+
+Object.assign(BaseItem, {displayName: 'ActionList.BaseItem'})
+
+export {BaseItem}

--- a/packages/react/src/ActionList/Item.test.tsx
+++ b/packages/react/src/ActionList/Item.test.tsx
@@ -13,9 +13,9 @@ function SimpleActionList(): JSX.Element {
       <ActionList.Item>Copy link</ActionList.Item>
       <ActionList.Item>Edit file</ActionList.Item>
       <ActionList.Item variant="danger">Delete file</ActionList.Item>
-      <ActionList.LinkItem href="//github.com" title="anchor" aria-keyshortcuts="d">
+      <ActionList.Item href="//github.com" title="anchor" aria-keyshortcuts="d">
         Link Item
-      </ActionList.LinkItem>
+      </ActionList.Item>
       <ActionList.Item inactiveText="Unavailable due to an outage">Inactive item</ActionList.Item>
       <ActionList.Item inactiveText="Unavailable due to an outage" loading>
         Loading and inactive item
@@ -63,6 +63,7 @@ describe('ActionList.Item', () => {
   it('should have aria-keyshortcuts applied to the correct element', async () => {
     const {container} = HTMLRender(<SimpleActionList />)
     const linkOptions = await waitFor(() => container.querySelectorAll('a'))
+    console.log(linkOptions[0])
     expect(linkOptions[0]).toHaveAttribute('aria-keyshortcuts', 'd')
     expect(linkOptions[0].parentElement).not.toHaveAttribute('aria-keyshortcuts', 'd')
   })
@@ -185,9 +186,9 @@ describe('ActionList.Item', () => {
     const onClick = vi.fn()
     const component = HTMLRender(
       <ActionList role="listbox">
-        <ActionList.LinkItem role="link" onClick={onClick}>
+        <ActionList.Item role="link" onClick={onClick}>
           Primer React
-        </ActionList.LinkItem>
+        </ActionList.Item>
       </ActionList>,
     )
     const link = await waitFor(() => component.getByRole('link'))

--- a/packages/react/src/ActionList/Item.tsx
+++ b/packages/react/src/ActionList/Item.tsx
@@ -1,323 +1,74 @@
 import React from 'react'
-
-import {useId} from '../hooks/useId'
-import {useSlots} from '../hooks/useSlots'
+import {BaseItem} from './BaseItem'
+import {LinkItem} from './LinkItem'
+import type {LinkProps, ActionListLinkItemProps} from './LinkItem'
+import type {ActionListItemProps} from './shared'
 import {ActionListContainerContext} from './ActionListContainerContext'
-import {Description} from './Description'
-import {GroupContext} from './Group'
-import type {ActionListItemProps, ActionListProps} from './shared'
-import {Selection} from './Selection'
-import {LeadingVisual, TrailingVisual, VisualOrIndicator} from './Visuals'
-import {ItemContext, ListContext} from './shared'
-import {TrailingAction} from './TrailingAction'
-import {ConditionalWrapper} from '../internal/components/ConditionalWrapper'
 import {invariant} from '../utils/invariant'
-import VisuallyHidden from '../_VisuallyHidden'
-import classes from './ActionList.module.css'
-import {clsx} from 'clsx'
-import {BoxWithFallback} from '../internal/components/BoxWithFallback'
 import {fixedForwardRef} from '../utils/modern-polymorphic'
 
-type ActionListSubItemProps = {
-  children?: React.ReactNode
-}
+// Export SubItem from BaseItem for backward compatibility
+export {SubItem} from './BaseItem'
 
-export const SubItem: React.FC<ActionListSubItemProps> = ({children}) => {
-  return <>{children}</>
-}
+// Combine Item props with optional link props - defaults to 'li' | 'a' to support both use cases
+export type ActionListCombinedItemProps<As extends React.ElementType = 'li' | 'a'> = ActionListItemProps<As> & LinkProps
 
-SubItem.displayName = 'ActionList.SubItem'
+const UnwrappedItem = <As extends React.ElementType = 'li' | 'a'>(
+  props: ActionListCombinedItemProps<As>,
+  forwardedRef: React.Ref<HTMLElement>,
+) => {
+  const {href, target, rel, download, hrefLang, media, ping, type, referrerPolicy, ...restProps} = props
+  const {container, listRole} = React.useContext(ActionListContainerContext)
 
-const ButtonItemContainerNoBox = React.forwardRef<HTMLButtonElement, React.HTMLAttributes<HTMLButtonElement>>(
-  ({children, style, ...props}, forwardedRef) => {
-    return (
-      <button type="button" ref={forwardedRef as React.Ref<HTMLButtonElement>} style={style} {...props}>
-        {children}
-      </button>
-    )
-  },
-)
-
-const DivItemContainerNoBox = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({children, ...props}, forwardedRef) => {
-    return (
-      <div ref={forwardedRef as React.Ref<HTMLDivElement>} {...props}>
-        {children}
-      </div>
-    )
-  },
-)
-
-const UnwrappedItem = <As extends React.ElementType = 'li'>(
-  {
-    variant = 'default',
-    size = 'medium',
-    disabled = false,
-    inactiveText,
-    selected = undefined,
-    active = false,
-    onSelect: onSelectUser,
-    sx: sxProp,
-    id,
-    role,
-    loading,
-    _PrivateItemWrapper,
-    className,
-    groupId: _groupId,
-    renderItem: _renderItem,
-    handleAddItem: _handleAddItem,
-    ...props
-  }: ActionListItemProps<As>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  forwardedRef: React.Ref<any>,
-): JSX.Element => {
-  const baseSlots = {
-    leadingVisual: LeadingVisual,
-    trailingVisual: TrailingVisual,
-    trailingAction: TrailingAction,
-    subItem: SubItem,
-  }
-
-  const [partialSlots, childrenWithoutSlots] = useSlots(props.children, {...baseSlots, description: Description})
-
-  const slots = {description: undefined, ...partialSlots}
-
-  const {container, afterSelect, selectionAttribute, defaultTrailingVisual} =
-    React.useContext(ActionListContainerContext)
-
-  // Be sure to avoid rendering the container unless there is a default
-  const wrappedDefaultTrailingVisual = defaultTrailingVisual ? (
-    <TrailingVisual>{defaultTrailingVisual}</TrailingVisual>
-  ) : null
-  const trailingVisual = slots.trailingVisual ?? wrappedDefaultTrailingVisual
-
-  const {role: listRole, selectionVariant: listSelectionVariant} = React.useContext(ListContext)
-  const {selectionVariant: groupSelectionVariant} = React.useContext(GroupContext)
-  const inactive = Boolean(inactiveText)
-  // TODO change `menuContext` check to ```listRole !== undefined && ['menu', 'listbox'].includes(listRole)```
-  // once we have a better way to handle existing usage in dotcom that incorrectly use ActionList.TrailingAction
+  // Determine if we're in a menu context where links are not allowed
   const menuContext = container === 'ActionMenu' || container === 'SelectPanel' || container === 'FilteredActionList'
-  // TODO: when we change `menuContext` to check `listRole` instead of `container`
-  const showInactiveIndicator = inactive && !(listRole !== undefined && ['menu', 'listbox'].includes(listRole))
+  const listboxContext = listRole === 'listbox' || listRole === 'menu'
+  const invalidLinkContext = menuContext || listboxContext
 
-  const onSelect = React.useCallback(
-    (
-      event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-      afterSelect?: Function,
-    ) => {
-      if (typeof onSelectUser === 'function') onSelectUser(event)
-      if (event.defaultPrevented) return
-      if (typeof afterSelect === 'function') afterSelect(event)
-    },
-    [onSelectUser],
-  )
-
-  const selectionVariant: ActionListProps['selectionVariant'] = groupSelectionVariant
-    ? groupSelectionVariant
-    : listSelectionVariant
-
-  /** Infer item role based on the container */
-  let inferredItemRole: ActionListItemProps['role']
-  if (container === 'ActionMenu') {
-    if (selectionVariant === 'single') inferredItemRole = 'menuitemradio'
-    else if (selectionVariant === 'multiple') inferredItemRole = 'menuitemcheckbox'
-    else inferredItemRole = 'menuitem'
-  } else if (listRole === 'listbox') {
-    if (selectionVariant !== undefined && !role) inferredItemRole = 'option'
-  }
-
-  const itemRole = role || inferredItemRole
-
-  if (slots.trailingAction) {
+  // If href is provided but we're in an invalid context, show a warning and render as BaseItem
+  if (href) {
     invariant(
-      !menuContext,
-      `ActionList.TrailingAction can not be used within a list with an ARIA role of "menu" or "listbox".`,
+      !invalidLinkContext,
+      `ActionList.Item with href cannot be used within a list with role="${listRole}" or container="${container}". ` +
+        `Links are not permitted in menu contexts due to accessibility constraints. ` +
+        `Use ActionList.Item with an onSelect handler instead.`,
     )
   }
 
-  /** Infer the proper selection attribute based on the item's role */
-  let inferredSelectionAttribute: 'aria-selected' | 'aria-checked' | undefined
-  if (itemRole === 'menuitemradio' || itemRole === 'menuitemcheckbox') inferredSelectionAttribute = 'aria-checked'
-  else if (itemRole === 'option') inferredSelectionAttribute = 'aria-selected'
+  // If href is provided OR we have a custom 'as' component (for Router-like components) and we're in a valid context, render as LinkItem
+  // Also check for common Router props like 'to'
+  const shouldUseLinkItem = (href || restProps.to) && !invalidLinkContext
 
-  const itemSelectionAttribute = selectionAttribute || inferredSelectionAttribute
-  // Ensures ActionList.Item retains list item semantics if a valid ARIA role is applied, or if item is inactive
-  const listItemSemantics =
-    role === 'option' || role === 'menuitem' || role === 'menuitemradio' || role === 'menuitemcheckbox'
+  if (shouldUseLinkItem) {
+    const linkProps = {
+      download,
+      href,
+      hrefLang,
+      media,
+      ping,
+      rel,
+      target,
+      type,
+      referrerPolicy,
+      ...restProps, // This includes the 'as' prop for polymorphic components
+    } as ActionListLinkItemProps
 
-  const listRoleTypes = ['listbox', 'menu', 'list']
-  const listSemantics = (listRole && listRoleTypes.includes(listRole)) || inactive || listItemSemantics
-  const buttonSemantics = !listSemantics && !_PrivateItemWrapper
-
-  const clickHandler = React.useCallback(
-    (event: React.MouseEvent<HTMLElement>) => {
-      if (disabled || inactive || loading) return
-      onSelect(event, afterSelect)
-    },
-    [onSelect, disabled, inactive, afterSelect, loading],
-  )
-
-  const keyPressHandler = React.useCallback(
-    (event: React.KeyboardEvent<HTMLElement>) => {
-      if (disabled || inactive || loading) return
-      if ([' ', 'Enter'].includes(event.key)) {
-        if (event.key === ' ') {
-          event.preventDefault() // prevent scrolling on Space
-          // immediately reset defaultPrevented once its job is done
-          // so as to not disturb the functions that use that event after this
-          event.defaultPrevented = false
-        }
-        onSelect(event, afterSelect)
-      }
-    },
-    [onSelect, disabled, loading, inactive, afterSelect],
-  )
-
-  const itemId = useId(id)
-  const labelId = `${itemId}--label`
-  const inlineDescriptionId = `${itemId}--inline-description`
-  const blockDescriptionId = `${itemId}--block-description`
-  const trailingVisualId = `${itemId}--trailing-visual`
-  const inactiveWarningId = inactive && !showInactiveIndicator ? `${itemId}--warning-message` : undefined
-
-  const DefaultItemWrapper = listSemantics ? DivItemContainerNoBox : ButtonItemContainerNoBox
-
-  const ItemWrapper = _PrivateItemWrapper || DefaultItemWrapper
-
-  // only apply aria-selected and aria-checked to selectable items
-  const selectableRoles = ['menuitemradio', 'menuitemcheckbox', 'option']
-  const includeSelectionAttribute = itemSelectionAttribute && itemRole && selectableRoles.includes(itemRole)
-
-  let focusable
-
-  if (showInactiveIndicator) {
-    focusable = true
+    return <LinkItem ref={forwardedRef as any} {...linkProps} />
   }
 
-  // Extract the variant prop value from the description slot component
-  const descriptionVariant = slots.description?.props.variant ?? 'inline'
+  const itemProps = {
+    ref: forwardedRef,
+    ...restProps,
+  } as ActionListItemProps
 
-  const menuItemProps = {
-    onClick: clickHandler,
-    onKeyPress: !buttonSemantics ? keyPressHandler : undefined,
-    'aria-disabled': disabled ? true : undefined,
-    'data-inactive': inactive ? true : undefined,
-    'data-loading': loading && !inactive ? true : undefined,
-    tabIndex: focusable ? undefined : 0,
-    'aria-labelledby': `${labelId} ${slots.trailingVisual ? trailingVisualId : ''} ${
-      slots.description && descriptionVariant === 'inline' ? inlineDescriptionId : ''
-    }`,
-    'aria-describedby':
-      [
-        slots.description && descriptionVariant === 'block' ? blockDescriptionId : undefined,
-        inactiveWarningId ?? undefined,
-      ]
-        .filter(String)
-        .join(' ')
-        .trim() || undefined,
-    ...(includeSelectionAttribute && {[itemSelectionAttribute]: selected}),
-    role: itemRole,
-    id: itemId,
-  }
-
-  const containerProps = _PrivateItemWrapper
-    ? {role: itemRole ? 'none' : undefined, ...props}
-    : // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      (listSemantics && {...menuItemProps, ...props, ref: forwardedRef}) || {}
-
-  const wrapperProps = _PrivateItemWrapper
-    ? menuItemProps
-    : !listSemantics && {
-        ...menuItemProps,
-        ...props,
-        ref: forwardedRef,
-      }
-
-  return (
-    <ItemContext.Provider
-      value={{
-        variant,
-        size,
-        disabled,
-        inactive: Boolean(inactiveText),
-        inlineDescriptionId,
-        blockDescriptionId,
-        trailingVisualId,
-      }}
-    >
-      <BoxWithFallback
-        {...containerProps}
-        as="li"
-        sx={sxProp}
-        ref={listSemantics ? forwardedRef : null}
-        data-variant={variant === 'danger' ? variant : undefined}
-        data-active={active ? true : undefined}
-        data-inactive={inactiveText ? true : undefined}
-        data-has-subitem={slots.subItem ? true : undefined}
-        data-has-description={slots.description ? true : false}
-        className={clsx(classes.ActionListItem, className)}
-      >
-        <ItemWrapper
-          {...wrapperProps}
-          className={classes.ActionListContent}
-          data-size={size}
-          // @ts-ignore: ItemWrapper is polymorphic and the ref type depends on the rendered element ('button' or 'li')
-          ref={forwardedRef}
-        >
-          <span className={classes.Spacer} />
-          <Selection selected={selected} className={classes.LeadingAction} />
-          <VisualOrIndicator
-            inactiveText={showInactiveIndicator ? inactiveText : undefined}
-            itemHasLeadingVisual={Boolean(slots.leadingVisual)}
-            labelId={labelId}
-            loading={loading}
-            position="leading"
-          >
-            {slots.leadingVisual}
-          </VisualOrIndicator>
-          <span className={classes.ActionListSubContent} data-component="ActionList.Item--DividerContainer">
-            <ConditionalWrapper
-              if={!!slots.description}
-              className={classes.ItemDescriptionWrap}
-              data-description-variant={descriptionVariant}
-            >
-              <span id={labelId} className={classes.ItemLabel}>
-                {childrenWithoutSlots}
-                {/* Loading message needs to be in here so it is read with the label */}
-                {/* If the item is inactive, we do not simultaneously announce that it is loading */}
-                {loading === true && !inactive && <VisuallyHidden>Loading</VisuallyHidden>}
-              </span>
-              {slots.description}
-            </ConditionalWrapper>
-            <VisualOrIndicator
-              inactiveText={showInactiveIndicator ? inactiveText : undefined}
-              itemHasLeadingVisual={Boolean(slots.leadingVisual)}
-              labelId={labelId}
-              loading={loading}
-              position="trailing"
-            >
-              {trailingVisual}
-            </VisualOrIndicator>
-
-            {
-              // If the item is inactive, but it's not in an overlay (e.g. ActionMenu, SelectPanel),
-              // render the inactive warning message directly in the item.
-              !showInactiveIndicator && inactiveText ? (
-                <span className={classes.InactiveWarning} id={inactiveWarningId}>
-                  {inactiveText}
-                </span>
-              ) : null
-            }
-          </span>
-        </ItemWrapper>
-        {!inactive && !loading && !menuContext && Boolean(slots.trailingAction) && slots.trailingAction}
-        {slots.subItem}
-      </BoxWithFallback>
-    </ItemContext.Provider>
-  )
+  return <BaseItem {...itemProps} />
 }
 
+/**
+ * A unified ActionList item that can function as either a button-like item or a link,
+ * depending on whether an href prop is provided. This component automatically chooses
+ * the appropriate implementation while enforcing accessibility constraints.
+ */
 const Item = fixedForwardRef(UnwrappedItem)
 
 Object.assign(Item, {displayName: 'ActionList.Item'})

--- a/packages/react/src/ActionList/LinkItem.tsx
+++ b/packages/react/src/ActionList/LinkItem.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 import Link from '../Link'
-import {Item} from './Item'
+import {BaseItem} from './BaseItem'
 import type {ActionListItemProps} from './shared'
 
 // adopted from React.AnchorHTMLAttributes
-type LinkProps = {
+export type LinkProps = {
   download?: string
   href?: string
   hrefLang?: string
@@ -28,7 +28,7 @@ export type ActionListLinkItemProps = Pick<
 export const LinkItem = React.forwardRef(
   ({sx, active, inactiveText, variant, size, as: Component, className, ...props}, forwardedRef) => {
     return (
-      <Item
+      <BaseItem
         className={className}
         active={active}
         inactiveText={inactiveText}
@@ -51,7 +51,7 @@ export const LinkItem = React.forwardRef(
         }}
       >
         {props.children}
-      </Item>
+      </BaseItem>
     )
   },
 ) as PolymorphicForwardRefComponent<'a', ActionListLinkItemProps>

--- a/packages/react/src/ActionList/index.ts
+++ b/packages/react/src/ActionList/index.ts
@@ -1,7 +1,7 @@
 import {List} from './List'
 import {Group, GroupHeading} from './Group'
-import {Item} from './Item'
 import {LinkItem} from './LinkItem'
+import {Item} from './Item'
 import {Divider} from './Divider'
 import {Description} from './Description'
 import {TrailingAction} from './TrailingAction'
@@ -12,6 +12,7 @@ export type {ActionListProps} from './shared'
 export type {ActionListGroupProps, ActionListGroupHeadingProps} from './Group'
 export type {ActionListItemProps} from './shared'
 export type {ActionListLinkItemProps} from './LinkItem'
+export type {ActionListCombinedItemProps} from './Item'
 export type {ActionListDividerProps} from './Divider'
 export type {ActionListDescriptionProps} from './Description'
 export type {ActionListLeadingVisualProps, ActionListTrailingVisualProps} from './Visuals'
@@ -25,10 +26,10 @@ export const ActionList = Object.assign(List, {
   /** Collects related `Items` in an `ActionList`. */
   Group,
 
-  /** An actionable or selectable `Item` */
+  /** An actionable or selectable `Item` that can also function as a link when href is provided */
   Item,
 
-  /** A `Item` that renders a full-size anchor inside ListItem */
+  /** @deprecated Use ActionList.Item with href prop instead. A `Item` that renders a full-size anchor inside ListItem */
   LinkItem,
 
   /** Visually separates `Item`s or `Group`s in an `ActionList`. */

--- a/packages/react/src/ActionMenu/ActionMenu.examples.stories.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.examples.stories.tsx
@@ -250,7 +250,7 @@ export const ShortcutMenu = () => {
               Edit comment
               <ActionList.TrailingVisual>⌘E</ActionList.TrailingVisual>
             </ActionList.Item>
-            <ActionList.LinkItem href="#">View file</ActionList.LinkItem>
+            <ActionList.Item href="#">View file</ActionList.Item>
             <ActionList.Divider />
             <ActionList.Item variant="danger">
               Delete file
@@ -297,7 +297,7 @@ export const ContextMenu = () => {
                 Edit comment
                 <ActionList.TrailingVisual>⌘E</ActionList.TrailingVisual>
               </ActionList.Item>
-              <ActionList.LinkItem href="#">View file</ActionList.LinkItem>
+              <ActionList.Item href="#">View file</ActionList.Item>
               <ActionList.Divider />
               <ActionList.Item variant="danger">
                 Delete file
@@ -571,12 +571,12 @@ export const OnlyInactiveItems = () => (
             <ArchiveIcon />
           </ActionList.LeadingVisual>
         </ActionList.Item>
-        <ActionList.LinkItem href="/" inactiveText="Unavailable due to an outage">
+        <ActionList.Item href="/" inactiveText="Unavailable due to an outage">
           Settings
           <ActionList.LeadingVisual>
             <GearIcon />
           </ActionList.LeadingVisual>
-        </ActionList.LinkItem>
+        </ActionList.Item>
         <ActionList.Item onSelect={() => alert('Make a copy clicked')} inactiveText="Unavailable due to an outage">
           Make a copy
           <ActionList.LeadingVisual>
@@ -586,24 +586,24 @@ export const OnlyInactiveItems = () => (
         <ActionList.Divider />
         <ActionList.Group>
           <ActionList.GroupHeading>Github projects</ActionList.GroupHeading>
-          <ActionList.LinkItem href="/" inactiveText="Unavailable due to an outage">
+          <ActionList.Item href="/" inactiveText="Unavailable due to an outage">
             What&apos;s new
             <ActionList.LeadingVisual>
               <RocketIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem href="/" inactiveText="Unavailable due to an outage">
+          </ActionList.Item>
+          <ActionList.Item href="/" inactiveText="Unavailable due to an outage">
             Give feedback
             <ActionList.LeadingVisual>
               <CommentIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem href="/" inactiveText="Unavailable due to an outage">
+          </ActionList.Item>
+          <ActionList.Item href="/" inactiveText="Unavailable due to an outage">
             GitHub Docs
             <ActionList.LeadingVisual>
               <BookIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
+          </ActionList.Item>
         </ActionList.Group>
       </ActionList>
     </ActionMenu.Overlay>

--- a/packages/react/src/ActionMenu/ActionMenu.features.stories.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.features.stories.tsx
@@ -33,12 +33,12 @@ export const LinksAndActions = () => (
             <ArchiveIcon />
           </ActionList.LeadingVisual>
         </ActionList.Item>
-        <ActionList.LinkItem href="/">
+        <ActionList.Item href="/">
           Settings
           <ActionList.LeadingVisual>
             <GearIcon />
           </ActionList.LeadingVisual>
-        </ActionList.LinkItem>
+        </ActionList.Item>
         <ActionList.Item onSelect={() => alert('Make a copy clicked')}>
           Make a copy
           <ActionList.LeadingVisual>
@@ -48,24 +48,24 @@ export const LinksAndActions = () => (
         <ActionList.Divider />
         <ActionList.Group>
           <ActionList.GroupHeading>GitHub projects</ActionList.GroupHeading>
-          <ActionList.LinkItem href="/">
+          <ActionList.Item href="/">
             What&apos;s new
             <ActionList.LeadingVisual>
               <RocketIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem href="/">
+          </ActionList.Item>
+          <ActionList.Item href="/">
             Give feedback
             <ActionList.LeadingVisual>
               <CommentIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem href="/">
+          </ActionList.Item>
+          <ActionList.Item href="/">
             GitHub Docs
             <ActionList.LeadingVisual>
               <BookIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
+          </ActionList.Item>
         </ActionList.Group>
       </ActionList>
     </ActionMenu.Overlay>
@@ -153,12 +153,12 @@ export const InactiveItems = () => (
             <ArchiveIcon />
           </ActionList.LeadingVisual>
         </ActionList.Item>
-        <ActionList.LinkItem href="/" inactiveText="Unavailable due to an outage">
+        <ActionList.Item href="/" inactiveText="Unavailable due to an outage">
           Settings
           <ActionList.LeadingVisual>
             <GearIcon />
           </ActionList.LeadingVisual>
-        </ActionList.LinkItem>
+        </ActionList.Item>
         <ActionList.Item onSelect={() => alert('Make a copy clicked')} inactiveText="Unavailable due to an outage">
           Make a copy
           <ActionList.LeadingVisual>
@@ -168,24 +168,24 @@ export const InactiveItems = () => (
         <ActionList.Divider />
         <ActionList.Group>
           <ActionList.GroupHeading>Github projects</ActionList.GroupHeading>
-          <ActionList.LinkItem href="/">
+          <ActionList.Item href="/">
             What&apos;s new
             <ActionList.LeadingVisual>
               <RocketIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem href="/">
+          </ActionList.Item>
+          <ActionList.Item href="/">
             Give feedback
             <ActionList.LeadingVisual>
               <CommentIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem href="/">
+          </ActionList.Item>
+          <ActionList.Item href="/">
             GitHub Docs
             <ActionList.LeadingVisual>
               <BookIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
+          </ActionList.Item>
         </ActionList.Group>
       </ActionList>
     </ActionMenu.Overlay>
@@ -218,24 +218,24 @@ export const LoadingItems = () => (
         <ActionList.Divider />
         <ActionList.Group>
           <ActionList.GroupHeading>Github projects</ActionList.GroupHeading>
-          <ActionList.LinkItem href="/">
+          <ActionList.Item href="/">
             What&apos;s new
             <ActionList.LeadingVisual>
               <RocketIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem href="/">
+          </ActionList.Item>
+          <ActionList.Item href="/">
             Give feedback
             <ActionList.LeadingVisual>
               <CommentIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem href="/">
+          </ActionList.Item>
+          <ActionList.Item href="/">
             GitHub Docs
             <ActionList.LeadingVisual>
               <BookIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
+          </ActionList.Item>
         </ActionList.Group>
       </ActionList>
     </ActionMenu.Overlay>
@@ -301,12 +301,12 @@ export const DisabledItems = () => (
             <ArchiveIcon />
           </ActionList.LeadingVisual>
         </ActionList.Item>
-        <ActionList.LinkItem href="/">
+        <ActionList.Item href="/">
           Settings
           <ActionList.LeadingVisual>
             <GearIcon />
           </ActionList.LeadingVisual>
-        </ActionList.LinkItem>
+        </ActionList.Item>
         <ActionList.Item disabled={true}>
           Make a copy
           <ActionList.LeadingVisual>
@@ -316,24 +316,24 @@ export const DisabledItems = () => (
         <ActionList.Divider />
         <ActionList.Group>
           <ActionList.GroupHeading>Github projects</ActionList.GroupHeading>
-          <ActionList.LinkItem href="/">
+          <ActionList.Item href="/">
             What&apos;s new
             <ActionList.LeadingVisual>
               <RocketIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem href="/">
+          </ActionList.Item>
+          <ActionList.Item href="/">
             Give feedback
             <ActionList.LeadingVisual>
               <CommentIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
-          <ActionList.LinkItem href="/">
+          </ActionList.Item>
+          <ActionList.Item href="/">
             GitHub Docs
             <ActionList.LeadingVisual>
               <BookIcon />
             </ActionList.LeadingVisual>
-          </ActionList.LinkItem>
+          </ActionList.Item>
         </ActionList.Group>
       </ActionList>
     </ActionMenu.Overlay>

--- a/packages/react/src/ActionMenu/ActionMenu.test.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.test.tsx
@@ -25,9 +25,9 @@ function Example(): JSX.Element {
               <ActionList.Item variant="danger" onSelect={event => event.preventDefault()}>
                 Delete file
               </ActionList.Item>
-              <ActionList.LinkItem href="//github.com" title="anchor" aria-keyshortcuts="s">
+              <ActionList.Item href="//github.com" title="anchor" aria-keyshortcuts="s">
                 Github
-              </ActionList.LinkItem>
+              </ActionList.Item>
             </ActionList>
           </ActionMenu.Overlay>
         </ActionMenu>
@@ -422,9 +422,9 @@ describe('ActionMenu', () => {
                 <ActionList.Item variant="danger" onSelect={event => event.preventDefault()}>
                   Delete file
                 </ActionList.Item>
-                <ActionList.LinkItem href="//github.com" title="anchor" aria-keyshortcuts="s">
+                <ActionList.Item href="//github.com" title="anchor" aria-keyshortcuts="s">
                   Github
-                </ActionList.LinkItem>
+                </ActionList.Item>
               </ActionList>
             </ActionMenu.Overlay>
           </ActionMenu>
@@ -453,9 +453,9 @@ describe('ActionMenu', () => {
                 <ActionList.Item variant="danger" onSelect={event => event.preventDefault()}>
                   Delete file
                 </ActionList.Item>
-                <ActionList.LinkItem href="//github.com" title="anchor" aria-keyshortcuts="s">
+                <ActionList.Item href="//github.com" title="anchor" aria-keyshortcuts="s">
                   Github
-                </ActionList.LinkItem>
+                </ActionList.Item>
               </ActionList>
             </ActionMenu.Overlay>
           </ActionMenu>
@@ -631,9 +631,9 @@ describe('ActionMenu', () => {
                   <ActionList.Item variant="danger" onSelect={event => event.preventDefault()}>
                     Delete file
                   </ActionList.Item>
-                  <ActionList.LinkItem href="//github.com" title="anchor" aria-keyshortcuts="s">
+                  <ActionList.Item href="//github.com" title="anchor" aria-keyshortcuts="s">
                     Github
-                  </ActionList.LinkItem>
+                  </ActionList.Item>
                 </ActionList>
               </ActionMenu.Overlay>
             </ActionMenu>
@@ -659,9 +659,9 @@ describe('ActionMenu', () => {
                   <ActionList.Item variant="danger" onSelect={event => event.preventDefault()}>
                     Delete file
                   </ActionList.Item>
-                  <ActionList.LinkItem href="//github.com" title="anchor" aria-keyshortcuts="s">
+                  <ActionList.Item href="//github.com" title="anchor" aria-keyshortcuts="s">
                     Github
-                  </ActionList.LinkItem>
+                  </ActionList.Item>
                 </ActionList>
               </ActionMenu.Overlay>
             </ActionMenu>

--- a/packages/react/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react/src/Breadcrumbs/Breadcrumbs.tsx
@@ -121,14 +121,14 @@ const BreadcrumbsMenuItem = React.forwardRef<HTMLDetailsElement, BreadcrumbsMenu
               const children = item.props.children
               const selected = item.props.selected
               return (
-                <ActionList.LinkItem
+                <ActionList.Item
                   key={index}
                   href={href}
                   aria-current={selected ? 'page' : undefined}
                   className={classes.MenuItem}
                 >
                   {children}
-                </ActionList.LinkItem>
+                </ActionList.Item>
               )
             })}
           </ActionList>

--- a/packages/react/src/Dialog/Dialog.features.stories.tsx
+++ b/packages/react/src/Dialog/Dialog.features.stories.tsx
@@ -339,10 +339,10 @@ export const NewIssues = () => {
           title="New issue"
           renderBody={() => (
             <ActionList>
-              <ActionList.LinkItem ref={initialFocusRef} href="https://github.com">
+              <ActionList.Item ref={initialFocusRef} href="https://github.com">
                 Item 1
-              </ActionList.LinkItem>
-              <ActionList.LinkItem href="https://github.com">Link</ActionList.LinkItem>
+              </ActionList.Item>
+              <ActionList.Item href="https://github.com">Link</ActionList.Item>
             </ActionList>
           )}
         ></Dialog>

--- a/packages/react/src/NavList/NavList.tsx
+++ b/packages/react/src/NavList/NavList.tsx
@@ -83,7 +83,7 @@ const Item = React.forwardRef<HTMLAnchorElement, NavListItemProps>(
     }
 
     return (
-      <ActionList.LinkItem
+      <ActionList.Item
         ref={ref}
         aria-current={ariaCurrent}
         active={Boolean(ariaCurrent) && ariaCurrent !== 'false'}
@@ -91,7 +91,7 @@ const Item = React.forwardRef<HTMLAnchorElement, NavListItemProps>(
         {...props}
       >
         {children}
-      </ActionList.LinkItem>
+      </ActionList.Item>
     )
   },
 ) as PolymorphicForwardRefComponent<'a', NavListItemProps>

--- a/packages/react/src/PageLayout/PageLayout.examples.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.examples.stories.tsx
@@ -243,9 +243,9 @@ export const FilterBottomSheet: StoryFn = () => {
           {isOpen && (
             <Dialog title="Filter" onClose={onDialogClose} position={{narrow: 'bottom'}}>
               <ActionList>
-                <ActionList.LinkItem href="#red">Red</ActionList.LinkItem>
-                <ActionList.LinkItem href="#blue">Vegetables</ActionList.LinkItem>
-                <ActionList.LinkItem href="#green">Animals</ActionList.LinkItem>
+                <ActionList.Item href="#red">Red</ActionList.Item>
+                <ActionList.Item href="#blue">Vegetables</ActionList.Item>
+                <ActionList.Item href="#green">Animals</ActionList.Item>
               </ActionList>
             </Dialog>
           )}
@@ -326,9 +326,9 @@ export const FilterActionMenu: StoryFn = () => {
           {isOpen && (
             <Dialog title="Filter" onClose={onDialogClose} position={{narrow: 'bottom'}}>
               <ActionList>
-                <ActionList.LinkItem href="#red">Red</ActionList.LinkItem>
-                <ActionList.LinkItem href="#blue">Vegetables</ActionList.LinkItem>
-                <ActionList.LinkItem href="#green">Animals</ActionList.LinkItem>
+                <ActionList.Item href="#red">Red</ActionList.Item>
+                <ActionList.Item href="#blue">Vegetables</ActionList.Item>
+                <ActionList.Item href="#green">Animals</ActionList.Item>
               </ActionList>
             </Dialog>
           )}
@@ -545,7 +545,7 @@ export const FiltersBottomSheetTwoLevels: StoryFn = () => {
                 <ActionList.Group>
                   <ActionList.GroupHeading>Categories</ActionList.GroupHeading>
                   {categories.map(category => (
-                    <ActionList.LinkItem
+                    <ActionList.Item
                       key={category.hash}
                       href={category.hash}
                       active={
@@ -555,7 +555,7 @@ export const FiltersBottomSheetTwoLevels: StoryFn = () => {
                       }
                     >
                       {category.name}
-                    </ActionList.LinkItem>
+                    </ActionList.Item>
                   ))}
                 </ActionList.Group>
                 <ActionList.Divider />
@@ -740,7 +740,7 @@ FiltersBottomSheetTwoLevels.storyName = 'Filters w/ 2 levels (btm sheet on narro
 //               <ActionMenu.Overlay>
 //                 <ActionList>
 //                   {categories.map(category => (
-//                     <ActionList.LinkItem href={category.hash}>{category.name}</ActionList.LinkItem>
+//                     <ActionList.Item href={category.hash}>{category.name}</ActionList.Item>
 //                   ))}
 //                 </ActionList>
 //               </ActionMenu.Overlay>

--- a/packages/react/src/Pagination/mocks/ReactRouterLink.tsx
+++ b/packages/react/src/Pagination/mocks/ReactRouterLink.tsx
@@ -5,7 +5,7 @@ export type ReactRouterLikeLinkProps = {to: string; children: React.ReactNode; c
 export const ReactRouterLikeLink = React.forwardRef<HTMLAnchorElement, ReactRouterLikeLinkProps>(
   ({to, children, ...props}, ref) => {
     return (
-      <a ref={ref} href={to} {...props}>
+      <a ref={ref} {...props} href={to}>
         {children}
       </a>
     )

--- a/packages/react/src/UnderlineNav/UnderlineNav.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNav.tsx
@@ -366,7 +366,7 @@ export const UnderlineNav = forwardRef(
                     }
 
                     return (
-                      <ActionList.LinkItem
+                      <ActionList.Item
                         key={menuItemChildren}
                         sx={menuItemStyles}
                         onClick={(
@@ -393,7 +393,7 @@ export const UnderlineNav = forwardRef(
                             )
                           )}
                         </span>
-                      </ActionList.LinkItem>
+                      </ActionList.Item>
                     )
                   })}
                 </ActionList>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes [#5916](https://github.com/github/primer/issues/5916)

Combines `ActionList.Item` and `ActionList.LinkItem` into a single unified `ActionList.Item` component that automatically switches between button and link behavior based on props. Developers no longer need to choose between `Item` and `LinkItem`

## Changes
- **New unified API**: `ActionList.Item` now supports both button and link functionality. Automatically uses link behavior when `href`, `to`, or link-related props are provided. Existing `ActionList.Item` usage continues to work unchanged
- **Internal refactor**: 
  - Renamed original `Item` to `BaseItem` 
  - New `Item` component routes to `BaseItem` or `LinkItem` based on props
  - Updated `LinkItem` to use `BaseItem` internally
- **Documentation updates**: Updated API docs to reflect the combined functionality
 
## Usage Examples
```tsx
// Button behavior (default)
<ActionList.Item onSelect={handleSelect}>
  Button item
</ActionList.Item>

// Link behavior 
<ActionList.Item href="/dashboard">
  Link item
</ActionList.Item>

// React Router link 
<ActionList.Item to="/settings" as={Link}>
  Router link item
</ActionList.Item>
```

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [X] Major release; if selected, include a written rollout or migration plan

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
