### PR TITLE
chore: graduate primer_react_overlay_max_height_clamp_to_viewport

### DIFF
--- a/.changeset/graduate-overlay-max-height-clamp.md
+++ b/.changeset/graduate-overlay-max-height-clamp.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': minor
+---
+
+Overlay: Graduate `primer_react_overlay_max_height_clamp_to_viewport` feature flag
+
+The max-height of overlays is now clamped to the viewport height by default using `min(size, 100dvh)`. This prevents overlays from extending beyond the viewport on smaller screens.

--- a/packages/react/src/ActionMenu/ActionMenu.module.css
+++ b/packages/react/src/ActionMenu/ActionMenu.module.css
@@ -25,23 +25,43 @@
 
   /* Max-height size tokens (mirror Overlay sizes) */
   &:where([data-max-height-xsmall]) {
-    max-height: min(192px, 100dvh);
+    max-height: min(192px, 100vh);
+
+    @supports (height: 100dvh) {
+      max-height: min(192px, 100dvh);
+    }
   }
 
   &:where([data-max-height-small]) {
-    max-height: min(256px, 100dvh);
+    max-height: min(256px, 100vh);
+
+    @supports (height: 100dvh) {
+      max-height: min(256px, 100dvh);
+    }
   }
 
   &:where([data-max-height-medium]) {
-    max-height: min(320px, 100dvh);
+    max-height: min(320px, 100vh);
+
+    @supports (height: 100dvh) {
+      max-height: min(320px, 100dvh);
+    }
   }
 
   &:where([data-max-height-large]) {
-    max-height: min(432px, 100dvh);
+    max-height: min(432px, 100vh);
+
+    @supports (height: 100dvh) {
+      max-height: min(432px, 100dvh);
+    }
   }
 
   &:where([data-max-height-xlarge]) {
-    max-height: min(600px, 100dvh);
+    max-height: min(600px, 100vh);
+
+    @supports (height: 100dvh) {
+      max-height: min(600px, 100dvh);
+    }
   }
 
   &:where([data-max-height-fit-content]) {

--- a/packages/react/src/ActionMenu/ActionMenu.module.css
+++ b/packages/react/src/ActionMenu/ActionMenu.module.css
@@ -25,43 +25,22 @@
 
   /* Max-height size tokens (mirror Overlay sizes) */
   &:where([data-max-height-xsmall]) {
-    max-height: 192px;
-  }
-
-  &:where([data-max-height-small]) {
-    max-height: 256px;
-  }
-
-  &:where([data-max-height-medium]) {
-    max-height: 320px;
-  }
-
-  &:where([data-max-height-large]) {
-    max-height: 432px;
-  }
-
-  &:where([data-max-height-xlarge]) {
-    max-height: 600px;
-  }
-
-  /* Max-height size tokens clamped to viewport (enabled via feature flag) */
-  &:where([data-max-height-clamp-to-viewport][data-max-height-xsmall]) {
     max-height: min(192px, 100dvh);
   }
 
-  &:where([data-max-height-clamp-to-viewport][data-max-height-small]) {
+  &:where([data-max-height-small]) {
     max-height: min(256px, 100dvh);
   }
 
-  &:where([data-max-height-clamp-to-viewport][data-max-height-medium]) {
+  &:where([data-max-height-medium]) {
     max-height: min(320px, 100dvh);
   }
 
-  &:where([data-max-height-clamp-to-viewport][data-max-height-large]) {
+  &:where([data-max-height-large]) {
     max-height: min(432px, 100dvh);
   }
 
-  &:where([data-max-height-clamp-to-viewport][data-max-height-xlarge]) {
+  &:where([data-max-height-xlarge]) {
     max-height: min(600px, 100dvh);
   }
 

--- a/packages/react/src/ActionMenu/ActionMenu.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.tsx
@@ -330,8 +330,6 @@ const Overlay: FCWithSlotMarker<React.PropsWithChildren<MenuOverlayProps>> = ({
     }
   }, [anchorRef])
 
-  const featureFlagMaxHeightClampToViewport = useFeatureFlag('primer_react_overlay_max_height_clamp_to_viewport')
-
   const isInsideDialog = useContext(DialogContext) !== undefined
 
   return (
@@ -354,7 +352,6 @@ const Overlay: FCWithSlotMarker<React.PropsWithChildren<MenuOverlayProps>> = ({
         ref={containerRef}
         className={styles.ActionMenuContainer}
         data-variant={responsiveVariant}
-        {...(featureFlagMaxHeightClampToViewport ? {'data-max-height-clamp-to-viewport': ''} : {})}
         {...(overlayProps.overflow ? {[`data-overflow-${overlayProps.overflow}`]: ''} : {})}
         {...(overlayProps.maxHeight ? {[`data-max-height-${overlayProps.maxHeight}`]: ''} : {})}
       >

--- a/packages/react/src/ActionMenu/ActionMenu.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.tsx
@@ -18,7 +18,6 @@ import styles from './ActionMenu.module.css'
 import {useResponsiveValue, type ResponsiveValue} from '../hooks/useResponsiveValue'
 import {isSlot} from '../utils/is-slot'
 import type {FCWithSlotMarker, WithSlotMarker} from '../utils/types/Slots'
-import {useFeatureFlag} from '../FeatureFlags'
 import {DialogContext} from '../Dialog/Dialog'
 
 export type MenuCloseHandler = (

--- a/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
+++ b/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
@@ -7,5 +7,4 @@ export const DefaultFeatureFlags = FeatureFlagScope.create({
   primer_react_select_panel_order_selected_at_top: false,
   primer_react_select_panel_remove_active_descendant: false,
   primer_react_spinner_synchronize_animations: false,
-  primer_react_overlay_max_height_clamp_to_viewport: false,
 })

--- a/packages/react/src/Overlay/Overlay.module.css
+++ b/packages/react/src/Overlay/Overlay.module.css
@@ -102,23 +102,43 @@
   }
 
   &:where([data-max-height-xsmall]) {
-    max-height: min(192px, 100dvh);
+    max-height: min(192px, 100vh);
+
+    @supports (height: 100dvh) {
+      max-height: min(192px, 100dvh);
+    }
   }
 
   &:where([data-max-height-small]) {
-    max-height: min(256px, 100dvh);
+    max-height: min(256px, 100vh);
+
+    @supports (height: 100dvh) {
+      max-height: min(256px, 100dvh);
+    }
   }
 
   &:where([data-max-height-medium]) {
-    max-height: min(320px, 100dvh);
+    max-height: min(320px, 100vh);
+
+    @supports (height: 100dvh) {
+      max-height: min(320px, 100dvh);
+    }
   }
 
   &:where([data-max-height-large]) {
-    max-height: min(432px, 100dvh);
+    max-height: min(432px, 100vh);
+
+    @supports (height: 100dvh) {
+      max-height: min(432px, 100dvh);
+    }
   }
 
   &:where([data-max-height-xlarge]) {
-    max-height: min(600px, 100dvh);
+    max-height: min(600px, 100vh);
+
+    @supports (height: 100dvh) {
+      max-height: min(600px, 100dvh);
+    }
   }
 
   &:where([data-max-height-fit-content]) {

--- a/packages/react/src/Overlay/Overlay.module.css
+++ b/packages/react/src/Overlay/Overlay.module.css
@@ -102,43 +102,22 @@
   }
 
   &:where([data-max-height-xsmall]) {
-    max-height: 192px;
-  }
-
-  &:where([data-max-height-small]) {
-    max-height: 256px;
-  }
-
-  &:where([data-max-height-medium]) {
-    max-height: 320px;
-  }
-
-  &:where([data-max-height-large]) {
-    max-height: 432px;
-  }
-
-  &:where([data-max-height-xlarge]) {
-    max-height: 600px;
-  }
-
-  /* Max-height size tokens clamped to viewport (enabled via feature flag) */
-  &:where([data-max-height-clamp-to-viewport][data-max-height-xsmall]) {
     max-height: min(192px, 100dvh);
   }
 
-  &:where([data-max-height-clamp-to-viewport][data-max-height-small]) {
+  &:where([data-max-height-small]) {
     max-height: min(256px, 100dvh);
   }
 
-  &:where([data-max-height-clamp-to-viewport][data-max-height-medium]) {
+  &:where([data-max-height-medium]) {
     max-height: min(320px, 100dvh);
   }
 
-  &:where([data-max-height-clamp-to-viewport][data-max-height-large]) {
+  &:where([data-max-height-large]) {
     max-height: min(432px, 100dvh);
   }
 
-  &:where([data-max-height-clamp-to-viewport][data-max-height-xlarge]) {
+  &:where([data-max-height-xlarge]) {
     max-height: min(600px, 100dvh);
   }
 

--- a/packages/react/src/Overlay/Overlay.tsx
+++ b/packages/react/src/Overlay/Overlay.tsx
@@ -192,7 +192,6 @@ const Overlay = React.forwardRef<HTMLDivElement, internalOverlayProps>(
     forwardedRef,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): ReactElement<any> => {
-    const featureFlagMaxHeightClampToViewport = useFeatureFlag('primer_react_overlay_max_height_clamp_to_viewport')
     const overlayRef = useRef<HTMLDivElement>(null)
     const mergedRef = useMergedRefs(forwardedRef, overlayRef)
     const slideAnimationDistance = 8 // var(--base-size-8), hardcoded to do some math
@@ -245,7 +244,6 @@ const Overlay = React.forwardRef<HTMLDivElement, internalOverlayProps>(
         height={height}
         visibility={visibility}
         data-responsive={responsiveVariant}
-        {...(featureFlagMaxHeightClampToViewport ? {'data-max-height-clamp-to-viewport': ''} : {})}
         {...props}
       />
     )


### PR DESCRIPTION
This pull request removes the feature flag controlling the "max-height clamp to viewport" behavior for overlays and action menus, making the viewport-clamped max-height the default. Now, all overlays and action menus will have their max-height restricted to the viewport without needing a feature flag.

Max-height size token rules use `min(Xpx, 100vh)` as the default fallback for browsers that don't support dynamic viewport units, and progressively enhance to `min(Xpx, 100dvh)` via `@supports (height: 100dvh)` in supporting browsers.

### Changelog

#### New

#### Changed

- Max-height size token rules in `Overlay.module.css` and `ActionMenu.module.css` now use `min(Xpx, 100vh)` as a fallback, with `@supports (height: 100dvh)` overriding to `min(Xpx, 100dvh)` for browsers that support dynamic viewport units

#### Removed

- `primer_react_overlay_max_height_clamp_to_viewport` FF and associated code

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))