### PR TITLE
Added buttonCount control (2-6 buttons) to ButtonGroup Playground in Storybook

### DIFF
--- a/packages/react/src/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.stories.tsx
@@ -27,7 +27,7 @@ export const Playground: StoryFn<ButtonProps & {buttonCount: number}> = args => 
   const {buttonCount = 3, ...buttonProps} = args
   const buttons = Array.from({length: buttonCount}, (_, i) => (
     <Button key={i} {...buttonProps}>
-      Button {i + 1}
+      {`Button ${i + 1}`}
     </Button>
   ))
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Part of [#5262](https://github.com/github/primer/issues/5262)

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] None; Only storybook playground changes.

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
