### PR TITLE
Add accessible "inactive" description to Inactive Buttons storybook story

### DIFF
--- a/packages/react/src/Button/Button.features.stories.tsx
+++ b/packages/react/src/Button/Button.features.stories.tsx
@@ -5,6 +5,7 @@ import {Stack} from '../Stack/Stack'
 import {announce} from '@primer/live-region-element'
 import {Tooltip} from '../TooltipV2/Tooltip'
 import {KeybindingHint} from '../KeybindingHint'
+import {VisuallyHidden} from '@primer/react'
 export default {
   title: 'Components/Button/Features',
 }
@@ -129,14 +130,18 @@ export const Disabled = () => (
 
 export const Inactive = () => (
   <div style={{display: 'flex', flexDirection: 'row', gap: '1rem'}}>
-    <Button inactive>Default</Button>
-    <Button variant="primary" inactive>
+    <VisuallyHidden id="inactive-state">Inactive</VisuallyHidden>
+
+    <Button inactive aria-describedby="inactive-state">
+      Default
+    </Button>
+    <Button variant="primary" inactive aria-describedby="inactive-state">
       Primary
     </Button>
-    <Button variant="danger" inactive>
+    <Button variant="danger" inactive aria-describedby="inactive-state">
       Danger
     </Button>
-    <Button variant="invisible" inactive>
+    <Button variant="invisible" inactive aria-describedby="inactive-state">
       Invisible
     </Button>
   </div>


### PR DESCRIPTION
Addresses https://github.com/github/accessibility-audits/issues/14866

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->


#### Changed

- Added accessible "inactive" description to [Buttons: Inactive storybook story](https://primer.style/react/storybook/?path=/story/components-button-features--inactive) to satisfy the a11y audit issue
- Kept `inactive` as a visual/UX state rather than enforcing `disabled` semantics in `ButtonBase`. In real usage, inactive buttons should provide context (e.g. banner/tooltip/dialog) explaining why the action can’t be completed.
- Avoided a component-level `aria-disabled` default for `inactive` to prevent conflicts with consumers that use native `disabled` or explicitly set ARIA attributes.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
