### PR TITLE
ci: make Recommend integration tests workflow fork-safe

### DIFF
--- a/.github/workflows/recommend-integration-tests.yml
+++ b/.github/workflows/recommend-integration-tests.yml
@@ -49,23 +49,51 @@ jobs:
               repo: context.repo.repo
             }
 
+            // When this workflow runs for a PR opened from a fork, the
+            // GITHUB_TOKEN has read-only access to the upstream repo and
+            // any write call (addLabels / createComment) returns
+            // `Resource not accessible by integration` (HTTP 403). That
+            // is the right security boundary, but it causes this check
+            // to fail on every fork PR which is misleading: the failure
+            // is not a problem with the PR's source code.
+            //
+            // Soft-fail those writes so the check stays green for fork
+            // PRs. Maintainers can still apply the label manually if
+            // they want to recommend integration tests for the change.
+            const isFork = context.payload.pull_request?.head?.repo?.full_name !== context.payload.repository?.full_name
+            const softWrite = async (operation, fn) => {
+              try {
+                await fn()
+              } catch (error) {
+                if (error.status === 403) {
+                  core.info(`Skipped ${operation}: GITHUB_TOKEN cannot write to this repository from a forked PR. A maintainer can apply the '${INTEGRATION_LABEL_NAMES.recommended}' label manually if integration tests are warranted.`)
+                  return
+                }
+                throw error
+              }
+            }
+
             const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, issue);
             const integrationLabels = labels.filter(label => label.name.startsWith('integration-tests'))
             const hasPassingLabel = integrationLabels.find(label => label.name === INTEGRATION_LABEL_NAMES.passing)
 
             if (integrationLabels.length === 0) {
               // recommend integration tests
-              await github.rest.issues.addLabels({...issue, labels: [INTEGRATION_LABEL_NAMES.recommended]})
-              await github.rest.issues.createComment({
-                ...issue,
-                body: '<!-- recommend-integration-tests.yml -->\n\n # ⚠️ Action required \n\n :wave: Hi, this pull request contains changes to the source code that github/github-ui depends on. If you are GitHub staff, test these changes with github/github-ui using the [integration workflow](https://github.com/github/github-ui/actions/workflows/primer-react-pr-test.yml). Check the [integration testing docs](https://gh.io/testing_primer_at_dotcom) for step-by-step instructions. Or, apply the `integration-tests: skipped manually` label to skip these checks.\n\nTo publish a canary release for integration testing, apply the `Canary Release` label to this PR.'
-              })
+              await softWrite('addLabels', () => github.rest.issues.addLabels({...issue, labels: [INTEGRATION_LABEL_NAMES.recommended]}))
+              if (!isFork) {
+                await softWrite('createComment', () => github.rest.issues.createComment({
+                  ...issue,
+                  body: '<!-- recommend-integration-tests.yml -->\n\n # ⚠️ Action required \n\n :wave: Hi, this pull request contains changes to the source code that github/github-ui depends on. If you are GitHub staff, test these changes with github/github-ui using the [integration workflow](https://github.com/github/github-ui/actions/workflows/primer-react-pr-test.yml). Check the [integration testing docs](https://gh.io/testing_primer_at_dotcom) for step-by-step instructions. Or, apply the `integration-tests: skipped manually` label to skip these checks.\n\nTo publish a canary release for integration testing, apply the `Canary Release` label to this PR.'
+                }))
+              }
             } else if (hasPassingLabel) {
               // recommend running integration tests again as there are new commits that might change the status
               // note: we don't remove 'integration-tests: passing' label because this is only a suggestion/nudge
-              await github.rest.issues.addLabels({...issue, labels: [INTEGRATION_LABEL_NAMES.recommended]})
-              await github.rest.issues.createComment({
-                ...issue,
-                body: '<!-- recommend-integration-tests.yml -->\n\n # ⚠️ Action required \n\n :wave: Hi, there are new commits since the last successful integration test. If you are GitHub staff, test these changes with github/github-ui using the [integration workflow](https://github.com/github/github-ui/actions/workflows/primer-react-pr-test.yml). Check the [integration testing docs](https://gh.io/testing_primer_at_dotcom) for step-by-step instructions. Or, apply the `integration-tests: skipped manually` label to skip these checks.'
-              })
+              await softWrite('addLabels', () => github.rest.issues.addLabels({...issue, labels: [INTEGRATION_LABEL_NAMES.recommended]}))
+              if (!isFork) {
+                await softWrite('createComment', () => github.rest.issues.createComment({
+                  ...issue,
+                  body: '<!-- recommend-integration-tests.yml -->\n\n # ⚠️ Action required \n\n :wave: Hi, there are new commits since the last successful integration test. If you are GitHub staff, test these changes with github/github-ui using the [integration workflow](https://github.com/github/github-ui/actions/workflows/primer-react-pr-test.yml). Check the [integration testing docs](https://gh.io/testing_primer_at_dotcom) for step-by-step instructions. Or, apply the `integration-tests: skipped manually` label to skip these checks.'
+                }))
+              }
             }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

## Problem

The `Recommend integration tests` workflow runs on every `pull_request` event, including PRs opened from forks. When triggered by a fork PR the provided `GITHUB_TOKEN` has read-only access to the upstream repo and any write call (`addLabels` / `createComment`) fails with:

```
HttpError: Resource not accessible by integration (HTTP 403)
```

That failure surfaces as a red ❌ `recommend` check on every fork PR — even when the underlying source code is fine and all other checks (lint, tests, type-check, build, VRT, AAT, CodeQL) pass. It's misleading because the job's role is to *suggest* integration testing, not to gate the PR on its own infra success.

Example: see the three PRs I have open (#7855, #7856, #7857) — all 34 functional checks pass, and only the `recommend` workflow fails because of this permission limitation.

## Fix

Wrap the label and comment API calls in a small helper that catches HTTP 403s and logs an actionable `core.info` message instead of throwing. The job runs to completion green, and maintainers can apply the `integration-tests: recommended` label manually if the change warrants integration testing.

Additionally, comment writes are skipped entirely on fork PRs (`context.payload.pull_request.head.repo.full_name !== context.payload.repository.full_name`). The bot's comment recommends running an internal-only workflow that a fork PR author cannot trigger anyway — better to suppress the noise.

## Before / After

Before:
- Fork PR opens → `recommend` job fails with `Resource not accessible by integration` → red ❌ on the PR.

After:
- Fork PR opens → `recommend` job catches the 403, logs `Skipped addLabels: GITHUB_TOKEN cannot write to this repository from a forked PR. A maintainer can apply the 'integration-tests: recommended' label manually if integration tests are warranted.` → green ✅ on the PR.
- Internal-branch PR behaviour unchanged: the job still adds the label and posts the comment.

## Changelog

#### New
- (none)

#### Changed
- `.github/workflows/recommend-integration-tests.yml` — wrap label/comment writes in `try/catch` keyed on HTTP 403 so the job no longer fails on fork PRs.

#### Removed
- (none)

## Rollout strategy

- [x] Patch release (CI-only change, no runtime impact)
- [ ] Minor release
- [ ] Major release
- [ ] None

> This is a CI-only change with no impact on the published `@primer/react` package, so it does not include a changeset. Please apply the `skip changeset` label.

## Testing & Reviewing

- YAML validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Logic is small enough to reason about by inspection — the only added complexity is a `softWrite(operation, fn)` helper that distinguishes 403 from other errors.
- Will be exercised in CI as soon as this PR opens (it's itself a fork PR, so it should self-validate that the new code path is green).

## Merge checklist

- [x] Added/updated tests *(N/A — workflow file change; behaviour will be exercised by every PR opened against this repo, including this one)*
- [x] Added/updated documentation *(inline comments explaining the soft-fail rationale)*
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility) *(N/A — CI workflow change)*
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
