### PR TITLE
perf(Timeline): Document acceptable :has() selector usage

### DIFF
--- a/.changeset/perf-timeline-has-selector.md
+++ b/.changeset/perf-timeline-has-selector.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+perf(Timeline): Document acceptable :has() selector usage with adjacent sibling
+
+Added documentation explaining the :has(+ [data-condensed]) selector is O(1) complexity.

--- a/packages/react/src/Timeline/Timeline.module.css
+++ b/packages/react/src/Timeline/Timeline.module.css
@@ -105,6 +105,7 @@
   border: 0;
   border-top: var(--borderWidth-thicker) solid var(--borderColor-default);
 
+  /* NOTE: Uses adjacent sibling :has() - checks only the next sibling. O(1) complexity. */
   &:has(+ [data-condensed]) {
     margin-bottom: calc(-1 * var(--base-size-12));
   }


### PR DESCRIPTION
## Closing - Documentation only, no code change

This PR only adds a comment explaining that an existing :has() selector uses adjacent sibling combinator (O(1)). No actual code or behavior changes.

```diff
+  /* NOTE: Uses adjacent sibling :has() - checks only the next sibling. O(1) complexity. */
   &:has(+ [data-condensed]) {
```

While the documentation is helpful, it doesn't warrant a patch release since there's no behavior change.