### PR TITLE
fix(TokenTextContainer): Update the line-height to use a primer primitives CSS variable

### DIFF
--- a/.changeset/small-comics-kick.md
+++ b/.changeset/small-comics-kick.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Update TokenTextContainer `line-height` to use primer primitives CSS variable `var(--base-text-lineHeight-normal)`

--- a/packages/react/src/Token/_TokenTextContainer.module.css
+++ b/packages/react/src/Token/_TokenTextContainer.module.css
@@ -5,8 +5,7 @@
   margin: 0;
   overflow: hidden;
   font: inherit;
-  /* stylelint-disable-next-line primer/typography */
-  line-height: normal;
+  line-height: var(--base-text-lineHeight-normal);
   color: inherit;
 
   /* reset anchor styles */


### PR DESCRIPTION
While looking at https://github.com/github/github-ui/pull/18258 I found that the TokenTextContainer was using `line-height: normal;` I think this might have been a bug when we converted the component from styled components. As the previous styled system `lineHeight: normal` would have converted to the "normal" value of the css variable.

I'm fixing by using the CSS variable `var(--base-text-lineHeight-normal)`;

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

Fixing TokenTextContainer line-height to use primer primitives

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

I'm not expecting this to make too much of a difference in prod, the bug I noticed was very subtle line height shift. Here's a gif toggling between the change:

![CleanShot 2026-04-10 at 09 34 53](https://github.com/user-attachments/assets/fcc80e46-3985-4613-920d-0763a25b8eac)

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
