### PR TITLE
perf(TextInputWrapper): replace :not() attribute chains with positive markers

### DIFF
--- a/.changeset/perf-textinputwrapper-not-chains.md
+++ b/.changeset/perf-textinputwrapper-not-chains.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+TextInput / TextInputWithTokens / Select / Autocomplete: Replace chained `:not([data-leading-visual])`, `:not([data-trailing-visual])`, and `:not([data-trailing-action])` attribute negations in `TextInputWrapper` styles with positive `data-no-leading-visual`, `data-no-trailing-visual`, and `data-no-trailing-action` markers emitted by the wrapper components. Eliminates the 2- and 3-deep `:not()` chains that previously evaluated against every input on every state change. No visual or behavioral changes.

--- a/packages/react/src/TextInput/TextInput.test.tsx
+++ b/packages/react/src/TextInput/TextInput.test.tsx
@@ -411,4 +411,43 @@ describe('TextInput', () => {
       expect(container.querySelector('[data-component="TextInput.CharacterCounter"]')).toBeInTheDocument()
     })
   })
+
+  describe('data-no-* visual markers', () => {
+    it('sets all data-no-* markers when no visuals or actions are provided', () => {
+      const {container} = render(<TextInput name="test" />)
+      const wrapper = container.querySelector('[data-component="TextInput"]')
+      expect(wrapper).toHaveAttribute('data-no-leading-visual', 'true')
+      expect(wrapper).toHaveAttribute('data-no-trailing-visual', 'true')
+      expect(wrapper).toHaveAttribute('data-no-trailing-action', 'true')
+    })
+
+    it('drops data-no-leading-visual when leadingVisual is provided', () => {
+      const {container} = render(<TextInput name="test" leadingVisual={SearchIcon} />)
+      const wrapper = container.querySelector('[data-component="TextInput"]')
+      expect(wrapper).not.toHaveAttribute('data-no-leading-visual')
+      expect(wrapper).toHaveAttribute('data-leading-visual', 'true')
+      expect(wrapper).toHaveAttribute('data-no-trailing-visual', 'true')
+      expect(wrapper).toHaveAttribute('data-no-trailing-action', 'true')
+    })
+
+    it('drops data-no-trailing-visual when trailingVisual is provided', () => {
+      const {container} = render(<TextInput name="test" trailingVisual={SearchIcon} />)
+      const wrapper = container.querySelector('[data-component="TextInput"]')
+      expect(wrapper).toHaveAttribute('data-no-leading-visual', 'true')
+      expect(wrapper).not.toHaveAttribute('data-no-trailing-visual')
+      expect(wrapper).toHaveAttribute('data-trailing-visual', 'true')
+      expect(wrapper).toHaveAttribute('data-no-trailing-action', 'true')
+    })
+
+    it('drops data-no-trailing-action when trailingAction is provided', () => {
+      const {container} = render(
+        <TextInput name="test" trailingAction={<TextInput.Action aria-label="Clear">Clear</TextInput.Action>} />,
+      )
+      const wrapper = container.querySelector('[data-component="TextInput"]')
+      expect(wrapper).toHaveAttribute('data-no-leading-visual', 'true')
+      expect(wrapper).toHaveAttribute('data-no-trailing-visual', 'true')
+      expect(wrapper).not.toHaveAttribute('data-no-trailing-action')
+      expect(wrapper).toHaveAttribute('data-trailing-action', 'true')
+    })
+  })
 })

--- a/packages/react/src/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -7,6 +7,9 @@ exports[`TextInput > renders contrast 1`] = `
     class="TextInput-wrapper prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
     data-component="TextInput"
     data-contrast="true"
+    data-no-leading-visual="true"
+    data-no-trailing-action="true"
+    data-no-trailing-visual="true"
   >
     <input
       class="prc-components-Input-sKHcw"
@@ -25,6 +28,9 @@ exports[`TextInput > renders error 1`] = `
     aria-busy="false"
     class="TextInput-wrapper prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
     data-component="TextInput"
+    data-no-leading-visual="true"
+    data-no-trailing-action="true"
+    data-no-trailing-visual="true"
     data-validation="error"
   >
     <input
@@ -46,6 +52,9 @@ exports[`TextInput > renders monospace 1`] = `
     class="TextInput-wrapper prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
     data-component="TextInput"
     data-monospace="true"
+    data-no-leading-visual="true"
+    data-no-trailing-action="true"
+    data-no-trailing-visual="true"
   >
     <input
       class="prc-components-Input-sKHcw"
@@ -64,6 +73,9 @@ exports[`TextInput > renders placeholder 1`] = `
     aria-busy="false"
     class="TextInput-wrapper prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
     data-component="TextInput"
+    data-no-leading-visual="true"
+    data-no-trailing-action="true"
+    data-no-trailing-visual="true"
   >
     <input
       class="prc-components-Input-sKHcw"
@@ -83,6 +95,9 @@ exports[`TextInput > should render a password input 1`] = `
     aria-busy="false"
     class="TextInput-wrapper prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
     data-component="TextInput"
+    data-no-leading-visual="true"
+    data-no-trailing-action="true"
+    data-no-trailing-visual="true"
   >
     <input
       class="prc-components-Input-sKHcw"

--- a/packages/react/src/TextInputWithTokens/__snapshots__/TextInputWithTokens.test.tsx.snap
+++ b/packages/react/src/TextInputWithTokens/__snapshots__/TextInputWithTokens.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
         data-leading-visual="true"
+        data-no-trailing-action="true"
         data-size="medium"
         data-trailing-visual="true"
       >
@@ -462,6 +463,7 @@ exports[`TextInputWithTokens > renders a leadingVisual and trailingVisual 1`] = 
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
       data-leading-visual="true"
+      data-no-trailing-action="true"
       data-size="medium"
       data-trailing-visual="true"
     >
@@ -971,6 +973,9 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <div
@@ -1097,6 +1102,9 @@ exports[`TextInputWithTokens > renders a truncated set of tokens 1`] = `
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
     >
       <div
@@ -1285,6 +1293,9 @@ exports[`TextInputWithTokens > renders as block layout 1`] = `
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-block="true"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <div
@@ -1311,6 +1322,9 @@ exports[`TextInputWithTokens > renders as block layout 1`] = `
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-block="true"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
     >
       <div
@@ -1397,6 +1411,9 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
         data-token-wrapping="true"
         style="max-height: 20px;"
@@ -1800,6 +1817,9 @@ exports[`TextInputWithTokens > renders at a maximum height when specified 1`] = 
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
       data-token-wrapping="true"
       style="max-height: 20px;"
@@ -2264,6 +2284,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="small"
       >
         <div
@@ -2665,6 +2688,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 1`] = `
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="small"
     >
       <div
@@ -3127,6 +3153,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="small"
       >
         <div
@@ -3527,6 +3556,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="small"
       >
         <div
@@ -3928,6 +3960,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 2`] = `
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="small"
     >
       <div
@@ -4390,6 +4425,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="small"
       >
         <div
@@ -4790,6 +4828,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="small"
       >
         <div
@@ -5190,6 +5231,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <div
@@ -5591,6 +5635,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 3`] = `
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
     >
       <div
@@ -6053,6 +6100,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="small"
       >
         <div
@@ -6453,6 +6503,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="small"
       >
         <div
@@ -6853,6 +6906,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <div
@@ -7253,6 +7309,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <div
@@ -7654,6 +7713,9 @@ exports[`TextInputWithTokens > renders tokens at the specified sizes 4`] = `
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
     >
       <div
@@ -8116,6 +8178,9 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
         data-token-wrapping="true"
       >
@@ -8518,6 +8583,9 @@ exports[`TextInputWithTokens > renders tokens on a single line when specified 1`
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
       data-token-wrapping="true"
     >
@@ -8981,6 +9049,9 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <div
@@ -9182,6 +9253,9 @@ exports[`TextInputWithTokens > renders tokens without a remove button when speci
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
     >
       <div
@@ -9444,6 +9518,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
         data-size="medium"
         data-trailing-visual="true"
       >
@@ -9883,6 +9959,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
         data-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <span
@@ -10359,6 +10437,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
         data-size="medium"
         data-trailing-visual="true"
       >
@@ -10798,6 +10878,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
         data-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <span
@@ -11296,6 +11378,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
         data-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <span
@@ -11794,6 +11878,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
         data-leading-visual="true"
+        data-no-trailing-action="true"
         data-size="medium"
         data-trailing-visual="true"
       >
@@ -12292,6 +12377,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
         data-size="medium"
         data-trailing-visual="true"
       >
@@ -12752,6 +12839,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
         data-leading-visual="true"
+        data-no-trailing-action="true"
         data-size="medium"
         data-trailing-visual="true"
       >
@@ -13250,6 +13338,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
         data-size="medium"
         data-trailing-visual="true"
       >
@@ -13710,6 +13800,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
         data-leading-visual="true"
+        data-no-trailing-action="true"
         data-size="small"
         data-trailing-visual="true"
       >
@@ -14230,6 +14321,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
         data-leading-visual="true"
+        data-no-trailing-action="true"
         data-size="medium"
         data-trailing-visual="true"
       >
@@ -14750,6 +14842,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
         data-leading-visual="true"
+        data-no-trailing-action="true"
         data-size="medium"
         data-trailing-visual="true"
       >
@@ -15272,6 +15365,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
       data-size="medium"
       data-trailing-visual="true"
     >
@@ -15711,6 +15806,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
       data-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
     >
       <span
@@ -16187,6 +16284,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
       data-size="medium"
       data-trailing-visual="true"
     >
@@ -16626,6 +16725,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
       data-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
     >
       <span
@@ -17124,6 +17225,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
       data-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
     >
       <span
@@ -17622,6 +17725,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
       data-leading-visual="true"
+      data-no-trailing-action="true"
       data-size="medium"
       data-trailing-visual="true"
     >
@@ -18120,6 +18224,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
       data-size="medium"
       data-trailing-visual="true"
     >
@@ -18580,6 +18686,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
       data-leading-visual="true"
+      data-no-trailing-action="true"
       data-size="medium"
       data-trailing-visual="true"
     >
@@ -19078,6 +19185,8 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
       data-size="medium"
       data-trailing-visual="true"
     >
@@ -19538,6 +19647,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
       data-leading-visual="true"
+      data-no-trailing-action="true"
       data-size="small"
       data-trailing-visual="true"
     >
@@ -20058,6 +20168,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
       data-leading-visual="true"
+      data-no-trailing-action="true"
       data-size="medium"
       data-trailing-visual="true"
     >
@@ -20578,6 +20689,7 @@ exports[`TextInputWithTokens > renders with a loading indicator 1`] = `
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
       data-leading-visual="true"
+      data-no-trailing-action="true"
       data-size="medium"
       data-trailing-visual="true"
     >
@@ -21161,6 +21273,9 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <div
@@ -21562,6 +21677,9 @@ exports[`TextInputWithTokens > renders with tokens 1`] = `
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
     >
       <div
@@ -22024,6 +22142,9 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <div
@@ -22393,6 +22514,9 @@ exports[`TextInputWithTokens > renders with tokens using a custom token componen
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
     >
       <div
@@ -22823,6 +22947,9 @@ exports[`TextInputWithTokens > renders without tokens 1`] = `
       <span
         class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
         data-component="TextInputWithTokens"
+        data-no-leading-visual="true"
+        data-no-trailing-action="true"
+        data-no-trailing-visual="true"
         data-size="medium"
       >
         <div
@@ -22848,6 +22975,9 @@ exports[`TextInputWithTokens > renders without tokens 1`] = `
     <span
       class="prc-TextInputWithTokens-TextInputWrapper-LKe0T prc-components-TextInputWrapper--nxNz prc-components-TextInputBaseWrapper-fStx7"
       data-component="TextInputWithTokens"
+      data-no-leading-visual="true"
+      data-no-trailing-action="true"
+      data-no-trailing-visual="true"
       data-size="medium"
     >
       <div

--- a/packages/react/src/internal/components/TextInputWrapper.module.css
+++ b/packages/react/src/internal/components/TextInputWrapper.module.css
@@ -33,7 +33,7 @@
   }
 
   &:where([data-trailing-action][data-focused]),
-  &:where(:not([data-trailing-action]):focus-within) {
+  &:where([data-no-trailing-action]:focus-within) {
     border-color: var(--borderColor-accent-emphasis);
     outline: var(--borderWidth-thick) solid var(--borderColor-accent-emphasis);
     outline-offset: -1px;
@@ -70,7 +70,7 @@
     border-color: var(--borderColor-danger-emphasis);
 
     &:where([data-trailing-action][data-focused]),
-    &:where(:not([data-trailing-action])):focus-within {
+    &:where([data-no-trailing-action]):focus-within {
       border-color: var(--control-borderColor-danger);
       outline: 2px solid var(--control-borderColor-danger);
       outline-offset: -1px;
@@ -182,13 +182,13 @@
   }
 
   /* With trailing visual */
-  &:where([data-trailing-visual]:not([data-trailing-action])) {
+  &:where([data-trailing-visual][data-no-trailing-action]) {
     padding-right: var(--base-size-8);
   }
 
   /* Only trailing visual */
-  &:where(:not([data-leading-visual])[data-trailing-visual]),
-  &:where(:not([data-leading-visual])[data-trailing-action]) {
+  &:where([data-no-leading-visual][data-trailing-visual]),
+  &:where([data-no-leading-visual][data-trailing-action]) {
     > input,
     > select {
       padding-left: var(--base-size-8);
@@ -196,14 +196,14 @@
   }
 
   /* Only leading visual */
-  &:where(:not([data-trailing-visual]):not([data-trailing-action])) > input,
-  &:where(:not([data-trailing-visual]):not([data-trailing-action])) > select {
+  &:where([data-no-trailing-visual][data-no-trailing-action]) > input,
+  &:where([data-no-trailing-visual][data-no-trailing-action]) > select {
     padding-right: var(--base-size-8);
   }
 
   /* No visuals at all */
-  &:where(:not([data-leading-visual]):not([data-trailing-visual]):not([data-trailing-action])) > input,
-  &:where(:not([data-leading-visual]):not([data-trailing-visual]):not([data-trailing-action])) > select {
+  &:where([data-no-leading-visual][data-no-trailing-visual][data-no-trailing-action]) > input,
+  &:where([data-no-leading-visual][data-no-trailing-visual][data-no-trailing-action]) > select {
     padding-left: var(--base-size-12);
     padding-right: var(--base-size-12);
   }
@@ -215,7 +215,7 @@
     padding-left: var(--base-size-12);
   }
 
-  &:where([data-trailing-visual]:not([data-trailing-action])) {
+  &:where([data-trailing-visual][data-no-trailing-action]) {
     padding-right: var(--base-size-12);
   }
 }

--- a/packages/react/src/internal/components/TextInputWrapper.tsx
+++ b/packages/react/src/internal/components/TextInputWrapper.tsx
@@ -75,6 +75,7 @@ export const TextInputBaseWrapper = React.forwardRef<HTMLElement, StyledTextInpu
         data-monospace={monospace || undefined}
         data-size={size || undefined}
         data-trailing-action={hasTrailingAction || undefined}
+        data-no-trailing-action={hasTrailingAction ? undefined : true}
         data-validation={validationStatus || undefined}
         data-variant={variant || undefined}
         style={memoizedStyle}
@@ -95,7 +96,9 @@ export const TextInputWrapper = React.forwardRef<HTMLElement, StyledBaseWrapperP
       ref={forwardRef}
       className={clsx(className, styles.TextInputWrapper)}
       data-leading-visual={hasLeadingVisual || undefined}
+      data-no-leading-visual={hasLeadingVisual ? undefined : true}
       data-trailing-visual={hasTrailingVisual || undefined}
+      data-no-trailing-visual={hasTrailingVisual ? undefined : true}
       {...restProps}
     />
   )


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

Replaces 2- and 3-deep `:not([data-...])` attribute chains in the `TextInputWrapper` CSS with positive `data-no-*` markers emitted by the wrapper components. Same visual output; reduces the per-input style-recalculation cost on form-heavy pages.

**Wrapper now emits, alongside the existing positive markers:**

```tsx
data-no-leading-visual={hasLeadingVisual ? undefined : true}
data-no-trailing-visual={hasTrailingVisual ? undefined : true}
data-no-trailing-action={hasTrailingAction ? undefined : true}
```

**CSS replacements (mechanical, all in [TextInputWrapper.module.css](packages/react/src/internal/components/TextInputWrapper.module.css)):**

| Before | After |
| --- | --- |
| `:where(:not([data-trailing-action]):focus-within)` | `:where([data-no-trailing-action]:focus-within)` |
| `:where([data-trailing-visual]:not([data-trailing-action]))` | `:where([data-trailing-visual][data-no-trailing-action])` |
| `:where(:not([data-leading-visual])[data-trailing-visual])` | `:where([data-no-leading-visual][data-trailing-visual])` |
| `:where(:not([data-leading-visual])[data-trailing-action])` | `:where([data-no-leading-visual][data-trailing-action])` |
| `:where(:not([data-trailing-visual]):not([data-trailing-action])) > input` | `:where([data-no-trailing-visual][data-no-trailing-action]) > input` |
| `:where(:not([data-leading-visual]):not([data-trailing-visual]):not([data-trailing-action])) > input` | `:where([data-no-leading-visual][data-no-trailing-visual][data-no-trailing-action]) > input` |

The 3-chain selector was particularly hot: it ran the negation chain against every input on every focus, value, or validation-status change. It now resolves with three positive attribute checks.

### Changelog

#### New

- `data-no-leading-visual`, `data-no-trailing-visual`, and `data-no-trailing-action` markers on the `TextInputWrapper` / `TextInputBaseWrapper` DOM nodes, set when the corresponding props are absent.

#### Changed

- Internal: `TextInputWrapper` styling no longer uses chained `:not([data-...])` attribute negations.
- Updated snapshots in `TextInput` and `TextInputWithTokens` to include the new attributes.

#### Removed

- 2- and 3-deep `:not([data-...])` attribute chains from `TextInputWrapper.module.css`.

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Visual parity confirmed by:

- Every selector that previously matched a state still matches with the equivalent positive marker (1:1 mapping, including the focus-within and `[data-validation='error']` branches).
- Existing 317 tests in `TextInput`, `TextInputWithTokens`, `Autocomplete`, `Select`, `FormControl` pass.
- 19 snapshots updated to include the new attributes; reviewed diffs to confirm only added `data-no-*` lines.
- 4 new focused tests cover the marker contract (all-absent, leading only, trailing visual only, trailing action only).

Part of an ongoing series replacing expensive style-recalc selectors on high-frequency components with JS-derived data attributes (after Button #7893 and ActionList #7894).

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
