### PR TITLE
[🔨 WIP] Support responsive overflow in ButtonGroup

### DIFF
--- a/packages/react/src/ButtonGroup/ButtonGroup.docs.json
+++ b/packages/react/src/ButtonGroup/ButtonGroup.docs.json
@@ -25,6 +25,12 @@
     {
       "name": "ref",
       "type": "React.RefObject<HTMLDivElement>"
+    },
+    {
+      "name": "overflowAriaLabel",
+      "type": "string",
+      "defaultValue": "\"More actions\"",
+      "description": "Accessible label announced for the overflow trigger button."
     }
   ],
   "subcomponents": []

--- a/packages/react/src/ButtonGroup/ButtonGroup.module.css
+++ b/packages/react/src/ButtonGroup/ButtonGroup.module.css
@@ -3,7 +3,12 @@
   vertical-align: middle;
   isolation: isolate;
 
-  & > *:not([data-loading-wrapper]) {
+  &[data-phase='measuring'] {
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  & > [data-button-group-slot]:not([data-loading-wrapper]) {
     /* stylelint-disable-next-line primer/spacing */
     margin-inline-end: -1px;
     position: relative;
@@ -46,7 +51,7 @@
   }
 
   /* if child is loading button */
-  & > *[data-loading-wrapper] {
+  & > [data-button-group-slot][data-loading-wrapper] {
     /* stylelint-disable-next-line primer/spacing */
     margin-inline-end: -1px;
     position: relative;
@@ -79,4 +84,19 @@
       }
     }
   }
+}
+
+.MeasurementItem {
+  display: inline-flex;
+}
+
+.OverflowOverlay {
+  display: flex;
+  flex-direction: column;
+  gap: var(--base-size-8);
+  padding: var(--base-size-8);
+}
+
+.OverflowItem {
+  display: flex;
 }

--- a/packages/react/src/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.stories.tsx
@@ -23,6 +23,17 @@ export const Default = () => (
   </ButtonGroup>
 )
 
+export const Overflow = () => (
+  <div style={{maxWidth: '220px'}}>
+    <ButtonGroup>
+      <Button>Button 1</Button>
+      <Button>Button 2</Button>
+      <Button>Button 3</Button>
+      <Button>Button 4</Button>
+    </ButtonGroup>
+  </div>
+)
+
 export const Playground: StoryFn<ButtonProps & {buttonCount: number}> = args => {
   const {buttonCount = 3, ...buttonProps} = args
   const buttons = Array.from({length: buttonCount}, (_, i) => (

--- a/packages/react/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.test.tsx
@@ -1,5 +1,5 @@
 import {render, screen} from '@testing-library/react'
-import ButtonGroup from './ButtonGroup'
+import ButtonGroup, {calculateVisibleCount} from './ButtonGroup'
 import {describe, expect, it} from 'vitest'
 
 describe('ButtonGroup', () => {
@@ -16,5 +16,37 @@ describe('ButtonGroup', () => {
   it('should respect role prop', () => {
     render(<ButtonGroup role="toolbar" />)
     expect(screen.getByRole('toolbar')).toBeInTheDocument()
+  })
+})
+
+describe('calculateVisibleCount', () => {
+  it('returns total items when container is wide enough', () => {
+    const result = calculateVisibleCount({
+      itemWidths: [80, 80, 80],
+      containerWidth: 240,
+      overflowWidth: 32,
+    })
+
+    expect(result).toBe(3)
+  })
+
+  it('returns zero when nothing fits', () => {
+    const result = calculateVisibleCount({
+      itemWidths: [120, 80],
+      containerWidth: 60,
+      overflowWidth: 32,
+    })
+
+    expect(result).toBe(0)
+  })
+
+  it('avoids leaving a single item in overflow', () => {
+    const result = calculateVisibleCount({
+      itemWidths: [120, 100, 100],
+      containerWidth: 230,
+      overflowWidth: 40,
+    })
+
+    expect(result).toBe(1)
   })
 })

--- a/packages/react/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.tsx
@@ -1,34 +1,318 @@
 import React, {type PropsWithChildren} from 'react'
-import classes from './ButtonGroup.module.css'
 import {clsx} from 'clsx'
+import {KebabHorizontalIcon} from '@primer/octicons-react'
+
+import classes from './ButtonGroup.module.css'
+import {IconButton} from '../Button'
+import {AnchoredOverlay} from '../AnchoredOverlay'
 import {FocusKeys, useFocusZone} from '../hooks/useFocusZone'
+import {useResizeObserver} from '../hooks/useResizeObserver'
 import {useProvidedRefOrCreate} from '../hooks'
+import {useId} from '../hooks/useId'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
+
+type Phase = 'measuring' | 'ready'
+
+const DEFAULT_OVERFLOW_ARIA_LABEL = 'More actions'
+const BORDER_OVERLAP_PX = 1
+
+type Layout = {
+  visibleCount: number
+}
+
+type ItemDescriptor = {
+  key: React.Key
+  node: React.ReactNode
+}
+
+export function calculateVisibleCount({
+  itemWidths,
+  containerWidth,
+  overflowWidth,
+}: {
+  itemWidths: number[]
+  containerWidth: number
+  overflowWidth: number
+}): number {
+  const totalItems = itemWidths.length
+
+  if (totalItems === 0) {
+    return 0
+  }
+
+  if (containerWidth <= 0) {
+    return 0
+  }
+
+  if (overflowWidth <= 0) {
+    return totalItems
+  }
+
+  // Calculate total width if everything were visible without overflow
+  const totalWidthWithoutOverflow = itemWidths.reduce((total, width, index) => {
+    const overlapAdjustment = index > 0 ? BORDER_OVERLAP_PX : 0
+    return total + Math.max(width - overlapAdjustment, 0)
+  }, 0)
+
+  if (totalWidthWithoutOverflow <= containerWidth) {
+    return totalItems
+  }
+
+  let usedWidth = 0
+  let visibleCount = 0
+
+  for (let index = 0; index < totalItems; index++) {
+    const width = itemWidths[index]
+    const contribution = Math.max(width - (index > 0 ? BORDER_OVERLAP_PX : 0), 0)
+    const nextUsedWidth = usedWidth + contribution
+    const itemsRemaining = totalItems - (index + 1)
+
+    if (itemsRemaining === 0) {
+      if (nextUsedWidth <= containerWidth) {
+        visibleCount = totalItems
+      }
+      break
+    }
+
+    const overflowContribution = Math.max(overflowWidth - BORDER_OVERLAP_PX, 0)
+    if (nextUsedWidth + overflowContribution > containerWidth) {
+      visibleCount = index
+      break
+    }
+
+    usedWidth = nextUsedWidth
+    visibleCount = index + 1
+  }
+
+  if (visibleCount < 0) {
+    visibleCount = 0
+  }
+
+  const overflowCount = totalItems - visibleCount
+  if (overflowCount === 1) {
+    visibleCount = Math.max(visibleCount - 1, 0)
+  }
+
+  return visibleCount
+}
 
 export type ButtonGroupProps = PropsWithChildren<{
   /** The role of the group */
   role?: string
   /** className passed in for styling */
   className?: string
+  /** Accessible label for the overflow trigger */
+  overflowAriaLabel?: string
 }>
 
-const ButtonGroup = React.forwardRef(function ButtonGroup(
-  {as: BaseComponent = 'div', children, className, role, ...rest},
-  forwardRef,
-) {
-  const buttons = React.Children.map(children, (child, index) => <div key={index}>{child}</div>)
-  const buttonRef = useProvidedRefOrCreate(forwardRef as React.RefObject<HTMLDivElement>)
+const ButtonGroup = React.forwardRef(function ButtonGroup(props, forwardRef) {
+  const {
+    as: BaseComponent = 'div',
+    children,
+    className,
+    role,
+    overflowAriaLabel = DEFAULT_OVERFLOW_ARIA_LABEL,
+    ...rest
+  } = props
+  const items = React.useMemo<ItemDescriptor[]>(() => {
+    return React.Children.toArray(children).map((child, index) => {
+      if (React.isValidElement(child) && child.key !== null) {
+        return {key: child.key, node: child}
+      }
+
+      return {key: index, node: child as React.ReactNode}
+    })
+  }, [children])
+
+  const hasItems = items.length > 0
+
+  const containerRef = useProvidedRefOrCreate(forwardRef as React.RefObject<HTMLDivElement>)
+  const measurementItemRefs = React.useRef<Array<HTMLDivElement | null>>([])
+  const overflowMeasurementRef = React.useRef<HTMLDivElement | null>(null)
+  const previousWidthRef = React.useRef<number | null>(null)
+  const previousItemCountRef = React.useRef<number>(items.length)
+
+  const [phase, setPhase] = React.useState<Phase>(hasItems ? 'measuring' : 'ready')
+  const [layout, setLayout] = React.useState<Layout>({visibleCount: items.length})
+  const [isOverflowOpen, setOverflowOpen] = React.useState(false)
+
+  React.useEffect(() => {
+    if (previousItemCountRef.current !== items.length) {
+      previousItemCountRef.current = items.length
+      setPhase(items.length > 0 ? 'measuring' : 'ready')
+    }
+  }, [items.length])
+
+  React.useEffect(() => {
+    if (phase === 'measuring') {
+      measurementItemRefs.current = []
+      overflowMeasurementRef.current = null
+    }
+  }, [phase])
+
+  React.useLayoutEffect(() => {
+    if (phase !== 'measuring') {
+      return
+    }
+
+    const containerWidth = containerRef.current?.getBoundingClientRect().width ?? 0
+    if (containerWidth === 0) {
+      return
+    }
+
+    const itemWidths = items.map((_, index) => {
+      const ref = measurementItemRefs.current[index]
+      return ref ? ref.getBoundingClientRect().width : 0
+    })
+
+    const overflowWidth = overflowMeasurementRef.current?.getBoundingClientRect().width ?? 0
+
+    if (itemWidths.some(width => width === 0) && items.length > 0) {
+      return
+    }
+
+    const visibleCount = calculateVisibleCount({
+      itemWidths,
+      containerWidth,
+      overflowWidth,
+    })
+
+    setLayout({visibleCount})
+    setPhase('ready')
+  }, [containerRef, items, phase])
+
+  const scheduleMeasurement = React.useCallback(() => {
+    setPhase(current => (current === 'measuring' || !hasItems ? current : 'measuring'))
+  }, [hasItems])
+
+  useResizeObserver(entries => {
+    const entry = entries[0]
+    const width = entry.contentRect.width
+    if (previousWidthRef.current === width) {
+      return
+    }
+    previousWidthRef.current = width
+    scheduleMeasurement()
+  }, containerRef as React.RefObject<HTMLElement>)
+
+  React.useEffect(() => {
+    if (layout.visibleCount >= items.length && isOverflowOpen) {
+      setOverflowOpen(false)
+    }
+  }, [isOverflowOpen, items.length, layout.visibleCount])
 
   useFocusZone({
-    containerRef: buttonRef,
+    containerRef,
     disabled: role !== 'toolbar',
     bindKeys: FocusKeys.ArrowHorizontal,
     focusOutBehavior: 'wrap',
   })
 
+  const overflowMenuId = useId()
+  const overflowAriaLabelText = overflowAriaLabel
+
+  const visibleItems = React.useMemo(() => {
+    return items.slice(0, layout.visibleCount)
+  }, [items, layout.visibleCount])
+
+  const overflowItems = React.useMemo(() => {
+    return items.slice(layout.visibleCount)
+  }, [items, layout.visibleCount])
+
+  const setMeasurementRef = React.useCallback(
+    (index: number) => (node: HTMLDivElement | null) => {
+      measurementItemRefs.current[index] = node
+    },
+    [],
+  )
+
+  const renderOverflowTrigger = (measurement: boolean) => {
+    const trigger = (
+      <IconButton
+        icon={KebabHorizontalIcon}
+        aria-label={overflowAriaLabelText}
+        aria-haspopup="menu"
+        aria-expanded={measurement ? undefined : isOverflowOpen}
+        variant="invisible"
+        size="medium"
+      />
+    )
+
+    if (measurement) {
+      return trigger
+    }
+
+    return (
+      <AnchoredOverlay
+        open={isOverflowOpen}
+        onOpen={() => setOverflowOpen(true)}
+        onClose={() => setOverflowOpen(false)}
+        renderAnchor={anchorProps => (
+          <IconButton
+            {...anchorProps}
+            icon={KebabHorizontalIcon}
+            aria-label={overflowAriaLabelText}
+            aria-haspopup="menu"
+            aria-controls={overflowMenuId}
+            aria-expanded={isOverflowOpen}
+            variant="invisible"
+            size="medium"
+          />
+        )}
+        focusTrapSettings={{disabled: false}}
+        focusZoneSettings={{bindKeys: FocusKeys.ArrowVertical, focusOutBehavior: 'wrap'}}
+      >
+        <div className={classes.OverflowOverlay} id={overflowMenuId} role="menu" aria-label={overflowAriaLabelText}>
+          {overflowItems.map(item => (
+            <div key={item.key} role="none" className={classes.OverflowItem}>
+              {item.node}
+            </div>
+          ))}
+        </div>
+      </AnchoredOverlay>
+    )
+  }
+
   return (
-    <BaseComponent ref={buttonRef} className={clsx(className, classes.ButtonGroup)} role={role} {...rest}>
-      {buttons}
+    <BaseComponent
+      ref={containerRef}
+      className={clsx(className, classes.ButtonGroup)}
+      data-phase={phase}
+      role={role}
+      {...rest}
+    >
+      {phase === 'measuring' ? (
+        <>
+          {items.map((item, index) => (
+            <div
+              key={item.key}
+              ref={setMeasurementRef(index)}
+              data-button-group-slot
+              className={classes.MeasurementItem}
+            >
+              {item.node}
+            </div>
+          ))}
+          {hasItems ? (
+            <div ref={overflowMeasurementRef} data-button-group-slot data-kind="overflow-trigger">
+              {renderOverflowTrigger(true)}
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <>
+          {visibleItems.map(item => (
+            <div key={item.key} data-button-group-slot>
+              {item.node}
+            </div>
+          ))}
+          {overflowItems.length > 0 ? (
+            <div data-button-group-slot data-kind="overflow-trigger">
+              {renderOverflowTrigger(false)}
+            </div>
+          ) : null}
+        </>
+      )}
     </BaseComponent>
   )
 }) as PolymorphicForwardRefComponent<'div', ButtonGroupProps>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/6096

> NOTE: ⚠️ This is a WIP PR, the approach here can be changed as there's multiple ways of tackling this issue.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

* Added automatic overflow detection and handling in `ButtonGroup.tsx`, including logic to measure button widths, calculate how many buttons fit, and move excess buttons into an overflow menu triggered by an icon button. The overflow menu uses `AnchoredOverlay` for accessibility and keyboard navigation.
* Introduced the `overflowAriaLabel` prop to `ButtonGroup`, with a default value of "More actions", ensuring the overflow trigger button is accessible to screen readers.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
