### PR TITLE
feat: add CSS Layer support to additional foundations

### DIFF
--- a/.changeset/css-layers-foundations-b.md
+++ b/.changeset/css-layers-foundations-b.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Details, CSSComponent, UnderlinePanels, Flash, Header, Heading, Hidden, InlineMessage, ButtonReset: Improve custom class override behavior for component styles

--- a/.changeset/css-layers-foundations-b.md
+++ b/.changeset/css-layers-foundations-b.md
@@ -2,4 +2,4 @@
 '@primer/react': patch
 ---
 
-Details, CSSComponent, UnderlinePanels, Flash, Header, Heading, Hidden, InlineMessage, ButtonReset: Improve custom class override behavior for component styles
+Details, CSSComponent, UnderlinePanels, Flash, Header, Heading, Hidden, InlineMessage, ButtonReset: Add CSS layer support for component styles

--- a/packages/react/src/Details/Details.module.css
+++ b/packages/react/src/Details/Details.module.css
@@ -1,7 +1,9 @@
-.Details > summary {
-  list-style: none;
-}
+@layer primer.components.Details {
+  .Details > summary {
+    list-style: none;
+  }
 
-.Details > summary::-webkit-details-marker {
-  display: none;
+  .Details > summary::-webkit-details-marker {
+    display: none;
+  }
 }

--- a/packages/react/src/Flash/Flash.module.css
+++ b/packages/react/src/Flash/Flash.module.css
@@ -1,60 +1,62 @@
-.Flash {
-  position: relative;
-  padding: var(--base-size-16);
-  margin-top: 0;
-  color: var(--fgColor-default);
-  border-style: solid;
-  border-width: var(--borderWidth-thin);
-  border-radius: var(--borderRadius-medium);
+@layer primer.components.Flash {
+  .Flash {
+    position: relative;
+    padding: var(--base-size-16);
+    margin-top: 0;
+    color: var(--fgColor-default);
+    border-style: solid;
+    border-width: var(--borderWidth-thin);
+    border-radius: var(--borderRadius-medium);
 
-  &:where([data-variant='default']) {
-    background-color: var(--bgColor-accent-muted);
-    border-color: var(--borderColor-accent-muted);
+    &:where([data-variant='default']) {
+      background-color: var(--bgColor-accent-muted);
+      border-color: var(--borderColor-accent-muted);
+
+      & :where(svg) {
+        color: var(--fgColor-accent);
+      }
+    }
+
+    &:where([data-variant='success']) {
+      background-color: var(--bgColor-success-muted);
+      border-color: var(--borderColor-success-muted);
+
+      & :where(svg) {
+        color: var(--fgColor-success);
+      }
+    }
+
+    &:where([data-variant='danger']) {
+      background-color: var(--bgColor-danger-muted);
+      border-color: var(--borderColor-danger-muted);
+
+      & :where(svg) {
+        color: var(--fgColor-danger);
+      }
+    }
+
+    &:where([data-variant='warning']) {
+      background-color: var(--bgColor-attention-muted);
+      border-color: var(--borderColor-attention-muted);
+
+      & :where(svg) {
+        color: var(--fgColor-attention);
+      }
+    }
+
+    &:where([data-full]) {
+      /* stylelint-disable-next-line primer/spacing */
+      margin-top: -1px;
+      border-width: var(--borderWidth-thin) 0;
+      border-radius: 0;
+    }
+
+    & :where(p:last-child) {
+      margin-bottom: 0;
+    }
 
     & :where(svg) {
-      color: var(--fgColor-accent);
+      margin-right: var(--base-size-8);
     }
-  }
-
-  &:where([data-variant='success']) {
-    background-color: var(--bgColor-success-muted);
-    border-color: var(--borderColor-success-muted);
-
-    & :where(svg) {
-      color: var(--fgColor-success);
-    }
-  }
-
-  &:where([data-variant='danger']) {
-    background-color: var(--bgColor-danger-muted);
-    border-color: var(--borderColor-danger-muted);
-
-    & :where(svg) {
-      color: var(--fgColor-danger);
-    }
-  }
-
-  &:where([data-variant='warning']) {
-    background-color: var(--bgColor-attention-muted);
-    border-color: var(--borderColor-attention-muted);
-
-    & :where(svg) {
-      color: var(--fgColor-attention);
-    }
-  }
-
-  &:where([data-full]) {
-    /* stylelint-disable-next-line primer/spacing */
-    margin-top: -1px;
-    border-width: var(--borderWidth-thin) 0;
-    border-radius: 0;
-  }
-
-  & :where(p:last-child) {
-    margin-bottom: 0;
-  }
-
-  & :where(svg) {
-    margin-right: var(--base-size-8);
   }
 }

--- a/packages/react/src/Header/Header.module.css
+++ b/packages/react/src/Header/Header.module.css
@@ -1,39 +1,41 @@
-.Header {
-  z-index: 32;
-  display: flex;
-  padding: var(--base-size-16);
-  overflow: auto;
-  font-size: var(--text-body-size-medium);
-  line-height: var(--text-title-lineHeight-large);
-  color: var(--header-fgColor-default);
-  background-color: var(--header-bgColor);
-  align-items: center;
-  flex-wrap: nowrap;
-}
-
-.HeaderItem {
-  display: flex;
-  margin-right: var(--base-size-16);
-  align-self: stretch;
-  align-items: center;
-  flex-wrap: nowrap;
-
-  &:where([data-full]) {
-    flex: auto;
-  }
-}
-
-.HeaderLink {
-  display: flex;
-  font-weight: var(--text-title-weight-large);
-  color: var(--header-fgColor-logo);
-  text-decoration: none;
-  white-space: nowrap;
-  cursor: pointer;
-  align-items: center;
-
-  &:hover,
-  &:focus {
+@layer primer.components.Header {
+  .Header {
+    z-index: 32;
+    display: flex;
+    padding: var(--base-size-16);
+    overflow: auto;
+    font-size: var(--text-body-size-medium);
+    line-height: var(--text-title-lineHeight-large);
     color: var(--header-fgColor-default);
+    background-color: var(--header-bgColor);
+    align-items: center;
+    flex-wrap: nowrap;
+  }
+
+  .HeaderItem {
+    display: flex;
+    margin-right: var(--base-size-16);
+    align-self: stretch;
+    align-items: center;
+    flex-wrap: nowrap;
+
+    &:where([data-full]) {
+      flex: auto;
+    }
+  }
+
+  .HeaderLink {
+    display: flex;
+    font-weight: var(--text-title-weight-large);
+    color: var(--header-fgColor-logo);
+    text-decoration: none;
+    white-space: nowrap;
+    cursor: pointer;
+    align-items: center;
+
+    &:hover,
+    &:focus {
+      color: var(--header-fgColor-default);
+    }
   }
 }

--- a/packages/react/src/Heading/Heading.module.css
+++ b/packages/react/src/Heading/Heading.module.css
@@ -1,17 +1,19 @@
-:where(.Heading) {
-  margin: 0;
-  font-size: var(--text-title-size-large);
-  font-weight: var(--base-text-weight-semibold);
+@layer primer.components.Heading {
+  :where(.Heading) {
+    margin: 0;
+    font-size: var(--text-title-size-large);
+    font-weight: var(--base-text-weight-semibold);
 
-  &:where([data-variant='large']) {
-    font: var(--text-title-shorthand-large);
-  }
+    &:where([data-variant='large']) {
+      font: var(--text-title-shorthand-large);
+    }
 
-  &:where([data-variant='medium']) {
-    font: var(--text-title-shorthand-medium);
-  }
+    &:where([data-variant='medium']) {
+      font: var(--text-title-shorthand-medium);
+    }
 
-  &:where([data-variant='small']) {
-    font: var(--text-title-shorthand-small);
+    &:where([data-variant='small']) {
+      font: var(--text-title-shorthand-small);
+    }
   }
 }

--- a/packages/react/src/Hidden/Hidden.module.css
+++ b/packages/react/src/Hidden/Hidden.module.css
@@ -1,13 +1,15 @@
-.Hidden {
-  @media screen and (--viewportRange-narrow) {
-    display: var(--hiddenDisplay-narrow, block);
-  }
+@layer primer.components.Hidden {
+  .Hidden {
+    @media screen and (--viewportRange-narrow) {
+      display: var(--hiddenDisplay-narrow, block);
+    }
 
-  @media screen and (--viewportRange-regular) {
-    display: var(--hiddenDisplay-regular, block);
-  }
+    @media screen and (--viewportRange-regular) {
+      display: var(--hiddenDisplay-regular, block);
+    }
 
-  @media screen and (--viewportRange-wide) {
-    display: var(--hiddenDisplay-wide, block);
+    @media screen and (--viewportRange-wide) {
+      display: var(--hiddenDisplay-wide, block);
+    }
   }
 }

--- a/packages/react/src/InlineMessage/InlineMessage.module.css
+++ b/packages/react/src/InlineMessage/InlineMessage.module.css
@@ -1,44 +1,46 @@
-.InlineMessage {
-  display: grid;
-  /* stylelint-disable-next-line primer/typography */
-  font-size: var(--inline-message-fontSize);
-  /* stylelint-disable-next-line primer/typography */
-  line-height: var(--inline-message-lineHeight);
-  /* stylelint-disable-next-line primer/colors */
-  color: var(--inline-message-fgColor);
-  column-gap: 0.5rem;
-  grid-template-columns: auto 1fr;
-  align-items: start;
+@layer primer.components.InlineMessage {
+  .InlineMessage {
+    display: grid;
+    /* stylelint-disable-next-line primer/typography */
+    font-size: var(--inline-message-fontSize);
+    /* stylelint-disable-next-line primer/typography */
+    line-height: var(--inline-message-lineHeight);
+    /* stylelint-disable-next-line primer/colors */
+    color: var(--inline-message-fgColor);
+    column-gap: 0.5rem;
+    grid-template-columns: auto 1fr;
+    align-items: start;
 
-  --inline-message-fgColor: var(--fgColor-default);
+    --inline-message-fgColor: var(--fgColor-default);
 
-  &[data-size='small'] {
-    --inline-message-fontSize: var(--text-body-size-small);
-    --inline-message-lineHeight: var(--text-body-lineHeight-small, 1.6666);
+    &[data-size='small'] {
+      --inline-message-fontSize: var(--text-body-size-small);
+      --inline-message-lineHeight: var(--text-body-lineHeight-small, 1.6666);
+    }
+
+    &[data-size='medium'] {
+      --inline-message-fontSize: var(--text-body-size-medium);
+      --inline-message-lineHeight: var(--text-body-lineHeight-medium, 1.4285);
+    }
+
+    &[data-variant='warning'] {
+      --inline-message-fgColor: var(--fgColor-attention);
+    }
+
+    &[data-variant='critical'] {
+      --inline-message-fgColor: var(--fgColor-danger);
+    }
+
+    &[data-variant='success'] {
+      --inline-message-fgColor: var(--fgColor-success);
+    }
+
+    &[data-variant='unavailable'] {
+      --inline-message-fgColor: var(--fgColor-muted);
+    }
   }
 
-  &[data-size='medium'] {
-    --inline-message-fontSize: var(--text-body-size-medium);
-    --inline-message-lineHeight: var(--text-body-lineHeight-medium, 1.4285);
+  .InlineMessageIcon {
+    min-height: calc(var(--inline-message-lineHeight) * var(--inline-message-fontSize));
   }
-
-  &[data-variant='warning'] {
-    --inline-message-fgColor: var(--fgColor-attention);
-  }
-
-  &[data-variant='critical'] {
-    --inline-message-fgColor: var(--fgColor-danger);
-  }
-
-  &[data-variant='success'] {
-    --inline-message-fgColor: var(--fgColor-success);
-  }
-
-  &[data-variant='unavailable'] {
-    --inline-message-fgColor: var(--fgColor-muted);
-  }
-}
-
-.InlineMessageIcon {
-  min-height: calc(var(--inline-message-lineHeight) * var(--inline-message-fontSize));
 }

--- a/packages/react/src/__tests__/css-layers.test.ts
+++ b/packages/react/src/__tests__/css-layers.test.ts
@@ -16,6 +16,15 @@ const allowlist = new Set([
   path.resolve(import.meta.dirname, '../CircleBadge/CircleBadge.module.css'),
   path.resolve(import.meta.dirname, '../deprecated/FilteredSearch/FilteredSearch.module.css'),
   path.resolve(import.meta.dirname, '../deprecated/UnderlineNav/UnderlineNav.module.css'),
+  path.resolve(import.meta.dirname, '../Details/Details.module.css'),
+  path.resolve(import.meta.dirname, '../experimental/CSSComponent/component.module.css'),
+  path.resolve(import.meta.dirname, '../experimental/UnderlinePanels/UnderlinePanels.module.css'),
+  path.resolve(import.meta.dirname, '../Flash/Flash.module.css'),
+  path.resolve(import.meta.dirname, '../Header/Header.module.css'),
+  path.resolve(import.meta.dirname, '../Heading/Heading.module.css'),
+  path.resolve(import.meta.dirname, '../Hidden/Hidden.module.css'),
+  path.resolve(import.meta.dirname, '../InlineMessage/InlineMessage.module.css'),
+  path.resolve(import.meta.dirname, '../internal/components/ButtonReset.module.css'),
 ])
 const files = Array.from(allowlist).map(file => {
   return [path.relative(path.resolve(import.meta.dirname, '..'), file), file]

--- a/packages/react/src/experimental/CSSComponent/component.module.css
+++ b/packages/react/src/experimental/CSSComponent/component.module.css
@@ -1,8 +1,10 @@
-.Component {
-  width: fit-content;
-  /* stylelint-disable-next-line primer/spacing */
-  padding: var(--control-xsmall-paddingBlock) var(--control-xsmall-paddingInline-normal);
-  color: var(--fgColor-muted);
-  background-color: var(--bgColor-default);
-  border: var(--borderWidth-thin) solid var(--borderColor-default);
+@layer primer.components.CSSComponent {
+  .Component {
+    width: fit-content;
+    /* stylelint-disable-next-line primer/spacing */
+    padding: var(--control-xsmall-paddingBlock) var(--control-xsmall-paddingInline-normal);
+    color: var(--fgColor-muted);
+    background-color: var(--bgColor-default);
+    border: var(--borderWidth-thin) solid var(--borderColor-default);
+  }
 }

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.module.css
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.module.css
@@ -1,10 +1,12 @@
-.StyledUnderlineWrapper {
-  width: 100%;
-  overflow-x: auto;
-  overflow-y: hidden;
-  -webkit-overflow-scrolling: auto;
-}
+@layer primer.components.UnderlinePanels {
+  .StyledUnderlineWrapper {
+    width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: auto;
+  }
 
-.StyledUnderlineWrapper[data-icons-visible='false'] [data-component='icon'] {
-  display: none;
+  .StyledUnderlineWrapper[data-icons-visible='false'] [data-component='icon'] {
+    display: none;
+  }
 }

--- a/packages/react/src/internal/components/ButtonReset.module.css
+++ b/packages/react/src/internal/components/ButtonReset.module.css
@@ -1,17 +1,19 @@
-.ButtonReset {
-  margin: 0;
-  display: inline-flex;
-  padding: 0;
-  border: 0;
-  appearance: none;
-  background: none;
-  cursor: pointer;
-  text-align: start;
-  font: inherit;
-  color: inherit;
-  align-items: center;
-
-  &::-moz-focus-inner {
+@layer primer.components.ButtonReset {
+  .ButtonReset {
+    margin: 0;
+    display: inline-flex;
+    padding: 0;
     border: 0;
+    appearance: none;
+    background: none;
+    cursor: pointer;
+    text-align: start;
+    font: inherit;
+    color: inherit;
+    align-items: center;
+
+    &::-moz-focus-inner {
+      border: 0;
+    }
   }
 }


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/6275

Migrates Details, CSSComponent, UnderlinePanels, Flash, Header, Heading, Hidden, InlineMessage, and ButtonReset styles into named Primer component CSS layers.

### Changelog

#### New

- Adds CSS layer coverage for Details, CSSComponent, UnderlinePanels, Flash, Header, Heading, Hidden, InlineMessage, and ButtonReset.

#### Changed

- Wraps Details, CSSComponent, UnderlinePanels, Flash, Header, Heading, Hidden, InlineMessage, and ButtonReset CSS module styles in named `@layer primer.components.*` layers.

#### Removed

- None

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- Run `cd packages/react && npx vitest run src/__tests__/css-layers.test.ts --config vitest.config.mts`.
- Review this PR as part of the CSS layers stack; this entry covers Details, CSSComponent, UnderlinePanels, Flash, Header, Heading, Hidden, InlineMessage, and ButtonReset.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

