### PR TITLE
ci: use primer integration app for status checks

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Generate token for primer
         id: generate_primer_token
-        uses: actions/create-github-app-token@v67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         with:
           app-id: 902635
           owner: 'primer'


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Use the Primer Integration App for setting status checks so that required checks come from the same source.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Use the Primer Integration App for setting status checks from github-ui

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

Update our workflow to use the Primer Integration App token for setting status checks. This should help fix our issues when requiring these status checks but GitHub Actions is reporting on them.