### PR TITLE
lock-release.yml: Fix auto-merge not triggering by turning it off and on again

### DIFF
--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -29,26 +29,23 @@ jobs:
           owner: primer
           repositories: react
           private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
-      - name: Lock main branch
+      - name: Toggle rulesets
         run: |
-          # Lock main but allow react-release-conductor team to push
+          # Allow react-release-conductor to bypass merge queue
           gh api \
             --method PUT \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/primer/react/branches/main/protection \
-            --input - <<EOF
-          {
-            "lock_branch": true,
-            "restrictions": {
-              "teams": ["react-release-conductor"],
-              "users": []
-            },
-            "required_status_checks": null,
-            "enforce_admins": true,
-            "required_pull_request_reviews": null
-          }
-          EOF
+            /repos/primer/react/rulesets/4089335 \
+            -F "bypass_actors[][actor_id]=12276524" \
+            -f "bypass_actors[][actor_type]=Team" \
+            -f "bypass_actors[][bypass_mode]=always"
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/primer/react/rulesets/3801256 \
+            -f "enforcement=active"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
@@ -65,15 +62,32 @@ jobs:
           owner: primer
           repositories: react
           private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
-      - name: Unlock main branch
+      - name: Toggle rulesets
         run: |
-          # Delete the branch protection rule entirely.
-          # Note: This workflow is the only thing using legacy branch protection.
-          # All other branch rules use rulesets, which are unaffected by this delete.
           gh api \
-            --method DELETE \
+            --method PUT \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/primer/react/branches/main/protection
+            /repos/primer/react/rulesets/4089335 \
+            -F "bypass_actors[]"
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/primer/react/rulesets/3801256 \
+            -f "enforcement=disabled"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Update all PRs that are toggled merge when ready
+        run: |
+          PR_NUMBERS=$(gh pr list -L 100 -R primer/react --state open --json number,baseRefName,autoMergeRequest,reviewDecision -q '.[] | select(.autoMergeRequest != null) | select(.baseRefName == "main") | select(.reviewDecision == "APPROVED") | .number')
+          if [ -n "$PR_NUMBERS" ]; then
+            echo "Updating $PR_NUMBERS"
+            for pr in $PR_NUMBERS; do
+              gh pr update-branch -R primer/react "$pr" || echo "Warning: failed to update PR #$pr (likely has conflicts)"
+            done
+          else
+            echo "No PRs to update."
+          fi
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/lock-release.yml
+++ b/.github/workflows/lock-release.yml
@@ -82,9 +82,10 @@ jobs:
         run: |
           PR_NUMBERS=$(gh pr list -L 100 -R primer/react --state open --json number,baseRefName,autoMergeRequest,reviewDecision -q '.[] | select(.autoMergeRequest != null) | select(.baseRefName == "main") | select(.reviewDecision == "APPROVED") | .number')
           if [ -n "$PR_NUMBERS" ]; then
-            echo "Updating $PR_NUMBERS"
+            echo "Re-enabling auto-merge on $PR_NUMBERS"
             for pr in $PR_NUMBERS; do
-              gh pr update-branch -R primer/react "$pr" || echo "Warning: failed to update PR #$pr (likely has conflicts)"
+              gh pr merge "$pr" -R primer/react --disable-auto || echo "Warning: failed to disable auto-merge on PR #$pr"
+              gh pr merge "$pr" -R primer/react --auto --squash || echo "Warning: failed to enable auto-merge on PR #$pr"
             done
           else
             echo "No PRs to update."


### PR DESCRIPTION
- Follow up for https://github.com/primer/react/pulls?q=is:pr+author:siddharthkp+is:closed


### Problem:

If the main branch is locked by rulesets, enabling auto merge on a pull request says it will be merged. But it's not merged when the main branch is unlocked.

This is because auto merge is not reevaluated when the rule set changes. Right now, we try to solve this problem by merging main into pull requests that are marked for auto-merge because a new commit + CI will trigger auto-merge. But, this doesn't work for us because the integration tests require you to run them again, because of a new commit, blocking auto-merge.

### Solution

Instead of merging main, if we remove the pull request from auto merge and then put it back in auto merge, that solves the problem. Classic have you tried turning it off and on again.

<img width="585" height="200" alt="bot disabed and enabled auto-merge" src="https://github.com/user-attachments/assets/cffb3ec7-dca3-4eb2-a56a-e57a9ddd7339" />


### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; workflow change

### Testing & Reviewing

Tested by running the action from this branch: https://github.com/primer/react/actions/runs/24237799981/job/70764667067#step:4:16