### PR TITLE
sync mcp versions with 0.3.0 release

### DIFF
--- a/.changeset/mcp-design-tokens-update.md
+++ b/.changeset/mcp-design-tokens-update.md
@@ -1,5 +1,0 @@
----
-"@primer/mcp": minor
----
-
-Replace design token tools with enhanced search and bundle system. The single `list_tokens` tool is replaced by `find_tokens`, `get_token_group_bundle`, `get_design_token_specs`, and `get_token_usage_patterns` for improved token discovery and usage guidance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27026,7 +27026,7 @@
     },
     "packages/mcp": {
       "name": "@primer/mcp",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@modelcontextprotocol/sdk": "^1.24.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,7 +2,7 @@
   "name": "@primer/mcp",
   "private": true,
   "description": "An MCP server that connects AI tools to the Primer Design System",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "bin": {
     "mcp": "./bin/mcp.js"


### PR DESCRIPTION
- Bumping the version of `@primer/mcp` to `0.3.0` to match what was published manually. 
- Removes the changeset so we don't bump the version _again_ in the next release 