### PR TITLE
fix(Dialog): close on first Escape press when close button is focused

### DIFF
--- a/.changeset/dialog-escape-close-button-tooltip.md
+++ b/.changeset/dialog-escape-close-button-tooltip.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Dialog: Fix `Escape` key not closing the dialog on the first keypress when the close button is focused

--- a/packages/react/src/Dialog/Dialog.test.tsx
+++ b/packages/react/src/Dialog/Dialog.test.tsx
@@ -176,10 +176,52 @@ describe('Dialog', () => {
 
     expect(onClose).not.toHaveBeenCalled()
 
-    await user.keyboard('{Escape}') // escape once to remove focus from the close button
-    await user.keyboard('{Escape}') // escape again to trigger the onClose
+    await user.keyboard('{Escape}')
 
     expect(onClose).toHaveBeenCalledWith('escape')
+  })
+
+  it('calls `onClose` with a single "Escape" keypress when multiple dialogs can be opened', async () => {
+    const user = userEvent.setup()
+
+    function ButtonWithDialog({label, onClose}: {label: string; onClose: () => void}) {
+      const [isOpen, setIsOpen] = React.useState(false)
+      const buttonRef = React.useRef<HTMLButtonElement>(null)
+      return (
+        <>
+          <Button ref={buttonRef} onClick={() => setIsOpen(true)}>
+            {label}
+          </Button>
+          {isOpen && (
+            <Dialog
+              title={label}
+              onClose={() => {
+                onClose()
+                setIsOpen(false)
+              }}
+              returnFocusRef={buttonRef}
+            >
+              body
+            </Dialog>
+          )}
+        </>
+      )
+    }
+
+    const onCloseFirst = vi.fn()
+    const onCloseSecond = vi.fn()
+    const {getByText} = render(
+      <>
+        <ButtonWithDialog label="Dialog 1" onClose={onCloseFirst} />
+        <ButtonWithDialog label="Dialog 2" onClose={onCloseSecond} />
+      </>,
+    )
+
+    await user.click(getByText('Dialog 1'))
+    await user.keyboard('{Escape}')
+
+    expect(onCloseFirst).toHaveBeenCalled()
+    expect(onCloseSecond).not.toHaveBeenCalled()
   })
 
   it('changes the <body> style for `overflow` if it is not set to "hidden"', () => {

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -220,6 +220,20 @@ const DefaultHeader: React.FC<React.PropsWithChildren<DialogHeaderProps>> = ({
   const onCloseClick = useCallback(() => {
     onClose('close-button')
   }, [onClose])
+  const onCloseKeyDown = useCallback<React.KeyboardEventHandler>(
+    event => {
+      if (event.key === 'Escape') {
+        // When the close button is focused its tooltip is open, and the
+        // tooltip's own Escape handler (registered on `document`) would
+        // otherwise swallow this keypress. Handle Escape here and stop it from
+        // reaching the document-level handler so the dialog closes on the first
+        // press while keeping the tooltip fully functional.
+        event.stopPropagation()
+        onClose('escape')
+      }
+    },
+    [onClose],
+  )
   return (
     <Dialog.Header>
       <div className={classes.HeaderInner}>
@@ -227,7 +241,7 @@ const DefaultHeader: React.FC<React.PropsWithChildren<DialogHeaderProps>> = ({
           <Dialog.Title id={dialogLabelId}>{title ?? 'Dialog'}</Dialog.Title>
           {subtitle && <Dialog.Subtitle id={dialogDescriptionId}>{subtitle}</Dialog.Subtitle>}
         </div>
-        <Dialog.CloseButton onClose={onCloseClick} />
+        <Dialog.CloseButton onClose={onCloseClick} onKeyDown={onCloseKeyDown} />
       </div>
     </Dialog.Header>
   )
@@ -506,12 +520,16 @@ const Buttons: React.FC<React.PropsWithChildren<{buttons: DialogButtonProps[]}>>
   )
 }
 
-const CloseButton: React.FC<React.PropsWithChildren<{onClose: () => void}>> = ({onClose}) => {
+const CloseButton: React.FC<React.PropsWithChildren<{onClose: () => void; onKeyDown?: React.KeyboardEventHandler}>> = ({
+  onClose,
+  onKeyDown,
+}) => {
   return (
     <IconButton
       icon={XIcon}
       aria-label="Close"
       onClick={onClose}
+      onKeyDown={onKeyDown}
       variant="invisible"
       data-component="Dialog.CloseButton"
     />


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/2604

When a `Dialog` opens, focus moves to its close button. Because icon buttons now render a tooltip by default, the tooltip's own `Escape` handler (registered on `document` via `useOnEscapePress`) runs first and calls `stopImmediatePropagation()` + `preventDefault()` to dismiss the tooltip — swallowing the first `Escape` keypress so the dialog doesn't close. Users had to press `Escape` twice (the previous test even worked around this), and in a multi-dialog setup the first `Escape` could shift focus to the wrong return-focus target instead of closing the dialog.

### Fix

Intercept the `Escape` keydown **on the close button itself**. React dispatches `onKeyDown` at the root container, which sits below `document` in the DOM, so calling `stopPropagation()` there prevents the event from reaching the tooltip's document-level handler. We close the dialog directly with the `'escape'` gesture, and the tooltip stays fully functional.

#### Considered but rejected: disabling the tooltip

The simplest fix was to set `unsafeDisableTooltip` on the close button. We chose **not** to do this because the tooltip contributes to the button's discoverability/affordance and we didn't want to regress the accessibility/UX of the close button just to work around the event handling. Intercepting the event keeps the tooltip — and its behavior — intact while fixing the bug.

### Changelog

#### Changed

- `Dialog` now closes on the first `Escape` keypress when the close button is focused, instead of requiring a second press.

### Rollout strategy

- [x] Patch release

### Testing & Reviewing

1. Render two buttons that each open their own `Dialog` (each with a `returnFocusRef`).
2. Open the first dialog and press `Escape` once.
3. The dialog should close on the first press and focus should return to its own trigger button.

Added a regression test in `Dialog.test.tsx` covering the single-`Escape` close and the multi-dialog scenario, and updated the existing Escape test to expect a single keypress. All 40 Dialog tests pass; type-check is clean.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui