### PR TITLE
Revert "Remove breadcrumbs overflow menu feature flag"

### DIFF
--- a/.changeset/chilled-eggs-warn.md
+++ b/.changeset/chilled-eggs-warn.md
@@ -1,5 +1,0 @@
----
-"@primer/react": patch
----
-
-Breadcrumbs: Remove feature flag for overflow_menu, this behavior is now the default

--- a/packages/react/src/Breadcrumbs/Breadcrumbs.features.stories.tsx
+++ b/packages/react/src/Breadcrumbs/Breadcrumbs.features.stories.tsx
@@ -2,6 +2,7 @@ import type {Meta} from '@storybook/react-vite'
 import type React from 'react'
 import type {ComponentProps} from '../utils/types'
 import Breadcrumbs from './Breadcrumbs'
+import {FeatureFlags} from '../FeatureFlags'
 
 export default {
   title: 'Components/Breadcrumbs/Features',
@@ -22,7 +23,23 @@ export const OverflowWrap = () => (
   </Breadcrumbs>
 )
 
-export const OverflowMenu = () => (
+export const OverflowMenuFeatureFlagEnabled = () => (
+  <FeatureFlags flags={{primer_react_breadcrumbs_overflow_menu: true}}>
+    <Breadcrumbs overflow="menu">
+      <Breadcrumbs.Item href="#">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Products</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Category</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Subcategory</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Item</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Details</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#" selected>
+        Current Page
+      </Breadcrumbs.Item>
+    </Breadcrumbs>
+  </FeatureFlags>
+)
+
+export const OverflowMenuFeatureFlagDisabled = () => (
   <Breadcrumbs overflow="menu">
     <Breadcrumbs.Item href="#">Home</Breadcrumbs.Item>
     <Breadcrumbs.Item href="#">Products</Breadcrumbs.Item>
@@ -36,7 +53,7 @@ export const OverflowMenu = () => (
   </Breadcrumbs>
 )
 
-export const OverflowMenuShowRoot = () => (
+export const OverflowMenuShowRootFeatureFlagDisabled = () => (
   <Breadcrumbs overflow="menu-with-root">
     <Breadcrumbs.Item href="#">github</Breadcrumbs.Item>
     <Breadcrumbs.Item href="#">Teams</Breadcrumbs.Item>
@@ -49,18 +66,35 @@ export const OverflowMenuShowRoot = () => (
   </Breadcrumbs>
 )
 
+export const OverflowMenuShowRootFeatureFlagEnabled = () => (
+  <FeatureFlags flags={{primer_react_breadcrumbs_overflow_menu: true}}>
+    <Breadcrumbs overflow="menu-with-root">
+      <Breadcrumbs.Item href="#">github</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Teams</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Engineering</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">core-productivity</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">collaboration-workflows-flex</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#" selected>
+        global-navigation-reviewers
+      </Breadcrumbs.Item>
+    </Breadcrumbs>
+  </FeatureFlags>
+)
+
 export const SpaciousVariantWithOverflowMenu = () => (
-  <Breadcrumbs overflow="menu" variant="spacious">
-    <Breadcrumbs.Item href="#">Home</Breadcrumbs.Item>
-    <Breadcrumbs.Item href="#">Products</Breadcrumbs.Item>
-    <Breadcrumbs.Item href="#">Category</Breadcrumbs.Item>
-    <Breadcrumbs.Item href="#">Subcategory</Breadcrumbs.Item>
-    <Breadcrumbs.Item href="#">Item</Breadcrumbs.Item>
-    <Breadcrumbs.Item href="#">Details</Breadcrumbs.Item>
-    <Breadcrumbs.Item href="#" selected>
-      Current Page
-    </Breadcrumbs.Item>
-  </Breadcrumbs>
+  <FeatureFlags flags={{primer_react_breadcrumbs_overflow_menu: true}}>
+    <Breadcrumbs overflow="menu" variant="spacious">
+      <Breadcrumbs.Item href="#">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Products</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Category</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Subcategory</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Item</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">Details</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#" selected>
+        Current Page
+      </Breadcrumbs.Item>
+    </Breadcrumbs>
+  </FeatureFlags>
 )
 
 export const SpaciousVariantWithOverflowWrap = () => (

--- a/packages/react/src/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/packages/react/src/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -2,6 +2,13 @@ import Breadcrumbs from '..'
 import {render as HTMLRender, screen, waitFor, within} from '@testing-library/react'
 import {describe, expect, it, vi} from 'vitest'
 import userEvent from '@testing-library/user-event'
+import {FeatureFlags} from '../../FeatureFlags'
+
+// Helper function to render with theme and feature flags
+const renderWithTheme = (component: React.ReactElement, flags?: Record<string, boolean>) => {
+  const wrappedComponent = flags ? <FeatureFlags flags={flags}>{component}</FeatureFlags> : <>{component}</>
+  return HTMLRender(wrappedComponent)
+}
 
 // Mock ResizeObserver for tests
 const mockObserve = vi.fn()
@@ -50,26 +57,30 @@ describe('Breadcrumbs', () => {
     expect(selectedItem).toHaveAttribute('aria-current', 'page')
   })
 
-  it('sets data-overflow attribute when overflow is menu', () => {
-    const {container} = HTMLRender(
+  it('sets data-overflow attribute when overflow is menu with feature flag', () => {
+    const {container} = renderWithTheme(
       <Breadcrumbs overflow="menu">
         <Breadcrumbs.Item href="/home">Home</Breadcrumbs.Item>
       </Breadcrumbs>,
+      {primer_react_breadcrumbs_overflow_menu: true},
     )
+
     expect(container.firstChild).toHaveAttribute('data-overflow', 'menu')
   })
 
   it('sets data-overflow attribute when overflow is wrap', () => {
-    const {container} = HTMLRender(
+    const {container} = renderWithTheme(
       <Breadcrumbs overflow="wrap">
         <Breadcrumbs.Item href="/home">Home</Breadcrumbs.Item>
       </Breadcrumbs>,
+      {primer_react_breadcrumbs_overflow_menu: true},
     )
+
     expect(container.firstChild).toHaveAttribute('data-overflow', 'wrap')
   })
 
   it('renders all items when overflow is wrap', () => {
-    HTMLRender(
+    renderWithTheme(
       <Breadcrumbs overflow="wrap">
         <Breadcrumbs.Item href="/1">Item 1</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/2">Item 2</Breadcrumbs.Item>
@@ -78,6 +89,7 @@ describe('Breadcrumbs', () => {
         <Breadcrumbs.Item href="/5">Item 5</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/6">Item 6</Breadcrumbs.Item>
       </Breadcrumbs>,
+      {primer_react_breadcrumbs_overflow_menu: true},
     )
 
     // All items should be visible in wrap mode
@@ -90,7 +102,7 @@ describe('Breadcrumbs', () => {
   })
 
   it('shows overflow menu when more than 5 items in menu mode', () => {
-    HTMLRender(
+    renderWithTheme(
       <Breadcrumbs overflow="menu">
         <Breadcrumbs.Item href="/1">Item 1</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/2">Item 2</Breadcrumbs.Item>
@@ -99,6 +111,7 @@ describe('Breadcrumbs', () => {
         <Breadcrumbs.Item href="/5">Item 5</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/6">Item 6</Breadcrumbs.Item>
       </Breadcrumbs>,
+      {primer_react_breadcrumbs_overflow_menu: true},
     )
 
     // Should have overflow menu button
@@ -113,11 +126,12 @@ describe('Breadcrumbs', () => {
 
   it('show root in menu', () => {
     expect(() => {
-      HTMLRender(
+      renderWithTheme(
         <Breadcrumbs overflow="menu-with-root">
           <Breadcrumbs.Item href="/home">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/docs">Docs</Breadcrumbs.Item>
         </Breadcrumbs>,
+        {primer_react_breadcrumbs_overflow_menu: true},
       )
     }).not.toThrow()
   })
@@ -125,7 +139,7 @@ describe('Breadcrumbs', () => {
   it('includes root item in overflow menu when overflow is menu-with-root', async () => {
     const user = userEvent.setup()
 
-    HTMLRender(
+    renderWithTheme(
       <Breadcrumbs overflow="menu-with-root">
         <Breadcrumbs.Item href="/home">Home</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/category">Category</Breadcrumbs.Item>
@@ -137,6 +151,7 @@ describe('Breadcrumbs', () => {
           Reviews
         </Breadcrumbs.Item>
       </Breadcrumbs>,
+      {primer_react_breadcrumbs_overflow_menu: true},
     )
 
     // Should have overflow menu button
@@ -171,7 +186,7 @@ describe('Breadcrumbs', () => {
   })
 
   it('renders accessible overflow menu', () => {
-    HTMLRender(
+    renderWithTheme(
       <Breadcrumbs overflow="menu">
         <Breadcrumbs.Item href="/1">Item 1</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/2">Item 2</Breadcrumbs.Item>
@@ -180,6 +195,7 @@ describe('Breadcrumbs', () => {
         <Breadcrumbs.Item href="/5">Item 5</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/6">Item 6</Breadcrumbs.Item>
       </Breadcrumbs>,
+      {primer_react_breadcrumbs_overflow_menu: true},
     )
 
     const menuButton = screen.getByRole('button', {name: /more breadcrumb items/i})
@@ -199,7 +215,7 @@ describe('Breadcrumbs', () => {
     })
     globalThis.ResizeObserver = mockResizeObserver
 
-    HTMLRender(
+    renderWithTheme(
       <Breadcrumbs overflow="menu">
         <Breadcrumbs.Item href="/1">Item 1</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/2">Item 2</Breadcrumbs.Item>
@@ -208,6 +224,7 @@ describe('Breadcrumbs', () => {
         <Breadcrumbs.Item href="/5">Item 5</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/6">Item 6</Breadcrumbs.Item>
       </Breadcrumbs>,
+      {primer_react_breadcrumbs_overflow_menu: true},
     )
 
     expect(resizeCallback).toBeDefined()
@@ -258,7 +275,7 @@ describe('Breadcrumbs', () => {
 
     const user = userEvent.setup()
 
-    HTMLRender(
+    renderWithTheme(
       <Breadcrumbs overflow="menu">
         <Breadcrumbs.Item href="/home">Home</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/category">Category</Breadcrumbs.Item>
@@ -268,6 +285,7 @@ describe('Breadcrumbs', () => {
         <Breadcrumbs.Item href="/specifications">Specifications</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/reviews">Reviews</Breadcrumbs.Item>
       </Breadcrumbs>,
+      {primer_react_breadcrumbs_overflow_menu: true},
     )
 
     expect(resizeCallback).toBeDefined()
@@ -294,7 +312,9 @@ describe('Breadcrumbs', () => {
 
     // Close menu by clicking outside
     await user.click(document.body)
-    await waitFor(() => {})
+    await waitFor(() => {
+      expect
+    })
 
     // Simulate a very narrow container resize that would affect overflow calculation
     if (resizeCallback) {
@@ -341,7 +361,7 @@ describe('Breadcrumbs', () => {
     it('closes menu on Escape key press', async () => {
       const user = userEvent.setup()
 
-      HTMLRender(
+      renderWithTheme(
         <Breadcrumbs overflow="menu">
           <Breadcrumbs.Item href="/home">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/docs">Docs</Breadcrumbs.Item>
@@ -352,6 +372,7 @@ describe('Breadcrumbs', () => {
             Advanced
           </Breadcrumbs.Item>
         </Breadcrumbs>,
+        {primer_react_breadcrumbs_overflow_menu: true},
       )
 
       // Open the overflow menu
@@ -377,7 +398,7 @@ describe('Breadcrumbs', () => {
     it('closes menu when clicking outside', async () => {
       const user = userEvent.setup()
 
-      HTMLRender(
+      renderWithTheme(
         <div>
           <button type="button" data-testid="outside-button">
             Outside Button
@@ -393,6 +414,7 @@ describe('Breadcrumbs', () => {
             </Breadcrumbs.Item>
           </Breadcrumbs>
         </div>,
+        {primer_react_breadcrumbs_overflow_menu: true},
       )
 
       // Open the overflow menu
@@ -417,7 +439,7 @@ describe('Breadcrumbs', () => {
     it('allows tab navigation through menu items', async () => {
       const user = userEvent.setup()
 
-      HTMLRender(
+      renderWithTheme(
         <Breadcrumbs overflow="menu">
           <Breadcrumbs.Item href="/home">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/docs">Docs</Breadcrumbs.Item>
@@ -428,6 +450,7 @@ describe('Breadcrumbs', () => {
             Advanced
           </Breadcrumbs.Item>
         </Breadcrumbs>,
+        {primer_react_breadcrumbs_overflow_menu: true},
       )
 
       // Open the overflow menu
@@ -456,7 +479,7 @@ describe('Breadcrumbs', () => {
     it('maintains focus on menu button when menu is closed', async () => {
       const user = userEvent.setup()
 
-      HTMLRender(
+      renderWithTheme(
         <Breadcrumbs overflow="menu">
           <Breadcrumbs.Item href="/home">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/docs">Docs</Breadcrumbs.Item>
@@ -467,6 +490,7 @@ describe('Breadcrumbs', () => {
             Advanced
           </Breadcrumbs.Item>
         </Breadcrumbs>,
+        {primer_react_breadcrumbs_overflow_menu: true},
       )
 
       const menuButton = screen.getByRole('button', {name: /more breadcrumb items/i})
@@ -491,27 +515,29 @@ describe('Breadcrumbs', () => {
     })
   })
 
-  describe('variant prop', () => {
+  describe('variant prop (feature flag on)', () => {
     it('sets data-variant="normal" by default', () => {
-      const {container} = HTMLRender(
+      const {container} = renderWithTheme(
         <Breadcrumbs overflow="menu">
           <Breadcrumbs.Item href="/home">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/docs" selected>
             Docs
           </Breadcrumbs.Item>
         </Breadcrumbs>,
+        {primer_react_breadcrumbs_overflow_menu: true},
       )
       expect(container.firstChild).toHaveAttribute('data-variant', 'normal')
     })
 
     it('sets data-variant="spacious" when variant prop provided', () => {
-      const {container} = HTMLRender(
+      const {container} = renderWithTheme(
         <Breadcrumbs overflow="menu" variant="spacious">
           <Breadcrumbs.Item href="/home">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/docs" selected>
             Docs
           </Breadcrumbs.Item>
         </Breadcrumbs>,
+        {primer_react_breadcrumbs_overflow_menu: true},
       )
       expect(container.firstChild).toHaveAttribute('data-variant', 'spacious')
     })

--- a/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
+++ b/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
@@ -2,6 +2,7 @@ import {FeatureFlagScope} from './FeatureFlagScope'
 
 export const DefaultFeatureFlags = FeatureFlagScope.create({
   primer_react_action_list_item_as_button: false,
+  primer_react_breadcrumbs_overflow_menu: false,
   primer_react_overlay_overflow: false,
   primer_react_segmented_control_tooltip: false,
   primer_react_select_panel_fullscreen_on_narrow: false,


### PR DESCRIPTION
Reverts primer/react#7054

Reverting to get integration checks back to green on main. See https://github.com/primer/react/pull/7054#issuecomment-3444294285