### PR TITLE
ci: update recommend workflow to not run on forks

### DIFF
--- a/.github/workflows/recommend-integration-tests.yml
+++ b/.github/workflows/recommend-integration-tests.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   recommend:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Follow up to: https://github.com/primer/react/pull/7862

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Update the recommend integration tests workflow to not run on Pull Requests from forks. If we would like this message to appear on forks, then we could use a `workflow_run` event in the future

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Gate the recommend job on whether the pull request is from the original repository

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is a change to our CI