### PR TITLE
Update PagerDuty token in workflow file to Org Token

### DIFF
--- a/.github/workflows/assign_release_conductor.yml
+++ b/.github/workflows/assign_release_conductor.yml
@@ -23,7 +23,7 @@ jobs:
         id: pagerduty
         with:
           schedule-id: 'P3IIVC4'
-          token: ${{ secrets.PAGERDUTY_API_KEY_SID }}
+          token: ${{ secrets.PAGERDUTY_TOKEN_SHARED }}
       - run: echo ${{ steps.pagerduty.outputs.user }} is release conductor
       - name: Add user as assignee and reviewer
         uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1


### PR DESCRIPTION
Update the PagerDuty token to use the shared token. Noticed the current token is failing https://github.com/primer/react/actions/runs/18855171295/job/53801102881