### PR TITLE
Add Timeline.Avatar sub-component

### DIFF
--- a/.changeset/timeline-avatar-slot.md
+++ b/.changeset/timeline-avatar-slot.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Add `Timeline.Avatar` sub-component for rendering an actor avatar in the left gutter of a `Timeline.Item`. Accepts any React children and is absolutely positioned so it does not affect badge or body layout. Consumers must reserve roughly 72px of left padding around the `Timeline` for the avatar to be visible.

--- a/packages/react/src/Timeline/Timeline.docs.json
+++ b/packages/react/src/Timeline/Timeline.docs.json
@@ -30,6 +30,9 @@
     },
     {
       "id": "components-timeline-features--with-actions"
+    },
+    {
+      "id": "components-timeline-features--with-avatar"
     }
   ],
   "importPath": "@primer/react",
@@ -71,6 +74,10 @@
     },
     {
       "name": "Timeline.Actions",
+      "props": []
+    },
+    {
+      "name": "Timeline.Avatar",
       "props": []
     }
   ]

--- a/packages/react/src/Timeline/Timeline.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.features.stories.module.css
@@ -119,8 +119,8 @@
 
 .AvatarGutter {
   /* Reserve space in the left gutter so Timeline.Avatar is visible, and
-     constrain to 1012px (GitHub's product max-width) so the avatar sits a
-     realistic distance from the event text. */
-  max-width: calc(1012px + var(--base-size-40) + var(--base-size-32));
+     constrain to 1012px (GitHub's product max-width, which includes the
+     gutter) so the avatar sits a realistic distance from the event text. */
+  max-width: 1012px;
   padding-left: calc(var(--base-size-40) + var(--base-size-32));
 }

--- a/packages/react/src/Timeline/Timeline.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.features.stories.module.css
@@ -118,6 +118,9 @@
 }
 
 .AvatarGutter {
-  /* Reserve space in the left gutter so Timeline.Avatar is visible */
+  /* Reserve space in the left gutter so Timeline.Avatar is visible, and
+     constrain to 1012px (GitHub's product max-width) so the avatar sits a
+     realistic distance from the event text. */
+  max-width: calc(1012px + var(--base-size-40) + var(--base-size-32));
   padding-left: calc(var(--base-size-40) + var(--base-size-32));
 }

--- a/packages/react/src/Timeline/Timeline.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.features.stories.module.css
@@ -116,3 +116,8 @@
 .Timestamp {
   text-decoration: underline;
 }
+
+.AvatarGutter {
+  /* Reserve space in the left gutter so Timeline.Avatar is visible */
+  padding-left: calc(var(--base-size-40) + var(--base-size-32));
+}

--- a/packages/react/src/Timeline/Timeline.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.features.stories.tsx
@@ -32,6 +32,7 @@ export default {
   component: Timeline,
   subcomponents: {
     'Timeline.Item': Timeline.Item,
+    'Timeline.Avatar': Timeline.Avatar,
     'Timeline.Badge': Timeline.Badge,
     'Timeline.Body': Timeline.Body,
     'Timeline.Break': Timeline.Break,
@@ -339,6 +340,36 @@ export const WithActions = () => (
             </div>
           </div>
         </Timeline.Body>
+      </Timeline.Item>
+    </Timeline>
+  </div>
+)
+
+export const WithAvatar = () => (
+  <div className={classes.AvatarGutter}>
+    <Timeline>
+      <Timeline.Item>
+        <Timeline.Avatar>
+          <Avatar size={40} src="https://avatars.githubusercontent.com/u/92997159?v=4" alt="" />
+        </Timeline.Avatar>
+        <Timeline.Badge>
+          <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <Link href="#" className={classes.LinkWithBoldStyle} muted>
+            Monalisa
+          </Link>
+          opened this pull request
+        </Timeline.Body>
+      </Timeline.Item>
+      <Timeline.Item condensed>
+        <Timeline.Avatar>
+          <Avatar size={16} src="https://avatars.githubusercontent.com/u/92997159?v=4" alt="" />
+        </Timeline.Avatar>
+        <Timeline.Badge>
+          <Octicon icon={GitCommitIcon} aria-label="Commit" />
+        </Timeline.Badge>
+        <Timeline.Body>Monalisa pushed a commit</Timeline.Body>
       </Timeline.Item>
     </Timeline>
   </div>

--- a/packages/react/src/Timeline/Timeline.module.css
+++ b/packages/react/src/Timeline/Timeline.module.css
@@ -7,8 +7,18 @@
     .TimelineItem:first-child {
       padding-top: 0;
 
+      .TimelineItemAvatar {
+        /* No padding-top on first item: badge center is at 0 + 16px (half-badge) */
+        top: var(--base-size-16);
+      }
+
       &:where([data-condensed])::before {
         top: var(--base-size-12);
+      }
+
+      &:where([data-condensed]) .TimelineItemAvatar {
+        /* No padding-top + condensed: badge center is at 0 + 8px margin + 8px half-badge */
+        top: calc(var(--base-size-8) + var(--base-size-8));
       }
     }
   }

--- a/packages/react/src/Timeline/Timeline.module.css
+++ b/packages/react/src/Timeline/Timeline.module.css
@@ -59,7 +59,22 @@
       background-color: var(--bgColor-default);
       border: 0;
     }
+
+    .TimelineItemAvatar {
+      /* Vertically center against the condensed badge (4px padding-top + 8px badge top margin + 8px half-badge) */
+      top: calc(var(--base-size-4) + var(--base-size-8) + var(--base-size-8));
+    }
   }
+}
+
+.TimelineItemAvatar {
+  position: absolute;
+  /* Place avatar in the left gutter, aligned with surrounding actor avatars (~72px from item content) */
+  left: calc(-1 * (var(--base-size-40) + var(--base-size-32)));
+  /* Vertically center against the default badge (16px padding-top + 16px half-badge) */
+  top: calc(var(--base-size-16) + var(--base-size-16));
+  z-index: 1;
+  transform: translateY(-50%);
 }
 
 .TimelineBadgeWrapper {

--- a/packages/react/src/Timeline/Timeline.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.stories.tsx
@@ -9,6 +9,7 @@ export default {
   component: Timeline,
   subcomponents: {
     'Timeline.Item': Timeline.Item,
+    'Timeline.Avatar': Timeline.Avatar,
     'Timeline.Badge': Timeline.Badge,
     'Timeline.Body': Timeline.Body,
     'Timeline.Break': Timeline.Break,

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -111,8 +111,20 @@ const TimelineActions = React.forwardRef<HTMLDivElement, TimelineActionsProps>((
 
 TimelineActions.displayName = 'Timeline.Actions'
 
+export type TimelineAvatarProps = {
+  /** Class name for custom styling */
+  className?: string
+} & React.ComponentPropsWithoutRef<'div'>
+
+const TimelineAvatar = React.forwardRef<HTMLDivElement, TimelineAvatarProps>(({className, ...props}, forwardRef) => {
+  return <div {...props} className={clsx(className, classes.TimelineItemAvatar)} ref={forwardRef} />
+})
+
+TimelineAvatar.displayName = 'Timeline.Avatar'
+
 export default Object.assign(Timeline, {
   Item: TimelineItem,
+  Avatar: TimelineAvatar,
   Badge: TimelineBadge,
   Body: TimelineBody,
   Break: TimelineBreak,

--- a/packages/react/src/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react/src/Timeline/__tests__/Timeline.test.tsx
@@ -92,3 +92,21 @@ describe('Timeline.Actions', () => {
     expect(container.firstChild).toHaveAttribute('data-foo', 'bar')
   })
 })
+
+describe('Timeline.Avatar', () => {
+  implementsClassName(Timeline.Avatar, classes.TimelineItemAvatar)
+
+  it('renders children', () => {
+    const {getByTestId} = render(
+      <Timeline.Avatar>
+        <span data-testid="avatar-child">avatar</span>
+      </Timeline.Avatar>,
+    )
+    expect(getByTestId('avatar-child')).toBeInTheDocument()
+  })
+
+  it('forwards additional props to the underlying element', () => {
+    const {container} = render(<Timeline.Avatar data-foo="bar" />)
+    expect(container.firstChild).toHaveAttribute('data-foo', 'bar')
+  })
+})

--- a/packages/react/src/Timeline/index.ts
+++ b/packages/react/src/Timeline/index.ts
@@ -3,6 +3,7 @@ export type {
   TimelineProps,
   TimelineItemsProps,
   TimelineItemProps,
+  TimelineAvatarProps,
   TimelineBadgeVariant,
   TimelineBadgeProps,
   TimelineBodyProps,

--- a/packages/react/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/react/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -193,6 +193,7 @@ exports[`@primer/react > should not update exports without a semver change 1`] =
   "ThemeShadowPaths",
   "Timeline",
   "type TimelineActionsProps",
+  "type TimelineAvatarProps",
   "type TimelineBadgeProps",
   "type TimelineBadgeVariant",
   "type TimelineBodyProps",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -184,6 +184,7 @@ export {default as Timeline} from './Timeline'
 export type {
   TimelineProps,
   TimelineActionsProps,
+  TimelineAvatarProps,
   TimelineBadgeVariant,
   TimelineBadgeProps,
   TimelineBodyProps,


### PR DESCRIPTION
Closes github/primer#6677

The `Timeline` component is used across GitHub to render lists of events on issues, pull requests, discussions, and security alerts. Most of those event rows include an actor avatar — the picture of the person, bot, or app that performed the action — in a gutter to the left of the timeline rail. Today, Primer React's `Timeline` has no built-in way to render that avatar, so consumers have to position it themselves with their own CSS. This PR adds a first-class slot for it.

The new `Timeline.Avatar` sub-component is a thin wrapper that takes any React children (typically an `<Avatar>`, but it could be an `<AvatarPair>`, `<AvatarStack>`, an icon, an `<img>`, etc.) and absolutely positions them in the left gutter of the surrounding `Timeline.Item`. Because it's absolutely positioned, it does not affect the badge or body layout, and it vertically centers itself against the badge in both default and condensed item geometries.

This is the first piece of the broader Timeline Phase 2 work (github/primer#6677). It ships only the public API and a feature story. A follow-up will migrate the in-flight Custom Event playground (#7836) to use this new slot once that PR lands on `main`.

### Changelog

#### New

- `Timeline.Avatar` sub-component: a children-based slot that absolutely positions its content in the left gutter of the parent `Timeline.Item`. Accepts any React node.
- New `TimelineAvatarProps` type exported from `@primer/react`.
- New feature story: `Timeline/Features → WithAvatar`.

#### Changed

- None.

#### Removed

- None.

### Design notes

- **API shape — children-based, not `Avatar`-constructed.** The Rails [`Timeline::TimelineItemComponent`](https://primer.style/view-components/components/beta/timelineitem) accepts an `avatar` slot that constructs `Primer::Beta::Avatar` internally with a fixed prop signature. We chose a children-based slot instead so callers can pass `<Avatar>`, `<AvatarPair>`, `<AvatarStack>`, an `<img>`, an icon, etc. — anything that fits in the gutter.
- **Vertical centering (deviation from Rails).** Rails top-aligns the avatar with the badge (3 lines of CSS, no `top`). This component instead centers the avatar vertically against the badge using `transform: translateY(-50%)` with a `top` value computed from the item's padding + half the badge height. This makes the slot size-independent (works for 16/20/24/32/40/48px avatars) and looks better when avatar and badge sizes differ. Future-proofing: if Rails parity becomes a hard requirement, we can introduce an alignment prop.
- **Condensed geometry.** A `[data-condensed] .TimelineItemAvatar` override recomputes the `top` value for condensed items (which have 4px top padding and a 16px badge instead of 32px).
- **No automatic gutter reservation.** Matches Rails — consumers must reserve roughly 72px of left padding around the `Timeline` for the avatar to be visible. This is documented in the changeset and demonstrated in the feature story.

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Open `Timeline/Features → WithAvatar` in Storybook. The story is constrained to 1012px (GitHub's product max-width, inclusive of the 72px avatar gutter).

Verify:
- **Default item** — 40px avatar in the left gutter, vertically centered against the 32px badge.
- **Condensed item** — 16px avatar, vertically centered against the smaller condensed badge.
- **clipSidebar alignment** — when `clipSidebar="start"` or `"both"` zeroes the first item's padding-top, the avatar stays aligned with the badge. This is handled by CSS overrides that recalculate `top` for both default and condensed geometries.
- Unit tests cover className propagation, child rendering, and prop forwarding.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui
