### PR TITLE
IconButton: Fix flaky visual screenshot test

### DIFF
--- a/e2e/components/IconButton.test.ts
+++ b/e2e/components/IconButton.test.ts
@@ -47,7 +47,7 @@ const stories = [
       await page.keyboard.press('Tab') // focus on icon button
       await page.getByText('Bold').waitFor({state: 'visible'})
       // eslint-disable-next-line playwright/no-wait-for-timeout
-      await page.waitForTimeout(100) // wait until after "tooltip delay" for a stable screenshot
+      await page.waitForTimeout(1000) // wait until after "tooltip delay" for a stable screenshot
     },
   },
   {


### PR DESCRIPTION
- Noticed this test was failing on unrelated PRs after https://github.com/primer/react/pull/6889. 
   - Example: https://github.com/primer/react/pull/6969#issuecomment-3387194322
- Quick and dirty fix is to wait a little longer than the default short delay. Done better than perfect.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
