### PR TITLE
Timeline: Use list semantics for screen reader navigation

### DIFF
--- a/.changeset/timeline-list-semantics.md
+++ b/.changeset/timeline-list-semantics.md
@@ -1,13 +1,17 @@
 ---
-'@primer/react': minor
+'@primer/react': patch
 ---
 
-Timeline: Render as `<ol>` with `<li>` items for list semantics
+Timeline: Add `primer_react_timeline_list_semantics` feature flag to opt into list semantics
 
-Timeline now renders as an ordered list (`<ol>`) instead of a `<div>`, and Timeline.Item renders as `<li>` instead of `<div>`. This gives screen reader users list navigation — they can hear the total number of events and their position in the sequence ("item 3 of 12").
+When the `primer_react_timeline_list_semantics` feature flag is enabled, `Timeline` renders as `<ol role="list">` and `Timeline.Item` / `Timeline.Break` render as `<li>` so screen reader users get list navigation (total item count, position in sequence). The default behavior is unchanged — `Timeline` and its subcomponents still render as `<div>` until the flag is opted into.
 
-Timeline.Break renders as `<li role="presentation">` so it does not contribute to the list item count.
+Enable the flag with the `FeatureFlags` provider:
 
-An explicit `role="list"` is applied to the `<ol>` to restore list semantics in Safari/VoiceOver, which strips them when `list-style: none` is applied.
+```tsx
+import {FeatureFlags} from '@primer/react/experimental'
 
-**Migration:** If you pass a `ref` to `Timeline`, the ref type changes from `HTMLDivElement` to `HTMLOListElement`. If you pass a `ref` to `Timeline.Item` or `Timeline.Break`, the ref type changes from `HTMLDivElement` to `HTMLLIElement`. All other props continue to work unchanged.
+<FeatureFlags flags={{primer_react_timeline_list_semantics: true}}>
+  <Timeline>…</Timeline>
+</FeatureFlags>
+```

--- a/.changeset/timeline-list-semantics.md
+++ b/.changeset/timeline-list-semantics.md
@@ -1,0 +1,13 @@
+---
+'@primer/react': minor
+---
+
+Timeline: Render as `<ol>` with `<li>` items for list semantics
+
+Timeline now renders as an ordered list (`<ol>`) instead of a `<div>`, and Timeline.Item renders as `<li>` instead of `<div>`. This gives screen reader users list navigation — they can hear the total number of events and their position in the sequence ("item 3 of 12").
+
+Timeline.Break renders as `<li role="presentation">` so it does not contribute to the list item count.
+
+An explicit `role="list"` is applied to the `<ol>` to restore list semantics in Safari/VoiceOver, which strips them when `list-style: none` is applied.
+
+**Migration:** If you pass a `ref` to `Timeline`, the ref type changes from `HTMLDivElement` to `HTMLOListElement`. If you pass a `ref` to `Timeline.Item` or `Timeline.Break`, the ref type changes from `HTMLDivElement` to `HTMLLIElement`. All other props continue to work unchanged.

--- a/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
+++ b/packages/react/src/FeatureFlags/DefaultFeatureFlags.ts
@@ -6,4 +6,5 @@ export const DefaultFeatureFlags = FeatureFlagScope.create({
   primer_react_select_panel_order_selected_at_top: false,
   primer_react_styled_react_use_primer_theme_providers: false,
   primer_react_action_list_group_heading_trailing_action: false,
+  primer_react_timeline_list_semantics: false,
 })

--- a/packages/react/src/Timeline/Timeline.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.features.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
+import {FeatureFlags} from '../FeatureFlags'
 import Timeline from './Timeline'
 import {
   CheckIcon,
@@ -374,4 +375,30 @@ export const WithAvatar = () => (
       </Timeline.Item>
     </Timeline>
   </div>
+)
+
+export const WithListSemantics = () => (
+  <FeatureFlags flags={{primer_react_timeline_list_semantics: true}}>
+    <Timeline>
+      <Timeline.Item>
+        <Timeline.Badge>
+          <GitCommitIcon aria-label="Commit" />
+        </Timeline.Badge>
+        <Timeline.Body>Opted in: Timeline renders as an ordered list with list items.</Timeline.Body>
+      </Timeline.Item>
+      <Timeline.Item>
+        <Timeline.Badge>
+          <GitCommitIcon aria-label="Commit" />
+        </Timeline.Badge>
+        <Timeline.Body>Each Timeline.Item renders as a li.</Timeline.Body>
+      </Timeline.Item>
+      <Timeline.Break />
+      <Timeline.Item>
+        <Timeline.Badge>
+          <GitCommitIcon aria-label="Commit" />
+        </Timeline.Badge>
+        <Timeline.Body>Timeline.Break renders as a presentational li.</Timeline.Body>
+      </Timeline.Item>
+    </Timeline>
+  </FeatureFlags>
 )

--- a/packages/react/src/Timeline/Timeline.module.css
+++ b/packages/react/src/Timeline/Timeline.module.css
@@ -1,6 +1,9 @@
 .Timeline {
   display: flex;
   flex-direction: column;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 
   &:where([data-clip-sidebar='start']),
   &:where([data-clip-sidebar='both']) {

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -4,7 +4,7 @@ import classes from './Timeline.module.css'
 
 type StyledTimelineProps = {clipSidebar?: boolean | 'start' | 'end' | 'both'; className?: string}
 
-export type TimelineProps = StyledTimelineProps & React.ComponentPropsWithoutRef<'div'>
+export type TimelineProps = StyledTimelineProps & React.ComponentPropsWithoutRef<'ol'>
 
 function resolveClipSidebar(clipSidebar: TimelineProps['clipSidebar']): string | undefined {
   if (clipSidebar === true || clipSidebar === 'both') return 'both'
@@ -12,10 +12,13 @@ function resolveClipSidebar(clipSidebar: TimelineProps['clipSidebar']): string |
   return undefined
 }
 
-const Timeline = React.forwardRef<HTMLDivElement, TimelineProps>(({clipSidebar, className, ...props}, forwardRef) => {
+const Timeline = React.forwardRef<HTMLOListElement, TimelineProps>(({clipSidebar, className, ...props}, forwardRef) => {
   const resolvedClipSidebar = resolveClipSidebar(clipSidebar)
   return (
-    <div
+    <ol
+      // Explicit role restores list semantics in Safari/VoiceOver, which strips
+      // them when list-style: none is applied (WebKit intentional behaviour).
+      role="list"
       {...props}
       className={clsx(className, classes.Timeline)}
       ref={forwardRef}
@@ -31,14 +34,14 @@ type StyledTimelineItemProps = {condensed?: boolean; className?: string}
 /**
  * @deprecated Use the `TimelineItemProps` type instead
  */
-export type TimelineItemsProps = StyledTimelineItemProps & React.ComponentPropsWithoutRef<'div'>
+export type TimelineItemsProps = StyledTimelineItemProps & React.ComponentPropsWithoutRef<'li'>
 
-export type TimelineItemProps = StyledTimelineItemProps & React.ComponentPropsWithoutRef<'div'>
+export type TimelineItemProps = StyledTimelineItemProps & React.ComponentPropsWithoutRef<'li'>
 
-const TimelineItem = React.forwardRef<HTMLDivElement, TimelineItemProps>(
+const TimelineItem = React.forwardRef<HTMLLIElement, TimelineItemProps>(
   ({condensed, className, ...props}, forwardRef) => {
     return (
-      <div
+      <li
         {...props}
         className={clsx(className, 'Timeline-Item', classes.TimelineItem)}
         ref={forwardRef}
@@ -95,10 +98,10 @@ TimelineBody.displayName = 'TimelineBody'
 export type TimelineBreakProps = {
   /** Class name for custom styling */
   className?: string
-} & React.ComponentPropsWithoutRef<'div'>
+} & Omit<React.ComponentPropsWithoutRef<'li'>, 'role'>
 
-const TimelineBreak = React.forwardRef<HTMLDivElement, TimelineBreakProps>(({className, ...props}, forwardRef) => {
-  return <div {...props} className={clsx(className, classes.TimelineBreak)} ref={forwardRef} />
+const TimelineBreak = React.forwardRef<HTMLLIElement, TimelineBreakProps>(({className, ...props}, forwardRef) => {
+  return <li {...props} className={clsx(className, classes.TimelineBreak)} ref={forwardRef} role="presentation" />
 })
 
 TimelineBreak.displayName = 'TimelineBreak'

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -4,7 +4,7 @@ import classes from './Timeline.module.css'
 
 type StyledTimelineProps = {clipSidebar?: boolean | 'start' | 'end' | 'both'; className?: string}
 
-export type TimelineProps = StyledTimelineProps & React.ComponentPropsWithoutRef<'ol'>
+export type TimelineProps = StyledTimelineProps & Omit<React.ComponentPropsWithoutRef<'ol'>, 'role'>
 
 function resolveClipSidebar(clipSidebar: TimelineProps['clipSidebar']): string | undefined {
   if (clipSidebar === true || clipSidebar === 'both') return 'both'
@@ -16,10 +16,10 @@ const Timeline = React.forwardRef<HTMLOListElement, TimelineProps>(({clipSidebar
   const resolvedClipSidebar = resolveClipSidebar(clipSidebar)
   return (
     <ol
+      {...props}
       // Explicit role restores list semantics in Safari/VoiceOver, which strips
       // them when list-style: none is applied (WebKit intentional behaviour).
       role="list"
-      {...props}
       className={clsx(className, classes.Timeline)}
       ref={forwardRef}
       data-clip-sidebar={resolvedClipSidebar}

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -15,10 +15,11 @@ function resolveClipSidebar(clipSidebar: TimelineProps['clipSidebar']): string |
 const Timeline = React.forwardRef<HTMLOListElement, TimelineProps>(({clipSidebar, className, ...props}, forwardRef) => {
   const resolvedClipSidebar = resolveClipSidebar(clipSidebar)
   return (
+    // Explicit role restores list semantics in Safari/VoiceOver, which strips
+    // them when list-style: none is applied (WebKit intentional behaviour).
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles
     <ol
       {...props}
-      // Explicit role restores list semantics in Safari/VoiceOver, which strips
-      // them when list-style: none is applied (WebKit intentional behaviour).
       role="list"
       className={clsx(className, classes.Timeline)}
       ref={forwardRef}

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -1,5 +1,6 @@
 import {clsx} from 'clsx'
 import React from 'react'
+import {useFeatureFlag} from '../FeatureFlags'
 import classes from './Timeline.module.css'
 
 type StyledTimelineProps = {clipSidebar?: boolean | 'start' | 'end' | 'both'; className?: string}
@@ -12,21 +13,36 @@ function resolveClipSidebar(clipSidebar: TimelineProps['clipSidebar']): string |
   return undefined
 }
 
-const Timeline = React.forwardRef<HTMLOListElement, TimelineProps>(({clipSidebar, className, ...props}, forwardRef) => {
-  const resolvedClipSidebar = resolveClipSidebar(clipSidebar)
-  return (
-    // Explicit role restores list semantics in Safari/VoiceOver, which strips
-    // them when list-style: none is applied (WebKit intentional behaviour).
-    // eslint-disable-next-line jsx-a11y/no-redundant-roles
-    <ol
-      {...props}
-      role="list"
-      className={clsx(className, classes.Timeline)}
-      ref={forwardRef}
-      data-clip-sidebar={resolvedClipSidebar}
-    />
-  )
-})
+const Timeline = React.forwardRef<HTMLDivElement | HTMLOListElement, TimelineProps>(
+  ({clipSidebar, className, ...props}, forwardRef) => {
+    const useListSemantics = useFeatureFlag('primer_react_timeline_list_semantics')
+    const resolvedClipSidebar = resolveClipSidebar(clipSidebar)
+
+    if (useListSemantics) {
+      return (
+        // Explicit role restores list semantics in Safari/VoiceOver, which strips
+        // them when list-style: none is applied (WebKit intentional behaviour).
+        // eslint-disable-next-line jsx-a11y/no-redundant-roles
+        <ol
+          {...props}
+          role="list"
+          className={clsx(className, classes.Timeline)}
+          ref={forwardRef as React.ForwardedRef<HTMLOListElement>}
+          data-clip-sidebar={resolvedClipSidebar}
+        />
+      )
+    }
+
+    return (
+      <div
+        {...(props as React.ComponentPropsWithoutRef<'div'>)}
+        className={clsx(className, classes.Timeline)}
+        ref={forwardRef as React.ForwardedRef<HTMLDivElement>}
+        data-clip-sidebar={resolvedClipSidebar}
+      />
+    )
+  },
+)
 
 Timeline.displayName = 'Timeline'
 
@@ -39,13 +55,26 @@ export type TimelineItemsProps = StyledTimelineItemProps & React.ComponentPropsW
 
 export type TimelineItemProps = StyledTimelineItemProps & React.ComponentPropsWithoutRef<'li'>
 
-const TimelineItem = React.forwardRef<HTMLLIElement, TimelineItemProps>(
+const TimelineItem = React.forwardRef<HTMLDivElement | HTMLLIElement, TimelineItemProps>(
   ({condensed, className, ...props}, forwardRef) => {
+    const useListSemantics = useFeatureFlag('primer_react_timeline_list_semantics')
+
+    if (useListSemantics) {
+      return (
+        <li
+          {...props}
+          className={clsx(className, 'Timeline-Item', classes.TimelineItem)}
+          ref={forwardRef as React.ForwardedRef<HTMLLIElement>}
+          data-condensed={condensed ? '' : undefined}
+        />
+      )
+    }
+
     return (
-      <li
-        {...props}
+      <div
+        {...(props as React.ComponentPropsWithoutRef<'div'>)}
         className={clsx(className, 'Timeline-Item', classes.TimelineItem)}
-        ref={forwardRef}
+        ref={forwardRef as React.ForwardedRef<HTMLDivElement>}
         data-condensed={condensed ? '' : undefined}
       />
     )
@@ -101,9 +130,30 @@ export type TimelineBreakProps = {
   className?: string
 } & Omit<React.ComponentPropsWithoutRef<'li'>, 'role'>
 
-const TimelineBreak = React.forwardRef<HTMLLIElement, TimelineBreakProps>(({className, ...props}, forwardRef) => {
-  return <li {...props} className={clsx(className, classes.TimelineBreak)} ref={forwardRef} role="presentation" />
-})
+const TimelineBreak = React.forwardRef<HTMLDivElement | HTMLLIElement, TimelineBreakProps>(
+  ({className, ...props}, forwardRef) => {
+    const useListSemantics = useFeatureFlag('primer_react_timeline_list_semantics')
+
+    if (useListSemantics) {
+      return (
+        <li
+          {...props}
+          className={clsx(className, classes.TimelineBreak)}
+          ref={forwardRef as React.ForwardedRef<HTMLLIElement>}
+          role="presentation"
+        />
+      )
+    }
+
+    return (
+      <div
+        {...(props as React.ComponentPropsWithoutRef<'div'>)}
+        className={clsx(className, classes.TimelineBreak)}
+        ref={forwardRef as React.ForwardedRef<HTMLDivElement>}
+      />
+    )
+  },
+)
 
 TimelineBreak.displayName = 'TimelineBreak'
 

--- a/packages/react/src/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react/src/Timeline/__tests__/Timeline.test.tsx
@@ -1,20 +1,26 @@
 import {render} from '@testing-library/react'
+import type {ReactElement} from 'react'
 import {describe, expect, it} from 'vitest'
 import Timeline from '..'
+import {FeatureFlags} from '../../FeatureFlags'
 import {implementsClassName} from '../../utils/testing'
 import classes from '../Timeline.module.css'
+
+function renderWithListSemantics(ui: ReactElement) {
+  return render(<FeatureFlags flags={{primer_react_timeline_list_semantics: true}}>{ui}</FeatureFlags>)
+}
 
 describe('Timeline', () => {
   implementsClassName(Timeline, classes.Timeline)
 
-  it('renders as an ordered list', () => {
+  it('renders as a div by default (flag off)', () => {
     const {container} = render(<Timeline />)
-    expect(container.firstChild?.nodeName).toBe('OL')
+    expect(container.firstChild?.nodeName).toBe('DIV')
   })
 
-  it('has role="list" to restore semantics in Safari/VoiceOver', () => {
+  it('does not set role="list" by default (flag off)', () => {
     const {container} = render(<Timeline />)
-    expect(container.firstChild).toHaveAttribute('role', 'list')
+    expect(container.firstChild).not.toHaveAttribute('role')
   })
 
   it('renders with clipSidebar prop (boolean)', () => {
@@ -48,12 +54,39 @@ describe('Timeline', () => {
   })
 })
 
+describe('Timeline with primer_react_timeline_list_semantics flag', () => {
+  it('renders as an ordered list', () => {
+    const {container} = renderWithListSemantics(<Timeline />)
+    expect(container.firstChild?.nodeName).toBe('OL')
+  })
+
+  it('has role="list" to restore semantics in Safari/VoiceOver', () => {
+    const {container} = renderWithListSemantics(<Timeline />)
+    expect(container.firstChild).toHaveAttribute('role', 'list')
+  })
+
+  it('renders items as list items', () => {
+    const {container} = renderWithListSemantics(
+      <Timeline>
+        <Timeline.Item />
+      </Timeline>,
+    )
+    expect(container.querySelector('ol > li')).not.toBeNull()
+  })
+
+  it('renders break as a presentational list item', () => {
+    const {container} = renderWithListSemantics(<Timeline.Break />)
+    expect(container.firstChild?.nodeName).toBe('LI')
+    expect(container.firstChild).toHaveAttribute('role', 'presentation')
+  })
+})
+
 describe('Timeline.Item', () => {
   implementsClassName(Timeline.Item, classes.TimelineItem)
 
-  it('renders as a list item', () => {
+  it('renders as a div by default (flag off)', () => {
     const {container} = render(<Timeline.Item />)
-    expect(container.firstChild?.nodeName).toBe('LI')
+    expect(container.firstChild?.nodeName).toBe('DIV')
   })
 
   it('renders with condensed prop', () => {
@@ -88,10 +121,10 @@ describe('Timeline.Body', () => {
 describe('Timeline.Break', () => {
   implementsClassName(Timeline.Break, classes.TimelineBreak)
 
-  it('renders as a presentational list item', () => {
+  it('renders as a div by default (flag off)', () => {
     const {container} = render(<Timeline.Break />)
-    expect(container.firstChild?.nodeName).toBe('LI')
-    expect(container.firstChild).toHaveAttribute('role', 'presentation')
+    expect(container.firstChild?.nodeName).toBe('DIV')
+    expect(container.firstChild).not.toHaveAttribute('role')
   })
 })
 

--- a/packages/react/src/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react/src/Timeline/__tests__/Timeline.test.tsx
@@ -7,6 +7,16 @@ import classes from '../Timeline.module.css'
 describe('Timeline', () => {
   implementsClassName(Timeline, classes.Timeline)
 
+  it('renders as an ordered list', () => {
+    const {container} = render(<Timeline />)
+    expect(container.firstChild?.nodeName).toBe('OL')
+  })
+
+  it('has role="list" to restore semantics in Safari/VoiceOver', () => {
+    const {container} = render(<Timeline />)
+    expect(container.firstChild).toHaveAttribute('role', 'list')
+  })
+
   it('renders with clipSidebar prop (boolean)', () => {
     const {container} = render(<Timeline clipSidebar />)
     expect(container.firstChild).toHaveAttribute('data-clip-sidebar', 'both')
@@ -40,6 +50,12 @@ describe('Timeline', () => {
 
 describe('Timeline.Item', () => {
   implementsClassName(Timeline.Item, classes.TimelineItem)
+
+  it('renders as a list item', () => {
+    const {container} = render(<Timeline.Item />)
+    expect(container.firstChild?.nodeName).toBe('LI')
+  })
+
   it('renders with condensed prop', () => {
     const {container} = render(<Timeline.Item condensed />)
     expect(container).toMatchSnapshot()
@@ -71,6 +87,12 @@ describe('Timeline.Body', () => {
 
 describe('Timeline.Break', () => {
   implementsClassName(Timeline.Break, classes.TimelineBreak)
+
+  it('renders as a presentational list item', () => {
+    const {container} = render(<Timeline.Break />)
+    expect(container.firstChild?.nodeName).toBe('LI')
+    expect(container.firstChild).toHaveAttribute('role', 'presentation')
+  })
 })
 
 describe('Timeline.Actions', () => {

--- a/packages/react/src/Timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
+++ b/packages/react/src/Timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Timeline.Item > renders with condensed prop 1`] = `
 <div>
-  <div
+  <li
     class="Timeline-Item prc-Timeline-TimelineItem-yUFAS"
     data-condensed=""
   />

--- a/packages/react/src/Timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
+++ b/packages/react/src/Timeline/__tests__/__snapshots__/Timeline.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Timeline.Item > renders with condensed prop 1`] = `
 <div>
-  <li
+  <div
     class="Timeline-Item prc-Timeline-TimelineItem-yUFAS"
     data-condensed=""
   />


### PR DESCRIPTION
Refs github/primer#6679
Closes github/primer#2206
Closes github/primer#3354
Part of the Timeline redesign (github/primer#6654)

Timeline and Timeline.Item currently render as bare `<div>`s. Screen reader users have no way to know how many events are in the timeline or where they are in the sequence — they have to step through every event one by one.

This was originally flagged by @patrickhlauke in the [TetraLogical component audit](https://github.com/github/primer/issues/2206) (April 2023) and tracked for PRC in github/primer#3354.

This changes the rendered elements so assistive technology can announce list size and position (e.g. "item 3 of 12"):

- **Timeline** → `<ol role="list">` (was `<div>`)
- **Timeline.Item** → `<li>` (was `<div>`)
- **Timeline.Break** → `<li role="presentation">` (was `<div>`) — excluded from list item count since it's a visual separator, not a timeline event

The explicit `role="list"` on the `<ol>` restores list semantics in Safari/VoiceOver, which [strips them when `list-style: none` is applied](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html).

### Changelog

#### Changed

- `Timeline` renders as `<ol role="list">` instead of `<div>`. Ref type changes from `HTMLDivElement` to `HTMLOListElement`.
- `Timeline.Item` renders as `<li>` instead of `<div>`. Ref type changes from `HTMLDivElement` to `HTMLLIElement`.
- `Timeline.Break` renders as `<li role="presentation">` instead of `<div>`. Ref type changes from `HTMLDivElement` to `HTMLLIElement`. The `role` prop is omitted from the type to prevent overriding.

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None

**Note on semver:** The ref types narrowed (`HTMLDivElement` → `HTMLOListElement`/`HTMLLIElement`), which is technically a breaking type change. Marked as `minor` because: (1) Timeline refs are rarely used in practice, (2) the change is an accessibility improvement, not a feature removal, and (3) all HTML attributes continue to work identically. Open to `major` if reviewers prefer.

### Guidance for paginated timelines

> [!NOTE]
> Adding this as reference for [future work](https://github.com/github/primer/issues/6654) updating the Timeline component guidance on primer.style

GitHub timelines often contain pagination controls ("Load hidden items") and "show more" buttons interspersed between events. These are not timeline events and should not inflate the list item count. Guidance for consumers:

#### Wrapping non-event children

Any child of `Timeline` that is not a timeline event should render as `<li role="presentation">` (the same pattern `Timeline.Break` uses). This keeps it inside the `<ol>` (valid HTML) while excluding it from the list item count.

**Before loading hidden items (81 visible items):**

```jsx
<Timeline aria-label="Pull request timeline">
  {/* items 1–39 of 81 */}
  <li role="presentation">
    <button>Load 42 hidden items</button>
  </li>
  {/* items 40–81 of 81 */}
</Timeline>
```

**After loading hidden items (123 total items):**

```jsx
<Timeline aria-label="Pull request timeline">
  {/* items 1–39 of 123 */}
  {/* newly loaded: items 40–81 of 123 */}
  {/* items 82–123 of 123 */}
</Timeline>
```

#### Labelling the timeline

Pass a descriptive `aria-label` to `Timeline` (e.g. `"Pull request timeline"`). **Do not include counts in the label** — the native `<ol>` list count updates automatically as items are loaded, so a static count in the label would become stale after "load more" is activated. Screen readers announce the label plus the live item count on entry: *"list, Pull request timeline, 81 items"*.

#### Focus management after loading more items

When the "load more" button is activated and new items are inserted, the button itself is removed from the DOM. **Move focus to the first newly loaded `<li>`** so the user continues from where the gap was. Without explicit focus management, focus falls to `<body>` and the user loses their place.

#### Discoverability of load-more controls

Users navigating by list items (e.g. the "i" shortcut in VoiceOver) will skip `<li role="presentation">` elements, jumping from item 39 directly to item 40. The load-more button is still reachable via linear browsing (arrow keys) or Tab. This is acceptable because the loaded items are still coherent, but worth noting during AT testing.

#### Item numbering after loading

After loading hidden items, the native list numbering shifts: what was "item 40 of 81" becomes "item 82 of 123". This is correct — items are now in their true chronological position — but may be disorienting on first encounter. No action needed; this is inherent to how ordered lists work with dynamic content.

### Testing &amp; Reviewing

1. Open any Timeline story in Storybook
2. Inspect the DOM — confirm `<ol role="list">` wraps `<li>` items
3. If Timeline.Break is present, confirm it renders as `<li role="presentation">`
4. Test with VoiceOver + Safari: navigate to the timeline and confirm it announces as a list with item count
5. Test with VoiceOver + Chrome or NVDA + Firefox/Chrome: same check

### Tracking and consumer adoption

- **Tracking issue:** github/primer#6679 — status, rollout plan, and Phase 2 checklist
- **Consumer adoption (Phase 2):** github/github-ui#22083 — flips the flag in github-ui once a stable `@primer/react` ships with the flag
- **Reference branch for consumer fixes:** [`prc-integration-test-for-7910`](https://github.com/github/github-ui/tree/prc-integration-test-for-7910) on github-ui — contains the proven-out set of changes needed in github-ui (story wrappers, ref type updates, empty-list guards, etc.) when the flag is enabled

### What this PR ships

Adds the `primer_react_timeline_list_semantics` feature flag. **Default behavior is unchanged** — `Timeline` continues to render as `<div>` / `<div>` exactly as on `main`. Opting in via `<FeatureFlags flags={{primer_react_timeline_list_semantics: true}}>` switches to `<ol role="list">` / `<li>`. See the `WithListSemantics` story for a visual.

Integration tests should pass cleanly — the flag-off default has no consumer impact. That's the verification we want before merging.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook) — _no visual change; purely semantic_
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility) — _standard HTML elements, no client-only APIs_
- [ ] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui