### PR TITLE
Enforce React Refresh component-only exports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ import githubPlugin from 'eslint-plugin-github'
 import storybook from 'eslint-plugin-storybook'
 import react from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
+import {reactRefresh} from 'eslint-plugin-react-refresh'
 import {unsupportedPatterns as reactCompilerUnsupported} from './packages/react/script/react-compiler.mjs'
 import playwright from 'eslint-plugin-playwright'
 import prettierRecommended from 'eslint-plugin-prettier/recommended'
@@ -58,6 +59,22 @@ const config = defineConfig([
 
   ...fixupConfigRules([react.configs.flat.recommended, react.configs.flat['jsx-runtime']]),
   reactHooks.configs.flat['recommended-latest'],
+  {
+    files: ['**/*.{jsx,tsx}'],
+    plugins: {
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      'react-refresh/only-export-components': [
+        'error',
+        {
+          allowConstantExport: true,
+          allowExportNames: ['metadata'],
+          extraHOCs: ['assign', 'fixedForwardRef'],
+        },
+      ],
+    },
+  },
   // Disable react-compiler rule for files not yet migrated
   {
     files: reactCompilerUnsupported.map(p => `packages/react/${p}`),

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ import githubPlugin from 'eslint-plugin-github'
 import storybook from 'eslint-plugin-storybook'
 import react from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
-import {reactRefresh} from 'eslint-plugin-react-refresh'
+import reactRefreshPlugin from 'eslint-plugin-react-refresh'
 import {unsupportedPatterns as reactCompilerUnsupported} from './packages/react/script/react-compiler.mjs'
 import playwright from 'eslint-plugin-playwright'
 import prettierRecommended from 'eslint-plugin-prettier/recommended'
@@ -62,7 +62,7 @@ const config = defineConfig([
   {
     files: ['**/*.{jsx,tsx}'],
     plugins: {
-      'react-refresh': reactRefresh,
+      'react-refresh': reactRefreshPlugin,
     },
     rules: {
       'react-refresh/only-export-components': [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,7 @@ const config = defineConfig([
   reactHooks.configs.flat['recommended-latest'],
   {
     files: ['**/*.{jsx,tsx}'],
+    ignores: ['packages/styled-react/src/index.tsx'],
     plugins: {
       'react-refresh': reactRefreshPlugin,
     },


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

No linked issue.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Enables `react-refresh/only-export-components` as an error after the preceding stack layers move non-component exports out of component files.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

- Added `react-refresh/only-export-components` to the flat ESLint config.

#### Changed

- Configured the rule for this codebase's patterns, including constant exports, Next metadata, compound `Object.assign` components, and `fixedForwardRef`.
- Skips the styled-react TSX entrypoint barrel because the package build expects that filename and it only re-exports deprecated APIs.

#### Removed

- Nothing.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; lint enforcement only, no consumer-facing runtime change.

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To publish a canary release for integration testing, apply the "Canary Release" label to this PR -->

Validated the configured rule reported zero remaining React Refresh violations before enabling it. Full validation passed for format, lint, CSS lint, type-check, and build; full browser test runs hit transient timeouts, and the affected files passed on targeted rerun.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/primer/react/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
