### PR TITLE
perf(ActionBar): Document ResizeObserver throttling

### DIFF
--- a/.changeset/perf-actionbar-observer.md
+++ b/.changeset/perf-actionbar-observer.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+perf(ActionBar): Add comment noting ResizeObserver throttling for INP
+
+Document that useResizeObserver is throttled by default with rAF for better INP.

--- a/packages/react/src/ActionBar/ActionBar.tsx
+++ b/packages/react/src/ActionBar/ActionBar.tsx
@@ -320,6 +320,7 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
   const moreMenuBtnRef = useRef<HTMLButtonElement>(null)
   const containerRef = React.useRef<HTMLUListElement>(null)
 
+  // ResizeObserver is throttled by default (rAF) for better INP
   useResizeObserver((resizeObserverEntries: ResizeObserverEntry[]) => {
     const navWidth = resizeObserverEntries[0].contentRect.width
     const moreMenuWidth = moreMenuRef.current?.getBoundingClientRect().width ?? 0


### PR DESCRIPTION
## Closing - Documentation only, no code change

This PR only adds a comment. No actual code or behavior changes.

```diff
+  // ResizeObserver is throttled by default (rAF) for better INP
   useResizeObserver((resizeObserverEntries: ResizeObserverEntry[]) => {
```

The actual performance benefit comes from PR #7335 which adds throttling to useResizeObserver itself. This comment doesn't warrant a patch release.