### PR TITLE
styled-react: Remove version lock on peer dependency version for @primer/react

### DIFF
--- a/packages/styled-react/package.json
+++ b/packages/styled-react/package.json
@@ -60,7 +60,7 @@
     "typescript": "^5.9.2"
   },
   "peerDependencies": {
-    "@primer/react": "38.0.0",
+    "@primer/react": "^38.0.0",
     "@types/react": "18.x || 19.x",
     "@types/react-dom": "18.x || 19.x",
     "@types/react-is": "18.x || 19.x",


### PR DESCRIPTION
Removes the version lock on 38.0.0