### PR TITLE
ci: build Storybook once and share via artifact for VRT/AAT

### DIFF
--- a/.github/workflows/aat-reports.yml
+++ b/.github/workflows/aat-reports.yml
@@ -1,6 +1,12 @@
 name: AAT Reports
 on:
   workflow_call:
+    inputs:
+      storybook-artifact:
+        description: 'Name of the prebuilt Storybook artifact to download instead of building Storybook'
+        required: false
+        type: string
+        default: ''
     outputs:
       aat:
         value: ${{ jobs.aat.result }}
@@ -23,7 +29,16 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Download storybook
+        if: ${{ inputs.storybook-artifact != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ inputs.storybook-artifact }}
+          path: packages
       - name: Set up turbo cache
+        if: ${{ inputs.storybook-artifact == '' }}
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .turbo
@@ -32,9 +47,8 @@ jobs:
             ${{ runner.os }}-turbo-${{ github.job }}-shard-${{ matrix.shard }}-
             ${{ runner.os }}-turbo-${{ github.job }}-
             ${{ runner.os }}-turbo-
-      - name: Install dependencies
-        run: npm ci
       - name: Build storybook
+        if: ${{ inputs.storybook-artifact == '' }}
         run: npx turbo run build:storybook
       - name: Run storybook
         id: storybook

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -7,13 +7,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-storybook:
+    if: ${{ github.event.pull_request.head.repo.full_name == 'primer/react' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: Set up turbo cache
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-
+            ${{ runner.os }}-turbo-
+      - name: Install dependencies
+        run: npm ci
+      - name: Build storybook
+        run: npx turbo run build:storybook
+      - name: Upload storybook
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: storybook
+          path: |
+            packages/react/storybook-static
+            packages/styled-react/storybook-static
+          if-no-files-found: error
+          retention-days: 1
+
   vrt-reports:
     if: ${{ github.event.pull_request.head.repo.full_name == 'primer/react' }}
+    needs: build-storybook
     uses: ./.github/workflows/vrt-reports.yml
+    with:
+      storybook-artifact: storybook
 
   aat-reports:
     if: ${{ github.event.pull_request.head.repo.full_name == 'primer/react' }}
+    needs: build-storybook
     uses: ./.github/workflows/aat-reports.yml
+    with:
+      storybook-artifact: storybook
 
   build:
     if: ${{ always() && github.event.pull_request.head.repo.full_name == 'primer/react' }}

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -39,6 +39,17 @@ jobs:
             packages/styled-react/storybook-static
           if-no-files-found: error
           retention-days: 1
+      - name: Build docs preview
+        run: npm run build:docs:preview
+      - name: Upload docs preview
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: storybook-docs
+          path: |
+            docs/public/storybook
+            docs/public/index.html
+          if-no-files-found: error
+          retention-days: 1
 
   vrt-reports:
     if: ${{ github.event.pull_request.head.repo.full_name == 'primer/react' }}
@@ -56,21 +67,15 @@ jobs:
 
   build:
     if: ${{ always() && github.event.pull_request.head.repo.full_name == 'primer/react' }}
-    needs: [vrt-reports, aat-reports]
+    needs: [build-storybook, vrt-reports, aat-reports]
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - name: Download docs preview
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci
-      - name: Build docs preview
-        run: npm run build:docs:preview
+          name: storybook-docs
+          path: docs/public
       - name: Download VRT reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:

--- a/.github/workflows/deploy_preview_forks.yml
+++ b/.github/workflows/deploy_preview_forks.yml
@@ -7,13 +7,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-storybook:
+    if: ${{ github.repository != github.event.pull_request.head.repo.full_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: Set up turbo cache
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-
+            ${{ runner.os }}-turbo-
+      - name: Install dependencies
+        run: npm ci
+      - name: Build storybook
+        run: npx turbo run build:storybook
+      - name: Upload storybook
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: storybook
+          path: |
+            packages/react/storybook-static
+            packages/styled-react/storybook-static
+          if-no-files-found: error
+          retention-days: 1
+
   vrt-reports:
     if: ${{ github.repository != github.event.pull_request.head.repo.full_name }}
+    needs: build-storybook
     uses: ./.github/workflows/vrt-reports.yml
+    with:
+      storybook-artifact: storybook
 
   aat-reports:
     if: ${{ github.repository != github.event.pull_request.head.repo.full_name }}
+    needs: build-storybook
     uses: ./.github/workflows/aat-reports.yml
+    with:
+      storybook-artifact: storybook
 
   build:
     # target repository for pull_request is different from source repository

--- a/.github/workflows/deploy_preview_forks.yml
+++ b/.github/workflows/deploy_preview_forks.yml
@@ -39,6 +39,17 @@ jobs:
             packages/styled-react/storybook-static
           if-no-files-found: error
           retention-days: 1
+      - name: Build docs preview
+        run: npm run build:docs:preview
+      - name: Upload docs preview
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: storybook-docs
+          path: |
+            docs/public/storybook
+            docs/public/index.html
+          if-no-files-found: error
+          retention-days: 1
 
   vrt-reports:
     if: ${{ github.repository != github.event.pull_request.head.repo.full_name }}
@@ -57,20 +68,14 @@ jobs:
   build:
     # target repository for pull_request is different from source repository
     if: ${{ always() && github.repository != github.event.pull_request.head.repo.full_name }}
-    needs: [vrt-reports, aat-reports]
+    needs: [build-storybook, vrt-reports, aat-reports]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - name: Download docs preview
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci
-      - name: Build docs preview
-        run: npm run build:docs:preview
+          name: storybook-docs
+          path: docs/public
       - name: Download VRT reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -14,8 +14,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: Set up turbo cache
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-
+            ${{ runner.os }}-turbo-
+      - name: Install dependencies
+        run: npm ci
+      - name: Build storybook
+        run: npx turbo run build:storybook
+      - name: Upload storybook
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: storybook
+          path: |
+            packages/react/storybook-static
+            packages/styled-react/storybook-static
+          if-no-files-found: error
+          retention-days: 1
+
   vrt-reports:
+    needs: build-storybook
     uses: ./.github/workflows/vrt-reports.yml
+    with:
+      storybook-artifact: storybook
 
   aat-reports:
+    needs: build-storybook
     uses: ./.github/workflows/aat-reports.yml
+    with:
+      storybook-artifact: storybook

--- a/.github/workflows/vrt-reports.yml
+++ b/.github/workflows/vrt-reports.yml
@@ -1,6 +1,12 @@
 name: VRT Reports
 on:
   workflow_call:
+    inputs:
+      storybook-artifact:
+        description: 'Name of the prebuilt Storybook artifact to download instead of building Storybook'
+        required: false
+        type: string
+        default: ''
     outputs:
       vrt:
         value: ${{ jobs.vrt.result }}
@@ -23,7 +29,16 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Download storybook
+        if: ${{ inputs.storybook-artifact != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ inputs.storybook-artifact }}
+          path: packages
       - name: Set up turbo cache
+        if: ${{ inputs.storybook-artifact == '' }}
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .turbo
@@ -32,9 +47,8 @@ jobs:
             ${{ runner.os }}-turbo-${{ github.job }}-shard-${{ matrix.shard }}-
             ${{ runner.os }}-turbo-${{ github.job }}-
             ${{ runner.os }}-turbo-
-      - name: Install dependencies
-        run: npm ci
       - name: Build storybook
+        if: ${{ inputs.storybook-artifact == '' }}
         run: npx turbo run build:storybook
       - name: Run storybook
         id: storybook


### PR DESCRIPTION
Closes #

Speeds up CI on every PR by building Storybook **once** instead of rebuilding it in every VRT and AAT shard.

Previously the `vrt-reports` and `aat-reports` reusable workflows each ran `npx turbo run build:storybook` in all 8 shards — **16 Storybook builds per PR**. This change builds Storybook a single time in `deploy_preview.yml`, uploads it as a `storybook` artifact, and has each shard download it instead of building.

### Changelog

#### New

- `build-storybook` job in `deploy_preview.yml` that builds Storybook once and uploads `packages/react/storybook-static` + `packages/styled-react/storybook-static` as a `storybook` artifact.

#### Changed

- `vrt-reports.yml` and `aat-reports.yml` now accept an optional `storybook-artifact` `workflow_call` input. When provided, each shard downloads the prebuilt Storybook artifact instead of building it. `deploy_preview.yml` passes `storybook-artifact: storybook` and gates the report jobs on `needs: build-storybook`.

#### Removed

- Nothing removed. The in-workflow build + turbo cache steps are retained behind `if: inputs.storybook-artifact == ''` so the reusable workflows still function standalone.

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; CI/infra-only change, does not affect the published package.

### Testing & Reviewing

This only touches GitHub Actions workflows. To verify:

- On this PR, confirm the `build-storybook` job runs once and uploads the `storybook` artifact.
- Confirm each VRT/AAT shard shows a "Download storybook" step (no "Build storybook") and the `serve` steps start on ports 6006/6007.
- Confirm the final merged `vrt`/`aat` reports still upload and the `build`/`deploy-preview` jobs work as before.

Note: `build-storybook` runs on `ubuntu-latest` while the report shards run on self-hosted `vrt-runner`/`aat-runner`. Artifacts are portable across runner types, so the download works regardless.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [ ] Changes are SSR compatible
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui
