### PR TITLE
fix(rollup-plugin-import-css): register CSS files with rollup watcher

### DIFF
--- a/packages/rollup-plugin-import-css/src/index.ts
+++ b/packages/rollup-plugin-import-css/src/index.ts
@@ -64,6 +64,7 @@ export function importCSS(options: ImportCSSOptions): Plugin {
       }
 
       const sourceId = path.join(path.dirname(id), path.basename(id, '.js'))
+      this.addWatchFile(sourceId)
       const code = await fs.readFile(sourceId, 'utf8')
       const hash = getSourceHash(code)
       const relativePath = path.relative(rootDirectory, sourceId)


### PR DESCRIPTION
### Overview

Primer's internal `rollup-plugin-import-css` plugin reads CSS files via `fs.readFile` in its `transform` hook but never calls `this.addWatchFile()` to register them with rollup's file watcher. CSS-only edits are invisible in watch mode, while TSX/TS changes trigger rebuilds fine.

One-line fix: add `this.addWatchFile(sourceId)` before reading the file. Verified end-to-end in a github-ui Codespace — CSS changes now trigger rollup rebuilds and propagate through to github-ui's node_modules.

This primarily affects the primerize workflow in github-ui, where developers editing Primer CSS modules in watch mode see no rebuild until they also touch the importing TSX file.

### Rollout strategy

- [x] None — `rollup-plugin-import-css` is a private workspace package, not published to npm. No consumer-facing change.

### Changeset skipped

The affected package is private and internal (`"private": true`, version `0.0.0`). Nothing published, no version bump needed.