### PR TITLE
chore(package): remove overrides and update packageManger field

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,9 +94,6 @@
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.53.1"
   },
-  "overrides": {
-    "nwsapi": "2.2.2"
-  },
   "prettier": "@github/prettier-config",
   "size-limit": [
     {
@@ -110,5 +107,5 @@
       "running": false
     }
   ],
-  "packageManager": "npm@11.5.2+sha512.aac1241cfc3f41dc38780d64295c6c6b917a41e24288b33519a7b11adfc5a54a5f881c642d7557215b6c70e01e55655ed7ba666300fd0238bc75fb17478afaf3"
+  "packageManager": "npm@11.6.3+sha512.4085a763162e0e3acd19a4e9d23ad3aa0978e501ccf947dd7233c12a689ae0bb0190763c4ef12366990056b34eec438903ffed38fde4fbd722a17c2a7407ee92"
 }


### PR DESCRIPTION
Update our `package.json` so that `npm i` works as expected. Was running into this error off of `main`:

```
npm error Cannot read properties of undefined (reading 'ruleset')
npm error A complete log of this run can be found in: /Users/joshblack/.npm/_logs/2025-11-21T18_48_40_934Z-debug-0.log
```

On the latest version of Node.js

This also updates the npm client version to latest, as well, in the `packageManager` field.