### PR TITLE
perf(useIsMacOS): replace useState+useEffect with useSyncExternalStore

### DIFF
--- a/.changeset/perf-useismacOS-sync-external-store.md
+++ b/.changeset/perf-useismacOS-sync-external-store.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+perf(useIsMacOS): replace useState+useEffect with useSyncExternalStore to eliminate unnecessary re-render

--- a/packages/react/src/hooks/useIsMacOS.ts
+++ b/packages/react/src/hooks/useIsMacOS.ts
@@ -1,37 +1,30 @@
 import {isMacOS as ssrUnsafeIsMacOS} from '@primer/behaviors/utils'
 import {useSyncExternalStore} from 'react'
 
-// No-op subscribe function. Hoisted to module scope to avoid creating a new
-// function on every call. The platform never changes at runtime, so there is
-// nothing to subscribe to.
-const noop = () => () => {}
+// No-op. The platform never changes at runtime, so there is nothing to
+// subscribe to. Hoisted to avoid creating a new function on every call.
+const subscribe = () => () => {}
+
+// Safe default for SSR since we can't detect the platform on the server.
+const getServerSnapshot = () => false
 
 /**
  * SSR-safe hook for determining if the current platform is MacOS.
  *
  * Uses `useSyncExternalStore` to read the platform value:
  *
- * - On the **server**, `getServerSnapshot` returns `false` (safe default since
- *   we can't detect the platform during SSR).
+ * - On the **client**, `ssrUnsafeIsMacOS` reads `navigator.userAgent` and
+ *   returns the real value immediately, with no extra render pass.
  *
- * - On the **client**, `getSnapshot` calls `ssrUnsafeIsMacOS()` which reads
- *   `navigator.userAgent` and returns the real value immediately, with no
- *   extra render pass.
- *
- * - During **hydration**, if the server snapshot (`false`) differs from the
- *   client snapshot (`true` on a Mac), React handles the mismatch internally
- *   and commits the client value in a single synchronous pass, avoiding the
- *   layout shift that a deferred `useEffect` + `setState` would cause.
- *
- * The `subscribe` argument is a no-op because the platform is a static value
- * that never changes. This tells React the snapshot is stable, so it never
- * needs to re-check or re-render for this value after the initial mount.
+ * - On the **server**, returns `false`. During hydration, if the snapshots
+ *   differ, React handles the mismatch internally in a single synchronous
+ *   pass, avoiding the layout shift that a deferred `useEffect` + `setState`
+ *   would cause.
  *
  * Previous implementation used `useState` + `useEffect`, which caused an
  * unconditional second render on every mount (even on the client where the
- * initial value was already correct). This affected Tooltip, KeybindingHint,
- * and TreeView.
+ * initial value was already correct).
  */
 export function useIsMacOS() {
-  return useSyncExternalStore(noop, ssrUnsafeIsMacOS, () => false)
+  return useSyncExternalStore(subscribe, ssrUnsafeIsMacOS, getServerSnapshot)
 }


### PR DESCRIPTION
Closes #

`useIsMacOS` used `useState` + `useEffect` to detect the platform in an SSR-safe way. The `useState` initializer already computed the correct value on the client, but the `useEffect` unconditionally called `setIsMacOS` with the same value, scheduling a second render pass on every mount.

Replaced with `useSyncExternalStore`, the idiomatic React 18+ API for values that differ between server and client. During hydration, React handles the server/client mismatch internally in a single synchronous pass, no extra render needed.

Eliminates a guaranteed double-render on every mount for all consumers: **Tooltip**, **KeybindingHint**, and **TreeView**. The impact scales with the number of children, since the unnecessary re-render cascades to all of them.

### Measurements

Measured on the **TreeView stress test** (1000 tree items) as worst case. 2 runs each, reload-based traces, no CPU/network throttling.

| Metric | Before (main) | After (PR) | Delta |
|---|---|---|---|
| ✨ **LCP** (median) ✨ | **2,416ms** | **2,264ms** | **-152ms (-6.3%)** |
| **Render Delay** (median) | **2,216ms** | **2,095ms** | **-121ms (-5.5%)** |

<details>
<summary>Individual runs</summary>

**Before (main):**
- Run 1: LCP 2,421ms (TTFB 206ms, Render Delay 2,215ms)
- Run 2: LCP 2,410ms (TTFB 192ms, Render Delay 2,217ms)

**After (PR):**
- Run 1: LCP 2,268ms (TTFB 155ms, Render Delay 2,113ms)
- Run 2: LCP 2,259ms (TTFB 182ms, Render Delay 2,077ms)
</details>

TreeView shows the largest improvement because a single `useIsMacOS` call at the root triggers a re-render that cascades across 1000 child items. Tooltip and KeybindingHint will see smaller absolute gains but every instance still saves one full render cycle on mount.

### Changelog

#### New

N/A

#### Changed

- `useIsMacOS` now uses `useSyncExternalStore` instead of `useState` + `useEffect`, eliminating an unnecessary re-render on every mount

#### Removed

N/A

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

All 3 consumer test suites pass (89 tests total):
- `TooltipV2/__tests__/Tooltip.test.tsx`
- `KeybindingHint/KeybindingHint.test.tsx`
- `TreeView/TreeView.test.tsx`

To verify the double render is eliminated:
1. Add a `console.log('render')` inside the Tooltip component
2. Render a Tooltip in a test/story
3. Before: logs "render" twice on mount
4. After: logs "render" once

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
