### PR TITLE
Updating Dependabot config to upgrade @primer/* dependencies every day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/packages/react/'
     schedule:
-      interval: 'cron'
-      cronjob: '0 * * * *'
+      interval: 'daily'
     versioning-strategy: increase
     labels:
       - 'dependencies'


### PR DESCRIPTION
I wanted to update the frequency that dependabot will update `@primer/` owned dependencies. What I'm hoping to do with this is segment out the primer dependencies and put them on a more frequent schedule.

In theory the other dependencies will behave like they already were.

### Testing & Reviewing

This is tough to test, I looked closely at the docs for dependabot and hopefully got everything ok, but we'll need to keep an eye out and make adjustments if needed.

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
