### PR TITLE
Update FilteredActionList.tsx

### DIFF
--- a/.changeset/filtered-action-list-undefined-item-key.md
+++ b/.changeset/filtered-action-list-undefined-item-key.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+FilteredActionList: Guard against `undefined` items in the virtualizer's `getItemKey` callback to prevent a crash when `@tanstack/react-virtual` invokes it with an index whose item was just removed (e.g. when filtering shrinks the items list).

--- a/packages/react/src/FilteredActionList/FilteredActionList.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionList.tsx
@@ -297,8 +297,12 @@ export function FilteredActionList({
     overscan: 10,
     enabled: isVirtualized,
     getItemKey: index => {
-      const item = items[index]
-      return item?.key ?? item?.id?.toString() ?? index.toString()
+      // `measureElement` from @tanstack/react-virtual can invoke this with an index
+      // whose item has just been removed (e.g. during a filter that shrinks `items`),
+      // so guard against `items[index]` being undefined.
+      const item = items[index] as ItemInput | undefined
+      if (!item) return index.toString()
+      return item.key ?? item.id?.toString() ?? index.toString()
     },
     measureElement: el => (el as HTMLElement).scrollHeight,
   })

--- a/packages/react/src/FilteredActionList/FilteredActionList.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionList.tsx
@@ -298,7 +298,7 @@ export function FilteredActionList({
     enabled: isVirtualized,
     getItemKey: index => {
       const item = items[index]
-      return item.key ?? item.id?.toString() ?? index.toString()
+      return item?.key ?? item?.id?.toString() ?? index.toString()
     },
     measureElement: el => (el as HTMLElement).scrollHeight,
   })


### PR DESCRIPTION
Closes #

Fixes a crash in `FilteredActionList` where the virtualizer's `getItemKey` callback could be invoked with an index whose item was no longer present in `items`. `@tanstack/react-virtual`'s `measureElement` can fire with a stale index after the list shrinks (e.g. while filtering), causing `items[index]` to be `undefined` and the subsequent `item.key` access to throw.

The callback now treats `items[index]` as possibly `undefined` and falls back to `index.toString()` as the key when the item has been removed.

### Changelog

#### New

- N/A

#### Changed

- `FilteredActionList`: Guard against `undefined` entries in the virtualizer's `getItemKey` to prevent a runtime error when items are removed mid-render (e.g. during filtering).

#### Removed

- N/A

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- Open a story that renders `FilteredActionList` with virtualization enabled (e.g. the virtualized FilteredActionList story).
- Type into the filter input quickly so that `items` shrinks while the virtualizer is still measuring previously rendered rows.
- Before this change, this could throw `Cannot read properties of undefined (reading 'key')` from `getItemKey`. After this change, no error is thrown and the list re-renders with the filtered items.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))