### PR TITLE
SegmentedControl: include counter in button accessible name when aria-label is provided

### DIFF
--- a/.changeset/evil-islands-find.md
+++ b/.changeset/evil-islands-find.md
@@ -2,4 +2,4 @@
 '@primer/react': patch
 ---
 
-Fixes an accessibility issue where screen readers announce segmented control buttons without their associated count.
+SegmentedControl: Screen readers now announce buttons with their associated count. Fixes [accessibility-audits#14898](https://github.com/github/accessibility-audits/issues/14898)

--- a/packages/react/src/SegmentedControl/SegmentedControl.features.stories.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.features.stories.tsx
@@ -26,15 +26,11 @@ export const WithIcons = () => (
 
 export const WithCounterLabels = () => (
   <SegmentedControl aria-label="Issues by label">
-    <SegmentedControl.Button defaultSelected aria-label="Feature" count={5}>
+    <SegmentedControl.Button defaultSelected count={5}>
       Feature
     </SegmentedControl.Button>
-    <SegmentedControl.Button aria-label="Bug" count={3}>
-      Bug
-    </SegmentedControl.Button>
-    <SegmentedControl.Button aria-label="Good first issue" count={10}>
-      Good first issue
-    </SegmentedControl.Button>
+    <SegmentedControl.Button count={3}>Bug</SegmentedControl.Button>
+    <SegmentedControl.Button count={10}>Good first issue</SegmentedControl.Button>
   </SegmentedControl>
 )
 

--- a/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
@@ -319,7 +319,7 @@ describe('SegmentedControl', () => {
     expect(getByRole('img', {name: 'EyeIcon'})).toBeInTheDocument()
   })
 
-  it('includes the count in the accessible name when aria-label is provided', () => {
+  it('uses explicit aria-label as-is when count is provided', () => {
     const {getByRole} = render(
       <SegmentedControl aria-label="Issues by label">
         <SegmentedControl.Button defaultSelected aria-label="Feature" count={5}>
@@ -328,9 +328,10 @@ describe('SegmentedControl', () => {
       </SegmentedControl>,
     )
 
-    const button = getByRole('button', {name: 'Feature 5'})
+    const button = getByRole('button', {name: 'Feature'})
 
     expect(button).toBeInTheDocument()
+    expect(button).toHaveAttribute('aria-label', 'Feature')
   })
 
   it('uses aria-label without modification when count is undefined', () => {
@@ -348,7 +349,7 @@ describe('SegmentedControl', () => {
     expect(button).toHaveAttribute('aria-label', 'Feature')
   })
 
-  it('does not set aria-label when only count is provided and relies on text content', () => {
+  it('uses a default accessible name with count when aria-label is not provided', () => {
     const {getByRole} = render(
       <SegmentedControl aria-label="Issues by label">
         <SegmentedControl.Button defaultSelected count={5}>
@@ -357,10 +358,25 @@ describe('SegmentedControl', () => {
       </SegmentedControl>,
     )
 
-    const button = getByRole('button', {name: /Feature\s*\(\s*5\s*\)/})
+    const button = getByRole('button', {name: 'Feature, count: 5'})
 
     expect(button).toBeInTheDocument()
-    expect(button).not.toHaveAttribute('aria-label')
+    expect(button).toHaveAttribute('aria-label', 'Feature, count: 5')
+  })
+
+  it('handles a string count when aria-label is not provided', () => {
+    const {getByRole} = render(
+      <SegmentedControl aria-label="Issues by label">
+        <SegmentedControl.Button defaultSelected count="5">
+          Feature
+        </SegmentedControl.Button>
+      </SegmentedControl>,
+    )
+
+    const button = getByRole('button', {name: 'Feature, count: 5'})
+
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveAttribute('aria-label', 'Feature, count: 5')
   })
 
   it('handles a string count when aria-label is provided', () => {
@@ -372,9 +388,10 @@ describe('SegmentedControl', () => {
       </SegmentedControl>,
     )
 
-    const button = getByRole('button', {name: 'Feature 5'})
+    const button = getByRole('button', {name: 'Feature'})
 
     expect(button).toBeInTheDocument()
+    expect(button).toHaveAttribute('aria-label', 'Feature')
   })
 
   it('should warn the user if they neglect to specify a label for the segmented control', () => {

--- a/packages/react/src/SegmentedControl/SegmentedControlButton.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControlButton.tsx
@@ -42,7 +42,8 @@ const SegmentedControlButton: FCWithSlotMarker<React.PropsWithChildren<Segmented
   const {'aria-disabled': ariaDisabled, 'aria-label': ariaLabel, ...rest} = props
   // Use leadingVisual if provided, otherwise fall back to leadingIcon for backwards compatibility
   const LeadingVisual = leadingVisual ?? leadingIcon
-  const computedAriaLabel = ariaLabel !== undefined && count !== undefined ? `${ariaLabel} ${count}` : ariaLabel
+  const computedAriaLabel =
+    ariaLabel !== undefined ? ariaLabel : count !== undefined ? `${children}, count: ${count}` : undefined
 
   return (
     <li className={clsx(classes.Item)} data-selected={selected ? '' : undefined}>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Related issue: https://github.com/github/accessibility-audits/issues/14898

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

Fixes an accessibility issue where screen readers announce segmented control buttons without their associated count.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
