### PR TITLE
Mark useResponsiveValue as deprecated

### DIFF
--- a/.changeset/cold-lions-listen.md
+++ b/.changeset/cold-lions-listen.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Deprecate the `useResponsiveValue` hook.

--- a/.github/skills/deprecations/SKILL.md
+++ b/.github/skills/deprecations/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: deprecations
+description: 'Use when: deprecating Primer React components or hooks. Covers source annotations, docs metadata, changesets, docs page updates, and validation for deprecations.'
+---
+
+# Deprecating components and hooks in Primer React
+
+Use this skill when a task involves marking a public Primer React API as deprecated.
+
+## What to update
+
+### Source code
+
+- Add a JSDoc `@deprecated` annotation to the exported component, hook, prop, or type following existing patterns nearby.
+- Keep runtime behavior unchanged unless the task explicitly requires more than deprecation signaling.
+
+### Docs metadata
+
+- For components, mark the relevant `*.docs.json` file with `"status": "deprecated"`.
+- For hooks, mark the relevant `*.hookDocs.json` file with `"status": "deprecated"`.
+- If schema or build tooling does not yet support the docs metadata you need, update the corresponding schema/build files in `packages/react/script/*-json/`.
+
+### Documentation content
+
+- If the deprecated component has a docs page or JSON-backed docs content that supports deprecation guidance, add or update the deprecation guidance and recommended alternative.
+- Follow `contributor-docs/deprecating-components.md`.
+
+### Versioning
+
+- Add a changeset for public API deprecations.
+- Use the versioning guidance in `contributor-docs/versioning.md` to choose the correct bump.
+
+## Validation
+
+Prefer targeted validation first, then broader validation if needed:
+
+- Format changed files with `npx prettier --write <paths>`
+- Lint changed TypeScript files with `npx eslint --fix <paths>`
+- Rebuild generated docs metadata when related schema or docs JSON changes:
+
+```bash
+npm run build:hooks.json -w @primer/react
+```
+
+```bash
+npm run build:components.json -w @primer/react
+```
+
+- Run targeted tests for the affected API when available
+- Run broader repository validation before finalizing if the change touches shared build tooling
+
+## Common files
+
+- `packages/react/src/**/*.docs.json`
+- `packages/react/src/**/*.hookDocs.json`
+- `packages/react/script/components-json/*`
+- `packages/react/script/hooks-json/*`
+- `contributor-docs/deprecating-components.md`
+- `.changeset/*.md`

--- a/contributor-docs/deprecating-components.md
+++ b/contributor-docs/deprecating-components.md
@@ -11,7 +11,8 @@ When Primer maintainers are to deprecate a component, they will issue `@deprecat
 Issuing a `@deprecated` notice in a minor/patch release includes:
 
 - [ ] Adding a `@deprecated` annotation in the component's source code.
-- [ ] Adding a `Deprecation` section to the documentation of the component with the link of the recommended component and provide a diff. See [deprecated ActionList docs](https://primer.style/react/deprecated/ActionList#deprecation) as an example.
+- [ ] Marking the component or hook docs metadata as deprecated with `"status": "deprecated"` in the relevant `*.docs.json` or `*.hookDocs.json` file.
+- [ ] If the component has a docs page, adding a `Deprecation` section to the documentation with the link of the recommended component and provide a diff. See [deprecated ActionList docs](https://primer.style/react/deprecated/ActionList#deprecation) as an example.
 
 ## Developing a replacement component
 

--- a/packages/react/script/hooks-json/build.ts
+++ b/packages/react/script/hooks-json/build.ts
@@ -8,6 +8,7 @@ import Ajv from 'ajv'
 // Only includes fields we use in this script
 type Hook = {
   name: string
+  status?: 'deprecated'
   importPath: '@primer/react' | '@primer/react/experimental'
   stories: Array<{id: string}>
 }

--- a/packages/react/script/hooks-json/hook.schema.json
+++ b/packages/react/script/hooks-json/hook.schema.json
@@ -80,7 +80,7 @@
     },
     "status": {
       "type": "string",
-      "enum": ["deprecated"],
+      "enum": ["ready", "deprecated"],
       "description": "The status of the hook."
     },
     "importPath": {

--- a/packages/react/script/hooks-json/hook.schema.json
+++ b/packages/react/script/hooks-json/hook.schema.json
@@ -78,6 +78,11 @@
       "type": "string",
       "description": "The name of the hook."
     },
+    "status": {
+      "type": "string",
+      "enum": ["deprecated"],
+      "description": "The status of the hook."
+    },
     "importPath": {
       "type": "string",
       "description": "The path to import the hook from. i.e. '@primer/react/experimental'"

--- a/packages/react/src/hooks/useResponsiveValue.hookDocs.json
+++ b/packages/react/src/hooks/useResponsiveValue.hookDocs.json
@@ -1,5 +1,6 @@
 {
   "name": "useResponsiveValue",
+  "status": "deprecated",
   "importPath": "@primer/react",
   "stories": [],
   "parameters": [

--- a/packages/react/src/hooks/useResponsiveValue.ts
+++ b/packages/react/src/hooks/useResponsiveValue.ts
@@ -41,6 +41,8 @@ export function isResponsiveValue(value: any): value is ResponsiveValue<any> {
  * Resolves responsive values based on the current viewport width.
  * For example, if the current viewport width is narrow (less than 768px), the value of `{regular: 'foo', narrow: 'bar'}` will resolve to `'bar'`.
  *
+ * @deprecated Prefer responsive data attributes with `getResponsiveAttributes` and CSS media queries instead.
+ *
  * @example
  * const value = useResponsiveValue({regular: 'foo', narrow: 'bar'})
  * console.log(value) // 'bar'


### PR DESCRIPTION
[adr-018-responsive-values.md](https://github.com/primer/react/blob/bb18a24bd00281c43e9fd77b0e3bbff0fbe8de20/contributor-docs/adrs/adr-018-responsive-values.md) discourages the use of `useResponsiveValue` hook because it relies on matchMedia and needs to wait until client hydration to choose the right value.

> Authors can use a hook called useResponsiveValue to support resolving the value of a prop based on the current viewport size. The implementation of this hook uses [matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) which, unfortunately, has a downside: the value of a prop may shift when the component is server-side rendered. If the prop is used for styles or layout, then this will lead to a layout shift when the component hydrates and the viewport size is different than the fallback size on the server.

But, we still export this hook without any warnings. This came up in a [conversation on slack](https://github.slack.com/archives/C08FX205QG2/p1776100350655259).

Marking the hook as deprecated in the docs because we want people to use css media queries instead.




Bonus:
- Add a reusable `.github/skills/deprecations/SKILL.md` guide for deprecating components and hooks.
- Update `contributor-docs/deprecating-components.md` to document how deprecated status should be represented in component and hook docs metadata.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
