### PR TITLE
perf(Button): replace :has() icon-only-counter selector with data attribute

### DIFF
--- a/.changeset/perf-button-icon-only-counter.md
+++ b/.changeset/perf-button-icon-only-counter.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Button: Replace the icon-only-with-counter `:has(...):not(:has(...))` selector with a `data-icon-only-counter` attribute computed from props. Reduces style-recalculation cost on pages that render many Buttons. No visual or behavioral changes.

--- a/packages/react/src/Button/ButtonBase.module.css
+++ b/packages/react/src/Button/ButtonBase.module.css
@@ -640,8 +640,7 @@
 
   /* Icon-only + Counter */
 
-  /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- scoped to CSS Module, audited (github/github-ui#17224) */
-  &:where([data-has-count]):has([data-component='leadingVisual']):not(:has([data-component='text'])) {
+  &:where([data-icon-only-counter]) {
     /* stylelint-disable-next-line primer/spacing */
     padding-inline: var(--control-medium-paddingInline-condensed);
 

--- a/packages/react/src/Button/ButtonBase.tsx
+++ b/packages/react/src/Button/ButtonBase.tsx
@@ -99,6 +99,7 @@ const ButtonBase = forwardRef(({children, as: Component = 'button', ...props}, f
         data-variant={variant}
         data-label-wrap={labelWrap}
         data-has-count={count !== undefined ? true : undefined}
+        data-icon-only-counter={count !== undefined && LeadingVisual && !children ? true : undefined}
         aria-describedby={ariaDescribedByIds.filter(descriptionID => Boolean(descriptionID)).join(' ') || undefined}
         // aria-labelledby is needed because the accessible name becomes unset when the button is in a loading state.
         // We only set it when the button is in a loading state because it will supersede the aria-label when the screen

--- a/packages/react/src/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/Button/__tests__/Button.test.tsx
@@ -357,6 +357,32 @@ describe('data-component attributes', () => {
     })
   })
 
+  describe('data-icon-only-counter', () => {
+    it('is set when count, leadingVisual, and no children are present', () => {
+      const {container} = render(<Button leadingVisual={SearchIcon} count={5} aria-label="Search notifications" />)
+      expect(container.querySelector('[data-component="Button"]')).toHaveAttribute('data-icon-only-counter', 'true')
+    })
+
+    it('is not set when children are present', () => {
+      const {container} = render(
+        <Button leadingVisual={SearchIcon} count={5}>
+          Search
+        </Button>,
+      )
+      expect(container.querySelector('[data-component="Button"]')).not.toHaveAttribute('data-icon-only-counter')
+    })
+
+    it('is not set when leadingVisual is missing', () => {
+      const {container} = render(<Button count={5} aria-label="Notifications" />)
+      expect(container.querySelector('[data-component="Button"]')).not.toHaveAttribute('data-icon-only-counter')
+    })
+
+    it('is not set when count is missing', () => {
+      const {container} = render(<Button leadingVisual={SearchIcon} aria-label="Search" />)
+      expect(container.querySelector('[data-component="Button"]')).not.toHaveAttribute('data-icon-only-counter')
+    })
+  })
+
   describe('IconButton', () => {
     it('should have data-component="IconButton" on the button element', () => {
       const {container} = render(<IconButton icon={SearchIcon} aria-label="Search" />)


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

Replaces the icon-only-with-counter `:has(...):not(:has(...))` selector on `ButtonBase` with a JS-derived `data-icon-only-counter` attribute computed from props at render time. Same visual output; reduces the per-Button style-recalculation cost.

**Before:**

```css
&:where([data-has-count]):has([data-component='leadingVisual']):not(:has([data-component='text'])) {
  padding-inline: var(--control-medium-paddingInline-condensed);
}
```

**After:**

```tsx
data-icon-only-counter={count !== undefined && LeadingVisual && !children ? true : undefined}
```

```css
&:where([data-icon-only-counter]) {
  padding-inline: var(--control-medium-paddingInline-condensed);
}
```

`:has()` + `:not(:has())` compound selectors are among the most expensive selectors in the CSS engine, and they evaluate against every `.ButtonBase` instance on every DOM mutation inside the button. Buttons render dozens to hundreds of times per page in real GitHub views, so this is a measurable cost. The equivalent JS check is a constant-time prop comparison.

### Changelog

#### New

- `data-icon-only-counter` attribute on `ButtonBase` when an icon-only Button has a `count`

#### Changed

- Internal: `ButtonBase` no longer relies on `:has()` for icon-only-with-counter styling

#### Removed

- The `:has(...):not(:has(...))` compound selector from `ButtonBase.module.css`

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

No visual changes expected. The new attribute is only set when the existing `:has()` selector would have matched (`count` set + `leadingVisual` rendered + no `children`).

Existing Button unit tests pass locally (138 tests across Button + ActionList suites).

Part of a small series replacing `:has()` selectors on high-frequency components with JS-derived data attributes. A follow-up PR will apply the same pattern to `ActionList`.

### Merge checklist

- [x] Added/updated tests <!-- existing tests cover the behavior; no new behavior introduced -->
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
