### PR TITLE
Fix `usePaneWidth` triggering unnecessary React re-renders on every window resize

### DIFF
--- a/.changeset/silent-taxis-eat.md
+++ b/.changeset/silent-taxis-eat.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Fix `usePaneWidth` triggering unnecessary React re-renders on every window resize

--- a/packages/react/src/PageLayout/PageLayout.performance.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.performance.stories.tsx
@@ -543,7 +543,7 @@ export const KeyboardARIATest: Story = {
 // ============================================================================
 
 export const ResizablePaneReRenderCounter: Story = {
-  name: 'Re-render Counter (Issue #7801)',
+  name: 'Re-render Counter',
   render: () => {
     return (
       <SplitPageLayout>

--- a/packages/react/src/PageLayout/PageLayout.performance.stories.tsx
+++ b/packages/react/src/PageLayout/PageLayout.performance.stories.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react'
 import type {Meta, StoryObj} from '@storybook/react-vite'
 import {PageLayout} from './PageLayout'
+import {SplitPageLayout} from '../SplitPageLayout'
 import {Button} from '../Button'
 import Label from '../Label'
 import Heading from '../Heading'
@@ -532,6 +533,50 @@ export const KeyboardARIATest: Story = {
           </div>
         </PageLayout.Content>
       </PageLayout>
+    )
+  },
+}
+
+// ============================================================================
+// Story: Re-render test — reproduces unnecessary re-renders from usePaneWidth
+// https://github.com/primer/react/issues/7801
+// ============================================================================
+
+export const ResizablePaneReRenderCounter: Story = {
+  name: 'Re-render Counter (Issue #7801)',
+  render: () => {
+    return (
+      <SplitPageLayout>
+        <SplitPageLayout.Header>
+          <div style={{padding: '16px'}}>
+            <Heading as="h2">Re-render Test — Issue #7801</Heading>
+            <p style={{marginTop: '8px', fontSize: '14px', color: 'var(--fgColor-muted)'}}>
+              Open React DevTools Profiler, enable &quot;Highlight updates when components render&quot;, then resize the
+              browser window. Before the fix, all components re-render on every resize tick even when the computed max
+              width hasn&apos;t changed. After the fix, renders only happen when crossing the 1280px breakpoint or when
+              current width is clamped.
+            </p>
+          </div>
+        </SplitPageLayout.Header>
+
+        <SplitPageLayout.Pane position="start" resizable aria-label="Side pane">
+          <div style={{padding: '16px'}}>
+            <p>This pane is resizable. Try resizing the browser window.</p>
+          </div>
+        </SplitPageLayout.Pane>
+
+        <SplitPageLayout.Content>
+          <div style={{padding: '16px'}}>
+            <p>Content area — should not re-render on resize unless max width changes.</p>
+          </div>
+        </SplitPageLayout.Content>
+
+        <SplitPageLayout.Footer>
+          <div style={{padding: '16px'}}>
+            <p>Footer area.</p>
+          </div>
+        </SplitPageLayout.Footer>
+      </SplitPageLayout>
     )
   },
 }

--- a/packages/react/src/PageLayout/usePaneWidth.test.ts
+++ b/packages/react/src/PageLayout/usePaneWidth.test.ts
@@ -20,10 +20,12 @@ const {startTransitionSpy} = vi.hoisted(() => ({
   startTransitionSpy: vi.fn(),
 }))
 vi.mock('react', async importOriginal => {
-  const actual = await importOriginal<typeof import('react')>()
+  const actual = (await importOriginal()) as Record<string, unknown> & {
+    startTransition: (...args: [callback: () => void]) => void
+  }
   return {
     ...actual,
-    startTransition: (...args: Parameters<typeof actual.startTransition>) => {
+    startTransition: (...args: [callback: () => void]) => {
       startTransitionSpy(...args)
       return actual.startTransition(...args)
     },

--- a/packages/react/src/PageLayout/usePaneWidth.test.ts
+++ b/packages/react/src/PageLayout/usePaneWidth.test.ts
@@ -853,7 +853,7 @@ describe('usePaneWidth', () => {
       vi.useRealTimers()
     })
 
-    it('should skip startTransition when maxPaneWidth has not changed (#7801)', async () => {
+    it('should skip startTransition when maxPaneWidth has not changed', async () => {
       vi.useFakeTimers()
       // Start at 1000px — below the 1280 breakpoint, so diff = 511
       vi.stubGlobal('innerWidth', 1000)

--- a/packages/react/src/PageLayout/usePaneWidth.test.ts
+++ b/packages/react/src/PageLayout/usePaneWidth.test.ts
@@ -881,16 +881,36 @@ describe('usePaneWidth', () => {
       })
       expect(result.current.maxPaneWidth).toBe(389)
 
-      // Now resize again to a different width that produces the SAME max
-      // 900px -> 900px (no actual viewport change, same max = 389)
-      const renderCountBefore = result.current.maxPaneWidth
+      // Track render count to verify no unnecessary re-renders
+      let renderCount = 0
+      renderHook(() => {
+        renderCount++
+        return usePaneWidth({
+          width: 'medium',
+          minWidth: 256,
+          resizable: true,
+          widthStorageKey: 'test-skip-transition-counter',
+          ...createMockRefs(),
+        })
+      })
+      const renderCountAfterMount = renderCount
+
+      // Dispatch resize without changing viewport (same max = same value)
       window.dispatchEvent(new Event('resize'))
       await act(async () => {
         await vi.runAllTimersAsync()
       })
 
-      // maxPaneWidth should be unchanged — no re-render triggered
-      expect(result.current.maxPaneWidth).toBe(renderCountBefore)
+      // No additional renders should have occurred — startTransition was skipped
+      expect(renderCount).toBe(renderCountAfterMount)
+
+      // Also verify the original hook's value is unchanged
+      const previousMaxPaneWidth = result.current.maxPaneWidth
+      window.dispatchEvent(new Event('resize'))
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+      expect(result.current.maxPaneWidth).toBe(previousMaxPaneWidth)
 
       vi.useRealTimers()
     })

--- a/packages/react/src/PageLayout/usePaneWidth.test.ts
+++ b/packages/react/src/PageLayout/usePaneWidth.test.ts
@@ -14,6 +14,22 @@ import {
   ARROW_KEY_STEP,
 } from './usePaneWidth'
 
+// Spy on React.startTransition to verify it's not called unnecessarily on resize.
+// The spy calls through to the real implementation so all other tests are unaffected.
+const {startTransitionSpy} = vi.hoisted(() => ({
+  startTransitionSpy: vi.fn(),
+}))
+vi.mock('react', async importOriginal => {
+  const actual = await importOriginal<typeof import('react')>()
+  return {
+    ...actual,
+    startTransition: (...args: Parameters<typeof actual.startTransition>) => {
+      startTransitionSpy(...args)
+      return actual.startTransition(...args)
+    },
+  }
+})
+
 // Mock refs for hook testing
 const createMockRefs = () => ({
   paneRef: {current: document.createElement('div')} as React.RefObject<HTMLDivElement>,
@@ -855,11 +871,10 @@ describe('usePaneWidth', () => {
 
     it('should skip startTransition when maxPaneWidth has not changed', async () => {
       vi.useFakeTimers()
-      // Start at 1000px — below the 1280 breakpoint, so diff = 511
-      vi.stubGlobal('innerWidth', 1000)
+      vi.stubGlobal('innerWidth', 900)
       const refs = createMockRefs()
 
-      const {result} = renderHook(() =>
+      renderHook(() =>
         usePaneWidth({
           width: 'medium',
           minWidth: 256,
@@ -869,31 +884,8 @@ describe('usePaneWidth', () => {
         }),
       )
 
-      // Initial max: 1000 - 511 = 489
-      expect(result.current.maxPaneWidth).toBe(489)
-
-      // Resize to 900px — still below 1280 breakpoint, diff stays 511
-      // New max would be 900 - 511 = 389, which IS different, so state updates
-      vi.stubGlobal('innerWidth', 900)
-      window.dispatchEvent(new Event('resize'))
-      await act(async () => {
-        await vi.runAllTimersAsync()
-      })
-      expect(result.current.maxPaneWidth).toBe(389)
-
-      // Track render count to verify no unnecessary re-renders
-      let renderCount = 0
-      renderHook(() => {
-        renderCount++
-        return usePaneWidth({
-          width: 'medium',
-          minWidth: 256,
-          resizable: true,
-          widthStorageKey: 'test-skip-transition-counter',
-          ...createMockRefs(),
-        })
-      })
-      const renderCountAfterMount = renderCount
+      // Clear any startTransition calls from mount / initial render
+      startTransitionSpy.mockClear()
 
       // Dispatch resize without changing viewport (same max = same value)
       window.dispatchEvent(new Event('resize'))
@@ -901,16 +893,8 @@ describe('usePaneWidth', () => {
         await vi.runAllTimersAsync()
       })
 
-      // No additional renders should have occurred — startTransition was skipped
-      expect(renderCount).toBe(renderCountAfterMount)
-
-      // Also verify the original hook's value is unchanged
-      const previousMaxPaneWidth = result.current.maxPaneWidth
-      window.dispatchEvent(new Event('resize'))
-      await act(async () => {
-        await vi.runAllTimersAsync()
-      })
-      expect(result.current.maxPaneWidth).toBe(previousMaxPaneWidth)
+      // startTransition should NOT have been called — the guard should prevent it
+      expect(startTransitionSpy).not.toHaveBeenCalled()
 
       vi.useRealTimers()
     })

--- a/packages/react/src/PageLayout/usePaneWidth.test.ts
+++ b/packages/react/src/PageLayout/usePaneWidth.test.ts
@@ -853,6 +853,48 @@ describe('usePaneWidth', () => {
       vi.useRealTimers()
     })
 
+    it('should skip startTransition when maxPaneWidth has not changed (#7801)', async () => {
+      vi.useFakeTimers()
+      // Start at 1000px — below the 1280 breakpoint, so diff = 511
+      vi.stubGlobal('innerWidth', 1000)
+      const refs = createMockRefs()
+
+      const {result} = renderHook(() =>
+        usePaneWidth({
+          width: 'medium',
+          minWidth: 256,
+          resizable: true,
+          widthStorageKey: 'test-skip-transition',
+          ...refs,
+        }),
+      )
+
+      // Initial max: 1000 - 511 = 489
+      expect(result.current.maxPaneWidth).toBe(489)
+
+      // Resize to 900px — still below 1280 breakpoint, diff stays 511
+      // New max would be 900 - 511 = 389, which IS different, so state updates
+      vi.stubGlobal('innerWidth', 900)
+      window.dispatchEvent(new Event('resize'))
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+      expect(result.current.maxPaneWidth).toBe(389)
+
+      // Now resize again to a different width that produces the SAME max
+      // 900px -> 900px (no actual viewport change, same max = 389)
+      const renderCountBefore = result.current.maxPaneWidth
+      window.dispatchEvent(new Event('resize'))
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+
+      // maxPaneWidth should be unchanged — no re-render triggered
+      expect(result.current.maxPaneWidth).toBe(renderCountBefore)
+
+      vi.useRealTimers()
+    })
+
     it('should cleanup resize listener on unmount', () => {
       const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
       const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame')

--- a/packages/react/src/PageLayout/usePaneWidth.ts
+++ b/packages/react/src/PageLayout/usePaneWidth.ts
@@ -281,6 +281,8 @@ export function usePaneWidth({
   const currentWidthRef = React.useRef(currentWidth)
   // Max width for ARIA - SSR uses custom max or a sensible default, updated on mount
   const [maxPaneWidth, setMaxPaneWidth] = React.useState(() => customMaxWidth ?? SSR_DEFAULT_MAX_WIDTH)
+  // Track last maxPaneWidth to skip redundant startTransition calls on resize (see #7801)
+  const maxPaneWidthRef = React.useRef(maxPaneWidth)
 
   // Keep currentWidthRef in sync with state (ref is used during drag to avoid re-renders)
   useIsomorphicLayoutEffect(() => {
@@ -365,13 +367,19 @@ export function usePaneWidth({
       // Update ARIA via DOM - cheap, no React re-render
       updateAriaValues(handleRef.current, {max: actualMax, current: currentWidthRef.current})
 
-      // Defer state updates so parent re-renders see accurate values
-      startTransition(() => {
-        setMaxPaneWidth(actualMax)
-        if (wasClamped) {
-          setCurrentWidthState(actualMax)
-        }
-      })
+      // Only trigger React re-render if values actually changed.
+      // startTransition doesn't bail out on same-value updates like normal setState,
+      // so we guard explicitly to avoid unnecessary re-renders on every resize tick. (#7801)
+      const maxChanged = actualMax !== maxPaneWidthRef.current
+      if (maxChanged || wasClamped) {
+        maxPaneWidthRef.current = actualMax
+        startTransition(() => {
+          setMaxPaneWidth(actualMax)
+          if (wasClamped) {
+            setCurrentWidthState(actualMax)
+          }
+        })
+      }
     }
 
     // Initial calculation on mount — use viewport-based lookup to avoid
@@ -379,6 +387,7 @@ export function usePaneWidth({
     // freshly-committed DOM tree (measured at ~614ms on large pages).
     maxWidthDiffRef.current = getMaxWidthDiffFromViewport()
     const initialMax = getMaxPaneWidthRef.current()
+    maxPaneWidthRef.current = initialMax
     setMaxPaneWidth(initialMax)
     paneRef.current?.style.setProperty('--pane-max-width', `${initialMax}px`)
     updateAriaValues(handleRef.current, {min: minPaneWidth, max: initialMax, current: currentWidthRef.current})


### PR DESCRIPTION
Closes #7801

### Overview

When `SplitPageLayout` has a resizable pane (`resizable={true}`), the `usePaneWidth` hook calls `startTransition(() => setMaxPaneWidth(actualMax))` inside `syncAll()` on **every** window resize event — even when `actualMax` hasn't changed. Unlike normal `setState`, `startTransition` does **not** bail out on same-value updates, so this triggers unnecessary React concurrent renders on every resize tick (~60/sec during a drag).

On pages with many components consuming the layout context (e.g. GitHub PR conversation tab), this produces ~11 React scheduler calls totaling ~108ms in a single animation frame with CPU throttle, causing visible jank.

**Fix:** Added a `maxPaneWidthRef` to track the previous `maxPaneWidth` value, and guarded the `startTransition` call so it only fires when `actualMax` has actually changed or when the current width needs to be clamped. The CSS variable updates, ref updates, and ARIA updates (which don't cause React re-renders) remain unconditional.

### Changelog

#### New

- Added a Storybook performance test story (`Re-render Counter (Issue #7801)`) to help verify resize re-render behavior with React DevTools Profiler.

#### Changed

- `usePaneWidth`: `syncAll()` now skips `startTransition` when the computed max pane width hasn't changed, avoiding unnecessary React re-renders on window resize.

#### Removed

_None_

### Rollout strategy

- [x] Patch release

### Testing & Reviewing

1. Open the new Storybook story: **Components/PageLayout/Performance Tests/Re-render Counter (Issue #7801)**
2. Open React DevTools Profiler, enable "Highlight updates when components render"
3. Resize the browser window within the same side of the 1280px breakpoint
4. Verify no unnecessary re-renders occur (components should not flash/highlight)
5. Resize across the 1280px breakpoint and verify the state does update correctly

Unit test added: `should skip startTransition when maxPaneWidth has not changed (#7801)` in `usePaneWidth.test.ts`

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui