### PR TITLE
perf(UnderlinePanels): Simplify useResizeObserver usage

### DIFF
--- a/.changeset/perf-underlinepanels-observer.md
+++ b/.changeset/perf-underlinepanels-observer.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+perf(UnderlinePanels): Simplify useResizeObserver usage
+
+Remove unnecessary array dependency parameter from useResizeObserver call.

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.tsx
@@ -144,19 +144,15 @@ const UnderlinePanels: FCWithSlotMarker<UnderlinePanelsProps> = ({
 
   // when the wrapper resizes, check if the icons should be visible
   // by comparing the wrapper width to the list width
-  useResizeObserver(
-    (resizeObserverEntries: ResizeObserverEntry[]) => {
-      if (!tabsHaveIcons) {
-        return
-      }
+  useResizeObserver((resizeObserverEntries: ResizeObserverEntry[]) => {
+    if (!tabsHaveIcons) {
+      return
+    }
 
-      const wrapperWidth = resizeObserverEntries[0].contentRect.width
+    const wrapperWidth = resizeObserverEntries[0].contentRect.width
 
-      setIconsVisible(wrapperWidth > listWidth)
-    },
-    wrapperRef,
-    [],
-  )
+    setIconsVisible(wrapperWidth > listWidth)
+  }, wrapperRef)
 
   if (__DEV__) {
     const selectedTabs = tabs.filter(tab => {


### PR DESCRIPTION
## Closing - No meaningful performance impact

This PR only removes an unused array parameter from the useResizeObserver call. It's a code style cleanup, not a performance optimization.

The actual performance benefit comes from PR #7335 which adds throttling to useResizeObserver itself.

### What this changes
```diff
- useResizeObserver(callback, wrapperRef, [])
+ useResizeObserver(callback, wrapperRef)
```

This is just removing a no-op empty array parameter. No behavior change, no performance impact.