### PR TITLE
Move styled-react hooks out of component modules

### DIFF
--- a/packages/styled-react/src/components/BaseStyles.tsx
+++ b/packages/styled-react/src/components/BaseStyles.tsx
@@ -3,7 +3,7 @@ import {type CSSProperties, type PropsWithChildren, type JSX} from 'react'
 import {clsx} from 'clsx'
 // eslint-disable-next-line import/no-namespace
 import type * as styledSystem from 'styled-system'
-import {useTheme} from './ThemeProvider'
+import {useTheme} from './useTheme'
 
 import 'focus-visible'
 import {createGlobalStyle} from 'styled-components'

--- a/packages/styled-react/src/components/FeatureFlaggedTheming.tsx
+++ b/packages/styled-react/src/components/FeatureFlaggedTheming.tsx
@@ -1,15 +1,11 @@
 import type React from 'react'
-import {
-  ThemeProvider as PrimerThemeProvider,
-  useTheme as primerUseTheme,
-  BaseStyles as PrimerBaseStyles,
-} from '@primer/react'
+import {ThemeProvider as PrimerThemeProvider, BaseStyles as PrimerBaseStyles} from '@primer/react'
 import type {
   ThemeProviderProps as PrimerThemeProviderProps,
   BaseStylesProps as PrimerBaseStylesProps,
 } from '@primer/react'
 import {useFeatureFlag} from '@primer/react/experimental'
-import {ThemeProvider as StyledThemeProvider, useTheme as styledUseTheme, useColorSchemeVar} from './ThemeProvider'
+import {ThemeProvider as StyledThemeProvider} from './ThemeProvider'
 import type {ThemeProviderProps as StyledThemeProviderProps} from './ThemeProvider'
 import {BaseStyles as StyledBaseStyles} from './BaseStyles'
 import type {BaseStylesProps as StyledBaseStylesProps} from './BaseStyles'
@@ -25,18 +21,6 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>
   }
   return <StyledThemeProvider {...props}>{children}</StyledThemeProvider>
 }
-
-export function useTheme(): ReturnType<typeof primerUseTheme> {
-  const enabled = useFeatureFlag('primer_react_styled_react_use_primer_theme_providers')
-  const styledTheme = styledUseTheme()
-  const primerTheme = primerUseTheme()
-  if (enabled) {
-    return primerTheme as ReturnType<typeof primerUseTheme>
-  }
-  return styledTheme
-}
-
-export {useColorSchemeVar}
 
 export function BaseStyles(props: BaseStylesProps) {
   const enabled = useFeatureFlag('primer_react_styled_react_use_primer_theme_providers')

--- a/packages/styled-react/src/components/ThemeContext.ts
+++ b/packages/styled-react/src/components/ThemeContext.ts
@@ -1,0 +1,19 @@
+import React from 'react'
+import type {ColorMode, ColorModeWithAuto, Theme} from './ThemeProvider'
+
+export const ThemeContext = React.createContext<{
+  theme?: Theme
+  colorScheme?: string
+  colorMode?: ColorModeWithAuto
+  resolvedColorMode?: ColorMode
+  resolvedColorScheme?: string
+  dayScheme?: string
+  nightScheme?: string
+  setColorMode: React.Dispatch<React.SetStateAction<ColorModeWithAuto>>
+  setDayScheme: React.Dispatch<React.SetStateAction<string>>
+  setNightScheme: React.Dispatch<React.SetStateAction<string>>
+}>({
+  setColorMode: () => null,
+  setDayScheme: () => null,
+  setNightScheme: () => null,
+})

--- a/packages/styled-react/src/components/ThemeProvider.tsx
+++ b/packages/styled-react/src/components/ThemeProvider.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import {ThemeProvider as SCThemeProvider} from 'styled-components'
 import {theme as defaultTheme, useId, useSyncedState} from '@primer/react'
 import deepmerge from 'deepmerge'
+import {ThemeContext} from './ThemeContext'
+import {useTheme} from './useTheme'
 
 export const defaultColorMode = 'day'
 const defaultDayScheme = 'light'
@@ -9,7 +11,7 @@ const defaultNightScheme = 'dark'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Theme = {[key: string]: any}
-type ColorMode = 'day' | 'night' | 'light' | 'dark'
+export type ColorMode = 'day' | 'night' | 'light' | 'dark'
 export type ColorModeWithAuto = ColorMode | 'auto'
 
 export type ThemeProviderProps = {
@@ -24,23 +26,6 @@ export type ThemeProviderProps = {
    */
   contextOnly?: boolean
 }
-
-const ThemeContext = React.createContext<{
-  theme?: Theme
-  colorScheme?: string
-  colorMode?: ColorModeWithAuto
-  resolvedColorMode?: ColorMode
-  resolvedColorScheme?: string
-  dayScheme?: string
-  nightScheme?: string
-  setColorMode: React.Dispatch<React.SetStateAction<ColorModeWithAuto>>
-  setDayScheme: React.Dispatch<React.SetStateAction<string>>
-  setNightScheme: React.Dispatch<React.SetStateAction<string>>
-}>({
-  setColorMode: () => null,
-  setDayScheme: () => null,
-  setNightScheme: () => null,
-})
 
 // inspired from __NEXT_DATA__, we use application/json to avoid CSRF policy with inline scripts
 const serverHandoffCache = new Map<string, Record<string, unknown>>()
@@ -142,15 +127,6 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>
       </SCThemeProvider>
     </ThemeContext.Provider>
   )
-}
-
-export function useTheme() {
-  return React.useContext(ThemeContext)
-}
-
-export function useColorSchemeVar(values: Partial<Record<string, string>>, fallback: string) {
-  const {colorScheme = ''} = useTheme()
-  return values[colorScheme] ?? fallback
 }
 
 function subscribeToSystemColorMode(callback: () => void) {

--- a/packages/styled-react/src/components/useFeatureFlaggedTheme.ts
+++ b/packages/styled-react/src/components/useFeatureFlaggedTheme.ts
@@ -1,0 +1,20 @@
+import {useColorSchemeVar as primerUseColorSchemeVar, useTheme as primerUseTheme} from '@primer/react'
+import {useFeatureFlag} from '@primer/react/experimental'
+import {useColorSchemeVar as styledUseColorSchemeVar, useTheme as styledUseTheme} from './useTheme'
+
+export function useTheme(): ReturnType<typeof primerUseTheme> {
+  const enabled = useFeatureFlag('primer_react_styled_react_use_primer_theme_providers')
+  const styledTheme = styledUseTheme()
+  const primerTheme = primerUseTheme()
+  if (enabled) {
+    return primerTheme as ReturnType<typeof primerUseTheme>
+  }
+  return styledTheme
+}
+
+export function useColorSchemeVar(values: Partial<Record<string, string>>, fallback: string) {
+  const enabled = useFeatureFlag('primer_react_styled_react_use_primer_theme_providers')
+  const styledValue = styledUseColorSchemeVar(values, fallback)
+  const primerValue = primerUseColorSchemeVar(values, fallback)
+  return enabled ? primerValue : styledValue
+}

--- a/packages/styled-react/src/components/useTheme.ts
+++ b/packages/styled-react/src/components/useTheme.ts
@@ -1,0 +1,11 @@
+import React from 'react'
+import {ThemeContext} from './ThemeContext'
+
+export function useTheme() {
+  return React.useContext(ThemeContext)
+}
+
+export function useColorSchemeVar(values: Partial<Record<string, string>>, fallback: string) {
+  const {colorScheme = ''} = useTheme()
+  return values[colorScheme] ?? fallback
+}

--- a/packages/styled-react/src/index.tsx
+++ b/packages/styled-react/src/index.tsx
@@ -12,6 +12,14 @@ export {
    * @deprecated Theming in JavaScript is no longer supported. Prefer using
    * `@primer/primitives` and CSS Modules instead.
    */
+  type ThemeProviderProps,
+} from './components/FeatureFlaggedTheming'
+
+export {
+  /**
+   * @deprecated Theming in JavaScript is no longer supported. Prefer using
+   * `@primer/primitives` and CSS Modules instead.
+   */
   useTheme,
 
   /**
@@ -19,13 +27,7 @@ export {
    * `@primer/primitives` and CSS Modules instead.
    */
   useColorSchemeVar,
-
-  /**
-   * @deprecated Theming in JavaScript is no longer supported. Prefer using
-   * `@primer/primitives` and CSS Modules instead.
-   */
-  type ThemeProviderProps,
-} from './components/FeatureFlaggedTheming'
+} from './components/useFeatureFlaggedTheme'
 
 export {
   /**


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

No linked issue.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Splits styled-react theme hooks and context out of component modules while preserving deprecated public exports from the package entrypoint.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

- Added styled-react `ThemeContext.ts`, `useTheme.ts`, and `useFeatureFlaggedTheme.ts` modules.

#### Changed

- Updated styled-react BaseStyles, ThemeProvider, feature-flagged theming, and package entrypoint imports/exports to use the new hook modules.

#### Removed

- Removed exported hook declarations from styled-react component implementation files.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; internal refactor for a legacy package with existing deprecated exports preserved.

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To publish a canary release for integration testing, apply the "Canary Release" label to this PR -->

Review that styled-react still exports `useTheme` and `useColorSchemeVar` from its package entrypoint.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/primer/react/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
