### PR TITLE
Use only repo name in status-checks

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           app-id: 902635
           owner: 'primer'
-          repositories: 'primer/react'
+          repositories: 'react'
           private-key: ${{ secrets.PRIMER_INTEGRATION_APP_PRIVATE_KEY }}
           permission-statuses: 'write'
 


### PR DESCRIPTION
It seems like `repositories` set this way does not work even though the app is installed on this repo 🤔 https://github.com/organizations/primer/settings/installations/51066279

Trying out just `react` to see if that works.