### PR TITLE
fix: update DataTable sorting for zero values

### DIFF
--- a/.changeset/datatable-zero-sorting.md
+++ b/.changeset/datatable-zero-sorting.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+DataTable: Treat zero as a populated value when sorting numeric columns

--- a/packages/react/src/DataTable/__tests__/DataTable.test.tsx
+++ b/packages/react/src/DataTable/__tests__/DataTable.test.tsx
@@ -576,6 +576,10 @@ describe('DataTable', () => {
             },
             {
               id: 5,
+              value: 0,
+            },
+            {
+              id: 6,
               value: 1,
             },
           ]}
@@ -609,7 +613,7 @@ describe('DataTable', () => {
           return cell.textContent
         })
 
-      expect(rows).toEqual(['3', '2', '1', '', ''])
+      expect(rows).toEqual(['3', '2', '1', '0', '', ''])
 
       // Change to ascending
       await user.click(screen.getByText('Value'))
@@ -624,7 +628,55 @@ describe('DataTable', () => {
           return cell.textContent
         })
 
-      expect(rows).toEqual(['1', '2', '3', '', ''])
+      expect(rows).toEqual(['0', '1', '2', '3', '', ''])
+    })
+
+    it('should treat zero as a populated value when sorting numeric columns', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <DataTable
+          data={[
+            {
+              id: 1,
+              value: 0,
+            },
+            {
+              id: 2,
+              value: 2,
+            },
+            {
+              id: 3,
+              value: 1,
+            },
+          ]}
+          columns={[
+            {
+              header: 'Value',
+              field: 'value',
+              sortBy: true,
+            },
+          ]}
+        />,
+      )
+
+      function getRowOrder() {
+        return screen
+          .getAllByRole('row')
+          .filter(row => {
+            return queryByRole(row, 'cell')
+          })
+          .map(row => {
+            const cell = getByRole(row, 'cell')
+            return cell.textContent
+          })
+      }
+
+      await user.click(screen.getByText('Value'))
+      expect(getRowOrder()).toEqual(['0', '1', '2'])
+
+      await user.click(screen.getByText('Value'))
+      expect(getRowOrder()).toEqual(['2', '1', '0'])
     })
 
     it('should change the sort direction on mouse click', async () => {

--- a/packages/react/src/DataTable/useTable.ts
+++ b/packages/react/src/DataTable/useTable.ts
@@ -166,7 +166,10 @@ export function useTable<Data extends UniqueRow>({
         const valueA = get(a, header.column.field)
         const valueB = get(b, header.column.field)
 
-        if (valueA && valueB) {
+        const valueAIsBlank = isBlankValue(valueA)
+        const valueBIsBlank = isBlankValue(valueB)
+
+        if (!valueAIsBlank && !valueBIsBlank) {
           if (state.direction === SortDirection.ASC) {
             // @ts-ignore todo
             return sortMethod(valueA, valueB)
@@ -175,11 +178,11 @@ export function useTable<Data extends UniqueRow>({
           return sortMethod(valueB, valueA)
         }
 
-        if (valueA) {
+        if (!valueAIsBlank) {
           return -1
         }
 
-        if (valueB) {
+        if (!valueBIsBlank) {
           return 1
         }
         return 0
@@ -349,4 +352,8 @@ function get<ObjectType extends Record<string, any>, Path extends string>(
     return (value as any)[key]
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }, object as any)
+}
+
+function isBlankValue(value: unknown): value is null | undefined | '' {
+  return value === null || value === undefined || value === ''
 }


### PR DESCRIPTION
<!-- No linked issue -->

### Changelog

#### New

N/A

#### Changed

- DataTable now treats `0` as a populated value when sorting numeric columns.

#### Removed

N/A

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- `npx vitest run packages/react/src/DataTable/__tests__/DataTable.test.tsx`
- `npm run type-check`

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
