### PR TITLE
perf(Announce): Batch getComputedStyle reads to avoid layout thrashing

### DIFF
--- a/.changeset/perf-announce-batched-reads.md
+++ b/.changeset/perf-announce-batched-reads.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+perf(Announce): Batch getComputedStyle reads to avoid layout thrashing
+
+Combine display and visibility checks into a single getComputedStyle call.

--- a/packages/react/src/live-region/Announce.tsx
+++ b/packages/react/src/live-region/Announce.tsx
@@ -64,12 +64,9 @@ export function Announce<As extends React.ElementType = 'div'>(props: AnnouncePr
       return
     }
 
-    const style = window.getComputedStyle(element)
-    if (style.display === 'none') {
-      return
-    }
-
-    if (style.visibility === 'hidden') {
+    // Check if element is visible - batch these layout reads together
+    const {display, visibility} = window.getComputedStyle(element)
+    if (display === 'none' || visibility === 'hidden') {
       return
     }
 


### PR DESCRIPTION
## Closing - No meaningful performance impact

This PR was originally created as part of the INP optimization effort (#7312), but upon review, **the change has no measurable performance impact**.

### What the change does

```javascript
// Before
const style = window.getComputedStyle(element)
if (style.display === 'none') {
  return
}
if (style.visibility === 'hidden') {
  return
}

// After  
const {display, visibility} = window.getComputedStyle(element)
if (display === 'none' || visibility === 'hidden') {
  return
}
```

### Why it doesn't matter

Both versions call `getComputedStyle` **exactly once**. The original code was NOT calling it twice - it stored the result in a variable and read properties from it.

The only differences are:
- Destructuring syntax (style preference, not performance)
- One combined `if` instead of two (micro-optimization with no measurable impact)

### Conclusion

This is a code style change, not a performance optimization. Closing to keep the PR set focused on changes with actual INP impact.