### PR TITLE
InlineMessage: make `variant` prop optional

### DIFF
--- a/.changeset/inline-message-optional-variant.md
+++ b/.changeset/inline-message-optional-variant.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+InlineMessage: Make `variant` prop optional, defaulting to the standard foreground color with an info icon

--- a/packages/react/src/InlineMessage/InlineMessage.module.css
+++ b/packages/react/src/InlineMessage/InlineMessage.module.css
@@ -4,9 +4,13 @@
   font-size: var(--inline-message-fontSize);
   /* stylelint-disable-next-line primer/typography */
   line-height: var(--inline-message-lineHeight);
+  /* stylelint-disable-next-line primer/colors */
+  color: var(--inline-message-fgColor);
   column-gap: 0.5rem;
   grid-template-columns: auto 1fr;
   align-items: start;
+
+  --inline-message-fgColor: var(--fgColor-default);
 
   &[data-size='small'] {
     --inline-message-fontSize: var(--text-body-size-small);
@@ -19,19 +23,19 @@
   }
 
   &[data-variant='warning'] {
-    color: var(--fgColor-attention);
+    --inline-message-fgColor: var(--fgColor-attention);
   }
 
   &[data-variant='critical'] {
-    color: var(--fgColor-danger);
+    --inline-message-fgColor: var(--fgColor-danger);
   }
 
   &[data-variant='success'] {
-    color: var(--fgColor-success);
+    --inline-message-fgColor: var(--fgColor-success);
   }
 
   &[data-variant='unavailable'] {
-    color: var(--fgColor-muted);
+    --inline-message-fgColor: var(--fgColor-muted);
   }
 }
 

--- a/packages/react/src/InlineMessage/InlineMessage.module.css
+++ b/packages/react/src/InlineMessage/InlineMessage.module.css
@@ -4,8 +4,6 @@
   font-size: var(--inline-message-fontSize);
   /* stylelint-disable-next-line primer/typography */
   line-height: var(--inline-message-lineHeight);
-  /* stylelint-disable-next-line primer/colors */
-  color: var(--inline-message-fgColor, var(--fgColor-default));
   column-gap: 0.5rem;
   grid-template-columns: auto 1fr;
   align-items: start;
@@ -21,19 +19,19 @@
   }
 
   &[data-variant='warning'] {
-    --inline-message-fgColor: var(--fgColor-attention);
+    color: var(--fgColor-attention);
   }
 
   &[data-variant='critical'] {
-    --inline-message-fgColor: var(--fgColor-danger);
+    color: var(--fgColor-danger);
   }
 
   &[data-variant='success'] {
-    --inline-message-fgColor: var(--fgColor-success);
+    color: var(--fgColor-success);
   }
 
   &[data-variant='unavailable'] {
-    --inline-message-fgColor: var(--fgColor-muted);
+    color: var(--fgColor-muted);
   }
 }
 

--- a/packages/react/src/InlineMessage/InlineMessage.module.css
+++ b/packages/react/src/InlineMessage/InlineMessage.module.css
@@ -5,7 +5,7 @@
   /* stylelint-disable-next-line primer/typography */
   line-height: var(--inline-message-lineHeight);
   /* stylelint-disable-next-line primer/colors */
-  color: var(--inline-message-fgColor);
+  color: var(--inline-message-fgColor, var(--fgColor-default));
   column-gap: 0.5rem;
   grid-template-columns: auto 1fr;
   align-items: start;

--- a/packages/react/src/InlineMessage/InlineMessage.test.tsx
+++ b/packages/react/src/InlineMessage/InlineMessage.test.tsx
@@ -95,6 +95,18 @@ describe('InlineMessage', () => {
     expect(screen.getByTestId('container')).toHaveAttribute('data-variant', 'warning')
   })
 
+  it('should not set data-variant when variant is not provided', () => {
+    render(<InlineMessage data-testid="container">test</InlineMessage>)
+    expect(screen.getByTestId('container')).not.toHaveAttribute('data-variant')
+  })
+
+  it('should render InfoIcon when variant is not provided', () => {
+    const {container} = render(<InlineMessage>test without variant</InlineMessage>)
+    expect(screen.getByText('test without variant')).toBeInTheDocument()
+    const svg = container.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+  })
+
   it('should render leading visual', () => {
     render(
       <>

--- a/packages/react/src/InlineMessage/InlineMessage.test.tsx
+++ b/packages/react/src/InlineMessage/InlineMessage.test.tsx
@@ -103,7 +103,7 @@ describe('InlineMessage', () => {
   it('should render InfoIcon when variant is not provided', () => {
     const {container} = render(<InlineMessage>test without variant</InlineMessage>)
     expect(screen.getByText('test without variant')).toBeInTheDocument()
-    const svg = container.querySelector('svg')
+    const svg = container.querySelector('svg.octicon-info')
     expect(svg).toBeInTheDocument()
   })
 

--- a/packages/react/src/InlineMessage/InlineMessage.tsx
+++ b/packages/react/src/InlineMessage/InlineMessage.tsx
@@ -1,4 +1,4 @@
-import {AlertFillIcon, AlertIcon, CheckCircleFillIcon, CheckCircleIcon} from '@primer/octicons-react'
+import {AlertFillIcon, AlertIcon, CheckCircleFillIcon, CheckCircleIcon, InfoIcon} from '@primer/octicons-react'
 import {clsx} from 'clsx'
 import type React from 'react'
 import {isValidElementType} from 'react-is'
@@ -14,7 +14,7 @@ export type InlineMessageProps = React.ComponentPropsWithoutRef<'div'> & {
   /**
    * Specify the type of the InlineMessage
    */
-  variant: MessageVariant
+  variant?: MessageVariant
 
   /**
    * A custom leading visual (icon or other element) to display instead of the default variant icon.
@@ -52,9 +52,11 @@ export function InlineMessage({
     } else {
       icon = LeadingVisual
     }
-  } else {
+  } else if (variant) {
     // Use default icon based on variant and size
     icon = size === 'small' ? smallIcons[variant] : icons[variant]
+  } else {
+    icon = <InfoIcon className={classes.InlineMessageIcon} />
   }
 
   return (
@@ -62,7 +64,7 @@ export function InlineMessage({
       {...rest}
       className={clsx(className, classes.InlineMessage)}
       data-size={size}
-      data-variant={variant}
+      data-variant={variant ?? undefined}
       data-component="InlineMessage"
     >
       {icon}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

### Overview

Makes the `variant` prop on `InlineMessage` optional. When no variant is specified:
- The text renders with the default foreground color (`--fgColor-default`)
- The icon defaults to Primer's `InfoIcon`

This change **will not cause any regressions** because all existing `InlineMessage` usages were required to pass a `variant` — making the prop optional is purely additive.

### Changelog

#### New

- `InlineMessage` can now be rendered without a `variant` prop, displaying with the default foreground color and an `InfoIcon`

#### Changed

- `variant` prop type changed from required to optional

#### Removed

_None_

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- Tests added for the no-variant case verifying that `data-variant` is not set and that an icon still renders
- All existing tests continue to pass unchanged

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge