### PR TITLE
Add `counterProps` prop to `UnderlineNav.Item`

### DIFF
--- a/.changeset/underline-nav-counter-props.md
+++ b/.changeset/underline-nav-counter-props.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Add `counterProps` prop to `UnderlineNav.Item`, allowing consumers to pass additional HTML attributes to the counter wrapper element.

--- a/packages/react/src/UnderlineNav/UnderlineNav.test.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNav.test.tsx
@@ -238,6 +238,37 @@ describe('UnderlineNav', () => {
     const textSpan = item.querySelector('[data-component="text"]')
     expect(textSpan).toHaveAttribute('data-content', 'Simple Text')
   })
+
+  it('spreads counterProps onto the counter wrapper element', () => {
+    render(
+      <UnderlineNav aria-label="Test">
+        <UnderlineNav.Item counter={42} counterProps={{className: 'custom-counter'}}>
+          Issues
+        </UnderlineNav.Item>
+      </UnderlineNav>,
+    )
+
+    const item = screen.getByRole('link', {name: 'Issues (42)'})
+    const counterWrapper = item.querySelector('[data-component="counter"]')
+    expect(counterWrapper).toBeInTheDocument()
+    expect(counterWrapper).toHaveClass('custom-counter')
+    expect(counterWrapper!.textContent).toContain('42')
+  })
+
+  it('spreads counterProps onto the loading counter wrapper element', () => {
+    render(
+      <UnderlineNav aria-label="Test" loadingCounters={true}>
+        <UnderlineNav.Item counter={42} counterProps={{className: 'loading-custom-counter'}}>
+          Issues
+        </UnderlineNav.Item>
+      </UnderlineNav>,
+    )
+
+    const item = screen.getByRole('link', {name: 'Issues'})
+    const counterWrapper = item.querySelector('[data-component="counter"]')
+    expect(counterWrapper).toBeInTheDocument()
+    expect(counterWrapper).toHaveClass('loading-custom-counter')
+  })
 })
 
 describe('Keyboard Navigation', () => {

--- a/packages/react/src/UnderlineNav/UnderlineNavItem.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNavItem.tsx
@@ -57,6 +57,11 @@ export type UnderlineNavItemProps = {
    * Counter
    */
   counter?: number | string
+
+  /**
+   * Additional HTML attributes for the counter wrapper element
+   */
+  counterProps?: React.HTMLAttributes<HTMLSpanElement>
 } & LinkProps
 
 export const UnderlineNavItem = forwardRef(
@@ -66,6 +71,7 @@ export const UnderlineNavItem = forwardRef(
       href = '#',
       children,
       counter,
+      counterProps,
       onSelect,
       'aria-current': ariaCurrent,
       icon: Icon,
@@ -129,6 +135,7 @@ export const UnderlineNavItem = forwardRef(
           onKeyDown={keyDownHandler}
           onClick={clickHandler}
           counter={counter}
+          counterProps={counterProps}
           icon={leadingVisual ?? Icon}
           loadingCounters={loadingCounters}
           iconsVisible={iconsVisible}

--- a/packages/react/src/internal/components/UnderlineTabbedInterface.tsx
+++ b/packages/react/src/internal/components/UnderlineTabbedInterface.tsx
@@ -65,6 +65,7 @@ export type UnderlineItemProps<As extends React.ElementType> = {
   iconsVisible?: boolean
   loadingCounters?: boolean
   counter?: number | string
+  counterProps?: React.HTMLAttributes<HTMLSpanElement>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   icon?: FC<IconProps> | React.ReactElement<any>
   id?: string
@@ -72,7 +73,17 @@ export type UnderlineItemProps<As extends React.ElementType> = {
 } & React.ComponentPropsWithoutRef<As extends 'a' ? 'a' : As extends 'button' ? 'button' : As>
 
 export const UnderlineItem = React.forwardRef((props, ref) => {
-  const {as: Component = 'a', children, counter, icon: Icon, iconsVisible, loadingCounters, className, ...rest} = props
+  const {
+    as: Component = 'a',
+    children,
+    counter,
+    counterProps,
+    icon: Icon,
+    iconsVisible,
+    loadingCounters,
+    className,
+    ...rest
+  } = props
   const textContent = getTextContent(children)
   return (
     <Component {...rest} ref={ref} className={clsx(classes.UnderlineItem, className)}>
@@ -84,11 +95,11 @@ export const UnderlineItem = React.forwardRef((props, ref) => {
       )}
       {counter !== undefined ? (
         loadingCounters ? (
-          <span data-component="counter">
+          <span data-component="counter" {...counterProps}>
             <LoadingCounter />
           </span>
         ) : (
-          <span data-component="counter">
+          <span data-component="counter" {...counterProps}>
             <CounterLabel>{counter}</CounterLabel>
           </span>
         )


### PR DESCRIPTION
Part of https://github.com/github/github/issues/419591

Adds a new `counterProps` prop to `UnderlineNav.Item` that allows consumers to pass additional HTML attributes (e.g., `className`, `id`, `aria-*`) to the counter wrapper `<span>` element. This enables targeting the counter with a stable id, as needed by the follow-up PR in dotcom: https://github.com/github/github-ui/pull/14968

### Changelog

#### New

- `UnderlineNav.Item` now accepts a `counterProps` prop of type `React.HTMLAttributes<HTMLSpanElement>`, which spreads onto the `<span data-component="counter">` wrapper element (both in normal and loading states).

#### Changed

#### Removed

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Two new unit tests verify `counterProps` is spread correctly:
1. **Normal counter** — passes `className` via `counterProps` and asserts it appears on the `[data-component="counter"]` element alongside the counter value.
2. **Loading counter** — same pattern with `loadingCounters={true}`.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui