### PR TITLE
chore: clean up "sx" props from docs.json files

### DIFF
--- a/packages/react/src/deprecated/FilteredSearch/FilteredSearch.docs.json
+++ b/packages/react/src/deprecated/FilteredSearch/FilteredSearch.docs.json
@@ -10,11 +10,6 @@
       "name": "children",
       "type": "React.ReactNode",
       "description": "FilteredSearch is expected to contain an `ActionMenu` followed by a `TextInput`."
-    },
-    {
-      "name": "sx",
-      "type": "SystemStyleObject",
-      "deprecated": true
     }
   ],
   "subcomponents": []

--- a/packages/react/src/deprecated/UnderlineNav/UnderlineNav.docs.json
+++ b/packages/react/src/deprecated/UnderlineNav/UnderlineNav.docs.json
@@ -43,11 +43,6 @@
         {
           "name": "selected",
           "type": "boolean"
-        },
-        {
-          "name": "sx",
-          "type": "SystemStyleObject",
-          "deprecated": true
         }
       ]
     }

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.docs.json
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.docs.json
@@ -58,11 +58,6 @@
       "type": "boolean",
       "defaultValue": "false",
       "description": "Loading state for all counters. It displays loading animation for individual counters until all are resolved. It is needed to prevent multiple layout shift."
-    },
-    {
-      "name": "sx",
-      "type": "SystemStyleObject",
-      "deprecated": true
     }
   ],
   "subcomponents": [
@@ -92,23 +87,12 @@
           "type": "Component",
           "defaultValue": "",
           "description": "Icon rendered before the tab text label"
-        },
-        {
-          "name": "sx",
-          "type": "SystemStyleObject",
-          "deprecated": true
         }
       ]
     },
     {
       "name": "UnderlinePanels.Panel",
-      "props": [
-        {
-          "name": "sx",
-          "type": "SystemStyleObject",
-          "deprecated": true
-        }
-      ],
+      "props": [],
       "passthrough": {
         "element": "div",
         "url": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#Attributes"


### PR DESCRIPTION
Found some remaining sx props in docs files, cleaning up 🧹 