### PR TITLE
ensure `useMedia` avoids hydration issues

### DIFF
--- a/.changeset/smooth-ladybugs-hunt.md
+++ b/.changeset/smooth-ladybugs-hunt.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Refactor `useMedia` hook to use `useSyncExternalStore` for improved hydration safety

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "38.8.0",
+        "@primer/react": "38.9.0",
         "@primer/styled-react": "1.0.2",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
@@ -95,7 +95,7 @@
       "name": "example-nextjs",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "38.8.0",
+        "@primer/react": "38.9.0",
         "@primer/styled-react": "1.0.2",
         "next": "^16.1.5",
         "react": "^19.2.0",
@@ -138,7 +138,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.21.0",
-        "@primer/react": "38.8.0",
+        "@primer/react": "38.9.0",
         "@primer/styled-react": "1.0.2",
         "clsx": "^2.1.1",
         "next": "^16.1.5",
@@ -26883,7 +26883,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "38.8.0",
+      "version": "38.9.0",
       "license": "MIT",
       "dependencies": {
         "@github/mini-throttle": "^2.1.1",

--- a/packages/react/src/hooks/__tests__/useMedia.test.tsx
+++ b/packages/react/src/hooks/__tests__/useMedia.test.tsx
@@ -8,11 +8,14 @@ type MediaQueryEventListener = (event: {matches: boolean}) => void
 
 function mockMatchMedia({defaultMatch = false} = {}) {
   const listeners = new Set<MediaQueryEventListener>()
+  let currentMatch = defaultMatch
 
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: vi.fn().mockImplementation(query => ({
-      matches: defaultMatch,
+      get matches() {
+        return currentMatch
+      },
       media: query,
       onchange: null,
       addListener: vi.fn(), // deprecated
@@ -29,6 +32,7 @@ function mockMatchMedia({defaultMatch = false} = {}) {
 
   return {
     change({matches = false}) {
+      currentMatch = matches
       for (const listener of listeners) {
         listener({
           matches,


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Relates to #7493 
Closes https://github.com/github/primer/issues/6385

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

## Overview

This PR refactors the `useMedia` hook to use React's `useSyncExternalStore` API, which is specifically designed to safely subscribe to external stores (like browser media queries) while avoiding hydration mismatches between server and client rendering.

This is mostly defense in depth + gets rid of a post hydration render cycle when we useMedia with a default value - after hydration it's fine to intiialize with the query - useSyncExternalstore will handle this well for us and avoid an extra render pass

### Problem

The previous implementation used `useState` + `useEffect` to track media query changes. This pattern can cause hydration mismatches in SSR scenarios because:
1. The initial state is computed during render, which may differ between server and client
2. The `useEffect` callback runs after hydration, potentially causing a flash of incorrect content

#### Why `canUseDOM` in `useState` causes hydration issues

The root cause is how the `useState` initializer interacts with `canUseDOM`:

```tsx
const [matches, setMatches] = React.useState(() => {
  // ...
  if (canUseDOM) {
    return window.matchMedia(mediaQueryString).matches
  }
  return false
})
```

The `useState` initializer function runs **during the initial render** on both server and client:

- **Server-side render**: `canUseDOM` is `false` (no `window` exists) → state initializes to `false`
- **Client-side hydration**: `canUseDOM` is `true` → state initializes to `window.matchMedia(mediaQueryString).matches`

If the user's actual media query result is `true` (e.g., they have a coarse pointer, or their viewport is narrow), the client computes `true` while the server rendered `false`. React detects this mismatch during hydration because the initial client render doesn't match the server-rendered HTML, resulting in a hydration error.

Even when `defaultState` is provided, the subsequent `useEffect` that syncs state with `matchMedia` runs *after* hydration, which can still cause a visible flash of incorrect content.

### Solution

The new implementation:
- Uses `useSyncExternalStore` which React specifically designed for subscribing to external data sources with SSR support
- Provides a `getServerSnapshot` callback that returns the `defaultState` (or `false` with a warning) during server rendering
- React automatically uses `getServerSnapshot` during hydration to ensure consistency
- Simplifies the logic by separating context-based overrides from the actual media query subscription

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

- Introduced internal `useMediaQuery` helper that uses `useSyncExternalStore` for hydration-safe media query subscriptions

#### Changed

- `useMedia` now delegates to `useSyncExternalStore` instead of `useState` + `useEffect`
- Updated test mock to use a getter for `matches` property to properly support `useSyncExternalStore`'s snapshot pattern

#### Removed

- Removed manual state synchronization logic that was prone to hydration issues

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

This is a bug fix for hydration mismatches with no API changes to consumers.

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

- Existing tests have been updated to work with `useSyncExternalStore`
- The mock now tracks `currentMatch` state and uses a getter so that `useSyncExternalStore` can correctly read the current value via `getSnapshot`
- Test SSR scenarios in Next.js examples to verify no hydration warnings appear

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [x] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))