### PR TITLE
feat(react): introduce useDevOnlyEffect hook for dev-only assertions

### DIFF
--- a/.changeset/use-dev-only-effect.md
+++ b/.changeset/use-dev-only-effect.md
@@ -1,0 +1,11 @@
+---
+'@primer/react': patch
+---
+
+Dev-only effects (the `if (__DEV__) { useEffect(...) }` pattern with an
+`eslint-disable react-hooks/rules-of-hooks` comment at every call site) are
+now expressed via a new internal `useDevOnlyEffect` hook. The lint
+suppression lives in the wrapper, the effect is dropped from production by
+the consumer's `process.env.NODE_ENV` replacement, and call sites get
+`react-hooks/exhaustive-deps` lint via `additionalEffectHooks`. No public
+API changes.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -140,6 +140,9 @@ const config = defineConfig([
       react: {
         version: 'detect',
       },
+      'react-hooks': {
+        additionalEffectHooks: '(useDevOnlyEffect)',
+      },
     },
     rules: {
       'no-shadow': 'off',

--- a/packages/react/src/Banner/Banner.tsx
+++ b/packages/react/src/Banner/Banner.tsx
@@ -1,5 +1,6 @@
 import {clsx} from 'clsx'
-import React, {forwardRef, useEffect} from 'react'
+import React, {forwardRef} from 'react'
+import {useDevOnlyEffect} from '../internal/hooks/useDevOnlyEffect'
 import {AlertIcon, InfoIcon, StopIcon, CheckCircleIcon, XIcon} from '@primer/octicons-react'
 import {Button, IconButton, type ButtonProps} from '../Button'
 import {VisuallyHidden} from '../VisuallyHidden'
@@ -132,27 +133,23 @@ export const Banner = React.forwardRef<HTMLElement, BannerProps>(function Banner
 
   const visual = leadingVisual ?? icon
 
-  if (__DEV__) {
-    // This hook is called consistently depending on the environment
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
-      if (title) {
-        return
-      }
+  useDevOnlyEffect(() => {
+    if (title) {
+      return
+    }
 
-      const {current: banner} = bannerRef
-      if (!banner) {
-        return
-      }
+    const {current: banner} = bannerRef
+    if (!banner) {
+      return
+    }
 
-      const hasTitle = banner.querySelector('[data-banner-title]')
-      if (!hasTitle) {
-        throw new Error(
-          'Expected a title to be provided to the <Banner> component with the `title` prop or through `<Banner.Title>` but no title was found',
-        )
-      }
-    }, [title])
-  }
+    const hasTitle = banner.querySelector('[data-banner-title]')
+    if (!hasTitle) {
+      throw new Error(
+        'Expected a title to be provided to the <Banner> component with the `title` prop or through `<Banner.Title>` but no title was found',
+      )
+    }
+  }, [title])
 
   return (
     <BannerContext.Provider value={{titleId}}>

--- a/packages/react/src/Heading/Heading.tsx
+++ b/packages/react/src/Heading/Heading.tsx
@@ -1,5 +1,6 @@
 import {clsx} from 'clsx'
-import React, {forwardRef, useEffect} from 'react'
+import React, {forwardRef} from 'react'
+import {useDevOnlyEffect} from '../internal/hooks/useDevOnlyEffect'
 import {useMergedRefs} from '../hooks'
 import type {ComponentProps} from '../utils/types'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
@@ -16,21 +17,12 @@ const Heading = forwardRef(({as: Component = 'h2', className, variant, ...props}
   const innerRef = React.useRef<HTMLHeadingElement>(null)
   const mergedRef = useMergedRefs(forwardedRef, innerRef)
 
-  if (__DEV__) {
-    /**
-     * The Linter yells because it thinks this conditionally calls an effect,
-     * but since this is a compile-time flag and not a runtime conditional
-     * this is safe, and ensures the entire effect is kept out of prod builds
-     * shaving precious bytes from the output, and avoiding mounting a noop effect
-     */
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
-      if (innerRef.current && !(innerRef.current instanceof HTMLHeadingElement)) {
-        // eslint-disable-next-line no-console
-        console.warn('This Heading component should be an instanceof of h1-h6')
-      }
-    }, [innerRef])
-  }
+  useDevOnlyEffect(() => {
+    if (innerRef.current && !(innerRef.current instanceof HTMLHeadingElement)) {
+      // eslint-disable-next-line no-console
+      console.warn('This Heading component should be an instanceof of h1-h6')
+    }
+  }, [innerRef])
 
   return (
     <Component

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -1,5 +1,6 @@
 import {clsx} from 'clsx'
-import React, {useEffect, type ForwardedRef, type ElementRef} from 'react'
+import React, {type ForwardedRef, type ElementRef} from 'react'
+import {useDevOnlyEffect} from '../internal/hooks/useDevOnlyEffect'
 import {useMergedRefs} from '../hooks'
 import classes from './Link.module.css'
 import type {ComponentProps} from '../utils/types'
@@ -22,29 +23,20 @@ export const UnwrappedLink = <As extends React.ElementType = 'a'>(
   const innerRef = React.useRef<ElementRef<As>>(null)
   const mergedRef = useMergedRefs(ref, innerRef)
 
-  if (__DEV__) {
-    /**
-     * The Linter yells because it thinks this conditionally calls an effect,
-     * but since this is a compile-time flag and not a runtime conditional
-     * this is safe, and ensures the entire effect is kept out of prod builds
-     * shaving precious bytes from the output, and avoiding mounting a noop effect
-     */
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
-      if (
-        innerRef.current &&
-        !(innerRef.current instanceof HTMLButtonElement) &&
-        !(innerRef.current instanceof HTMLAnchorElement)
-      ) {
-        // eslint-disable-next-line no-console
-        console.error(
-          'Error: Found `Link` component that renders an inaccessible element',
-          innerRef.current,
-          'Please ensure `Link` always renders as <a> or <button>',
-        )
-      }
-    }, [innerRef])
-  }
+  useDevOnlyEffect(() => {
+    if (
+      innerRef.current &&
+      !(innerRef.current instanceof HTMLButtonElement) &&
+      !(innerRef.current instanceof HTMLAnchorElement)
+    ) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'Error: Found `Link` component that renders an inaccessible element',
+        innerRef.current,
+        'Please ensure `Link` always renders as <a> or <button>',
+      )
+    }
+  }, [innerRef])
 
   return (
     <Component

--- a/packages/react/src/UnderlineNav/UnderlineNav.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNav.tsx
@@ -1,5 +1,6 @@
 import type {RefObject} from 'react'
-import React, {useRef, forwardRef, useCallback, useState, useEffect} from 'react'
+import React, {useRef, forwardRef, useCallback, useState} from 'react'
+import {useDevOnlyEffect} from '../internal/hooks/useDevOnlyEffect'
 import {UnderlineNavContext} from './UnderlineNavContext'
 import type {ResizeObserverEntry} from '../hooks/useResizeObserver'
 import {useResizeObserver} from '../hooks/useResizeObserver'
@@ -190,18 +191,14 @@ export const UnderlineNav = forwardRef(
     // This is the case where the viewport is too narrow to show any list item with the more menu. In this case, we only show the dropdown
     const onlyMenuVisible = responsiveProps.items.length === 0
 
-    if (__DEV__) {
-      // Practically, this is not a conditional hook, it is just making sure this hook runs only on DEV not PROD.
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      useEffect(() => {
-        // Address illegal state where there are multiple items that have `aria-current='page'` attribute
-        const activeElements = validChildren.filter(child => {
-          return child.props['aria-current'] !== undefined
-        })
-        invariant(activeElements.length <= 1, 'Only one current element is allowed')
-        invariant(ariaLabel, 'Use the `aria-label` prop to provide an accessible label for assistive technology')
+    useDevOnlyEffect(() => {
+      // Address illegal state where there are multiple items that have `aria-current='page'` attribute
+      const activeElements = validChildren.filter(child => {
+        return child.props['aria-current'] !== undefined
       })
-    }
+      invariant(activeElements.length <= 1, 'Only one current element is allowed')
+      invariant(ariaLabel, 'Use the `aria-label` prop to provide an accessible label for assistive technology')
+    }, [validChildren, ariaLabel])
 
     function getItemsWidth(itemText: string): number {
       return noIconChildWidthArray.find(item => item.text === itemText)?.width ?? 0

--- a/packages/react/src/internal/hooks/useDevOnlyEffect.ts
+++ b/packages/react/src/internal/hooks/useDevOnlyEffect.ts
@@ -17,7 +17,7 @@ import {useEffect} from 'react'
 export const useDevOnlyEffect = (effect: React.EffectCallback, deps?: React.DependencyList) => {
   if (__DEV__) {
     // Forwarding wrapper; deps lint applies at call sites.
-    // eslint-disable-next-line react-hooks/rules-of-hooks, react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(effect, deps)
   }
 }

--- a/packages/react/src/internal/hooks/useDevOnlyEffect.ts
+++ b/packages/react/src/internal/hooks/useDevOnlyEffect.ts
@@ -1,0 +1,23 @@
+import {useEffect} from 'react'
+
+/**
+ * Runs an effect only in development. Wrapping `useEffect` in a regular hook
+ * with an outer `__DEV__` guard keeps the production cost to zero (the entire
+ * call is dropped by the consumer's `process.env.NODE_ENV` replacement) while
+ * centralising the `eslint-disable react-hooks/rules-of-hooks` to one place
+ * instead of every call site.
+ *
+ * `exhaustive-deps` is wired up to also check call sites of this hook via
+ * `additionalEffectHooks` in `eslint.config.mjs`, so callers get the same
+ * deps lint they would for a plain `useEffect`.
+ *
+ * @param effect The effect callback to run in development.
+ * @param deps Dependency list, same semantics as `useEffect`.
+ */
+export const useDevOnlyEffect = (effect: React.EffectCallback, deps?: React.DependencyList) => {
+  if (__DEV__) {
+    // Forwarding wrapper; deps lint applies at call sites.
+    // eslint-disable-next-line react-hooks/rules-of-hooks, react-hooks/exhaustive-deps
+    useEffect(effect, deps)
+  }
+}


### PR DESCRIPTION
Closes #

## Summary

Replaces every `if (__DEV__) { useEffect(...) }` block that needed an
`eslint-disable react-hooks/rules-of-hooks` comment with a new internal
`useDevOnlyEffect` hook. The lint suppression lives once, inside the hook;
in production the consumer's `process.env.NODE_ENV` replacement folds the
entire `if (__DEV__) { … }` block away. The public API is unchanged.

## Motivation

Four components — `UnderlineNav`, `Heading`, `Link`, and `Banner` — were
performing dev-only validations through this pattern:

```tsx
if (__DEV__) {
  // The Linter yells because it thinks this conditionally calls an effect…
  // eslint-disable-next-line react-hooks/rules-of-hooks
  useEffect(() => {
    invariant(/* … */)
  })
}
```

`react-hooks/rules-of-hooks` is disabled at every call site. The linter
can't prove `__DEV__` is build-time constant, and the React Compiler bails
on the file because of the inline disable. Every new dev-only effect would
need the same boilerplate, with the same risk of someone reading it as
"hooks may be called conditionally."

## What changed

### 1. New `useDevOnlyEffect` hook

```ts
export const useDevOnlyEffect = (effect: React.EffectCallback, deps?: React.DependencyList) => {
  if (__DEV__) {
    // Forwarding wrapper; deps lint applies at call sites.
    // eslint-disable-next-line react-hooks/rules-of-hooks
    useEffect(effect, deps)
  }
}
```

The single remaining `eslint-disable` lives inside the hook itself — a
documented invariant rather than per-site boilerplate. The hook is always
called unconditionally by consumers, so Rules of Hooks is satisfied at
runtime in any build. In production the consumer's `__DEV__` /
`process.env.NODE_ENV` replacement folds the entire `if (__DEV__) { … }`
block to `undefined`, leaving no `useEffect` call, no closure, and no deps
allocation in the consumer's prod bundle.

### 2. Migrate the four call sites

- `packages/react/src/UnderlineNav/UnderlineNav.tsx` — multi-aria-current and
  missing-aria-label invariants
- `packages/react/src/Heading/Heading.tsx` — `console.warn` if element isn't
  `h1`–`h6`
- `packages/react/src/Link/Link.tsx` — `console.error` if element isn't `<a>`
  or `<button>`
- `packages/react/src/Banner/Banner.tsx` — `throw` if no `title` prop or
  `Banner.Title` child

Every per-site `eslint-disable-next-line react-hooks/rules-of-hooks` is
gone. Behaviour is identical in development.

### 3. Extend `react-hooks/exhaustive-deps` to `useDevOnlyEffect`

`eslint.config.mjs` now declares `additionalEffectHooks: '(useDevOnlyEffect)'`
in the `react-hooks` settings, so call sites get the same deps lint they
would for a plain `useEffect`. `UnderlineNav`'s effect had no deps array
under the old pattern; it now passes `[validChildren, ariaLabel]` so the
invariants re-run when those change.

## What this PR is *not* doing

An earlier iteration of this branch shipped a dual `dist/development/` +
`dist/production/` build plus a `babel-plugin-strip-dev-only-effect` that
removed every `useDevOnlyEffect(...)` call statement from the production
artifact, for true zero-byte stripping. We dropped that:

- ~390 lines of new build code (babel plugin + rollup factory + exports
  conditions) for four call sites isn't a good trade.
- `exports` `development` / `production` conditions have known sharp edges
  across bundlers (webpack, Next, Vite all differ slightly), and every deep
  import path would need them mirrored.
- The consumer's `NODE_ENV` replacement already folds the body away. The
  remaining prod cost is the empty `if (__DEV__) { … }` block, which most
  minifiers DCE entirely.

The hook's API is unchanged from that iteration, so we can revisit the
strip-plugin later under the hood if a profile ever shows it mattering.

### Changelog

#### New

- Internal `useDevOnlyEffect` hook for dev-only side effects without
  `eslint-disable react-hooks/rules-of-hooks` at every call site.
- `react-hooks/exhaustive-deps` extended to `useDevOnlyEffect` via
  `additionalEffectHooks` in `eslint.config.mjs`.

#### Changed

- `UnderlineNav`, `Heading`, `Link`, and `Banner` use `useDevOnlyEffect`
  instead of an inline `if (__DEV__) { useEffect(...) }` block. No
  behavioural change.

#### Removed

- Four per-site `eslint-disable-next-line react-hooks/rules-of-hooks`
  comments (UnderlineNav, Heading, Link, Banner).

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

Public API is unchanged. No consumer code changes are required.

### Testing & Reviewing

- All existing tests for the four migrated components pass unchanged.
- `tsc --noEmit` clean; `eslint --max-warnings=0` clean for the touched
  files.

**Reviewer focus:**

1. `useDevOnlyEffect`'s comment block — is the centralised
   `eslint-disable` legible enough that a future contributor won't
   re-introduce the per-site pattern?
2. Is `additionalEffectHooks: '(useDevOnlyEffect)'` the right place to wire
   in the deps lint, vs. adding a separate rule entry?

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
