### PR TITLE
fix(lock-release): don't fail on PRs with merge conflicts

### DIFF
--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -83,7 +83,9 @@ jobs:
           PR_NUMBERS=$(gh pr list -L 100 -R primer/react --state open --json number,baseRefName,autoMergeRequest,reviewDecision -q '.[] | select(.autoMergeRequest != null) | select(.baseRefName == "main") | select(.reviewDecision == "APPROVED") | .number')
           if [ -n "$PR_NUMBERS" ]; then
             echo "Updating $PR_NUMBERS"
-            echo "$PR_NUMBERS" | xargs -I {} gh pr update-branch -R primer/react {}
+            for pr in $PR_NUMBERS; do
+              gh pr update-branch -R primer/react "$pr" || echo "Warning: failed to update PR #$pr (likely has conflicts)"
+            done
           else
             echo "No PRs to update."
           fi


### PR DESCRIPTION
Closes #

The `lock-release` unlock workflow has been failing because the "Update all PRs" step uses `xargs` to call `gh pr update-branch` for each auto-merge PR. When any PR has merge conflicts, `gh pr update-branch` exits non-zero, `xargs` propagates exit code 123, and the whole job fails under bash's `-e` flag.

This means the unlock step was reported as failed even though the rulesets were toggled successfully. The only "failure" was that some PRs had conflicts and couldn't be updated, which is expected and shouldn't block the workflow.

Replaced `xargs` with a `for` loop that gracefully handles per-PR failures with `|| echo "Warning: ..."`.

### Changelog

#### New

N/A

#### Changed

- `lock-release` unlock step no longer fails when some PRs have merge conflicts

#### Removed

N/A

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; CI workflow fix only, no package changes

### Testing & Reviewing

This was diagnosed from the recent run logs. The rulesets toggle fine, but the PR update step fails:

```
✓ PR branch updated
✓ PR branch updated
X Cannot update PR branch due to conflicts
X Cannot update PR branch due to conflicts
✓ PR branch updated
##[error]Process completed with exit code 123.
```

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
