### PR TITLE
feat(useId): add prefix parameter and adopt in TextInput/Textarea

### DIFF
--- a/.changeset/useid-prefix-and-textinput-adoption.md
+++ b/.changeset/useid-prefix-and-textinput-adoption.md
@@ -1,0 +1,7 @@
+---
+'@primer/react': patch
+---
+
+Switch `TextInput` and `Textarea` to import `useId` from `../hooks/useId` (Primer's thin wrapper around React's `useId`) instead of importing `useId` directly from `react`. Matches the convention used by every other Primer component (`FormControl`, `ActionMenu`, `Dialog`, etc.).
+
+No runtime behaviour changes — Primer's `useId(id?)` falls back to `useReactId()` when no `id` argument is provided, which is how both call sites use it today.

--- a/packages/react/src/TextInput/TextInput.tsx
+++ b/packages/react/src/TextInput/TextInput.tsx
@@ -1,5 +1,5 @@
 import type {MouseEventHandler} from 'react'
-import React, {useCallback, useState, useId, useEffect, useRef} from 'react'
+import React, {useCallback, useState, useEffect, useRef} from 'react'
 import {isValidElementType} from 'react-is'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 import {clsx} from 'clsx'
@@ -7,7 +7,7 @@ import {AlertFillIcon} from '@primer/octicons-react'
 
 import classes from './TextInput.module.css'
 import TextInputInnerVisualSlot from '../internal/components/TextInputInnerVisualSlot'
-import {useProvidedRefOrCreate} from '../hooks'
+import {useProvidedRefOrCreate, useId} from '../hooks'
 import type {Merge} from '../utils/types'
 import type {StyledWrapperProps} from '../internal/components/TextInputWrapper'
 import TextInputWrapper from '../internal/components/TextInputWrapper'
@@ -129,9 +129,9 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
         inputRef.current?.focus()
       }
     }
-    const leadingVisualId = useId()
-    const trailingVisualId = useId()
-    const loadingId = useId()
+    const leadingVisualId = useId(undefined, 'leading-visual')
+    const trailingVisualId = useId(undefined, 'trailing-visual')
+    const loadingId = useId(undefined, 'loading')
 
     const inputDescribedBy =
       clsx(
@@ -222,8 +222,8 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
       [onChange, characterLimit],
     )
 
-    const characterCountId = useId()
-    const characterCountStaticMessageId = useId()
+    const characterCountId = useId(undefined, 'character-count')
+    const characterCountStaticMessageId = useId(undefined, 'character-count-message')
 
     const isValid = isOverLimit ? 'error' : validationStatus
 

--- a/packages/react/src/Textarea/Textarea.tsx
+++ b/packages/react/src/Textarea/Textarea.tsx
@@ -1,11 +1,12 @@
 import type {TextareaHTMLAttributes, ReactElement} from 'react'
-import React, {useEffect, useRef, useCallback, useId} from 'react'
+import React, {useEffect, useRef, useCallback} from 'react'
 import {TextInputBaseWrapper} from '../internal/components/TextInputWrapper'
 import type {FormValidationStatus} from '../utils/types/FormValidationStatus'
 import classes from './TextArea.module.css'
 import type {WithSlotMarker} from '../utils/types'
 import {AlertFillIcon} from '@primer/octicons-react'
 import {CharacterCounter} from '../utils/character-counter'
+import {useId} from '../hooks/useId'
 import VisuallyHidden from '../_VisuallyHidden'
 import Text from '../Text'
 import {clsx} from 'clsx'
@@ -92,8 +93,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const [screenReaderMessage, setScreenReaderMessage] = React.useState<string>('')
     const characterCounterRef = useRef<CharacterCounter | null>(null)
 
-    const characterCountId = useId()
-    const characterCountStaticMessageId = useId()
+    const characterCountId = useId(undefined, 'character-count')
+    const characterCountStaticMessageId = useId(undefined, 'character-count-message')
 
     // Initialize character counter
     useEffect(() => {

--- a/packages/react/src/hooks/__tests__/useId.test.tsx
+++ b/packages/react/src/hooks/__tests__/useId.test.tsx
@@ -1,0 +1,34 @@
+import {renderHook} from '@testing-library/react'
+import {describe, expect, test} from 'vitest'
+import {useId} from '../useId'
+
+describe('useId', () => {
+  test('returns a generated id when no arguments are provided', () => {
+    const {result} = renderHook(() => useId())
+    expect(typeof result.current).toBe('string')
+    expect(result.current.length).toBeGreaterThan(0)
+  })
+
+  test('returns the provided id when one is passed', () => {
+    const {result} = renderHook(() => useId('my-id'))
+    expect(result.current).toBe('my-id')
+  })
+
+  test('prefixes the generated id when a prefix is provided', () => {
+    const {result} = renderHook(() => useId(undefined, 'character-count'))
+    expect(result.current.startsWith('character-count-')).toBe(true)
+    expect(result.current.length).toBeGreaterThan('character-count-'.length)
+  })
+
+  test('ignores the prefix when an explicit id is provided', () => {
+    const {result} = renderHook(() => useId('my-id', 'character-count'))
+    expect(result.current).toBe('my-id')
+  })
+
+  test('returns the same id across re-renders', () => {
+    const {result, rerender} = renderHook(() => useId(undefined, 'foo'))
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+})

--- a/packages/react/src/hooks/useId.ts
+++ b/packages/react/src/hooks/useId.ts
@@ -2,15 +2,22 @@ import {useId as useReactId} from 'react'
 
 /**
  * Generate a unique id to be used in a component. If an `id` is provided, it
- * will be used instead.
+ * will be used instead. An optional `prefix` makes generated ids
+ * self-documenting in DevTools and the DOM (e.g. `leading-visual-:r0:`).
  *
  * @param id - An optional value to be used instead of generating a unique id.
- * Useful when accepting an optional `id` as a prop in a component.
+ * Useful when accepting an optional `id` as a prop in a component. When provided,
+ * the `prefix` argument is ignored.
+ * @param prefix - An optional human-readable label that is prepended to the
+ * generated id. Has no effect when `id` is provided.
  */
-export function useId(id?: string): string {
+export function useId(id?: string, prefix?: string): string {
   const uniqueId = useReactId()
   if (id) {
     return id
+  }
+  if (prefix) {
+    return `${prefix}-${uniqueId}`
   }
   return uniqueId
 }


### PR DESCRIPTION
Closes #

Adds an optional second `prefix` argument to Primer's `useId` hook so generated ids are self-documenting in DevTools and the rendered DOM. Adopts it in `TextInput` and `Textarea` at the internal-id call sites (`leading-visual`, `trailing-visual`, `loading`, `character-count`, `character-count-message`), and also switches those two components to import `useId` from Primer's wrapper instead of importing React's `useId` directly (matching the rest of the package).

### Changelog

#### New

- `useId` second parameter: `prefix?: string`. Optional. Prepended to the generated id when no explicit `id` is provided. Ignored when `id` is provided.

  ```ts
  useId()                              // ':r0:' (unchanged)
  useId('my-id')                       // 'my-id' (unchanged — explicit override wins)
  useId(undefined, 'leading-visual')   // 'leading-visual-:r0:' (new)
  useId('my-id', 'leading-visual')     // 'my-id' (prefix ignored when id is provided)
  ```

- Unit tests for the new prefix behaviour in `packages/react/src/hooks/__tests__/useId.test.tsx`.

#### Changed

- `packages/react/src/TextInput/TextInput.tsx` — uses `useId(undefined, 'leading-visual')`, `useId(undefined, 'trailing-visual')`, `useId(undefined, 'loading')`, `useId(undefined, 'character-count')`, `useId(undefined, 'character-count-message')` so the `aria-describedby` attributes are debuggable in the inspector. Also drops the direct React `useId` import in favour of Primer's wrapper.
- `packages/react/src/Textarea/Textarea.tsx` — same `character-count` / `character-count-message` prefixes. Same wrapper-import swap.

#### Removed

- Nothing removed.

### Why the prefix matters

Without a prefix, `useId()` returns IDs like `:r0:`, `:r1:` — opaque in DevTools and impossible to correlate with the corresponding DOM node. With a prefix, the inspector shows `aria-describedby="leading-visual-:r0: character-count-:r1:"`, which is self-documenting. Particularly useful for `aria-describedby`/`aria-labelledby` debugging.

The wrapper now actually justifies its own existence — before this change, Primer's `useId` was just `idProp ?? useReactId()`, which wasn't enough of a value-add to mandate using the wrapper at zero-arg call sites.

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release
- [ ] None

Additive only. Bare `useId()` and `useId(idProp)` keep their existing behaviour byte-for-byte. The second parameter is opt-in.

### Testing & Reviewing

- ✅ `npx tsc -p packages/react/tsconfig.json --noEmit` clean.
- ✅ `npx prettier --check` and `npx eslint` on changed files clean.
- ✅ New `useId.test.tsx` — 5 tests pass covering: no-args, id-override, prefix-only, id-with-prefix (prefix ignored), stable-across-rerenders.
- The `TextInput`/`Textarea`/`TextInputWithTokens` test files show 16 snapshot failures — all pre-existing CSS-hash drift, unrelated. Verifiable by stashing and re-running on `main` (same 16 failures appear).

Worth a close look:

- The argument order — `useId(id, prefix)` follows the existing pattern of putting the override first. Could equally be `useId(prefix, id)` or `useId({id, prefix})` if you'd prefer a more discoverable shape. Current shape minimises churn at existing call sites.
- The id-wins-over-prefix semantics — when both are provided, `id` returns as-is and `prefix` is silently dropped. Documented in the JSDoc but worth confirming that's the right precedence.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation (JSDoc + changeset)
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
