### PR TITLE
Timeline: drop deprecated `Octicon` wrapper, consolidate `TimelineBadgeVariant` source

### DIFF
--- a/packages/react/src/Timeline/Timeline.dev.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dev.stories.tsx
@@ -1,7 +1,6 @@
 import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Timeline from './Timeline'
-import Octicon from '../Octicon'
 import {GitCommitIcon} from '@primer/octicons-react'
 
 export default {
@@ -19,7 +18,7 @@ export const Default = () => (
   <Timeline>
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>

--- a/packages/react/src/Timeline/Timeline.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.features.stories.tsx
@@ -1,7 +1,6 @@
 import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import Timeline from './Timeline'
-import Octicon from '../Octicon'
 import {
   FlameIcon,
   GitBranchIcon,
@@ -32,13 +31,13 @@ export const ClipSidebar = () => (
   <Timeline clipSidebar>
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
@@ -49,13 +48,13 @@ export const ClipSidebarStart = () => (
   <Timeline clipSidebar="start">
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
@@ -66,13 +65,13 @@ export const ClipSidebarEnd = () => (
   <Timeline clipSidebar="end">
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
@@ -83,26 +82,26 @@ export const CondensedItems = () => (
   <Timeline>
     <Timeline.Item condensed>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item condensed>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
     <Timeline.Break />
     <Timeline.Item condensed>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item condensed>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
@@ -113,14 +112,14 @@ export const TimelineBreak = () => (
   <Timeline>
     <Timeline.Item>
       <Timeline.Badge variant="done">
-        <Octicon icon={GitMergeIcon} aria-label="Merged" />
+        <GitMergeIcon aria-label="Merged" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
     <Timeline.Break />
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitBranchIcon} aria-label="Branch" />
+        <GitBranchIcon aria-label="Branch" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
@@ -131,55 +130,55 @@ export const BadgeVariants = () => (
   <Timeline>
     <Timeline.Item>
       <Timeline.Badge variant="accent">
-        <Octicon icon={GitPullRequestIcon} aria-label="Pull request" />
+        <GitPullRequestIcon aria-label="Pull request" />
       </Timeline.Badge>
       <Timeline.Body>Accent</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge variant="success">
-        <Octicon icon={IssueClosedIcon} aria-label="Closed" />
+        <IssueClosedIcon aria-label="Closed" />
       </Timeline.Badge>
       <Timeline.Body>Success</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge variant="attention">
-        <Octicon icon={FlameIcon} aria-label="Attention" />
+        <FlameIcon aria-label="Attention" />
       </Timeline.Badge>
       <Timeline.Body>Attention</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge variant="severe">
-        <Octicon icon={SkipIcon} aria-label="Severe" />
+        <SkipIcon aria-label="Severe" />
       </Timeline.Badge>
       <Timeline.Body>Severe</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge variant="danger">
-        <Octicon icon={XIcon} aria-label="Danger" />
+        <XIcon aria-label="Danger" />
       </Timeline.Badge>
       <Timeline.Body>Danger</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge variant="done">
-        <Octicon icon={GitMergeIcon} aria-label="Merged" />
+        <GitMergeIcon aria-label="Merged" />
       </Timeline.Badge>
       <Timeline.Body>Done</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge variant="open">
-        <Octicon icon={IssueOpenedIcon} aria-label="Open" />
+        <IssueOpenedIcon aria-label="Open" />
       </Timeline.Badge>
       <Timeline.Body>Open</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge variant="closed">
-        <Octicon icon={IssueClosedIcon} aria-label="Closed" />
+        <IssueClosedIcon aria-label="Closed" />
       </Timeline.Badge>
       <Timeline.Body>Closed</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge variant="sponsors">
-        <Octicon icon={HeartIcon} aria-label="Sponsors" />
+        <HeartIcon aria-label="Sponsors" />
       </Timeline.Badge>
       <Timeline.Body>Sponsors</Timeline.Body>
     </Timeline.Item>
@@ -190,7 +189,7 @@ export const WithInlineLinks = () => (
   <Timeline>
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>
         <Link href="#" className={classes.LinkWithBoldStyle} muted>

--- a/packages/react/src/Timeline/Timeline.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.stories.tsx
@@ -2,8 +2,7 @@ import type {Meta, StoryFn} from '@storybook/react-vite'
 import React from 'react'
 import {useArgs} from 'storybook/preview-api'
 import type {ComponentProps} from '../utils/types'
-import Timeline, {type TimelineBadgeVariant} from './Timeline'
-import Octicon from '../Octicon'
+import Timeline, {TimelineBadgeVariants, type TimelineBadgeVariant} from './Timeline'
 import Avatar from '../Avatar'
 import Link from '../Link'
 import RelativeTime from '../RelativeTime'
@@ -64,19 +63,19 @@ export const Default = () => (
   <Timeline>
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Badge>
-        <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        <GitCommitIcon aria-label="Commit" />
       </Timeline.Badge>
       <Timeline.Body>This is a message</Timeline.Body>
     </Timeline.Item>
@@ -122,18 +121,6 @@ const BADGE_ICONS = {
 } as const
 
 type BadgeIconName = keyof typeof BADGE_ICONS
-
-const BADGE_VARIANTS: TimelineBadgeVariant[] = [
-  'accent',
-  'success',
-  'attention',
-  'severe',
-  'danger',
-  'done',
-  'open',
-  'closed',
-  'sponsors',
-]
 
 type PlaygroundArgs = {
   actorSize: 'small' | 'large'
@@ -440,7 +427,7 @@ Playground.argTypes = {
   },
   badgeVariant: {
     control: {type: 'select'},
-    options: ['none', ...BADGE_VARIANTS],
+    options: ['none', ...TimelineBadgeVariants],
     table: {category: 'Badge'},
   },
   summaryText: {control: {type: 'text'}, table: {category: 'Event'}},

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -50,16 +50,19 @@ const TimelineItem = React.forwardRef<HTMLDivElement, TimelineItemProps>(
 
 TimelineItem.displayName = 'TimelineItem'
 
-export type TimelineBadgeVariant =
-  | 'accent'
-  | 'success'
-  | 'attention'
-  | 'severe'
-  | 'danger'
-  | 'done'
-  | 'open'
-  | 'closed'
-  | 'sponsors'
+export const TimelineBadgeVariants = [
+  'accent',
+  'success',
+  'attention',
+  'severe',
+  'danger',
+  'done',
+  'open',
+  'closed',
+  'sponsors',
+] as const
+
+export type TimelineBadgeVariant = (typeof TimelineBadgeVariants)[number]
 
 export type TimelineBadgeProps = {
   children?: React.ReactNode


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/6680

Two small Phase 1 cleanups surfaced during #7836 review, bundled because they're both touch-up work in the same component folder.

### Changelog

#### Changed

- Replace the deprecated `Octicon` wrapper with direct icon usage from `@primer/octicons-react` in all three Timeline story files (`Timeline.stories.tsx` Default, every usage in `Timeline.features.stories.tsx`, and the one usage in `Timeline.dev.stories.tsx`). The wrapper is a pure `forwardRef` passthrough, so this is a zero-DOM-difference swap — icons accept `aria-label` and other a11y props natively.
- Declare `TimelineBadgeVariants` as an `as const` array in `Timeline.tsx` and derive the `TimelineBadgeVariant` type from it. The Custom Event playground in `Timeline.stories.tsx` now imports the array directly, removing the duplicated runtime list per @adierkens' suggestion on #7836.

#### Removed

- Local `BADGE_VARIANTS` constant in `Timeline.stories.tsx` (now sourced from `Timeline.tsx`).
- `Octicon` imports in all three Timeline story files.

### Rollout strategy

- [x] None; stories-only change plus internal type-source refactor. The publicly exported `TimelineBadgeVariant` type and `Timeline.Badge` API are unchanged. The new `TimelineBadgeVariants` const is exported from `Timeline.tsx` for the stories to import via relative path, but is intentionally **not** re-exported from the package barrel — public API surface is unchanged.

### Testing & Reviewing

- All 15 Timeline unit tests pass.
- Visually verify Default, Features (every story), and the Custom Event Playground render unchanged in Storybook.

### Merge checklist

- [x] Added/updated tests — N/A, no behavior change
- [x] Added/updated documentation — N/A
- [x] Added/updated previews (Storybook) — stories still render identically
- [x] Changes are SSR compatible
- [ ] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

### Notes for reviewers

- Stacks on top of #7836. Base will be updated to `main` once #7836 merges.
- No changeset — `skip changeset` label applied.
- `integration-tests: skipped manually` label applied. github/github-ui only consumes runtime exports (`Timeline.Badge`, `TimelineBadgeVariant` type) — neither changed shape, and the new `TimelineBadgeVariants` const isn't in the public barrel. Nothing for the integration test to catch.