### PR TITLE
Defer focusZone initialization to avoid blocking paint

### DIFF
--- a/packages/react/src/TreeView/TreeView.test.tsx
+++ b/packages/react/src/TreeView/TreeView.test.tsx
@@ -14,7 +14,12 @@ function renderWithTheme(
   ui: Parameters<typeof render>[0],
   options?: Parameters<typeof render>[1],
 ): ReturnType<typeof render> {
-  return render(ui, options)
+  const result = render(ui, options)
+  // Flush deferred focus zone initialization (requestAnimationFrame)
+  act(() => {
+    vi.advanceTimersByTime(16)
+  })
+  return result
 }
 
 // Mock `scrollIntoView` because it's not implemented in JSDOM

--- a/packages/react/src/hooks/useFocusZone.ts
+++ b/packages/react/src/hooks/useFocusZone.ts
@@ -58,8 +58,15 @@ export function useFocusZone(
             ...settings,
             activeDescendantControl: activeDescendantControlRef.current ?? undefined,
           }
-          abortController.current = focusZone(containerRef.current, vanillaSettings)
+          const container = containerRef.current
+          const rafId = requestAnimationFrame(() => {
+            // Defer focus zone initialization to avoid blocking paint.
+            // Setting tabindex on focusable elements is invisible to the user,
+            // and keyboard navigation activating one frame later is imperceptible.
+            abortController.current = focusZone(container, vanillaSettings)
+          })
           return () => {
+            cancelAnimationFrame(rafId)
             abortController.current?.abort()
           }
         } else {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

<!-- Provide an overview of the changes, including before/after screenshots, videos, graphs when helpful -->

`focusZone()` synchronously walks the entire container DOM and sets `tabindex="-1"` on all focusable elements when it initializes. For a list with 25 rows (e.g. GitHub issues list), this takes ~18ms. The `tabindex` mutations also trigger a React re-render of the entire list (~48ms total blocked before paint).

This PR wraps the `beginFocusManagement()` call inside `useFocusZone` in `requestAnimationFrame` so it runs after the browser paints instead of blocking the initial render.

**Why this is safe:**
- Setting `tabindex` is invisible — it doesn't change anything the user can see
- Keyboard navigation activating one frame later (~16ms) is imperceptible since users can't press keys before they see the page
- The `AbortController` cleanup still works via `cancelAnimationFrame` + `abort()`

### Changelog

#### Changed

- `useFocusZone` now defers `focusZone()` initialization to a `requestAnimationFrame` callback to avoid blocking paint on large lists

#### New

#### Removed

### Rollout strategy

- [x] Patch release

### Testing & Reviewing

- TreeView tests updated to flush the deferred RAF via `vi.advanceTimersByTime(16)` after render (tests already use `vi.useFakeTimers`)
- ActionList and ActionBar tests pass without changes
- All 51 TreeView tests pass, all 15 ActionList tests pass

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui