### PR TITLE
feat(ActionBar): customizable overflow menu label

### DIFF
--- a/packages/react/src/ActionBar/ActionBar.stories.tsx
+++ b/packages/react/src/ActionBar/ActionBar.stories.tsx
@@ -21,8 +21,15 @@ export default meta
 type Story = StoryObj<typeof ActionBar>
 
 export const Playground: Story = {
-  render: ({'aria-labelledby': _, ...args}) => (
-    <ActionBar {...args} aria-label="Toolbar">
+  args: {
+    overflowLabel: 'More item',
+    size: 'medium',
+    flush: false,
+    gap: 'condensed',
+  },
+
+  render: ({'aria-labelledby': _, overflowLabel, ...args}) => (
+    <ActionBar {...args} overflowLabel={overflowLabel} aria-label="Toolbar">
       <ActionBar.IconButton icon={BoldIcon} aria-label="Bold"></ActionBar.IconButton>
       <ActionBar.IconButton icon={ItalicIcon} aria-label="Italic"></ActionBar.IconButton>
       <ActionBar.Divider />
@@ -48,11 +55,17 @@ Playground.argTypes = {
     description: 'Horizontal gap scale between items',
     table: {defaultValue: {summary: 'condensed'}},
   },
+  overflowLabel: {
+    control: {type: 'text'},
+    description: 'Accessible label for the overflow menu button',
+    table: {defaultValue: {summary: 'More items'}},
+  },
 }
 Playground.args = {
   size: 'medium',
   flush: false,
   gap: 'condensed',
+  overflowLabel: 'More items',
 }
 
 export const Default = () => (

--- a/packages/react/src/ActionBar/ActionBar.tsx
+++ b/packages/react/src/ActionBar/ActionBar.tsx
@@ -103,6 +103,12 @@ export type ActionBarProps = {
    * @default 'condensed'
    */
   gap?: GapScale
+
+  /**
+   * Accessible label for the overflow menu button
+   * @default "More items"
+   */
+  overflowLabel?: string
 } & A11yProps
 
 export type ActionBarIconButtonProps = {disabled?: boolean} & IconButtonProps
@@ -297,6 +303,7 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
     flush = false,
     className,
     gap = 'condensed',
+    overflowLabel
   } = props
 
   // We derive the numeric gap from computed style so layout math stays in sync with CSS
@@ -400,7 +407,7 @@ export const ActionBar: React.FC<React.PropsWithChildren<ActionBarProps>> = prop
           {menuItemIds.size > 0 && (
             <ActionMenu>
               <ActionMenu.Anchor>
-                <IconButton variant="invisible" aria-label={`More ${ariaLabel} items`} icon={KebabHorizontalIcon} />
+                <IconButton variant='invisible' aria-label={overflowLabel ?? "More items"} icon={KebabHorizontalIcon}/>
               </ActionMenu.Anchor>
               <ActionMenu.Overlay>
                 <ActionList>


### PR DESCRIPTION
Closes: #7437

### Changelog

#### New
- Added `overflowLabel` prop to `ActionBarProps` with default `"More items"`.
- Storybook updated to expose `overflowLabel` as a control.

#### Changed
- Overflow menu button `aria-label` now uses `overflowLabel` instead of hardcoded `"More {ariaLabel} items"`.

#### Removed
- None

### Rollout strategy
- [x] Patch release

### Testing & Reviewing
- Verified manually in Storybook:
  - Default shows `"More items"`.
  - Custom values (e.g. `"More actions"`) update correctly.
- Could not locate an existing test file for `ActionBar` under `src/__tests__`. Fix validated through Storybook preview.

### Merge checklist
- [ ] Added/updated tests (none found for ActionBar, validated manually)
- [x] Added/updated documentation (Storybook)
- [x] Added/updated previews (Storybook)
- [x] Changes are SSR compatible
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
