### PR TITLE
SelectPanel: Lock body scroll when modal variant is open

### DIFF
--- a/.changeset/gold-humans-tap.md
+++ b/.changeset/gold-humans-tap.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+SelectPanel: Lock body scroll when modal variant is on.

--- a/packages/react/src/SelectPanel/SelectPanel.module.css
+++ b/packages/react/src/SelectPanel/SelectPanel.module.css
@@ -226,7 +226,7 @@
 }
 
 .Backdrop {
-  position: absolute;
+  position: fixed;
   inset: 0;
   background-color: var(--overlay-backdrop-bgColor);
 }

--- a/packages/react/src/SelectPanel/SelectPanel.test.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.test.tsx
@@ -1203,7 +1203,9 @@ for (const usingRemoveActiveDescendant of [false, true]) {
 
         await user.click(screen.getByText('Select items'))
 
-        expect(document.body.style.overflow).toBe('hidden')
+        await waitFor(() => {
+          expect(document.body.style.overflow).toBe('hidden')
+        })
       })
 
       it('restores body scroll when modal is closed', async () => {
@@ -1212,10 +1214,14 @@ for (const usingRemoveActiveDescendant of [false, true]) {
         renderWithProp(<BasicSelectPanel variant="modal" onCancel={() => {}} />, usingRemoveActiveDescendant)
 
         await user.click(screen.getByText('Select items'))
-        expect(document.body.style.overflow).toBe('hidden')
+        await waitFor(() => {
+          expect(document.body.style.overflow).toBe('hidden')
+        })
 
         await user.click(screen.getByRole('button', {name: 'Cancel'}))
-        expect(document.body.style.overflow).not.toBe('hidden')
+        await waitFor(() => {
+          expect(document.body.style.overflow).not.toBe('hidden')
+        })
       })
     })
 

--- a/packages/react/src/SelectPanel/SelectPanel.test.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.test.tsx
@@ -1193,6 +1193,30 @@ for (const usingRemoveActiveDescendant of [false, true]) {
         expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument()
         expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument()
       })
+
+      it('locks body scroll when modal is open', async () => {
+        const user = userEvent.setup()
+
+        renderWithProp(<BasicSelectPanel variant="modal" onCancel={() => {}} />, usingRemoveActiveDescendant)
+
+        expect(document.body.style.overflow).not.toBe('hidden')
+
+        await user.click(screen.getByText('Select items'))
+
+        expect(document.body.style.overflow).toBe('hidden')
+      })
+
+      it('restores body scroll when modal is closed', async () => {
+        const user = userEvent.setup()
+
+        renderWithProp(<BasicSelectPanel variant="modal" onCancel={() => {}} />, usingRemoveActiveDescendant)
+
+        await user.click(screen.getByText('Select items'))
+        expect(document.body.style.overflow).toBe('hidden')
+
+        await user.click(screen.getByRole('button', {name: 'Cancel'}))
+        expect(document.body.style.overflow).not.toBe('hidden')
+      })
     })
 
     describe('sorting', () => {

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -362,9 +362,9 @@ function Panel({
     [items, itemsInViewSet, onSelectedChange, selected],
   )
 
-  // disable body scroll when the panel is open on narrow screens
+  // disable body scroll when the panel is open in modal mode or on narrow screens
   useEffect(() => {
-    if (open && isNarrowScreenSize && usingFullScreenOnNarrow) {
+    if (open && (variant === 'modal' || (isNarrowScreenSize && usingFullScreenOnNarrow))) {
       const bodyOverflowStyle = document.body.style.overflow || ''
       // If the body is already set to overflow: hidden, it likely means
       // that there is already a modal open. In that case, we should bail
@@ -379,7 +379,7 @@ function Panel({
         document.body.style.overflow = bodyOverflowStyle
       }
     }
-  }, [isNarrowScreenSize, open, usingFullScreenOnNarrow])
+  }, [isNarrowScreenSize, open, usingFullScreenOnNarrow, variant])
 
   useEffect(() => {
     if (open) {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/6548

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog
 
SelectPanel with `variant="modal"` did not lock the body's scrollbar, allowing users to scroll behind both the dialog and backdrop. Now body scroll is now locked when `variant="modal"` is open.

  | Before | After |
  |--------|-------|
  |    <img width="1089" height="672" alt="Screenshot 2026-04-14 at 2 45 28 PM" src="https://github.com/user-attachments/assets/15e28497-913b-4c83-9a57-c1cf24ff6edb" />    |   <img width="1019" height="692" alt="Screenshot 2026-04-14 at 2 45 38 PM" src="https://github.com/user-attachments/assets/2efaf3dc-2068-47a4-b33f-2744c918ee73" />   |

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [X] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To publish a canary release for integration testing, apply the "Canary Release" label to this PR -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
