### PR TITLE
Avatar: Add `srcTransformer` and `statusIcon` props

### DIFF
--- a/.changeset/clear-groups-cross.md
+++ b/.changeset/clear-groups-cross.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Avatar: Add `srcTransformer` prop to transform the image URL before rendering, and `statusIcon` slot to render an overlay icon at the bottom-right of the avatar

--- a/packages/react/src/Avatar/Avatar.docs.json
+++ b/packages/react/src/Avatar/Avatar.docs.json
@@ -15,6 +15,9 @@
     },
     {
       "id": "components-avatar-features--size-responsive"
+    },
+    {
+      "id": "components-avatar-features--src-transformer"
     }
   ],
   "importPath": "@primer/react",
@@ -43,6 +46,12 @@
       "required": false,
       "description": "URL of the avatar image.",
       "defaultValue": ""
+    },
+    {
+      "name": "srcTransformer",
+      "type": "(src: string, size: number) => string",
+      "required": false,
+      "description": "Optional function to transform the src URL before rendering. Receives the original src and the resolved numeric size in CSS pixels. Useful for appending query parameters for HiDPI/Retina support."
     }
   ],
   "subcomponents": []

--- a/packages/react/src/Avatar/Avatar.docs.json
+++ b/packages/react/src/Avatar/Avatar.docs.json
@@ -18,6 +18,9 @@
     },
     {
       "id": "components-avatar-features--src-transformer"
+    },
+    {
+      "id": "components-avatar-features--status-icon"
     }
   ],
   "importPath": "@primer/react",
@@ -52,6 +55,12 @@
       "type": "(src: string, size: number) => string",
       "required": false,
       "description": "Optional function to transform the src URL before rendering. Receives the original src and the resolved numeric size in CSS pixels. Useful for appending query parameters for HiDPI/Retina support."
+    },
+    {
+      "name": "statusIcon",
+      "type": "React.ReactNode",
+      "required": false,
+      "description": "Renders a status icon overlay positioned at the bottom-right of the avatar."
     }
   ],
   "subcomponents": []

--- a/packages/react/src/Avatar/Avatar.features.stories.tsx
+++ b/packages/react/src/Avatar/Avatar.features.stories.tsx
@@ -79,3 +79,12 @@ export const SizeResponsive = () => (
     />
   </div>
 )
+
+export const SrcTransformer = () => (
+  <Avatar
+    size={32}
+    alt="mona"
+    src="https://avatars.githubusercontent.com/u/7143434?v=4"
+    srcTransformer={(src, size) => `${src}&s=${size * 2}`}
+  />
+)

--- a/packages/react/src/Avatar/Avatar.features.stories.tsx
+++ b/packages/react/src/Avatar/Avatar.features.stories.tsx
@@ -1,4 +1,5 @@
 import type {Meta} from '@storybook/react-vite'
+import {XCircleFillIcon} from '@primer/octicons-react'
 import Avatar from './Avatar'
 
 export default {
@@ -86,5 +87,14 @@ export const SrcTransformer = () => (
     alt="mona"
     src="https://avatars.githubusercontent.com/u/7143434?v=4"
     srcTransformer={(src, size) => `${src}&s=${size * 2}`}
+  />
+)
+
+export const StatusIcon = () => (
+  <Avatar
+    size={20}
+    alt="status avatar"
+    src="https://avatars.githubusercontent.com/u/7143434?v=4"
+    statusIcon={<XCircleFillIcon size={12} fill="var(--fgColor-success)" />}
   />
 )

--- a/packages/react/src/Avatar/Avatar.module.css
+++ b/packages/react/src/Avatar/Avatar.module.css
@@ -32,3 +32,26 @@
     }
   }
 }
+
+.AvatarContainer {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: var(--avatarSize-regular);
+  height: var(--avatarSize-regular);
+  vertical-align: middle;
+}
+
+.StatusIcon {
+  position: absolute;
+  right: calc(-1 * var(--base-size-4));
+  bottom: calc(-1 * var(--base-size-4));
+  display: flex;
+  /* stylelint-disable-next-line primer/borders */
+  border-radius: 100px;
+  /* stylelint-disable-next-line primer/box-shadow */
+  box-shadow: 0 0 0 2px var(--bgColor-default, var(--color-canvas-default));
+  background-color: var(--bgColor-default, var(--color-canvas-default));
+  /* stylelint-disable-next-line primer/typography */
+  line-height: 1;
+}

--- a/packages/react/src/Avatar/Avatar.module.css
+++ b/packages/react/src/Avatar/Avatar.module.css
@@ -36,9 +36,6 @@
 .AvatarContainer {
   position: relative;
   display: inline-flex;
-  align-items: center;
-  width: var(--avatarSize-regular);
-  height: var(--avatarSize-regular);
   vertical-align: middle;
 }
 

--- a/packages/react/src/Avatar/Avatar.test.tsx
+++ b/packages/react/src/Avatar/Avatar.test.tsx
@@ -57,4 +57,55 @@ describe('Avatar', () => {
     expect(styleAttr).toContain('--avatarSize-regular: 20px')
     expect(styleAttr).toContain('background: black')
   })
+
+  describe('srcTransformer', () => {
+    it('transforms the src when srcTransformer is provided', () => {
+      render(
+        <Avatar
+          src="https://avatars.githubusercontent.com/u/1234"
+          size={40}
+          srcTransformer={(src, size) => `${src}?size=${size * 2}`}
+          data-testid="avatar"
+        />,
+      )
+      const avatar = screen.getByTestId('avatar')
+      expect(avatar).toHaveAttribute('src', 'https://avatars.githubusercontent.com/u/1234?size=80')
+    })
+
+    it('passes src unchanged when srcTransformer is not provided', () => {
+      render(<Avatar src="https://avatars.githubusercontent.com/u/1234" data-testid="avatar" />)
+      const avatar = screen.getByTestId('avatar')
+      expect(avatar).toHaveAttribute('src', 'https://avatars.githubusercontent.com/u/1234')
+    })
+
+    it('receives the resolved size for responsive values', () => {
+      const transformer = (src: string, size: number) => `${src}?size=${size * 2}`
+      render(
+        <Avatar
+          src="https://avatars.githubusercontent.com/u/1234"
+          size={{narrow: 16, regular: 20, wide: 24}}
+          srcTransformer={transformer}
+          data-testid="avatar"
+        />,
+      )
+      const avatar = screen.getByTestId('avatar')
+      // Should use the 'regular' size for the transformer
+      expect(avatar).toHaveAttribute('src', 'https://avatars.githubusercontent.com/u/1234?size=40')
+    })
+
+    it('uses default size when responsive value has no regular key', () => {
+      const transformer = (src: string, size: number) => `${src}?size=${size * 2}`
+      render(
+        <Avatar
+          src="https://avatars.githubusercontent.com/u/1234"
+          size={{narrow: 16, wide: 24}}
+          srcTransformer={transformer}
+          data-testid="avatar"
+        />,
+      )
+      const avatar = screen.getByTestId('avatar')
+      // Falls back to DEFAULT_AVATAR_SIZE (20)
+      expect(avatar).toHaveAttribute('src', 'https://avatars.githubusercontent.com/u/1234?size=40')
+    })
+  })
 })

--- a/packages/react/src/Avatar/Avatar.test.tsx
+++ b/packages/react/src/Avatar/Avatar.test.tsx
@@ -1,4 +1,5 @@
 import {describe, expect, it} from 'vitest'
+import React from 'react'
 import {render, screen} from '@testing-library/react'
 import Avatar from '../Avatar'
 import {implementsClassName} from '../utils/testing'
@@ -106,6 +107,34 @@ describe('Avatar', () => {
       const avatar = screen.getByTestId('avatar')
       // Falls back to DEFAULT_AVATAR_SIZE (20)
       expect(avatar).toHaveAttribute('src', 'https://avatars.githubusercontent.com/u/1234?size=40')
+    })
+  })
+
+  describe('statusIcon', () => {
+    it('renders the status icon in a container when provided', () => {
+      render(
+        <Avatar src="primer.png" size={20} statusIcon={<span data-testid="status">🟢</span>} data-testid="avatar" />,
+      )
+      const avatar = screen.getByTestId('avatar')
+      const status = screen.getByTestId('status')
+      expect(avatar).toBeInTheDocument()
+      expect(status).toBeInTheDocument()
+      // Status icon is rendered inside the container alongside the avatar
+      expect(avatar.parentElement).toBe(status.parentElement?.parentElement)
+    })
+
+    it('does not render a container when statusIcon is not provided', () => {
+      render(<Avatar src="primer.png" data-testid="avatar" />)
+      const avatar = screen.getByTestId('avatar')
+      // The img should not be wrapped in a container div
+      expect(avatar.parentElement?.classList.toString()).not.toContain('AvatarContainer')
+    })
+
+    it('still forwards ref to the img element when statusIcon is provided', () => {
+      const ref = React.createRef<HTMLImageElement>()
+      render(<Avatar ref={ref} src="primer.png" statusIcon={<span>🟢</span>} data-testid="avatar" />)
+      expect(ref.current).toBe(screen.getByTestId('avatar'))
+      expect(ref.current?.tagName).toBe('IMG')
     })
   })
 })

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -13,6 +13,8 @@ export type AvatarProps = {
   square?: boolean
   /** URL of the avatar image. */
   src: string
+  /** Transforms the `src` URL before rendering. Receives the original `src` and the resolved numeric `size`. */
+  srcTransformer?: (src: string, size: number) => string
   /** Provide alt text when the Avatar is used without the user's name next to it. */
   alt?: string
   /** Additional class name. */
@@ -20,7 +22,7 @@ export type AvatarProps = {
 } & React.ComponentPropsWithoutRef<'img'>
 
 const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(function Avatar(
-  {alt = '', size = DEFAULT_AVATAR_SIZE, square = false, className, style, ...rest},
+  {alt = '', size = DEFAULT_AVATAR_SIZE, square = false, className, style, src, srcTransformer, ...rest},
   ref,
 ) {
   const isResponsive = isResponsiveValue(size)
@@ -34,12 +36,16 @@ const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(function Avatar(
     cssSizeVars['--avatarSize-regular'] = `${size}px`
   }
 
+  const resolvedSize = isResponsive ? ((size as ResponsiveValue<number>).regular ?? DEFAULT_AVATAR_SIZE) : size
+  const resolvedSrc = srcTransformer ? srcTransformer(src, resolvedSize) : src
+
   return (
     <img
       data-component="Avatar"
       className={clsx(className, classes.Avatar)}
       ref={ref}
       alt={alt}
+      src={resolvedSrc}
       data-responsive={isResponsive ? '' : undefined}
       data-square={square ? '' : undefined}
       width={isResponsive ? undefined : size}

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -15,6 +15,8 @@ export type AvatarProps = {
   src: string
   /** Transforms the `src` URL before rendering. Receives the original `src` and the resolved numeric `size`. */
   srcTransformer?: (src: string, size: number) => string
+  /** Renders a status icon overlay positioned at the bottom-right of the avatar. */
+  statusIcon?: React.ReactNode
   /** Provide alt text when the Avatar is used without the user's name next to it. */
   alt?: string
   /** Additional class name. */
@@ -22,7 +24,7 @@ export type AvatarProps = {
 } & React.ComponentPropsWithoutRef<'img'>
 
 const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(function Avatar(
-  {alt = '', size = DEFAULT_AVATAR_SIZE, square = false, className, style, src, srcTransformer, ...rest},
+  {alt = '', size = DEFAULT_AVATAR_SIZE, square = false, className, style, src, srcTransformer, statusIcon, ...rest},
   ref,
 ) {
   const isResponsive = isResponsiveValue(size)
@@ -39,7 +41,7 @@ const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(function Avatar(
   const resolvedSize = isResponsive ? ((size as ResponsiveValue<number>).regular ?? DEFAULT_AVATAR_SIZE) : size
   const resolvedSrc = srcTransformer ? srcTransformer(src, resolvedSize) : src
 
-  return (
+  const img = (
     <img
       data-component="Avatar"
       className={clsx(className, classes.Avatar)}
@@ -61,6 +63,17 @@ const Avatar = React.forwardRef<HTMLImageElement, AvatarProps>(function Avatar(
       {...rest}
     />
   )
+
+  if (statusIcon) {
+    return (
+      <div className={classes.AvatarContainer} style={cssSizeVars as React.CSSProperties}>
+        {img}
+        <span className={classes.StatusIcon}>{statusIcon}</span>
+      </div>
+    )
+  }
+
+  return img
 })
 
 if (__DEV__) {


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/core-ux/issues/2493

Adds two new props to `Avatar` that close gaps identified in the [Primer audit](https://gist.github.com/adierkens/59e37fa32c3a2ac213670a36ac1ef1d3), eliminating the need for the `@github-ui/github-avatar` and `@github-ui/status-avatar` wrapper packages:

- **`srcTransformer`** — `(src: string, size: number) => string`, transforms the image URL before rendering (e.g. appending `?size=` for HiDPI support)
- **`statusIcon`** — `React.ReactNode`, renders an overlay positioned at the bottom-right of the avatar 

### Changelog

#### New

- `Avatar`: `srcTransformer` prop to transform image URLs before rendering
- `Avatar`: `statusIcon` slot to render a status icon overlay 
    <img width="55" height="56" alt="Screenshot 2026-05-22 at 11 44 09 AM" src="https://github.com/user-attachments/assets/21be066f-7490-4274-a7f2-e11ebcde4691" />

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [X] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To publish a canary release for integration testing, apply the "Canary Release" label to this PR -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
