### PR TITLE
feat(ThemeProvider): add contextOnly prop to prevent rendering of wrapping div

### DIFF
--- a/.changeset/styled-react-theme-provider-context-only.md
+++ b/.changeset/styled-react-theme-provider-context-only.md
@@ -1,0 +1,5 @@
+---
+'@primer/styled-react': minor
+---
+
+ThemeProvider: Add `contextOnly` prop as a no-op to match the `@primer/react` API

--- a/.changeset/theme-provider-context-only.md
+++ b/.changeset/theme-provider-context-only.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+ThemeProvider: Add `contextOnly` prop to opt out of rendering the wrapping `<div>` with `data-*` theme attributes

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "38.24.0",
+        "@primer/react": "38.25.0",
         "@primer/styled-react": "1.0.9",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
@@ -96,7 +96,7 @@
       "name": "example-nextjs",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "38.24.0",
+        "@primer/react": "38.25.0",
         "@primer/styled-react": "1.0.9",
         "next": "^16.1.7",
         "react": "^19.2.0",
@@ -139,7 +139,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.21.0",
-        "@primer/react": "38.24.0",
+        "@primer/react": "38.25.0",
         "@primer/styled-react": "1.0.9",
         "clsx": "^2.1.1",
         "next": "^16.1.7",
@@ -27700,7 +27700,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "38.24.0",
+      "version": "38.25.0",
       "license": "MIT",
       "dependencies": {
         "@github/mini-throttle": "^2.1.1",

--- a/packages/react/src/ThemeProvider.tsx
+++ b/packages/react/src/ThemeProvider.tsx
@@ -18,6 +18,12 @@ export type ThemeProviderProps = {
   dayScheme?: string
   nightScheme?: string
   preventSSRMismatch?: boolean
+  /**
+   * When true, only provides theme context to descendants without rendering
+   * a wrapping `<div>` with `data-*` theme attributes.
+   * @default false
+   */
+  contextOnly?: boolean
 }
 
 const ThemeContext = React.createContext<{
@@ -122,6 +128,10 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>
       setNightScheme,
     ],
   )
+
+  if (props.contextOnly) {
+    return <ThemeContext.Provider value={contextValue}>{children}</ThemeContext.Provider>
+  }
 
   return (
     <ThemeContext.Provider value={contextValue}>

--- a/packages/react/src/ThemeProvider.tsx
+++ b/packages/react/src/ThemeProvider.tsx
@@ -129,8 +129,21 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>
     ],
   )
 
+  const ssrHandoffScript = props.preventSSRMismatch ? (
+    <script
+      type="application/json"
+      id={`__PRIMER_DATA_${uniqueDataId}__`}
+      dangerouslySetInnerHTML={{__html: JSON.stringify({resolvedServerColorMode: resolvedColorMode})}}
+    />
+  ) : null
+
   if (props.contextOnly) {
-    return <ThemeContext.Provider value={contextValue}>{children}</ThemeContext.Provider>
+    return (
+      <ThemeContext.Provider value={contextValue}>
+        {children}
+        {ssrHandoffScript}
+      </ThemeContext.Provider>
+    )
   }
 
   return (
@@ -141,13 +154,7 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>
         data-dark-theme={nightScheme}
       >
         {children}
-        {props.preventSSRMismatch ? (
-          <script
-            type="application/json"
-            id={`__PRIMER_DATA_${uniqueDataId}__`}
-            dangerouslySetInnerHTML={{__html: JSON.stringify({resolvedServerColorMode: resolvedColorMode})}}
-          />
-        ) : null}
+        {ssrHandoffScript}
       </div>
     </ThemeContext.Provider>
   )

--- a/packages/react/src/__tests__/ThemeProvider.test.tsx
+++ b/packages/react/src/__tests__/ThemeProvider.test.tsx
@@ -524,3 +524,49 @@ describe('useTheme().resolvedColorScheme', () => {
     })
   })
 })
+
+describe('contextOnly', () => {
+  it('renders a div with data-* attributes by default', () => {
+    const {container} = render(
+      <ThemeProvider>
+        <span>Hello</span>
+      </ThemeProvider>,
+    )
+
+    const div = container.querySelector('[data-color-mode]')
+    expect(div).toBeInTheDocument()
+    expect(div?.tagName).toBe('DIV')
+    expect(div).toHaveAttribute('data-light-theme')
+    expect(div).toHaveAttribute('data-dark-theme')
+  })
+
+  it('does not render a div with data-* attributes when contextOnly is true', () => {
+    const {container} = render(
+      <ThemeProvider contextOnly>
+        <span>Hello</span>
+      </ThemeProvider>,
+    )
+
+    const div = container.querySelector('[data-color-mode]')
+    expect(div).not.toBeInTheDocument()
+  })
+
+  it('still provides theme context when contextOnly is true', () => {
+    function Consumer() {
+      const {colorMode, dayScheme, nightScheme} = useTheme()
+      return (
+        <span data-testid="consumer">
+          {colorMode}-{dayScheme}-{nightScheme}
+        </span>
+      )
+    }
+
+    render(
+      <ThemeProvider contextOnly colorMode="night" nightScheme="dark_dimmed">
+        <Consumer />
+      </ThemeProvider>,
+    )
+
+    expect(screen.getByTestId('consumer').textContent).toBe('night-light-dark_dimmed')
+  })
+})

--- a/packages/react/src/__tests__/ThemeProvider.test.tsx
+++ b/packages/react/src/__tests__/ThemeProvider.test.tsx
@@ -569,4 +569,19 @@ describe('contextOnly', () => {
 
     expect(screen.getByTestId('consumer').textContent).toBe('night-light-dark_dimmed')
   })
+
+  it('renders the preventSSRMismatch script tag when contextOnly and preventSSRMismatch are both true', () => {
+    const {container} = render(
+      <ThemeProvider contextOnly preventSSRMismatch>
+        <span>Hello</span>
+      </ThemeProvider>,
+    )
+
+    const div = container.querySelector('[data-color-mode]')
+    expect(div).not.toBeInTheDocument()
+
+    const script = container.querySelector('script[type="application/json"]')
+    expect(script).toBeInTheDocument()
+    expect(script?.textContent).toContain('resolvedServerColorMode')
+  })
 })

--- a/packages/styled-react/src/components/ThemeProvider.tsx
+++ b/packages/styled-react/src/components/ThemeProvider.tsx
@@ -18,6 +18,11 @@ export type ThemeProviderProps = {
   dayScheme?: string
   nightScheme?: string
   preventSSRMismatch?: boolean
+  /**
+   * No-op. Exists solely to match @primer/react's ThemeProvider API.
+   * @default false
+   */
+  contextOnly?: boolean
 }
 
 const ThemeContext = React.createContext<{


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Relates to https://github.com/github/primer/issues/6568

Seeing some issues in dotcom as a result of rendering the ThemeProvider div when switching from @primer/styled-react (no div) to @primer/react ThemeProvider. Adding opt-out mechanism via `contextOnly` prop.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->
- Added a `contextOnly` prop to `ThemeProviderProps` and updated the implementation so that when `contextOnly` is true, the provider only supplies theme context without rendering a wrapping `<div>` with `data-*` attributes.
- Added comprehensive tests for the new `contextOnly` behavior, verifying both the absence of the wrapper `<div>` and that theme context is still provided to descendants.
- Added a no-op `contextOnly` prop to `ThemeProviderProps` for API compatibility with `@primer/react`, as documented in the prop's comment.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To publish a canary release for integration testing, apply the "Canary Release" label to this PR -->

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
