### PR TITLE
ci: add npm workflow to pack packages

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -58,7 +58,7 @@ jobs:
               packages: result.map(pkg => ({
                 name: pkg.name,
                 version: pkg.version,
-                path: path.join(directory, pkg.filename),
+                path: path.join('packed', pkg.filename),
               })),
             };
 

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -41,6 +41,8 @@ jobs:
             const directory = path.resolve('packed');
             fs.mkdirSync(directory, {recursive: true});
 
+            core.startGroup('Packing npm packages');
+
             const {stdout: queryOutput} = await exec.getExecOutput('npm', ['query', '.workspace']);
             const workspaces = JSON.parse(queryOutput);
             const packages = workspaces.filter(pkg => pkg.private !== true).map(pkg => pkg.name);
@@ -49,6 +51,8 @@ jobs:
             const args = ['pack', ...packages.map(name => `--workspace=${name}`), '--pack-destination', directory, '--json'];
             const {stdout: packOutput} = await exec.getExecOutput('npm', args);
             const result = JSON.parse(packOutput);
+
+            core.endGroup();
 
             const metadata = {
               packages: result.map(pkg => ({
@@ -60,7 +64,6 @@ jobs:
 
             fs.writeFileSync(path.join(directory, 'metadata.json'), JSON.stringify(metadata, null, 2));
 
-            core.info('Packed:');
             core.info(JSON.stringify(metadata, null, 2));
       - name: Upload packed npm packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,72 @@
+name: npm
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: Set up turbo cache
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-
+            ${{ runner.os }}-turbo-
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Pack public packages
+        uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293
+        with:
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+
+            const directory = path.resolve('packed');
+            fs.mkdirSync(directory, {recursive: true});
+
+            const {stdout: queryOutput} = await exec.getExecOutput('npm', ['query', '.workspace']);
+            const workspaces = JSON.parse(queryOutput);
+            const packages = workspaces.filter(pkg => pkg.private !== true).map(pkg => pkg.name);
+            core.info(`Packing: ${packages.join(' ')}`);
+
+            const args = ['pack', ...packages.map(name => `--workspace=${name}`), '--pack-destination', directory, '--json'];
+            const {stdout: packOutput} = await exec.getExecOutput('npm', args);
+            const result = JSON.parse(packOutput);
+
+            const metadata = {
+              packages: result.map(pkg => ({
+                name: pkg.name,
+                version: pkg.version,
+                path: path.join(directory, pkg.filename),
+              })),
+            };
+
+            fs.writeFileSync(path.join(directory, 'metadata.json'), JSON.stringify(metadata, null, 2));
+
+            core.info('Packed:');
+            core.info(JSON.stringify(metadata, null, 2));
+      - name: Upload packed npm packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: npm-packages
+          path: |
+            packed/*.tgz
+            packed/metadata.json
+          if-no-files-found: error

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: ${{ runner.os }}-turbo-${{ github.job }}-default-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-default-
             ${{ runner.os }}-turbo-${{ github.job }}-
             ${{ runner.os }}-turbo-
       - name: Install dependencies

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Pack public packages
-        uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('node:fs');


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Part of https://github.com/github/primer/issues/6480

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Add a new workflow, `npm`, that will upload the `npm pack` artifacts for public packages. This can then be consumed by repos where we would like to test instead of us needing to publish a canary version

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

- Add a new workflow, `npm`, for uploading `npm pack` package artifacts

#### Changed

<!-- List of things changed in this PR -->

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] None; if selected, include a brief description as to why

This is adding a workflow for GitHub Actions