### PR TITLE
ci: update turbo usage in ci to improve caching

### DIFF
--- a/.github/workflows/aat-reports.yml
+++ b/.github/workflows/aat-reports.yml
@@ -27,8 +27,10 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ github.job }}-shard-${{ matrix.shard }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-shard-${{ matrix.shard }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-
             ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/aat-reports.yml
+++ b/.github/workflows/aat-reports.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build storybook
-        run: npx turbo build:storybook
+        run: npx turbo run build:storybook
       - name: Run storybook
         id: storybook
         working-directory: packages/react

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,11 +174,8 @@ jobs:
             ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
-      - name: Build doc-gen
-        run: npm run build --workspace @primer/doc-gen
       - name: Build storybook to generate story IDs
-        run: npm run build:storybook
-        working-directory: packages/react
+        run: npx turbo run build:storybook --filter=@primer/react
       - name: Build components.json
         run: npx tsx script/components-json/build.ts --storybook-data 'storybook-static/index.json'
         working-directory: packages/react

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Lint markdown
         run: npm run lint:md
       - name: Lint npm packages
-        run: npx turbo lint:npm
+        run: npx turbo run lint:npm
       - name: Check className test coverage
         run: npm run test:classname-coverage
 
@@ -71,8 +71,10 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-
             ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
@@ -104,8 +106,10 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-
             ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
@@ -136,15 +140,17 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-
             ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
       - if: ${{ matrix.react-version == 'react-19' }}
         run: node script/setup-react-19.mts
       - name: Build
-        run: npx turbo build
+        run: npx turbo run build
         continue-on-error: ${{ matrix.react-version == 'react-19' }}
 
   build-components-json:
@@ -161,8 +167,10 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ github.job }}-default-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-default-
+            ${{ runner.os }}-turbo-${{ github.job }}-
             ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
@@ -192,8 +200,10 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ github.job }}-default-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-default-
+            ${{ runner.os }}-turbo-${{ github.job }}-
             ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/vrt-reports.yml
+++ b/.github/workflows/vrt-reports.yml
@@ -27,8 +27,10 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ github.job }}-shard-${{ matrix.shard }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-shard-${{ matrix.shard }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-
             ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/vrt-reports.yml
+++ b/.github/workflows/vrt-reports.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build storybook
-        run: npx turbo build:storybook
+        run: npx turbo run build:storybook
       - name: Run storybook
         id: storybook
         working-directory: packages/react

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build storybook
-        run: npx turbo build:storybook
+        run: npx turbo run build:storybook
       - name: Run storybook
         id: storybook
         run: |

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -39,6 +39,15 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+      - name: Set up turbo cache
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.job }}-shard-${{ matrix.shard }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-shard-${{ matrix.shard }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-
+            ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
       - name: Build storybook

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "38.20.0",
+        "@primer/react": "38.21.0",
         "@primer/styled-react": "1.0.6",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
@@ -95,7 +95,7 @@
       "name": "example-nextjs",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "38.20.0",
+        "@primer/react": "38.21.0",
         "@primer/styled-react": "1.0.6",
         "next": "^16.1.7",
         "react": "^19.2.0",
@@ -138,7 +138,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.21.0",
-        "@primer/react": "38.20.0",
+        "@primer/react": "38.21.0",
         "@primer/styled-react": "1.0.6",
         "clsx": "^2.1.1",
         "next": "^16.1.7",
@@ -27628,7 +27628,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "38.20.0",
+      "version": "38.21.0",
       "license": "MIT",
       "dependencies": {
         "@github/mini-throttle": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "setup": "./script/setup",
-    "build": "turbo build --filter='!./examples/*'",
+    "build": "turbo run build --filter='!./examples/*'",
     "clean": "npm run clean --workspaces --if-present",
     "clean:all": "npm run clean && rimraf node_modules packages/*/node_modules examples/*/node_modules",
     "format": "prettier --cache --write '**/*.{js,css,md,mdx,ts,tsx,yml}'",
@@ -31,7 +31,7 @@
     "test:type-check": "tsc --noEmit",
     "test:update": "npm run test -- -u",
     "test:classname-coverage": "node script/check-classname-tests.mjs",
-    "type-check": "tsc --noEmit && turbo type-check",
+    "type-check": "tsc --noEmit && turbo run type-check",
     "release": "npm run build && changeset publish",
     "reset": "script/reset",
     "size": "size-limit"


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Update our turbo setup in CI to improve caching. At the moment, it seems like we run into this issue with our cache keys:

```
Failed to save: Unable to reserve cache with key Linux-turbo-58ba822d6361e4ea17c917d3b7cbfb03b6c11b6a, another job may be creating this cache.
```

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

This change updates our cache keys so that they save while allowing them to still restore from less specific cache keys

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Update cache keys in CI
- Update from `turbo` to `turbo run` following their recommendation for tasks

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to our internal CI
