### PR TITLE
Increase specificity of grid styles on action & nav list buttons

### DIFF
--- a/.changeset/tidy-chicken-burn.md
+++ b/.changeset/tidy-chicken-burn.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fix styles when button is used as ActionList.Item

--- a/packages/react/src/ActionList/ActionList.module.css
+++ b/packages/react/src/ActionList/ActionList.module.css
@@ -495,7 +495,6 @@ button.ActionListContent {
 }
 
 /* [ [spacer] [leadingAction] [leadingVisual] [content] ] */
-
 .ActionListContent,
   --subitem-depth: 0px;
 

--- a/packages/react/src/ActionList/ActionList.module.css
+++ b/packages/react/src/ActionList/ActionList.module.css
@@ -495,7 +495,7 @@ button.ActionListContent {
 }
 
 /* [ [spacer] [leadingAction] [leadingVisual] [content] ] */
-.ActionListContent,
+.ActionListContent {
   --subitem-depth: 0px;
 
   position: relative;

--- a/packages/react/src/ActionList/ActionList.module.css
+++ b/packages/react/src/ActionList/ActionList.module.css
@@ -486,6 +486,7 @@
 /* button or a tag */
 
 /* Uses the additional `button` selector to avoid the specificity conflicts when the reset styles for [buttons](packages/react/src/Link/Link.module.css) are bundled in a different order */
+/* stylelint-disable-next-line selector-no-qualifying-type */
 button.ActionListContent {
   display: grid;
   /* stylelint-disable-next-line primer/spacing */

--- a/packages/react/src/ActionList/ActionList.module.css
+++ b/packages/react/src/ActionList/ActionList.module.css
@@ -485,8 +485,18 @@
 
 /* button or a tag */
 
+/* Uses the additional `button` selector to avoid the specificity conflicts when the reset styles for [buttons](packages/react/src/Link/Link.module.css) are bundled in a different order */
+button.ActionListContent {
+  display: grid;
+  /* stylelint-disable-next-line primer/spacing */
+  padding-block: var(--control-medium-paddingBlock);
+  /* stylelint-disable-next-line primer/spacing */
+  padding-inline: var(--control-medium-paddingInline-condensed);
+}
+
 /* [ [spacer] [leadingAction] [leadingVisual] [content] ] */
-.ActionListContent {
+
+.ActionListContent,
   --subitem-depth: 0px;
 
   position: relative;


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/6388

The styles between the Link reset css for buttons and the ActionList's layout can potentially be applied in a different order for an unknown reason. This can lead to some visual regressions when using `ActionList.Item` or `NavList.Item` with the `as="button"` prop

### Changelog

#### Changed

- Adds additional specificity to buttons used as `ActionList.Item`s

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
