### PR TITLE
Revert "ToggleSwitch: Add `overflow: hidden` to `.StatusTextItem`"

### DIFF
--- a/.changeset/swift-keys-thank.md
+++ b/.changeset/swift-keys-thank.md
@@ -1,5 +1,0 @@
----
-'@primer/react': patch
----
-
-ToggleSwitch: Adds `overflow: hidden` to `.StatusTextItem` when hidden

--- a/packages/react/src/ToggleSwitch/ToggleSwitch.module.css
+++ b/packages/react/src/ToggleSwitch/ToggleSwitch.module.css
@@ -53,7 +53,6 @@
 .StatusTextItem:where([data-hidden='true']) {
   visibility: hidden;
   height: 0;
-  overflow: hidden;
 }
 
 .SwitchButton {


### PR DESCRIPTION
Reverts primer/react#7399

Causes a slight visual regression in ControlGroup (adds additional spacing). Let's address the issue in Dotcom first before shipping this change. 