### PR TITLE
[CSS Anchor Positioning] Disable feature flag if `portalContainerName` is true

### DIFF
--- a/.changeset/evil-coins-tease.md
+++ b/.changeset/evil-coins-tease.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+AnchoredOverlay: Disables CSS anchor positioning if `portalContainerName` is true. (behind `primer_react_css_anchor_positioning` feature flag)

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
@@ -175,7 +175,7 @@ describe.each([true, false])(
       expect(mockCloseCallback).toHaveBeenCalledWith('escape')
     })
 
-    it('should call onPositionChange when provided', async () => {
+    it.skipIf(withCSSAnchorPositioningFeatureFlag)('should call onPositionChange when provided', async () => {
       const mockPositionChangeCallback = vi.fn(({position}: {position: AnchorPosition}) => position)
       render(
         <AnchoredOverlayTestComponent

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
@@ -8,6 +8,7 @@ import BaseStyles from '../BaseStyles'
 import type {AnchorPosition} from '@primer/behaviors'
 import {implementsClassName} from '../utils/testing'
 import {FeatureFlags} from '../FeatureFlags'
+import {registerPortalRoot} from '../Portal'
 
 import overlayClasses from '../Overlay/Overlay.module.css'
 import anchoredOverlayClasses from './AnchoredOverlay.module.css'
@@ -174,9 +175,7 @@ describe.each([true, false])(
       expect(mockCloseCallback).toHaveBeenCalledWith('escape')
     })
 
-    // onPositionChange is not supported when the CSS anchor positioning flag is enabled,
-    // because positioning is handled by the browser rather than `useAnchoredPosition`.
-    it.skipIf(withCSSAnchorPositioningFeatureFlag)('should call onPositionChange when provided', async () => {
+    it('should call onPositionChange when provided', async () => {
       const mockPositionChangeCallback = vi.fn(({position}: {position: AnchorPosition}) => position)
       render(
         <AnchoredOverlayTestComponent
@@ -353,6 +352,67 @@ describe('AnchoredOverlay feature flag specific behavior', () => {
 
       const overlay = baseElement.querySelector('[data-component="AnchoredOverlay"]')
       expect(overlay).not.toHaveAttribute('popover')
+    })
+
+    describe('when overlayProps.portalContainerName is provided', () => {
+      it('should fall back to JS positioning (data-anchor-position="false") even with the flag enabled', () => {
+        const portalRoot = document.createElement('div')
+        document.body.appendChild(portalRoot)
+        registerPortalRoot(portalRoot, 'anchoredOverlayTestPortal')
+
+        const {baseElement} = render(
+          <FeatureFlags flags={{primer_react_css_anchor_positioning: true}}>
+            <BaseStyles>
+              <AnchoredOverlay
+                open={true}
+                onOpen={() => {}}
+                onClose={() => {}}
+                renderAnchor={props => <Button {...props}>Anchor Button</Button>}
+                overlayProps={{portalContainerName: 'anchoredOverlayTestPortal'}}
+              >
+                <button type="button">Focusable Child</button>
+              </AnchoredOverlay>
+            </BaseStyles>
+          </FeatureFlags>,
+        )
+
+        const overlay = baseElement.querySelector('[data-component="AnchoredOverlay"]')
+        expect(overlay).toHaveAttribute('data-anchor-position', 'false')
+        expect(overlay).not.toHaveClass(anchoredOverlayClasses.AnchoredOverlay)
+
+        portalRoot.remove()
+      })
+
+      it('should not opt into the Popover API even when renderAs="popover"', () => {
+        const portalRoot = document.createElement('div')
+        document.body.appendChild(portalRoot)
+        registerPortalRoot(portalRoot, 'anchoredOverlayTestPortalPopover')
+
+        const {baseElement} = render(
+          <FeatureFlags flags={{primer_react_css_anchor_positioning: true}}>
+            <BaseStyles>
+              <AnchoredOverlay
+                open={true}
+                onOpen={() => {}}
+                onClose={() => {}}
+                renderAnchor={props => <Button {...props}>Anchor Button</Button>}
+                renderAs="popover"
+                overlayProps={{portalContainerName: 'anchoredOverlayTestPortalPopover'}}
+              >
+                <button type="button">Focusable Child</button>
+              </AnchoredOverlay>
+            </BaseStyles>
+          </FeatureFlags>,
+        )
+
+        const overlay = baseElement.querySelector('[data-component="AnchoredOverlay"]')
+        expect(overlay).not.toHaveAttribute('popover')
+
+        const anchor = baseElement.querySelector('[aria-haspopup="true"]')
+        expect(anchor).not.toHaveAttribute('popovertarget')
+
+        portalRoot.remove()
+      })
     })
   })
 

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -175,7 +175,8 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
     () => typeof document !== 'undefined' && 'anchorName' in document.documentElement.style,
   )
 
-  const cssAnchorPositioning = cssAnchorPositioningFlag && supportsNativeCSSAnchorPositioning
+  const cssAnchorPositioning =
+    cssAnchorPositioningFlag && supportsNativeCSSAnchorPositioning && !overlayProps?.portalContainerName
   // Only use Popover API when both CSS anchor positioning is enabled AND renderAs is true
   const shouldRenderAsPopover = cssAnchorPositioning && renderAs === 'popover'
   const anchorRef = useProvidedRefOrCreate(externalAnchorRef)


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/6648

Disables `primer_react_css_anchor_positioning` if `portalContainerName` is true.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

* Disables `primer_react_css_anchor_positioning` if `portalContainerName` is present.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To publish a canary release for integration testing, apply the "Canary Release" label to this PR -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
