### PR TITLE
perf(SelectPanel): Document acceptable :has() selector usage

### DIFF
--- a/.changeset/perf-selectpanel-has-selector.md
+++ b/.changeset/perf-selectpanel-has-selector.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+perf(SelectPanel): Document acceptable :has() selector usage
+
+Added documentation explaining why the :has(input:placeholder-shown) selector is acceptable.

--- a/packages/react/src/experimental/SelectPanel2/SelectPanel.module.css
+++ b/packages/react/src/experimental/SelectPanel2/SelectPanel.module.css
@@ -112,7 +112,12 @@
 .TextInput {
   padding-left: var(--base-size-8) !important;
 
-  /* stylelint-disable-next-line selector-class-pattern */
+  /*
+   * NOTE: Uses descendant :has() - input is not direct child of TextInputWrapper
+   * due to TextInputInnerVisualSlot wrappers. This is acceptable performance
+   * as the search is scoped to this single element's subtree.
+   */
+  /* stylelint-disable-next-line selector-class-pattern -- global class from TextInput */
   &:has(input:placeholder-shown) :global(.TextInput-action) {
     display: none;
   }


### PR DESCRIPTION
## Closing - Documentation only, no code change

This PR only adds a comment explaining why an existing :has() selector is acceptable. No actual code or behavior changes.

```diff
+  /*
+   * NOTE: Uses descendant :has() - input is not direct child of TextInputWrapper
+   * due to TextInputInnerVisualSlot wrappers. This is acceptable performance
+   * as the search is scoped to this single element's subtree.
+   */
```

While the documentation is helpful, it doesn't warrant a patch release since there's no behavior change.