### PR TITLE
chore: forward @primer/react theming from @primer/styled-react under FF

### DIFF
--- a/.changeset/fuzzy-kangaroos-cover.md
+++ b/.changeset/fuzzy-kangaroos-cover.md
@@ -1,6 +1,5 @@
 ---
 "@primer/react": patch
-"@primer/styled-react": patch
 ---
 
-chore: forward @primer/react theming from @primer/styled-react under FF
+chore: add `primer_react_css_modules_theming` feature flag to DefaultFeatureFlags

--- a/.changeset/fuzzy-kangaroos-cover.md
+++ b/.changeset/fuzzy-kangaroos-cover.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+chore: forward @primer/react theming from @primer/styled-react under FF

--- a/.changeset/fuzzy-kangaroos-cover.md
+++ b/.changeset/fuzzy-kangaroos-cover.md
@@ -1,5 +1,6 @@
 ---
 "@primer/react": patch
+"@primer/styled-react": patch
 ---
 
 chore: forward @primer/react theming from @primer/styled-react under FF

--- a/.changeset/fuzzy-kangaroos-cover.md
+++ b/.changeset/fuzzy-kangaroos-cover.md
@@ -2,4 +2,4 @@
 "@primer/react": patch
 ---
 
-chore: add `primer_react_css_modules_theming` feature flag to DefaultFeatureFlags
+chore: add `primer_react_styled_react_use_primer_theme_providers` feature flag to DefaultFeatureFlags

--- a/.changeset/styled-react-forward-theming.md
+++ b/.changeset/styled-react-forward-theming.md
@@ -1,0 +1,5 @@
+---
+"@primer/styled-react": patch
+---
+
+chore: forward @primer/react theming from @primer/styled-react under feature flag

--- a/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
+++ b/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
@@ -4,4 +4,5 @@ export const DefaultFeatureFlags = FeatureFlagScope.create({
   primer_react_css_anchor_positioning: false,
   primer_react_select_panel_fullscreen_on_narrow: false,
   primer_react_select_panel_order_selected_at_top: false,
+  primer_react_styled_react_use_primer_theme_providers: false,
 })

--- a/packages/styled-react/src/__tests__/FeatureFlaggedTheming.browser.test.tsx
+++ b/packages/styled-react/src/__tests__/FeatureFlaggedTheming.browser.test.tsx
@@ -1,0 +1,127 @@
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+import React from 'react'
+import {ThemeProvider, useTheme, BaseStyles} from '../'
+import {FeatureFlags} from '@primer/react/experimental'
+
+// window.matchMedia() is not implemented by JSDOM so we have to create a mock:
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
+describe('FeatureFlaggedTheming', () => {
+  describe('when primer_react_styled_react_use_primer_theme_providers is disabled', () => {
+    it('ThemeProvider does not render a wrapper div with data-color-mode', () => {
+      render(
+        <FeatureFlags flags={{primer_react_styled_react_use_primer_theme_providers: false}}>
+          <ThemeProvider>
+            <div data-testid="child">Hello</div>
+          </ThemeProvider>
+        </FeatureFlags>,
+      )
+
+      // The styled ThemeProvider uses styled-components SCThemeProvider which
+      // does not inject a wrapper div. The child should not have a parent with data-color-mode.
+      const child = screen.getByTestId('child')
+      expect(child.parentElement).not.toHaveAttribute('data-color-mode')
+    })
+
+    it('useTheme returns styled theme context values', () => {
+      function ThemeConsumer() {
+        const theme = useTheme()
+        return <div data-testid="theme-consumer">{theme.colorMode ?? 'day'}</div>
+      }
+
+      render(
+        <FeatureFlags flags={{primer_react_styled_react_use_primer_theme_providers: false}}>
+          <ThemeProvider colorMode="night">
+            <ThemeConsumer />
+          </ThemeProvider>
+        </FeatureFlags>,
+      )
+
+      expect(screen.getByTestId('theme-consumer')).toHaveTextContent('night')
+    })
+
+    it('BaseStyles renders with data-color-mode and without data-component', () => {
+      render(
+        <FeatureFlags flags={{primer_react_styled_react_use_primer_theme_providers: false}}>
+          <ThemeProvider>
+            <BaseStyles data-testid="base-styles">
+              <div>Hello</div>
+            </BaseStyles>
+          </ThemeProvider>
+        </FeatureFlags>,
+      )
+
+      const baseStyles = screen.getByTestId('base-styles')
+      expect(baseStyles).toHaveAttribute('data-color-mode')
+      expect(baseStyles).toHaveAttribute('data-light-theme')
+      expect(baseStyles).toHaveAttribute('data-dark-theme')
+      expect(baseStyles).not.toHaveAttribute('data-component')
+    })
+  })
+
+  describe('when primer_react_styled_react_use_primer_theme_providers is enabled', () => {
+    it('ThemeProvider renders a wrapper div with data-color-mode', () => {
+      render(
+        <FeatureFlags flags={{primer_react_styled_react_use_primer_theme_providers: true}}>
+          <ThemeProvider>
+            <div data-testid="child">Hello</div>
+          </ThemeProvider>
+        </FeatureFlags>,
+      )
+
+      // The @primer/react ThemeProvider renders a <div> with data-color-mode
+      const child = screen.getByTestId('child')
+      expect(child.parentElement).toHaveAttribute('data-color-mode')
+      expect(child.parentElement).toHaveAttribute('data-light-theme')
+      expect(child.parentElement).toHaveAttribute('data-dark-theme')
+    })
+
+    it('useTheme returns primer theme context values', () => {
+      function ThemeConsumer() {
+        const theme = useTheme()
+        return <div data-testid="theme-consumer">{theme.colorMode ?? 'day'}</div>
+      }
+
+      render(
+        <FeatureFlags flags={{primer_react_styled_react_use_primer_theme_providers: true}}>
+          <ThemeProvider colorMode="night">
+            <ThemeConsumer />
+          </ThemeProvider>
+        </FeatureFlags>,
+      )
+
+      expect(screen.getByTestId('theme-consumer')).toHaveTextContent('night')
+    })
+
+    it('BaseStyles renders with data-component and without data-color-mode', () => {
+      render(
+        <FeatureFlags flags={{primer_react_styled_react_use_primer_theme_providers: true}}>
+          <ThemeProvider>
+            <BaseStyles data-testid="base-styles">
+              <div>Hello</div>
+            </BaseStyles>
+          </ThemeProvider>
+        </FeatureFlags>,
+      )
+
+      const baseStyles = screen.getByTestId('base-styles')
+      expect(baseStyles).toHaveAttribute('data-component', 'BaseStyles')
+      expect(baseStyles).not.toHaveAttribute('data-color-mode')
+      expect(baseStyles).not.toHaveAttribute('data-light-theme')
+      expect(baseStyles).not.toHaveAttribute('data-dark-theme')
+    })
+  })
+})

--- a/packages/styled-react/src/components/FeatureFlaggedTheming.tsx
+++ b/packages/styled-react/src/components/FeatureFlaggedTheming.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import {
+  ThemeProvider as PrimerThemeProvider,
+  useTheme as primerUseTheme,
+  BaseStyles as PrimerBaseStyles,
+} from '@primer/react'
+import type {
+  ThemeProviderProps as PrimerThemeProviderProps,
+  BaseStylesProps as PrimerBaseStylesProps,
+} from '@primer/react'
+import {useFeatureFlag} from '@primer/react/experimental'
+import {ThemeProvider as StyledThemeProvider, useTheme as styledUseTheme, useColorSchemeVar} from './ThemeProvider'
+import type {ThemeProviderProps as StyledThemeProviderProps} from './ThemeProvider'
+import {BaseStyles as StyledBaseStyles} from './BaseStyles'
+import type {BaseStylesProps as StyledBaseStylesProps} from './BaseStyles'
+
+export type ThemeProviderProps = StyledThemeProviderProps
+
+export type BaseStylesProps = StyledBaseStylesProps
+
+export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>> = ({children, ...props}) => {
+  const enabled = useFeatureFlag('primer_react_styled_react_use_primer_theme_providers')
+  if (enabled) {
+    return <PrimerThemeProvider {...(props as PrimerThemeProviderProps)}>{children}</PrimerThemeProvider>
+  }
+  return <StyledThemeProvider {...props}>{children}</StyledThemeProvider>
+}
+
+export function useTheme() {
+  const enabled = useFeatureFlag('primer_react_styled_react_use_primer_theme_providers')
+  const styledTheme = styledUseTheme()
+  const primerTheme = primerUseTheme()
+  if (enabled) {
+    return primerTheme
+  }
+  return styledTheme
+}
+
+export {useColorSchemeVar}
+
+export function BaseStyles(props: BaseStylesProps) {
+  const enabled = useFeatureFlag('primer_react_styled_react_use_primer_theme_providers')
+  if (enabled) {
+    return <PrimerBaseStyles {...(props as PrimerBaseStylesProps)} />
+  }
+  return <StyledBaseStyles {...props} />
+}

--- a/packages/styled-react/src/components/FeatureFlaggedTheming.tsx
+++ b/packages/styled-react/src/components/FeatureFlaggedTheming.tsx
@@ -26,12 +26,12 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>
   return <StyledThemeProvider {...props}>{children}</StyledThemeProvider>
 }
 
-export function useTheme() {
+export function useTheme(): ReturnType<typeof styledUseTheme> {
   const enabled = useFeatureFlag('primer_react_styled_react_use_primer_theme_providers')
   const styledTheme = styledUseTheme()
   const primerTheme = primerUseTheme()
   if (enabled) {
-    return primerTheme
+    return primerTheme as ReturnType<typeof styledUseTheme>
   }
   return styledTheme
 }

--- a/packages/styled-react/src/components/FeatureFlaggedTheming.tsx
+++ b/packages/styled-react/src/components/FeatureFlaggedTheming.tsx
@@ -26,12 +26,12 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>
   return <StyledThemeProvider {...props}>{children}</StyledThemeProvider>
 }
 
-export function useTheme(): ReturnType<typeof styledUseTheme> {
+export function useTheme(): ReturnType<typeof primerUseTheme> {
   const enabled = useFeatureFlag('primer_react_styled_react_use_primer_theme_providers')
   const styledTheme = styledUseTheme()
   const primerTheme = primerUseTheme()
   if (enabled) {
-    return primerTheme as ReturnType<typeof styledUseTheme>
+    return primerTheme as ReturnType<typeof primerUseTheme>
   }
   return styledTheme
 }

--- a/packages/styled-react/src/components/FeatureFlaggedTheming.tsx
+++ b/packages/styled-react/src/components/FeatureFlaggedTheming.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type React from 'react'
 import {
   ThemeProvider as PrimerThemeProvider,
   useTheme as primerUseTheme,

--- a/packages/styled-react/src/index.tsx
+++ b/packages/styled-react/src/index.tsx
@@ -39,7 +39,7 @@ export {
    * `@primer/primitives` and CSS Modules instead.
    */
   type ThemeProviderProps,
-} from './components/ThemeProvider'
+} from './components/FeatureFlaggedTheming'
 
 export {
   /**
@@ -53,7 +53,7 @@ export {
    * supported. Use the component from `@primer/react` with CSS Modules instead.
    */
   type BaseStylesProps,
-} from './components/BaseStyles'
+} from './components/FeatureFlaggedTheming'
 
 export {
   /**


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Relates to https://github.com/github/primer/issues/6635

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->
* Added a new feature flag, `primer_react_styled_react_use_primer_theme_providers`, to `DefaultFeatureFlags`, enabling toggling between Primer's and styled-components' theming providers.
* Implemented `FeatureFlaggedTheming.tsx`, which exports `ThemeProvider`, `useTheme`, `BaseStyles`, and `useColorSchemeVar` components/functions that switch behavior based on the feature flag's state.
* Updated `index.tsx` to re-export theming types and components from `FeatureFlaggedTheming` instead of the previous locations, centralizing the feature-flagged logic. 


### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To publish a canary release for integration testing, apply the "Canary Release" label to this PR -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
