### PR TITLE
Don't install glob globally when running the upload-versions/action

### DIFF
--- a/.github/actions/upload-versions/action.yml
+++ b/.github/actions/upload-versions/action.yml
@@ -13,7 +13,7 @@ runs:
         script: |
           const fs = require('node:fs');
 
-          const globber = glob.create(['packages/**/package.json', '!**/node_modules/**'].join('\n'))
+          const globber = await glob.create(['packages/**/package.json', '!**/node_modules/**'].join('\n'))
           const packageJsonPaths = await globber.glob()
           const output = {
             packages: [],


### PR DESCRIPTION
I noticed that the release candidate workflow was failing https://github.com/primer/react/actions/runs/18855169534/job/53802252272 because in that step we're npm installing glob globally to use in the upload script.

This fails because we're manually changing the version of primer/react to a release candidate version. But then versioning doesn't update the dependencies. So when installing glob, it fails because the next version of the project hasn't been published yet.
