### PR TITLE
exclude .stories.module.css from recommended integration test

### DIFF
--- a/.github/workflows/recommend-integration-tests.yml
+++ b/.github/workflows/recommend-integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Get source files changes
         id: source-files
         run: |
-          DIFF=$(git diff --name-only origin/main | grep 'packages/react' | grep -Ev '.stories.tsx|.docs.json' || true)
+          DIFF=$(git diff --name-only origin/main | grep 'packages/react' | grep -Ev '.stories.tsx|.stories.module.css|.docs.json' || true)
           if [ -z "$DIFF" ]; then
             echo "diff=" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
The [recommend-integration-tests.yml](https://github.com/primer/react/blob/main/.github/workflows/recommend-integration-tests.yml#L22) workflow looks at files changed and recommends integration testing. We exclude stories and doc files from this.

Also adding *.stories.module.css files to this list