### PR TITLE
ci: raise error if no report found for playwright

### DIFF
--- a/.github/workflows/aat-reports.yml
+++ b/.github/workflows/aat-reports.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version-file: '.nvmrc'
+          node-version: 24.15.0
           cache: 'npm'
       - name: install dependencies
         run: npm ci

--- a/.github/workflows/aat-reports.yml
+++ b/.github/workflows/aat-reports.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           name: aat
           path: playwright-report
+          if-no-files-found: error
       - name: Check aat-runner job status
         if: ${{ needs.aat-runner.result == 'failure' }}
         run: exit 1

--- a/.github/workflows/aat-reports.yml
+++ b/.github/workflows/aat-reports.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           name: aat-${{ matrix.shard }}
           path: blob-report
+          if-no-files-found: error
           retention-days: 1
 
   aat:

--- a/.github/workflows/vrt-reports.yml
+++ b/.github/workflows/vrt-reports.yml
@@ -97,6 +97,7 @@ jobs:
         with:
           name: vrt
           path: playwright-report
+          if-no-files-found: error
       - name: check vrt-runner job status
         if: ${{ needs.vrt-runner.result == 'failure' }}
         run: exit 1

--- a/.github/workflows/vrt-reports.yml
+++ b/.github/workflows/vrt-reports.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version-file: '.nvmrc'
+          node-version: 24.15.0
           cache: 'npm'
       - name: install dependencies
         run: npm ci


### PR DESCRIPTION
Update our vrt and aat reports to fail if no artifact is found for uploads. This should help to better identify when something is wrong in our deploy previews since sub-sequent jobs depend on these artifacts in order to deploy