### PR TITLE
Fix PageLayout pane layout shift when content loads asynchronously

### DIFF
--- a/packages/react/src/PageLayout/PageLayout.module.css
+++ b/packages/react/src/PageLayout/PageLayout.module.css
@@ -471,7 +471,7 @@
       display: none;
     }
 
-    width: auto;
+    width: var(--pane-width-size);
     margin-top: 0 !important;
     margin-bottom: 0 !important;
 

--- a/packages/react/src/PageLayout/PageLayout.module.css
+++ b/packages/react/src/PageLayout/PageLayout.module.css
@@ -471,7 +471,7 @@
       display: none;
     }
 
-    width: var(--pane-width-size);
+    width: var(--pane-width);
     margin-top: 0 !important;
     margin-bottom: 0 !important;
 
@@ -495,6 +495,7 @@
       margin-right: var(--spacing-column);
       flex-direction: row;
       order: var(--region-order-pane-start);
+      width: calc(var(--pane-width) + var(--spacing-column) + 1px);
     }
 
     &:where([data-position-regular='end']) {

--- a/packages/react/src/PageLayout/PageLayout.tsx
+++ b/packages/react/src/PageLayout/PageLayout.tsx
@@ -868,6 +868,11 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
             '--offset-header': typeof offsetHeader === 'number' ? `${offsetHeader}px` : offsetHeader,
             '--spacing-row': `var(--spacing-${rowGap})`,
             '--spacing-column': `var(--spacing-${columnGap})`,
+            '--pane-min-width': isCustomWidthOptions(width) ? width.min : `${minWidth}px`,
+            '--pane-max-width': isCustomWidthOptions(width) ? width.max : `calc(100vw - var(--pane-max-width-diff))`,
+            '--pane-width-custom': isCustomWidthOptions(width) ? width.default : undefined,
+            '--pane-width-size': `var(--pane-width-${isPaneWidth(width) ? width : 'custom'})`,
+            '--pane-width': `${currentWidth}px`,
             ...style,
           } as React.CSSProperties
         }
@@ -900,11 +905,6 @@ const Pane = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageLayout
           style={
             {
               '--spacing': `var(--spacing-${padding})`,
-              '--pane-min-width': isCustomWidthOptions(width) ? width.min : `${minWidth}px`,
-              '--pane-max-width': isCustomWidthOptions(width) ? width.max : `calc(100vw - var(--pane-max-width-diff))`,
-              '--pane-width-custom': isCustomWidthOptions(width) ? width.default : undefined,
-              '--pane-width-size': `var(--pane-width-${isPaneWidth(width) ? width : 'custom'})`,
-              '--pane-width': `${currentWidth}px`,
             } as React.CSSProperties
           }
         >


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/pull-requests/issues/23557

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

| Before | After |
| :- | :- |
| ![CleanShot 2026-03-27 at 13 04 28](https://github.com/user-attachments/assets/bc538946-e2a5-4e31-8de2-09747c459ba7) | ![CleanShot 2026-03-27 at 13 04 48](https://github.com/user-attachments/assets/b58e3ea3-4274-4c9e-84a7-772edd8d9af5) |


### Overview

Fixes a subtle layout shift on pages using `PageLayout.Pane` where the sidebar content is loaded asynchronously. When the pane content rendered after the initial load, the page would visibly jump because the `PaneWrapper` element had `width: auto` and didn't reserve space for the pane.

**Root cause:** The pane width CSS custom properties (`--pane-width-size`, `--pane-min-width`, `--pane-max-width`, etc.) were set on the inner pane element rather than the outer `PaneWrapper`. This meant the wrapper couldn't use them to reserve the correct width before pane content loaded.

**Fix:**
- Moved the pane width CSS custom properties from the inner pane `div` up to the `PaneWrapper` element
- Changed `PaneWrapper` from `width: auto` to `width: var(--pane-width-size)` so it reserves the correct pane width immediately, preventing layout reflow when content loads in

### Changelog

#### New

#### Changed

- `PageLayout.Pane`: Pane width CSS variables are now set on the `PaneWrapper` element instead of the inner pane div, and the wrapper width uses `var(--pane-width-size)` instead of `auto`

#### Removed

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

1. Use a `PageLayout` with a `Pane` that loads its content asynchronously (e.g., via `useEffect` or data fetching)
2. Observe that the page no longer shifts/jumps when the pane content appears
3. Verify that pane widths (`small`, `medium`, `large`, and custom) still render correctly

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))