### PR TITLE
perf(ActionList): replace :has() selectors with data attributes

### DIFF
--- a/.changeset/perf-actionlist-has-selectors.md
+++ b/.changeset/perf-actionlist-has-selectors.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+ActionList: Replace `:has(...)` selectors on `ActionList.Item`, `InactiveButtonWrap`, and `TrailingActionButton` with JS-derived data attributes (`data-has-trailing-action`, `data-trailing-action-loading`, `data-position`, `data-has-label`). Reduces style-recalculation cost on lists that render many items. No visual or behavioral changes.

--- a/packages/react/src/ActionList/ActionList.module.css
+++ b/packages/react/src/ActionList/ActionList.module.css
@@ -103,8 +103,7 @@
   border-radius: var(--borderRadius-medium);
 
   /* apply flex if trailing action exists as an immediate child */
-  /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- scoped to CSS Module, audited (github/github-ui#17224) */
-  &:has(> .TrailingAction) {
+  &[data-has-trailing-action] {
     display: flex;
     flex-wrap: nowrap;
   }
@@ -372,8 +371,7 @@
   }
 
   /* When TrailingAction is in loading state, keep labels and descriptions accessible */
-  /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- scoped to CSS Module, audited (github/github-ui#17224) */
-  &:has(.TrailingAction [data-loading='true']):not([data-is-disabled]) {
+  &[data-trailing-action-loading]:not([data-is-disabled]) {
     /* Ensure labels and descriptions maintain accessibility contrast */
     & .ItemLabel {
       color: var(--fgColor-default);
@@ -719,8 +717,7 @@ span wrapping svg or text */
   height: 100%;
 
   /* Preserve width consistency when loading state is active for text buttons only */
-  /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- scoped to CSS Module, audited (github/github-ui#17224) */
-  &[data-loading='true']:has([data-component='buttonContent']) {
+  &[data-loading='true'][data-has-label='true'] {
     /* Double the left padding to compensate for missing right padding */
     padding: 0 0 0 calc(var(--base-size-12) * 2);
 
@@ -739,13 +736,11 @@ span wrapping svg or text */
 }
 
 .InactiveButtonWrap {
-  /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- scoped to CSS Module, audited (github/github-ui#17224) */
-  &:has(.TrailingVisual) {
+  &[data-position='trailing'] {
     grid-area: trailingVisual;
   }
 
-  /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- scoped to CSS Module, audited (github/github-ui#17224) */
-  &:has(.LeadingVisual) {
+  &[data-position='leading'] {
     grid-area: leadingVisual;
   }
 }

--- a/packages/react/src/ActionList/Item.test.tsx
+++ b/packages/react/src/ActionList/Item.test.tsx
@@ -487,6 +487,49 @@ describe('ActionList.Item', () => {
         'data-trailing-action-loading',
       )
     })
+
+    // The TrailingAction element is only rendered when the item is not inactive,
+    // not loading, and not inside a menu-style container. The data attributes
+    // must mirror that gate or the styling will apply when no action is in the DOM.
+    it('does not set data-has-trailing-action when the item is inactive', () => {
+      const {container} = HTMLRender(
+        <ActionList>
+          <ActionList.Item inactiveText="Unavailable">
+            Item
+            <ActionList.TrailingAction icon={BookIcon} label="Action" />
+          </ActionList.Item>
+        </ActionList>,
+      )
+      expect(container.querySelector('[data-component="ActionList.Item"]')).not.toHaveAttribute(
+        'data-has-trailing-action',
+      )
+      expect(container.querySelector('[data-component="ActionList.Item"]')).not.toHaveAttribute(
+        'data-trailing-action-loading',
+      )
+    })
+
+    it('does not set data-has-trailing-action when the item is loading', () => {
+      const {container} = HTMLRender(
+        <ActionList>
+          <ActionList.Item loading>
+            Item
+            <ActionList.TrailingAction label="Action" loading />
+          </ActionList.Item>
+        </ActionList>,
+      )
+      expect(container.querySelector('[data-component="ActionList.Item"]')).not.toHaveAttribute(
+        'data-has-trailing-action',
+      )
+      expect(container.querySelector('[data-component="ActionList.Item"]')).not.toHaveAttribute(
+        'data-trailing-action-loading',
+      )
+    })
+
+    // The menuContext gate (ActionMenu/SelectPanel/FilteredActionList) is also
+    // applied in code but cannot be exercised in dev tests because passing
+    // TrailingAction in a menu-style container fires a dev-only invariant
+    // (see Item.tsx). The gating still matters for production builds where
+    // the invariant is a no-op.
   })
 
   describe('inactive indicator wrap data-position', () => {

--- a/packages/react/src/ActionList/Item.test.tsx
+++ b/packages/react/src/ActionList/Item.test.tsx
@@ -431,4 +431,116 @@ describe('ActionList.Item', () => {
       expect(queryByRole('menu')).toBeInTheDocument()
     })
   })
+
+  describe('data attributes derived from slots', () => {
+    it('sets data-has-trailing-action when a TrailingAction slot is present', () => {
+      const {container} = HTMLRender(
+        <ActionList>
+          <ActionList.Item>
+            Item
+            <ActionList.TrailingAction icon={BookIcon} label="Action" />
+          </ActionList.Item>
+        </ActionList>,
+      )
+      expect(container.querySelector('[data-component="ActionList.Item"]')).toHaveAttribute(
+        'data-has-trailing-action',
+        'true',
+      )
+    })
+
+    it('does not set data-has-trailing-action when no TrailingAction slot is present', () => {
+      const {container} = HTMLRender(
+        <ActionList>
+          <ActionList.Item>Item</ActionList.Item>
+        </ActionList>,
+      )
+      expect(container.querySelector('[data-component="ActionList.Item"]')).not.toHaveAttribute(
+        'data-has-trailing-action',
+      )
+    })
+
+    it('sets data-trailing-action-loading when the TrailingAction is loading', () => {
+      const {container} = HTMLRender(
+        <ActionList>
+          <ActionList.Item>
+            Item
+            <ActionList.TrailingAction label="Action" loading />
+          </ActionList.Item>
+        </ActionList>,
+      )
+      expect(container.querySelector('[data-component="ActionList.Item"]')).toHaveAttribute(
+        'data-trailing-action-loading',
+        'true',
+      )
+    })
+
+    it('does not set data-trailing-action-loading when the TrailingAction is not loading', () => {
+      const {container} = HTMLRender(
+        <ActionList>
+          <ActionList.Item>
+            Item
+            <ActionList.TrailingAction icon={BookIcon} label="Action" />
+          </ActionList.Item>
+        </ActionList>,
+      )
+      expect(container.querySelector('[data-component="ActionList.Item"]')).not.toHaveAttribute(
+        'data-trailing-action-loading',
+      )
+    })
+  })
+
+  describe('inactive indicator wrap data-position', () => {
+    it('renders the inactive wrap with data-position="trailing" when the item has no leading visual', () => {
+      const {container} = HTMLRender(
+        <ActionList>
+          <ActionList.Item inactiveText="Unavailable">Item</ActionList.Item>
+        </ActionList>,
+      )
+      const wrap = container.querySelector(`.${classes.InactiveButtonWrap}`)
+      expect(wrap).toHaveAttribute('data-position', 'trailing')
+    })
+
+    it('renders the inactive wrap with data-position="leading" when the item has a leading visual', () => {
+      const {container} = HTMLRender(
+        <ActionList>
+          <ActionList.Item inactiveText="Unavailable">
+            <ActionList.LeadingVisual>
+              <BookIcon />
+            </ActionList.LeadingVisual>
+            Item
+          </ActionList.Item>
+        </ActionList>,
+      )
+      const wrap = container.querySelector(`.${classes.InactiveButtonWrap}`)
+      expect(wrap).toHaveAttribute('data-position', 'leading')
+    })
+  })
+
+  describe('TrailingAction data-has-label', () => {
+    it('sets data-has-label on the text Button variant (no icon prop)', () => {
+      const {container} = HTMLRender(
+        <ActionList>
+          <ActionList.Item>
+            Item
+            <ActionList.TrailingAction label="Action" />
+          </ActionList.Item>
+        </ActionList>,
+      )
+      const action = container.querySelector(`.${classes.TrailingActionButton}`)
+      expect(action).toHaveAttribute('data-has-label', 'true')
+    })
+
+    it('does not set data-has-label on the IconButton variant (icon prop set)', () => {
+      const {container} = HTMLRender(
+        <ActionList>
+          <ActionList.Item>
+            Item
+            <ActionList.TrailingAction icon={BookIcon} label="Action" />
+          </ActionList.Item>
+        </ActionList>,
+      )
+      const action = container.querySelector(`.${classes.TrailingActionButton}`)
+      expect(action).not.toHaveAttribute('data-has-label')
+    })
+  })
 })

--- a/packages/react/src/ActionList/Item.tsx
+++ b/packages/react/src/ActionList/Item.tsx
@@ -324,6 +324,8 @@ const UnwrappedItem = <As extends React.ElementType = 'li'>(
         data-is-disabled={disabled ? true : undefined}
         data-has-subitem={slots.subItem ? true : undefined}
         data-has-description={slots.description ? true : false}
+        data-has-trailing-action={slots.trailingAction ? true : undefined}
+        data-trailing-action-loading={slots.trailingAction?.props.loading ? true : undefined}
         className={clsx(classes.ActionListItem, className)}
       >
         <ConditionalTooltip ref={forwardedRef} text={truncatedText} enabled={buttonSemantics}>

--- a/packages/react/src/ActionList/Item.tsx
+++ b/packages/react/src/ActionList/Item.tsx
@@ -312,6 +312,11 @@ const UnwrappedItem = <As extends React.ElementType = 'li'>(
     ],
   )
 
+  // The trailing action element is only rendered when none of these gates apply
+  // (see the JSX below). Mirror the same condition for the styling-related data
+  // attributes so the CSS only kicks in when the action is actually in the DOM.
+  const trailingActionRendered = !inactive && !loading && !menuContext && Boolean(slots.trailingAction)
+
   return (
     <ItemContext.Provider value={itemContextValue}>
       <li
@@ -324,8 +329,8 @@ const UnwrappedItem = <As extends React.ElementType = 'li'>(
         data-is-disabled={disabled ? true : undefined}
         data-has-subitem={slots.subItem ? true : undefined}
         data-has-description={slots.description ? true : false}
-        data-has-trailing-action={slots.trailingAction ? true : undefined}
-        data-trailing-action-loading={slots.trailingAction?.props.loading ? true : undefined}
+        data-has-trailing-action={trailingActionRendered ? true : undefined}
+        data-trailing-action-loading={trailingActionRendered && slots.trailingAction?.props.loading ? true : undefined}
         className={clsx(classes.ActionListItem, className)}
       >
         <ConditionalTooltip ref={forwardedRef} text={truncatedText} enabled={buttonSemantics}>

--- a/packages/react/src/ActionList/TrailingAction.tsx
+++ b/packages/react/src/ActionList/TrailingAction.tsx
@@ -59,6 +59,7 @@ export const TrailingAction = forwardRef(
             href={href}
             loading={loading}
             data-loading={Boolean(loading)}
+            data-has-label="true"
             ref={forwardedRef}
             className={classes.TrailingActionButton}
             {...props}

--- a/packages/react/src/ActionList/Visuals.tsx
+++ b/packages/react/src/ActionList/Visuals.tsx
@@ -70,7 +70,7 @@ export const VisualOrIndicator: React.FC<
   }
 
   return inactiveText ? (
-    <span className={classes.InactiveButtonWrap}>
+    <span className={classes.InactiveButtonWrap} data-position={position}>
       <Tooltip text={inactiveText} type="description">
         <button type="button" className={classes.InactiveButtonReset} aria-labelledby={labelId}>
           <VisualComponent>


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

Replaces four `:has(...)` selectors in `ActionList` with JS-derived data attributes computed from props/slots at render time. Same DOM output otherwise; reduces the per-Item style-recalculation cost.

ActionList items render many times per page in real GitHub views (navigation, dropdowns, issue lists), so each `:has()` selector evaluates many times on every DOM mutation inside the list. Hoisting the state to data attributes turns those into constant-time attribute matches.

**Replacements:**

| Where | Before | After |
| --- | --- | --- |
| `ActionListItem` | `&:has(> .TrailingAction)` | `&[data-has-trailing-action]` |
| `ActionListItem` | `&:has(.TrailingAction [data-loading='true']):not([data-is-disabled])` | `&[data-trailing-action-loading]:not([data-is-disabled])` |
| `InactiveButtonWrap` | `&:has(.TrailingVisual)` / `&:has(.LeadingVisual)` | `&[data-position='trailing']` / `&[data-position='leading']` |
| `TrailingActionButton` | `&[data-loading='true']:has([data-component='buttonContent'])` | `&[data-loading='true'][data-has-label='true']` |

The new attributes are derived from state the components already track:

- `data-has-trailing-action` ← `slots.trailingAction` presence
- `data-trailing-action-loading` ← `slots.trailingAction?.props.loading`
- `data-position` ← the existing `position` prop on `VisualOrIndicator`
- `data-has-label` ← the text-Button branch of `TrailingAction` (vs the `IconButton` branch)

### Changelog

#### New

- `data-has-trailing-action`, `data-trailing-action-loading` on `ActionList.Item`
- `data-position` on the inactive-state visual wrapper
- `data-has-label` on the text-Button variant of `ActionList.TrailingAction`

#### Changed

- Internal: `ActionList` styling no longer relies on `:has()` for the cases above

#### Removed

- Four `:has(...)` selectors from `ActionList.module.css`

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

No visual changes expected. Each new data attribute is set exactly when the equivalent `:has()` selector previously matched.

Existing `ActionList` unit tests pass locally (138 tests across the Button + ActionList suites).

Companion to #7893 (same pattern applied to Button). Independent — either can land first.

### Merge checklist

- [x] Added/updated tests <!-- existing tests cover the behavior; no new behavior introduced -->
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
