### PR TITLE
docs: terse changeset descriptions + re-evaluation instructions

### DIFF
--- a/.github/instructions/changesets.instructions.md
+++ b/.github/instructions/changesets.instructions.md
@@ -1,0 +1,30 @@
+---
+applyTo: '**'
+---
+
+# Keeping changesets accurate
+
+When you change source code in a package during a task, re-evaluate any existing
+changeset files in `.changeset/` so they stay accurate and necessary.
+
+## Re-evaluate after every change
+
+After adding, editing, or reverting changes in this PR, check the following:
+
+- **Does a changeset still need to exist?** If your latest changes removed the
+  only consumer-facing impact (the work is now docs-only, test-only, or
+  CI/infra-only), delete the now-unnecessary changeset and add the
+  `skip changeset` label instead.
+- **Is a changeset now required?** If you introduced new consumer-facing
+  behavior that no existing changeset covers, add one.
+- **Is the bump type still correct?** If the scope grew (e.g. a `patch` became a
+  breaking change) or shrank, update the semver bump in the changeset frontmatter.
+- **Is the description still accurate and terse?** Update the description to
+  match the final change, and keep it to one or two high-level, consumer-facing
+  sentences with no implementation detail.
+
+## Guidance
+
+For changeset format, semver bump selection, when a changeset is not needed, and
+how to write terse descriptions, follow the `changesets` skill at
+`.github/skills/changesets/SKILL.md`.

--- a/.github/skills/changesets/SKILL.md
+++ b/.github/skills/changesets/SKILL.md
@@ -27,11 +27,41 @@ Changeset files live in `.changeset/` and have a random name with a `.md` extens
 ActionMenu: Fix focus management when menu is closed with Escape key
 ```
 
-The description should be concise and follow this pattern:
+The description becomes a single line item in the public changelog and release
+notes, so keep it **terse**. Follow this pattern:
 
 - Start with the component or module name followed by a colon
-- Describe WHAT changed and WHY
-- Write from the consumer's perspective
+- Use **one or two sentences** describing WHAT changed at a high level
+- Write from the consumer's perspective — focus on the consumer-facing impact
+- Do **not** include implementation details, file paths, CSS selector or symbol
+  names, internal rationale, or before/after explanations
+- Do **not** use nested bullet lists or multi-paragraph walkthroughs. If a change
+  has several distinct parts, split it into
+  [separate changesets](#multiple-changesets-in-one-pr) instead
+
+### Writing good descriptions
+
+Aim for a description a consumer can scan in a few seconds.
+
+**Good** — terse and consumer-facing:
+
+```markdown
+UnderlinePanels: Improve rendering performance when toggling tab icons
+```
+
+**Avoid** — verbose, implementation-focused, multi-clause:
+
+```markdown
+UnderlinePanels: Eliminate the empty-tablist frame on mount and the cascading
+re-render when icons toggle. Tabs and panels are now derived in render
+(previously stored in state synced via `useEffect`), the list width is kept in a
+ref instead of state, and `iconsVisible` / `loadingCounters` flow to each tab
+via context — combined with `React.memo(Tab)`...
+```
+
+The "Avoid" example reads like a commit message or PR body. Save that level of
+detail for the pull request description; the changeset should summarize the
+consumer-facing effect only.
 
 ## How to create a changeset
 


### PR DESCRIPTION
### Changelog

Improves the guidance the agent and contributors follow when writing changesets, so release notes stay concise.

#### New

- Add `.github/instructions/changesets.instructions.md` that directs the agent to re-evaluate changeset accuracy and necessity whenever changes are made (whether a changeset is still needed, newly required, has the correct bump type, and a still-accurate terse description).

#### Changed

- Update the `changesets` skill (`.github/skills/changesets/SKILL.md`) to require terse, consumer-facing descriptions (one or two sentences), ban implementation detail and nested bullet lists, and add a Good vs. Avoid example pair.

#### Removed

- N/A

### Rollout strategy

- [x] None; documentation/instructions-only change. No published package code is affected, so no changeset is required (`skip changeset` label applied).

### Testing & Reviewing

Review the updated skill and the new instructions file for clarity. No build or test impact — these are agent customization/docs files only.

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui
