### PR TITLE
feat: add CSS Layer support to overlay consumers

### DIFF
--- a/.changeset/css-layers-overlay-consumers.md
+++ b/.changeset/css-layers-overlay-consumers.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+AnchoredOverlay, Autocomplete, Banner, Blankslate, Breadcrumbs, Dialog, ActionMenu, ActionBar, SelectPanel2: Improve custom class override behavior for component styles

--- a/.changeset/css-layers-overlay-consumers.md
+++ b/.changeset/css-layers-overlay-consumers.md
@@ -2,4 +2,4 @@
 '@primer/react': patch
 ---
 
-AnchoredOverlay, Autocomplete, Banner, Blankslate, Breadcrumbs, Dialog, ActionMenu, ActionBar, SelectPanel2: Improve custom class override behavior for component styles
+AnchoredOverlay, Autocomplete, Banner, Blankslate, Breadcrumbs, Dialog, ActionMenu, ActionBar, SelectPanel2: Add CSS layer support for component styles

--- a/packages/react/src/ActionBar/ActionBar.module.css
+++ b/packages/react/src/ActionBar/ActionBar.module.css
@@ -1,110 +1,112 @@
-.List {
-  position: relative;
-  display: flex;
-  min-width: 0;
+@layer primer.components.ActionBar {
+  .List {
+    position: relative;
+    display: flex;
+    min-width: 0;
 
-  /* wonder why this is here */
-  /* stylelint-disable-next-line primer/spacing */
-  margin-bottom: -1px;
-  list-style: none;
-  align-items: flex-start;
-  gap: var(--actionbar-gap, var(--stack-gap-condensed));
-  overflow: hidden;
-  /* Explicit height is required to clip wrapped items */
-  height: var(--actionbar-height, var(--control-small-size));
+    /* wonder why this is here */
+    /* stylelint-disable-next-line primer/spacing */
+    margin-bottom: -1px;
+    list-style: none;
+    align-items: flex-start;
+    gap: var(--actionbar-gap, var(--stack-gap-condensed));
+    overflow: hidden;
+    /* Explicit height is required to clip wrapped items */
+    height: var(--actionbar-height, var(--control-small-size));
 
-  /* Scroll-based animations have no effect unless the container is scrollable (has overflow, even with overflow:hidden)
-  so we can use them to detect overflow. It would be cleaner to use scroll-state container queries for this, but
-  browser support for scroll-driven animations is slightly better. */
-  animation: detect-overflow linear;
-  animation-timeline: scroll(self block);
+    /* Scroll-based animations have no effect unless the container is scrollable (has overflow, even with overflow:hidden)
+    so we can use them to detect overflow. It would be cleaner to use scroll-state container queries for this, but
+    browser support for scroll-driven animations is slightly better. */
+    animation: detect-overflow linear;
+    animation-timeline: scroll(self block);
 
-  /* After initial render, JS is used to control visibility which provides progressive enhancement for unsupported browsers */
-  &[data-has-overflow='true'] {
-    --morebutton-display: flex;
-  }
+    /* After initial render, JS is used to control visibility which provides progressive enhancement for unsupported browsers */
+    &[data-has-overflow='true'] {
+      --morebutton-display: flex;
+    }
 
-  &:where([data-size='small']) {
-    --actionbar-height: var(--control-small-size);
-  }
+    &:where([data-size='small']) {
+      --actionbar-height: var(--control-small-size);
+    }
 
-  &:where([data-size='medium']) {
-    --actionbar-height: var(--control-medium-size);
-  }
+    &:where([data-size='medium']) {
+      --actionbar-height: var(--control-medium-size);
+    }
 
-  &:where([data-size='large']) {
-    --actionbar-height: var(--control-large-size);
-  }
+    &:where([data-size='large']) {
+      --actionbar-height: var(--control-large-size);
+    }
 
-  /* Gap scale (mirrors Stack) */
-  &:where([data-gap='none']) {
-    --actionbar-gap: 0;
+    /* Gap scale (mirrors Stack) */
+    &:where([data-gap='none']) {
+      --actionbar-gap: 0;
 
-    .Divider {
-      padding: 0 var(--base-size-8);
+      .Divider {
+        padding: 0 var(--base-size-8);
+      }
+    }
+
+    &:where([data-gap='condensed']) {
+      --actionbar-gap: var(--stack-gap-condensed);
+    }
+
+    & [data-overflowing] {
+      /* Hide overflowing items. Even though they are clipped by `overflow: hidden`, setting `visibility: hidden` ensures
+      they can't accidentally be shown and also hides them from screen readers / keyboard nav. `!important` prevents
+      consumers from unintentionally overriding this and breaking accessibility. */
+      visibility: hidden !important;
     }
   }
 
-  &:where([data-gap='condensed']) {
-    --actionbar-gap: var(--stack-gap-condensed);
+  @keyframes detect-overflow {
+    0%,
+    100% {
+      --morebutton-display: flex;
+    }
   }
 
-  & [data-overflowing] {
-    /* Hide overflowing items. Even though they are clipped by `overflow: hidden`, setting `visibility: hidden` ensures
-    they can't accidentally be shown and also hides them from screen readers / keyboard nav. `!important` prevents
-    consumers from unintentionally overriding this and breaking accessibility. */
-    visibility: hidden !important;
+  .Nav {
+    display: flex;
+    padding-inline: var(--base-size-16);
+    justify-content: flex-end;
+    align-items: center;
+
+    &:where([data-flush='true']) {
+      padding-inline: 0;
+    }
   }
-}
 
-@keyframes detect-overflow {
-  0%,
-  100% {
-    --morebutton-display: flex;
+  .Divider {
+    &::before {
+      display: block;
+      width: var(--borderWidth-thin);
+      height: var(--base-size-20);
+      content: '';
+      /* stylelint-disable-next-line primer/colors */
+      background: var(--borderColor-muted);
+      /* stylelint-disable-next-line primer/spacing */
+      margin-top: calc((var(--actionbar-height) - var(--base-size-20)) / 2);
+    }
   }
-}
 
-.Nav {
-  display: flex;
-  padding-inline: var(--base-size-16);
-  justify-content: flex-end;
-  align-items: center;
-
-  &:where([data-flush='true']) {
-    padding-inline: 0;
+  .Group {
+    display: flex;
+    gap: inherit;
   }
-}
 
-.Divider {
-  &::before {
-    display: block;
-    width: var(--borderWidth-thin);
-    height: var(--base-size-20);
-    content: '';
-    /* stylelint-disable-next-line primer/colors */
-    background: var(--borderColor-muted);
-    /* stylelint-disable-next-line primer/spacing */
-    margin-top: calc((var(--actionbar-height) - var(--base-size-20)) / 2);
+  .OverflowContainer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: inherit;
+    justify-content: flex-end;
+    overflow: hidden;
+
+    .OverflowSpacer {
+      height: var(--actionbar-height);
+    }
   }
-}
 
-.Group {
-  display: flex;
-  gap: inherit;
-}
-
-.OverflowContainer {
-  display: flex;
-  flex-wrap: wrap;
-  gap: inherit;
-  justify-content: flex-end;
-  overflow: hidden;
-
-  .OverflowSpacer {
-    height: var(--actionbar-height);
+  .MoreButton {
+    display: var(--morebutton-display, none);
   }
-}
-
-.MoreButton {
-  display: var(--morebutton-display, none);
 }

--- a/packages/react/src/ActionMenu/ActionMenu.module.css
+++ b/packages/react/src/ActionMenu/ActionMenu.module.css
@@ -1,70 +1,72 @@
-.ActionMenuContainer {
-  /* add default max height */
-  max-height: 100vh;
+@layer primer.components.ActionMenu {
+  .ActionMenuContainer {
+    /* add default max height */
+    max-height: 100vh;
 
-  &:where([data-variant='fullscreen']) {
-    padding-top: var(--base-size-36);
-  }
-
-  /* Overflow variants */
-  &:where([data-overflow-auto]) {
-    overflow: auto;
-  }
-
-  &:where([data-overflow-hidden]) {
-    overflow: hidden;
-  }
-
-  &:where([data-overflow-scroll]) {
-    overflow: scroll;
-  }
-
-  &:where([data-overflow-visible]) {
-    overflow: visible;
-  }
-
-  /* Max-height size tokens (mirror Overlay sizes) */
-  &:where([data-max-height-xsmall]) {
-    max-height: min(192px, 100vh);
-
-    @supports (height: 100dvh) {
-      max-height: min(192px, 100dvh);
+    &:where([data-variant='fullscreen']) {
+      padding-top: var(--base-size-36);
     }
-  }
 
-  &:where([data-max-height-small]) {
-    max-height: min(256px, 100vh);
-
-    @supports (height: 100dvh) {
-      max-height: min(256px, 100dvh);
+    /* Overflow variants */
+    &:where([data-overflow-auto]) {
+      overflow: auto;
     }
-  }
 
-  &:where([data-max-height-medium]) {
-    max-height: min(320px, 100vh);
-
-    @supports (height: 100dvh) {
-      max-height: min(320px, 100dvh);
+    &:where([data-overflow-hidden]) {
+      overflow: hidden;
     }
-  }
 
-  &:where([data-max-height-large]) {
-    max-height: min(432px, 100vh);
-
-    @supports (height: 100dvh) {
-      max-height: min(432px, 100dvh);
+    &:where([data-overflow-scroll]) {
+      overflow: scroll;
     }
-  }
 
-  &:where([data-max-height-xlarge]) {
-    max-height: min(600px, 100vh);
-
-    @supports (height: 100dvh) {
-      max-height: min(600px, 100dvh);
+    &:where([data-overflow-visible]) {
+      overflow: visible;
     }
-  }
 
-  &:where([data-max-height-fit-content]) {
-    max-height: fit-content;
+    /* Max-height size tokens (mirror Overlay sizes) */
+    &:where([data-max-height-xsmall]) {
+      max-height: min(192px, 100vh);
+
+      @supports (height: 100dvh) {
+        max-height: min(192px, 100dvh);
+      }
+    }
+
+    &:where([data-max-height-small]) {
+      max-height: min(256px, 100vh);
+
+      @supports (height: 100dvh) {
+        max-height: min(256px, 100dvh);
+      }
+    }
+
+    &:where([data-max-height-medium]) {
+      max-height: min(320px, 100vh);
+
+      @supports (height: 100dvh) {
+        max-height: min(320px, 100dvh);
+      }
+    }
+
+    &:where([data-max-height-large]) {
+      max-height: min(432px, 100vh);
+
+      @supports (height: 100dvh) {
+        max-height: min(432px, 100dvh);
+      }
+    }
+
+    &:where([data-max-height-xlarge]) {
+      max-height: min(600px, 100vh);
+
+      @supports (height: 100dvh) {
+        max-height: min(600px, 100dvh);
+      }
+    }
+
+    &:where([data-max-height-fit-content]) {
+      max-height: fit-content;
+    }
   }
 }

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.module.css
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.module.css
@@ -1,151 +1,153 @@
-.ResponsiveCloseButtonContainer {
-  position: relative;
-}
-
-.ResponsiveCloseButton {
-  position: absolute;
-  top: var(--base-size-8);
-  right: var(--base-size-8);
-  display: none;
-
-  @media screen and (--viewportRange-narrow) {
-    display: inline-grid;
-  }
-}
-
-.AnchoredOverlay {
-  position-try-fallbacks:
-    flip-block,
-    flip-inline,
-    flip-block flip-inline,
-    --inline-end-center,
-    --inline-start-center,
-    --fit-block-bottom,
-    --fit-block-top;
-  position-visibility: anchors-visible;
-  z-index: 100;
-  position: fixed !important;
-
-  &[popover] {
-    inset: auto;
-    margin: 0;
-    padding: 0;
-    border: 0;
-    max-width: none;
+@layer primer.components.AnchoredOverlay {
+  .ResponsiveCloseButtonContainer {
+    position: relative;
   }
 
-  &[data-side='outside-bottom'] {
-    /* stylelint-disable primer/spacing */
+  .ResponsiveCloseButton {
+    position: absolute;
+    top: var(--base-size-8);
+    right: var(--base-size-8);
+    display: none;
+
+    @media screen and (--viewportRange-narrow) {
+      display: inline-grid;
+    }
+  }
+
+  .AnchoredOverlay {
+    position-try-fallbacks:
+      flip-block,
+      flip-inline,
+      flip-block flip-inline,
+      --inline-end-center,
+      --inline-start-center,
+      --fit-block-bottom,
+      --fit-block-top;
+    position-visibility: anchors-visible;
+    z-index: 100;
+    position: fixed !important;
+
+    &[popover] {
+      inset: auto;
+      margin: 0;
+      padding: 0;
+      border: 0;
+      max-width: none;
+    }
+
+    &[data-side='outside-bottom'] {
+      /* stylelint-disable primer/spacing */
+      top: calc(anchor(bottom) + var(--base-size-4));
+      left: anchor(left);
+
+      &[data-align='left'] {
+        left: auto;
+        right: calc(anchor(right) - var(--anchored-overlay-anchor-offset-left));
+        /* stylelint-disable max-nesting-depth */
+        &[data-responsive='fullscreen'] {
+          @media screen and (--viewportRange-narrow) {
+            right: auto;
+          }
+        }
+      }
+
+      &[data-align='right'] {
+        left: calc(anchor(left) - var(--anchored-overlay-anchor-offset-right));
+
+        &[data-responsive='fullscreen'] {
+          @media screen and (--viewportRange-narrow) {
+            left: auto;
+          }
+        }
+      }
+    }
+
+    &[data-side='outside-top'] {
+      margin-bottom: var(--base-size-4);
+      bottom: anchor(top);
+      left: anchor(left);
+
+      &[data-align='left'] {
+        left: auto;
+        right: anchor(right);
+      }
+
+      &[data-align='right'] {
+        left: calc(anchor(left) - var(--anchored-overlay-anchor-offset-right));
+
+        &[data-responsive='fullscreen'] {
+          @media screen and (--viewportRange-narrow) {
+            left: auto;
+          }
+        }
+      }
+    }
+
+    &[data-side='outside-left'] {
+      right: anchor(left);
+      /* Falls back to `anchor(top)` when JS hasn't overridden it. JS sets the
+         override when the overlay's bottom would overflow the viewport so we
+         can lift it up to keep the bottom edge on screen, mirroring the JS
+         anchored-positioning code path.
+
+         This override only applies when CSS cannot find space using the default position -
+         or any of its defined fallbacks.
+      */
+      top: var(--anchored-overlay-top-override, anchor(top));
+      margin-right: var(--base-size-4);
+      position-try-fallbacks: flip-inline, flip-block, flip-start, --outside-left-to-bottom;
+    }
+
+    &[data-side='outside-right'] {
+      left: anchor(right);
+      top: var(--anchored-overlay-top-override, anchor(top));
+      margin-left: var(--base-size-4);
+      position-try-fallbacks: flip-inline, flip-block, flip-start, --outside-right-to-bottom;
+    }
+  }
+
+  @position-try --outside-left-to-bottom {
+    right: anchor(right);
     top: calc(anchor(bottom) + var(--base-size-4));
+    margin: 0;
+    width: auto;
+  }
+
+  @position-try --outside-right-to-bottom {
     left: anchor(left);
-
-    &[data-align='left'] {
-      left: auto;
-      right: calc(anchor(right) - var(--anchored-overlay-anchor-offset-left));
-      /* stylelint-disable max-nesting-depth */
-      &[data-responsive='fullscreen'] {
-        @media screen and (--viewportRange-narrow) {
-          right: auto;
-        }
-      }
-    }
-
-    &[data-align='right'] {
-      left: calc(anchor(left) - var(--anchored-overlay-anchor-offset-right));
-
-      &[data-responsive='fullscreen'] {
-        @media screen and (--viewportRange-narrow) {
-          left: auto;
-        }
-      }
-    }
+    top: calc(anchor(bottom) + var(--base-size-4));
+    margin: 0;
+    width: auto;
   }
 
-  &[data-side='outside-top'] {
-    margin-bottom: var(--base-size-4);
-    bottom: anchor(top);
-    left: anchor(left);
-
-    &[data-align='left'] {
-      left: auto;
-      right: anchor(right);
-    }
-
-    &[data-align='right'] {
-      left: calc(anchor(left) - var(--anchored-overlay-anchor-offset-right));
-
-      &[data-responsive='fullscreen'] {
-        @media screen and (--viewportRange-narrow) {
-          left: auto;
-        }
-      }
-    }
-  }
-
-  &[data-side='outside-left'] {
-    right: anchor(left);
-    /* Falls back to `anchor(top)` when JS hasn't overridden it. JS sets the
-       override when the overlay's bottom would overflow the viewport so we
-       can lift it up to keep the bottom edge on screen, mirroring the JS
-       anchored-positioning code path.
-
-       This override only applies when CSS cannot find space using the default position -
-       or any of its defined fallbacks.
-    */
-    top: var(--anchored-overlay-top-override, anchor(top));
-    margin-right: var(--base-size-4);
-    position-try-fallbacks: flip-inline, flip-block, flip-start, --outside-left-to-bottom;
-  }
-
-  &[data-side='outside-right'] {
+  @position-try --inline-end-center {
     left: anchor(right);
-    top: var(--anchored-overlay-top-override, anchor(top));
+    top: auto;
+    bottom: auto;
     margin-left: var(--base-size-4);
-    position-try-fallbacks: flip-inline, flip-block, flip-start, --outside-right-to-bottom;
+    align-self: anchor-center;
   }
-}
 
-@position-try --outside-left-to-bottom {
-  right: anchor(right);
-  top: calc(anchor(bottom) + var(--base-size-4));
-  margin: 0;
-  width: auto;
-}
+  @position-try --inline-start-center {
+    right: anchor(left);
+    left: auto;
+    top: auto;
+    bottom: auto;
+    margin-right: var(--base-size-4);
+    align-self: anchor-center;
+  }
 
-@position-try --outside-right-to-bottom {
-  left: anchor(left);
-  top: calc(anchor(bottom) + var(--base-size-4));
-  margin: 0;
-  width: auto;
-}
+  @position-try --fit-block-bottom {
+    top: calc(anchor(bottom) + var(--base-size-4));
+    bottom: var(--base-size-8);
+    height: auto;
+    max-height: none;
+  }
 
-@position-try --inline-end-center {
-  left: anchor(right);
-  top: auto;
-  bottom: auto;
-  margin-left: var(--base-size-4);
-  align-self: anchor-center;
-}
-
-@position-try --inline-start-center {
-  right: anchor(left);
-  left: auto;
-  top: auto;
-  bottom: auto;
-  margin-right: var(--base-size-4);
-  align-self: anchor-center;
-}
-
-@position-try --fit-block-bottom {
-  top: calc(anchor(bottom) + var(--base-size-4));
-  bottom: var(--base-size-8);
-  height: auto;
-  max-height: none;
-}
-
-@position-try --fit-block-top {
-  top: var(--base-size-8);
-  bottom: calc(100vh - anchor(top) + var(--base-size-4));
-  height: auto;
-  max-height: none;
+  @position-try --fit-block-top {
+    top: var(--base-size-8);
+    bottom: calc(100vh - anchor(top) + var(--base-size-4));
+    height: auto;
+    max-height: none;
+  }
 }

--- a/packages/react/src/Autocomplete/AutocompleteMenu.module.css
+++ b/packages/react/src/Autocomplete/AutocompleteMenu.module.css
@@ -1,9 +1,11 @@
-.SpinnerWrapper {
-  display: flex;
-  justify-content: center;
-  padding: var(--base-size-16);
-}
+@layer primer.components.Autocomplete {
+  .SpinnerWrapper {
+    display: flex;
+    justify-content: center;
+    padding: var(--base-size-16);
+  }
 
-.EmptyStateWrapper {
-  padding: var(--base-size-16);
+  .EmptyStateWrapper {
+    padding: var(--base-size-16);
+  }
 }

--- a/packages/react/src/Autocomplete/AutocompleteOverlay.module.css
+++ b/packages/react/src/Autocomplete/AutocompleteOverlay.module.css
@@ -1,3 +1,5 @@
-.Overlay {
-  overflow: auto;
+@layer primer.components.Autocomplete {
+  .Overlay {
+    overflow: auto;
+  }
 }

--- a/packages/react/src/Banner/Banner.module.css
+++ b/packages/react/src/Banner/Banner.module.css
@@ -1,52 +1,22 @@
-.Banner {
-  display: grid;
-  padding: var(--base-size-8);
-  /* stylelint-disable-next-line primer/colors */
-  background-color: var(--banner-bgColor);
-  /* stylelint-disable-next-line primer/colors */
-  border: var(--borderWidth-thin) solid var(--banner-borderColor);
-  border-radius: var(--borderRadius-medium);
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: start;
+@layer primer.components.Banner {
+  .Banner {
+    display: grid;
+    padding: var(--base-size-8);
+    /* stylelint-disable-next-line primer/colors */
+    background-color: var(--banner-bgColor);
+    /* stylelint-disable-next-line primer/colors */
+    border: var(--borderWidth-thin) solid var(--banner-borderColor);
+    border-radius: var(--borderRadius-medium);
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: start;
 
-  &[data-actions-layout='default'] {
-    @supports (container-type: inline-size) {
-      container: banner / inline-size;
-    }
-  }
-
-  &[data-actions-layout='stacked'] {
-    & .BannerContainer {
-      flex-direction: column;
+    &[data-actions-layout='default'] {
+      @supports (container-type: inline-size) {
+        container: banner / inline-size;
+      }
     }
 
-    & .BannerActions :where([data-primary-action='trailing']) {
-      display: none;
-    }
-
-    & .BannerActions :where([data-primary-action='leading']) {
-      display: flex;
-    }
-  }
-
-  &[data-actions-layout='inline'] {
-    & .BannerContainer {
-      flex-wrap: nowrap;
-    }
-
-    & .BannerActions {
-      flex: 0 0 auto;
-    }
-
-    & .BannerActions :where([data-primary-action='trailing']) {
-      display: flex;
-    }
-
-    & .BannerActions :where([data-primary-action='leading']) {
-      display: none;
-    }
-
-    @media screen and (--viewportRange-narrow) {
+    &[data-actions-layout='stacked'] {
       & .BannerContainer {
         flex-direction: column;
       }
@@ -59,207 +29,239 @@
         display: flex;
       }
     }
+
+    &[data-actions-layout='inline'] {
+      & .BannerContainer {
+        flex-wrap: nowrap;
+      }
+
+      & .BannerActions {
+        flex: 0 0 auto;
+      }
+
+      & .BannerActions :where([data-primary-action='trailing']) {
+        display: flex;
+      }
+
+      & .BannerActions :where([data-primary-action='leading']) {
+        display: none;
+      }
+
+      @media screen and (--viewportRange-narrow) {
+        & .BannerContainer {
+          flex-direction: column;
+        }
+
+        & .BannerActions :where([data-primary-action='trailing']) {
+          display: none;
+        }
+
+        & .BannerActions :where([data-primary-action='leading']) {
+          display: flex;
+        }
+      }
+    }
+
+    &[data-layout='compact'] {
+      padding: var(--base-size-4);
+    }
+
+    &[data-flush] {
+      border-left: none;
+      border-right: none;
+      border-radius: 0;
+    }
+
+    &[data-variant='critical'] {
+      --banner-bgColor: var(--bgColor-danger-muted);
+      --banner-borderColor: var(--borderColor-danger-muted);
+      --banner-icon-fgColor: var(--fgColor-danger);
+    }
+
+    &[data-variant='info'] {
+      --banner-bgColor: var(--bgColor-accent-muted);
+      --banner-borderColor: var(--borderColor-accent-muted);
+      --banner-icon-fgColor: var(--fgColor-accent);
+    }
+
+    &[data-variant='success'] {
+      --banner-bgColor: var(--bgColor-success-muted);
+      --banner-borderColor: var(--borderColor-success-muted);
+      --banner-icon-fgColor: var(--fgColor-success);
+    }
+
+    &[data-variant='upsell'] {
+      --banner-bgColor: var(--bgColor-upsell-muted);
+      --banner-borderColor: var(--borderColor-upsell-muted);
+      --banner-icon-fgColor: var(--fgColor-upsell);
+    }
+
+    &[data-variant='warning'] {
+      --banner-bgColor: var(--bgColor-attention-muted);
+      --banner-borderColor: var(--borderColor-attention-muted);
+      --banner-icon-fgColor: var(--fgColor-attention);
+    }
   }
 
-  &[data-layout='compact'] {
-    padding: var(--base-size-4);
-  }
+  /* BannerContainer -------------------------------------------------------- */
 
-  &[data-flush] {
-    border-left: none;
-    border-right: none;
-    border-radius: 0;
-  }
-
-  &[data-variant='critical'] {
-    --banner-bgColor: var(--bgColor-danger-muted);
-    --banner-borderColor: var(--borderColor-danger-muted);
-    --banner-icon-fgColor: var(--fgColor-danger);
-  }
-
-  &[data-variant='info'] {
-    --banner-bgColor: var(--bgColor-accent-muted);
-    --banner-borderColor: var(--borderColor-accent-muted);
-    --banner-icon-fgColor: var(--fgColor-accent);
-  }
-
-  &[data-variant='success'] {
-    --banner-bgColor: var(--bgColor-success-muted);
-    --banner-borderColor: var(--borderColor-success-muted);
-    --banner-icon-fgColor: var(--fgColor-success);
-  }
-
-  &[data-variant='upsell'] {
-    --banner-bgColor: var(--bgColor-upsell-muted);
-    --banner-borderColor: var(--borderColor-upsell-muted);
-    --banner-icon-fgColor: var(--fgColor-upsell);
-  }
-
-  &[data-variant='warning'] {
-    --banner-bgColor: var(--bgColor-attention-muted);
-    --banner-borderColor: var(--borderColor-attention-muted);
-    --banner-icon-fgColor: var(--fgColor-attention);
-  }
-}
-
-/* BannerContainer -------------------------------------------------------- */
-
-.BannerContainer {
-  font-size: var(--text-body-size-medium);
-  align-items: start;
-  line-height: var(--text-body-lineHeight-medium);
-  row-gap: var(--base-size-4);
-  column-gap: var(--base-size-4);
-}
-
-.Banner :where(.BannerContainer) {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-}
-
-.Banner[data-dismissible]:not([data-title-hidden], [data-actions-layout='inline']) .BannerContainer {
-  display: grid;
-  grid-template-columns: auto;
-  grid-template-rows: auto;
-}
-
-/* BannerContent ---------------------------------------------------------- */
-
-.BannerContent {
-  display: grid;
-  row-gap: var(--base-size-4);
-  grid-column-start: 1;
-  margin-block: var(--base-size-8);
-}
-
-.Banner[data-title-hidden]:not([data-has-actions]) .BannerContent {
-  margin-block: var(--base-size-6);
-}
-
-@media screen and (min-width: 544px) {
-  .BannerContent {
-    flex: 1 1 0%;
-  }
-}
-
-.BannerTitle {
-  margin: 0;
-  font-size: inherit;
-  font-weight: var(--base-text-weight-semibold);
-}
-
-/* BannerIcon ------------------------------------------------------------- */
-
-.BannerIcon {
-  display: grid;
-  place-items: center;
-  padding: var(--base-size-8);
-}
-
-.BannerIcon svg {
-  /* 20px is the line box height of the trailing action buttons */
-  height: var(--base-size-20);
-  /* stylelint-disable-next-line primer/colors */
-  color: var(--banner-icon-fgColor);
-  /* stylelint-disable-next-line primer/colors */
-  fill: var(--banner-icon-fgColor);
-}
-
-/* stylelint-disable-next-line selector-max-specificity */
-.Banner[data-title-hidden]:not([data-has-actions]) .BannerIcon svg {
-  height: var(--base-size-16);
-}
-
-/* BannerDismiss ---------------------------------------------------------- */
-
-.BannerDismiss {
-  display: grid;
-  place-items: center;
-  padding: var(--base-size-8);
-  margin-inline-start: var(--base-size-4);
-}
-
-:where(.Banner)[data-has-actions] .BannerDismiss {
-  margin-block: var(--base-size-2);
-}
-
-.BannerDismiss svg {
-  /* stylelint-disable-next-line primer/colors */
-  color: var(--banner-icon-fgColor);
-}
-
-/* BannerActions ---------------------------------------------------------- */
-
-.BannerActionsContainer {
-  display: flex;
-  column-gap: var(--base-size-12);
-  align-items: center;
-  margin-block: var(--base-size-2);
-}
-
-.BannerActions :where([data-primary-action='trailing']) {
-  display: none;
-}
-
-.Banner[data-dismissible]:not([data-title-hidden], [data-actions-layout='inline']) .BannerActions {
-  margin-block-end: var(--base-size-6);
-}
-
-/* stylelint-disable-next-line selector-max-specificity */
-.Banner[data-dismissible]:not([data-title-hidden], [data-actions-layout='inline'])
-  .BannerActionsContainer[data-primary-action='trailing'] {
-  display: none;
-}
-
-/* stylelint-disable-next-line selector-max-specificity */
-.Banner[data-dismissible]:not([data-title-hidden], [data-actions-layout='inline'])
-  .BannerActionsContainer[data-primary-action='leading'] {
-  display: flex;
-}
-
-/* Layout ------------------------------------------------------------------- */
-
-@container banner (max-width: 500px) {
   .BannerContainer {
+    font-size: var(--text-body-size-medium);
+    align-items: start;
+    line-height: var(--text-body-lineHeight-medium);
+    row-gap: var(--base-size-4);
+    column-gap: var(--base-size-4);
+  }
+
+  .Banner :where(.BannerContainer) {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .Banner[data-dismissible]:not([data-title-hidden], [data-actions-layout='inline']) .BannerContainer {
     display: grid;
+    grid-template-columns: auto;
+    grid-template-rows: auto;
   }
 
-  :where(.Banner)[data-has-actions] .BannerContainer {
-    grid-template-rows: auto auto;
+  /* BannerContent ---------------------------------------------------------- */
+
+  .BannerContent {
+    display: grid;
+    row-gap: var(--base-size-4);
+    grid-column-start: 1;
+    margin-block: var(--base-size-8);
   }
 
-  .BannerActions {
+  .Banner[data-title-hidden]:not([data-has-actions]) .BannerContent {
+    margin-block: var(--base-size-6);
+  }
+
+  @media screen and (min-width: 544px) {
+    .BannerContent {
+      flex: 1 1 0%;
+    }
+  }
+
+  .BannerTitle {
+    margin: 0;
+    font-size: inherit;
+    font-weight: var(--base-text-weight-semibold);
+  }
+
+  /* BannerIcon ------------------------------------------------------------- */
+
+  .BannerIcon {
+    display: grid;
+    place-items: center;
+    padding: var(--base-size-8);
+  }
+
+  .BannerIcon svg {
+    /* 20px is the line box height of the trailing action buttons */
+    height: var(--base-size-20);
+    /* stylelint-disable-next-line primer/colors */
+    color: var(--banner-icon-fgColor);
+    /* stylelint-disable-next-line primer/colors */
+    fill: var(--banner-icon-fgColor);
+  }
+
+  /* stylelint-disable-next-line selector-max-specificity */
+  .Banner[data-title-hidden]:not([data-has-actions]) .BannerIcon svg {
+    height: var(--base-size-16);
+  }
+
+  /* BannerDismiss ---------------------------------------------------------- */
+
+  .BannerDismiss {
+    display: grid;
+    place-items: center;
+    padding: var(--base-size-8);
+    margin-inline-start: var(--base-size-4);
+  }
+
+  :where(.Banner)[data-has-actions] .BannerDismiss {
+    margin-block: var(--base-size-2);
+  }
+
+  .BannerDismiss svg {
+    /* stylelint-disable-next-line primer/colors */
+    color: var(--banner-icon-fgColor);
+  }
+
+  /* BannerActions ---------------------------------------------------------- */
+
+  .BannerActionsContainer {
+    display: flex;
+    column-gap: var(--base-size-12);
+    align-items: center;
+    margin-block: var(--base-size-2);
+  }
+
+  .BannerActions :where([data-primary-action='trailing']) {
+    display: none;
+  }
+
+  .Banner[data-dismissible]:not([data-title-hidden], [data-actions-layout='inline']) .BannerActions {
     margin-block-end: var(--base-size-6);
   }
 
-  .BannerActions [data-primary-action='trailing'] {
+  /* stylelint-disable-next-line selector-max-specificity */
+  .Banner[data-dismissible]:not([data-title-hidden], [data-actions-layout='inline'])
+    .BannerActionsContainer[data-primary-action='trailing'] {
     display: none;
   }
 
-  .BannerActions [data-primary-action='leading'] {
+  /* stylelint-disable-next-line selector-max-specificity */
+  .Banner[data-dismissible]:not([data-title-hidden], [data-actions-layout='inline'])
+    .BannerActionsContainer[data-primary-action='leading'] {
     display: flex;
   }
-}
 
-@container banner (min-width: 500px) {
-  .BannerContainer {
-    display: grid;
-    grid-template-columns: auto auto;
+  /* Layout ------------------------------------------------------------------- */
+
+  @container banner (max-width: 500px) {
+    .BannerContainer {
+      display: grid;
+    }
+
+    :where(.Banner)[data-has-actions] .BannerContainer {
+      grid-template-rows: auto auto;
+    }
+
+    .BannerActions {
+      margin-block-end: var(--base-size-6);
+    }
+
+    .BannerActions [data-primary-action='trailing'] {
+      display: none;
+    }
+
+    .BannerActions [data-primary-action='leading'] {
+      display: flex;
+    }
   }
 
-  :where(.Banner):not([data-dismissible])
-    :where(.BannerActionsContainer[data-primary-action='trailing'])
-    :where([data-variant='link']:only-child) {
-    padding-inline: 0 var(--base-size-12);
-  }
+  @container banner (min-width: 500px) {
+    .BannerContainer {
+      display: grid;
+      grid-template-columns: auto auto;
+    }
 
-  .BannerActions [data-primary-action='trailing'] {
-    display: flex;
-    min-height: var(--base-size-32, 2rem);
-  }
+    :where(.Banner):not([data-dismissible])
+      :where(.BannerActionsContainer[data-primary-action='trailing'])
+      :where([data-variant='link']:only-child) {
+      padding-inline: 0 var(--base-size-12);
+    }
 
-  .BannerActions [data-primary-action='leading'] {
-    display: none;
+    .BannerActions [data-primary-action='trailing'] {
+      display: flex;
+      min-height: var(--base-size-32, 2rem);
+    }
+
+    .BannerActions [data-primary-action='leading'] {
+      display: none;
+    }
   }
 }

--- a/packages/react/src/Blankslate/Blankslate.module.css
+++ b/packages/react/src/Blankslate/Blankslate.module.css
@@ -1,135 +1,137 @@
-.Container {
-  container: blankslate / inline-size;
-}
-
-.Blankslate {
-  display: grid;
-  justify-items: center;
-  /* stylelint-disable-next-line primer/spacing */
-  padding: var(--blankslate-padding);
-
-  &:where([data-border]) {
-    border: var(--borderWidth-thin) solid var(--borderColor-default);
-    border-radius: var(--borderRadius-medium);
+@layer primer.components.Blankslate {
+  .Container {
+    container: blankslate / inline-size;
   }
 
-  &:where([data-narrow]) {
-    max-width: 485px;
-    margin: 0 auto;
-  }
-
-  &:where([data-size='medium']) {
-    --blankslate-heading-text: var(--text-title-shorthand-medium);
-    --blankslate-heading-margin-block: 0 var(--base-size-4);
-    --blankslate-description-text: var(--text-body-shorthand-large);
-    --blankslate-padding: var(--base-size-32);
-    --blankslate-action-margin-block-end: var(--base-size-16);
-  }
-
-  &:where([data-size='medium'][data-spacious]) {
-    --blankslate-padding: var(--base-size-80) var(--base-size-40);
-  }
-
-  &:where([data-size='small']) {
-    --blankslate-heading-text: var(--text-title-shorthand-small);
-    --blankslate-heading-margin-block: 0 var(--base-size-4);
-    --blankslate-description-text: var(--text-body-shorthand-medium);
-    --blankslate-padding: var(--base-size-32) var(--base-size-20);
-    --blankslate-action-margin-block-end: var(--base-size-12);
-    --blankslate-visual-size: var(--base-size-24);
-  }
-
-  &:where([data-size='small'][data-spacious]) {
-    --blankslate-padding: var(--base-size-44) var(--base-size-28);
-  }
-
-  &:where([data-size='large']) {
-    --blankslate-heading-text: var(--text-title-shorthand-large);
-    --blankslate-heading-margin-block: var(--base-size-8) var(--base-size-4);
-    --blankslate-description-text: var(--text-body-shorthand-large);
-    --blankslate-description-margin-block: 0 var(--base-size-8);
-    --blankslate-padding: var(--base-size-32);
-    --blankslate-action-margin-block-end: var(--base-size-16);
-  }
-
-  &:where([data-size='large'][data-spacious]) {
-    --blankslate-padding: var(--base-size-80) var(--base-size-40);
-  }
-}
-
-.Heading,
-.Description {
-  margin: 0;
-  text-align: center;
-  text-wrap: balance;
-}
-
-.Heading {
-  /* stylelint-disable-next-line primer/typography */
-  font: var(--blankslate-heading-text);
-  /* stylelint-disable-next-line primer/spacing */
-  margin-block: var(--blankslate-heading-margin-block);
-}
-
-.Description {
-  /* stylelint-disable-next-line primer/typography */
-  font: var(--blankslate-description-text);
-  color: var(--fgColor-muted);
-  /* stylelint-disable-next-line primer/spacing */
-  margin-block: var(--blankslate-description-margin-block);
-}
-
-.Visual {
-  color: var(--fgColor-muted);
-  /* This display property exists so that the container matches the size of the inner svg element */
-  display: inline-flex;
-  margin-block-end: var(--base-size-8);
-  max-width: var(--blankslate-visual-size);
-
-  & svg {
-    width: 100%;
-  }
-}
-
-.Action {
-  /* stylelint-disable-next-line primer/typography */
-  font: var(--blankslate-description-text);
-  margin-block-start: var(--base-size-16);
-
-  &:where(:last-of-type) {
-    /* stylelint-disable-next-line primer/spacing */
-    margin-block-end: var(--blankslate-action-margin-block-end);
-  }
-}
-
-/* At the time these styles were written, 34rem was our "small" breakpoint width */
-@container blankslate (max-width: 34rem) {
   .Blankslate {
-    --blankslate-padding: var(--base-size-20);
+    display: grid;
+    justify-items: center;
+    /* stylelint-disable-next-line primer/spacing */
+    padding: var(--blankslate-padding);
 
-    &:where([data-spacious='true']) {
+    &:where([data-border]) {
+      border: var(--borderWidth-thin) solid var(--borderColor-default);
+      border-radius: var(--borderRadius-medium);
+    }
+
+    &:where([data-narrow]) {
+      max-width: 485px;
+      margin: 0 auto;
+    }
+
+    &:where([data-size='medium']) {
+      --blankslate-heading-text: var(--text-title-shorthand-medium);
+      --blankslate-heading-margin-block: 0 var(--base-size-4);
+      --blankslate-description-text: var(--text-body-shorthand-large);
+      --blankslate-padding: var(--base-size-32);
+      --blankslate-action-margin-block-end: var(--base-size-16);
+    }
+
+    &:where([data-size='medium'][data-spacious]) {
+      --blankslate-padding: var(--base-size-80) var(--base-size-40);
+    }
+
+    &:where([data-size='small']) {
+      --blankslate-heading-text: var(--text-title-shorthand-small);
+      --blankslate-heading-margin-block: 0 var(--base-size-4);
+      --blankslate-description-text: var(--text-body-shorthand-medium);
+      --blankslate-padding: var(--base-size-32) var(--base-size-20);
+      --blankslate-action-margin-block-end: var(--base-size-12);
+      --blankslate-visual-size: var(--base-size-24);
+    }
+
+    &:where([data-size='small'][data-spacious]) {
       --blankslate-padding: var(--base-size-44) var(--base-size-28);
     }
 
-    --blankslate-heading-text: var(--text-title-shorthand-small);
-    --blankslate-description-text: var(--text-body-shorthand-medium);
+    &:where([data-size='large']) {
+      --blankslate-heading-text: var(--text-title-shorthand-large);
+      --blankslate-heading-margin-block: var(--base-size-8) var(--base-size-4);
+      --blankslate-description-text: var(--text-body-shorthand-large);
+      --blankslate-description-margin-block: 0 var(--base-size-8);
+      --blankslate-padding: var(--base-size-32);
+      --blankslate-action-margin-block-end: var(--base-size-16);
+    }
+
+    &:where([data-size='large'][data-spacious]) {
+      --blankslate-padding: var(--base-size-80) var(--base-size-40);
+    }
+  }
+
+  .Heading,
+  .Description {
+    margin: 0;
+    text-align: center;
+    text-wrap: balance;
+  }
+
+  .Heading {
+    /* stylelint-disable-next-line primer/typography */
+    font: var(--blankslate-heading-text);
+    /* stylelint-disable-next-line primer/spacing */
+    margin-block: var(--blankslate-heading-margin-block);
+  }
+
+  .Description {
+    /* stylelint-disable-next-line primer/typography */
+    font: var(--blankslate-description-text);
+    color: var(--fgColor-muted);
+    /* stylelint-disable-next-line primer/spacing */
+    margin-block: var(--blankslate-description-margin-block);
   }
 
   .Visual {
-    max-width: var(--base-size-24);
-    margin-bottom: var(--base-size-8);
     color: var(--fgColor-muted);
+    /* This display property exists so that the container matches the size of the inner svg element */
+    display: inline-flex;
+    margin-block-end: var(--base-size-8);
+    max-width: var(--blankslate-visual-size);
+
+    & svg {
+      width: 100%;
+    }
   }
 
   .Action {
-    margin-top: var(--base-size-8);
+    /* stylelint-disable-next-line primer/typography */
+    font: var(--blankslate-description-text);
+    margin-block-start: var(--base-size-16);
 
-    &:first-of-type {
-      margin-top: var(--base-size-16);
+    &:where(:last-of-type) {
+      /* stylelint-disable-next-line primer/spacing */
+      margin-block-end: var(--blankslate-action-margin-block-end);
+    }
+  }
+
+  /* At the time these styles were written, 34rem was our "small" breakpoint width */
+  @container blankslate (max-width: 34rem) {
+    .Blankslate {
+      --blankslate-padding: var(--base-size-20);
+
+      &:where([data-spacious='true']) {
+        --blankslate-padding: var(--base-size-44) var(--base-size-28);
+      }
+
+      --blankslate-heading-text: var(--text-title-shorthand-small);
+      --blankslate-description-text: var(--text-body-shorthand-medium);
     }
 
-    &:last-of-type {
-      margin-bottom: calc(var(--base-size-8) / 2);
+    .Visual {
+      max-width: var(--base-size-24);
+      margin-bottom: var(--base-size-8);
+      color: var(--fgColor-muted);
+    }
+
+    .Action {
+      margin-top: var(--base-size-8);
+
+      &:first-of-type {
+        margin-top: var(--base-size-16);
+      }
+
+      &:last-of-type {
+        margin-bottom: calc(var(--base-size-8) / 2);
+      }
     }
   }
 }

--- a/packages/react/src/Breadcrumbs/Breadcrumbs.module.css
+++ b/packages/react/src/Breadcrumbs/Breadcrumbs.module.css
@@ -1,166 +1,168 @@
-.BreadcrumbsBase {
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.BreadcrumbsList {
-  padding-left: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-[data-overflow='menu'],
-[data-overflow='menu-with-root'] {
-  & .BreadcrumbsList {
-    white-space: nowrap;
+@layer primer.components.Breadcrumbs {
+  .BreadcrumbsBase {
     display: flex;
-    flex-direction: row;
-  }
-}
-
-.ItemSeparator {
-  color: var(--fgColor-muted);
-  display: flex;
-  align-self: center;
-  justify-content: center;
-  white-space: nowrap;
-  user-select: none;
-}
-
-.ItemWrapper {
-  display: inline-block;
-  font-size: var(--text-body-size-medium);
-  list-style: none;
-
-  &::after {
-    display: inline-block;
-    height: 0.8em;
-    /* stylelint-disable-next-line primer/spacing */
-    margin: 0 0.5em;
-    font-size: var(--text-body-size-medium);
-    content: '';
-    /* stylelint-disable-next-line primer/borders, primer/colors */
-    border-right: 0.1em solid var(--fgColor-muted);
-    transform: rotate(15deg) translateY(0.0625em);
+    justify-content: space-between;
+    width: 100%;
   }
 
-  &:first-child {
-    margin-left: 0;
+  .BreadcrumbsList {
+    padding-left: 0;
+    margin-top: 0;
+    margin-bottom: 0;
   }
 
-  &:last-child {
-    &::after {
-      content: none;
+  [data-overflow='menu'],
+  [data-overflow='menu-with-root'] {
+    & .BreadcrumbsList {
+      white-space: nowrap;
+      display: flex;
+      flex-direction: row;
     }
   }
-}
 
-.Item {
-  display: inline-block;
-  font-size: var(--text-body-size-medium);
-
-  &:focus-visible {
-    border-radius: var(--borderRadius-small);
-
-    @mixin focusOutline 2px;
+  .ItemSeparator {
+    color: var(--fgColor-muted);
+    display: flex;
+    align-self: center;
+    justify-content: center;
+    white-space: nowrap;
+    user-select: none;
   }
-}
 
-[data-variant='normal'] {
-  & .Item {
-    color: var(--fgColor-link);
-    text-decoration: none;
+  .ItemWrapper {
+    display: inline-block;
+    font-size: var(--text-body-size-medium);
+    list-style: none;
 
-    &:not([aria-current]) {
-      &:hover {
-        text-decoration: underline;
+    &::after {
+      display: inline-block;
+      height: 0.8em;
+      /* stylelint-disable-next-line primer/spacing */
+      margin: 0 0.5em;
+      font-size: var(--text-body-size-medium);
+      content: '';
+      /* stylelint-disable-next-line primer/borders, primer/colors */
+      border-right: 0.1em solid var(--fgColor-muted);
+      transform: rotate(15deg) translateY(0.0625em);
+    }
+
+    &:first-child {
+      margin-left: 0;
+    }
+
+    &:last-child {
+      &::after {
+        content: none;
       }
     }
+  }
+
+  .Item {
+    display: inline-block;
+    font-size: var(--text-body-size-medium);
 
     &:focus-visible {
-      text-decoration: none;
-    }
+      border-radius: var(--borderRadius-small);
 
-    &[aria-current] {
+      @mixin focusOutline 2px;
+    }
+  }
+
+  [data-variant='normal'] {
+    & .Item {
+      color: var(--fgColor-link);
+      text-decoration: none;
+
+      &:not([aria-current]) {
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+
+      &:focus-visible {
+        text-decoration: none;
+      }
+
+      &[aria-current] {
+        color: var(--fgColor-default);
+      }
+    }
+  }
+
+  [data-variant='spacious'] {
+    & .Item {
       color: var(--fgColor-default);
-    }
-  }
-}
-
-[data-variant='spacious'] {
-  & .Item {
-    color: var(--fgColor-default);
-    text-decoration: none;
-    padding-inline: var(--base-size-6);
-    padding-block: var(--base-size-4);
-    border-radius: var(--borderRadius-medium);
-
-    &:hover {
-      background: var(--control-transparent-bgColor-hover);
       text-decoration: none;
-    }
+      padding-inline: var(--base-size-6);
+      padding-block: var(--base-size-4);
+      border-radius: var(--borderRadius-medium);
 
-    &[aria-current] {
-      font-weight: var(--base-text-weight-semibold);
-    }
-  }
-}
+      &:hover {
+        background: var(--control-transparent-bgColor-hover);
+        text-decoration: none;
+      }
 
-.BreadcrumbsItem {
-  display: inline-grid;
-  grid-auto-flow: column;
-  align-items: center;
-  flex: 0 99999 auto;
-  min-width: auto;
-  white-space: nowrap;
-  list-style: none;
-
-  /* allow menu items to wrap line */
-  /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- scoped to CSS Module, audited (github/github-ui#17224) */
-  &:has(.MenuOverlay) {
-    white-space: normal;
-  }
-
-  &:first-child {
-    margin-left: 0;
-  }
-
-  &:last-child {
-    .ItemSeparator {
-      display: none;
+      &[aria-current] {
+        font-weight: var(--base-text-weight-semibold);
+      }
     }
   }
 
-  .MenuDetails {
-    position: relative;
-    display: inline-block;
+  .BreadcrumbsItem {
+    display: inline-grid;
+    grid-auto-flow: column;
+    align-items: center;
+    flex: 0 99999 auto;
+    min-width: auto;
+    white-space: nowrap;
+    list-style: none;
 
-    & summary {
-      list-style: none;
-      cursor: pointer;
+    /* allow menu items to wrap line */
+    /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- scoped to CSS Module, audited (github/github-ui#17224) */
+    &:has(.MenuOverlay) {
+      white-space: normal;
+    }
 
-      &::-webkit-details-marker {
+    &:first-child {
+      margin-left: 0;
+    }
+
+    &:last-child {
+      .ItemSeparator {
         display: none;
       }
     }
-  }
 
-  .MenuOverlay {
-    position: absolute;
-    z-index: 1;
-    box-shadow: var(--shadow-floating-small);
-    border-radius: var(--borderRadius-large);
-    background-color: var(--overlay-bgColor);
-    min-width: var(--overlay-width-xsmall);
-    max-height: 100vh;
-    max-width: var(--overlay-width-small);
-    overflow: hidden;
-    /* stylelint-disable-next-line primer/spacing */
-    top: calc(var(--overlay-offset) + var(--control-small-size));
+    .MenuDetails {
+      position: relative;
+      display: inline-block;
 
-    @media (prefers-reduced-motion: no-preference) {
-      animation: overlay-appear 200ms cubic-bezier(0.33, 1, 0.68, 1);
+      & summary {
+        list-style: none;
+        cursor: pointer;
+
+        &::-webkit-details-marker {
+          display: none;
+        }
+      }
+    }
+
+    .MenuOverlay {
+      position: absolute;
+      z-index: 1;
+      box-shadow: var(--shadow-floating-small);
+      border-radius: var(--borderRadius-large);
+      background-color: var(--overlay-bgColor);
+      min-width: var(--overlay-width-xsmall);
+      max-height: 100vh;
+      max-width: var(--overlay-width-small);
+      overflow: hidden;
+      /* stylelint-disable-next-line primer/spacing */
+      top: calc(var(--overlay-offset) + var(--control-small-size));
+
+      @media (prefers-reduced-motion: no-preference) {
+        animation: overlay-appear 200ms cubic-bezier(0.33, 1, 0.68, 1);
+      }
     }
   }
 }

--- a/packages/react/src/Dialog/Dialog.module.css
+++ b/packages/react/src/Dialog/Dialog.module.css
@@ -1,114 +1,96 @@
-/* The --prc-dialog-scrollgutter property is used only on the body element to
- * simulate scrollbar-gutter:stable. This property is not and should not
- * be used elsewhere in the DOM. There is a performance penalty to
- * setting inherited properties which can cause a large style recalc to
- * occur, so it benefits us to prevent inheritance for this property.
- * See https://web.dev/blog/at-property-performance
- */
-@property --prc-dialog-scrollgutter {
-  initial-value: 0;
-  inherits: false;
-  syntax: '<length>';
-}
-
-@keyframes dialog-backdrop-appear {
-  0% {
-    opacity: 0;
+@layer primer.components.Dialog {
+  /* The --prc-dialog-scrollgutter property is used only on the body element to
+   * simulate scrollbar-gutter:stable. This property is not and should not
+   * be used elsewhere in the DOM. There is a performance penalty to
+   * setting inherited properties which can cause a large style recalc to
+   * occur, so it benefits us to prevent inheritance for this property.
+   * See https://web.dev/blog/at-property-performance
+   */
+  @property --prc-dialog-scrollgutter {
+    initial-value: 0;
+    inherits: false;
+    syntax: '<length>';
   }
 
-  100% {
-    opacity: 1;
+  @keyframes dialog-backdrop-appear {
+    0% {
+      opacity: 0;
+    }
+
+    100% {
+      opacity: 1;
+    }
   }
-}
 
-@keyframes Overlay--motion-scaleFade {
-  0% {
-    opacity: 0;
-    transform: scale(0.5);
+  @keyframes Overlay--motion-scaleFade {
+    0% {
+      opacity: 0;
+      transform: scale(0.5);
+    }
+
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
   }
 
-  100% {
-    opacity: 1;
-    transform: scale(1);
+  @keyframes Overlay--motion-slideUp {
+    from {
+      transform: translateY(100%);
+    }
   }
-}
 
-@keyframes Overlay--motion-slideUp {
-  from {
-    transform: translateY(100%);
+  @keyframes Overlay--motion-slideInRight {
+    from {
+      transform: translateX(-100%);
+    }
   }
-}
 
-@keyframes Overlay--motion-slideInRight {
-  from {
-    transform: translateX(-100%);
+  @keyframes Overlay--motion-slideInLeft {
+    from {
+      transform: translateX(100%);
+    }
   }
-}
 
-@keyframes Overlay--motion-slideInLeft {
-  from {
-    transform: translateX(100%);
+  /* Used to determine whether there should be a border between the body and footer */
+  @keyframes detect-scroll {
+    from,
+    to {
+      --can-scroll: 1;
+    }
   }
-}
 
-/* Used to determine whether there should be a border between the body and footer */
-@keyframes detect-scroll {
-  from,
-  to {
-    --can-scroll: 1;
-  }
-}
-
-.Backdrop {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: flex;
-  background-color: var(--overlay-backdrop-bgColor);
-  animation: dialog-backdrop-appear 200ms cubic-bezier(0.33, 1, 0.68, 1);
-  align-items: center;
-  justify-content: center;
-
-  &[data-position-regular='center'] {
+  .Backdrop {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    background-color: var(--overlay-backdrop-bgColor);
+    animation: dialog-backdrop-appear 200ms cubic-bezier(0.33, 1, 0.68, 1);
     align-items: center;
     justify-content: center;
-  }
 
-  &[data-position-regular='left'] {
-    align-items: center;
-    justify-content: flex-start;
-  }
-
-  &[data-position-regular='right'] {
-    align-items: center;
-    justify-content: flex-end;
-  }
-
-  /* align only applies when regular position is center (or absent).
-   * :where() zeroes out the :not() specificity so narrow-position rules (coming later)
-   * always win when data-position-narrow is bottom or fullscreen. */
-  &:where(:not([data-position-regular='left']):not([data-position-regular='right'])) {
-    &[data-align='top'] {
-      align-items: flex-start;
-    }
-
-    &[data-align='center'] {
-      align-items: center;
-    }
-
-    &[data-align='bottom'] {
-      align-items: flex-end;
-    }
-  }
-
-  @media (max-width: 767px) {
-    &[data-position-narrow='center'] {
+    &[data-position-regular='center'] {
       align-items: center;
       justify-content: center;
+    }
 
-      /* align still applies when narrow position is center */
+    &[data-position-regular='left'] {
+      align-items: center;
+      justify-content: flex-start;
+    }
+
+    &[data-position-regular='right'] {
+      align-items: center;
+      justify-content: flex-end;
+    }
+
+    /* align only applies when regular position is center (or absent).
+     * :where() zeroes out the :not() specificity so narrow-position rules (coming later)
+     * always win when data-position-narrow is bottom or fullscreen. */
+    &:where(:not([data-position-regular='left']):not([data-position-regular='right'])) {
       &[data-align='top'] {
         align-items: flex-start;
       }
@@ -122,259 +104,279 @@
       }
     }
 
-    &[data-position-narrow='bottom'] {
-      align-items: end;
-      justify-content: center;
+    @media (max-width: 767px) {
+      &[data-position-narrow='center'] {
+        align-items: center;
+        justify-content: center;
+
+        /* align still applies when narrow position is center */
+        &[data-align='top'] {
+          align-items: flex-start;
+        }
+
+        &[data-align='center'] {
+          align-items: center;
+        }
+
+        &[data-align='bottom'] {
+          align-items: flex-end;
+        }
+      }
+
+      &[data-position-narrow='bottom'] {
+        align-items: end;
+        justify-content: center;
+      }
     }
   }
-}
 
-.Dialog {
-  display: flex;
-  /* stylelint-disable-next-line primer/responsive-widths */
-  width: var(--dialog-width, 640px);
-  min-width: 296px;
-  max-width: calc(100dvw - 64px);
-  height: auto;
-  max-height: calc(100dvh - 64px);
-  flex-direction: column;
-  background-color: var(--overlay-bgColor);
-  border-radius: var(--borderRadius-large);
-  border-radius: var(--borderRadius-large, var(--borderRadius-large));
-  box-shadow: var(--shadow-floating-small);
-  opacity: 1;
-
-  &:where([data-width='small']) {
-    width: 296px;
-  }
-
-  &:where([data-width='medium']) {
-    width: 320px;
-  }
-
-  &:where([data-width='large']) {
+  .Dialog {
+    display: flex;
     /* stylelint-disable-next-line primer/responsive-widths */
-    width: 480px;
-  }
-
-  &:where([data-height='small']) {
-    height: 480px;
-  }
-
-  &:where([data-height='large']) {
-    height: 640px;
-  }
-
-  @media screen and (prefers-reduced-motion: no-preference) {
-    animation: Overlay--motion-scaleFade 0.2s cubic-bezier(0.33, 1, 0.68, 1) 1ms 1 normal none running;
-  }
-
-  &[data-position-regular='center'] {
+    width: var(--dialog-width, 640px);
+    min-width: 296px;
+    max-width: calc(100dvw - 64px);
+    height: auto;
+    max-height: calc(100dvh - 64px);
+    flex-direction: column;
+    background-color: var(--overlay-bgColor);
+    border-radius: var(--borderRadius-large);
     border-radius: var(--borderRadius-large, var(--borderRadius-large));
+    box-shadow: var(--shadow-floating-small);
+    opacity: 1;
+
+    &:where([data-width='small']) {
+      width: 296px;
+    }
+
+    &:where([data-width='medium']) {
+      width: 320px;
+    }
+
+    &:where([data-width='large']) {
+      /* stylelint-disable-next-line primer/responsive-widths */
+      width: 480px;
+    }
+
+    &:where([data-height='small']) {
+      height: 480px;
+    }
+
+    &:where([data-height='large']) {
+      height: 640px;
+    }
 
     @media screen and (prefers-reduced-motion: no-preference) {
       animation: Overlay--motion-scaleFade 0.2s cubic-bezier(0.33, 1, 0.68, 1) 1ms 1 normal none running;
     }
 
-    /* align margins only apply when regular position is center */
-    &[data-align='top'] {
-      margin-top: var(--base-size-64);
-    }
-
-    &[data-align='bottom'] {
-      margin-bottom: var(--base-size-64);
-    }
-  }
-
-  &[data-position-regular='left'] {
-    height: 100dvh;
-    max-height: unset;
-    border-radius: var(--borderRadius-large, var(--borderRadius-large));
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-
-    @media screen and (prefers-reduced-motion: no-preference) {
-      animation: Overlay--motion-slideInRight 0.25s cubic-bezier(0.33, 1, 0.68, 1) 1ms 1 normal none running;
-    }
-  }
-
-  &[data-position-regular='right'] {
-    height: 100dvh;
-    max-height: unset;
-    border-radius: var(--borderRadius-large, var(--borderRadius-large));
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-
-    @media screen and (prefers-reduced-motion: no-preference) {
-      animation: Overlay--motion-slideInLeft 0.25s cubic-bezier(0.33, 1, 0.68, 1) 0s 1 normal none running;
-    }
-  }
-
-  @media (max-width: 767px) {
-    &[data-position-narrow='center'] {
-      /* stylelint-disable-next-line primer/responsive-widths */
-      width: var(--dialog-width, 640px);
-      height: auto;
+    &[data-position-regular='center'] {
       border-radius: var(--borderRadius-large, var(--borderRadius-large));
-
-      &:where([data-width='small']) {
-        width: 296px;
-      }
-
-      &:where([data-width='medium']) {
-        width: 320px;
-      }
-
-      &:where([data-width='large']) {
-        /* stylelint-disable-next-line primer/responsive-widths */
-        width: 480px;
-      }
-
-      &:where([data-height='small']) {
-        height: 480px;
-      }
-
-      &:where([data-height='large']) {
-        height: 640px;
-      }
-    }
-
-    @media (max-height: 280px) {
-      max-height: calc(100dvh - 12px);
-      max-width: calc(100dvw - 12px);
-    }
-
-    &[data-position-narrow='bottom'] {
-      width: 100dvw;
-      max-width: 100dvw;
-      height: auto;
-      max-height: calc(100dvh - 64px);
-      border-radius: var(--borderRadius-large, var(--borderRadius-large));
-      border-bottom-right-radius: 0;
-      border-bottom-left-radius: 0;
-
-      /* reset align margins since position wins at narrow */
-      &[data-align] {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      @media screen and (prefers-reduced-motion: no-preference) {
-        animation: Overlay--motion-slideUp 0.25s cubic-bezier(0.33, 1, 0.68, 1) 1ms 1 normal none running;
-      }
-    }
-
-    &[data-position-narrow='fullscreen'] {
-      width: 100%;
-      max-width: 100dvw;
-      height: 100%;
-      max-height: 100dvh;
-      border-radius: unset !important;
-      flex-grow: 1;
-
-      /* reset align margins since fullscreen wins at narrow */
-      &[data-align] {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
 
       @media screen and (prefers-reduced-motion: no-preference) {
         animation: Overlay--motion-scaleFade 0.2s cubic-bezier(0.33, 1, 0.68, 1) 1ms 1 normal none running;
       }
+
+      /* align margins only apply when regular position is center */
+      &[data-align='top'] {
+        margin-top: var(--base-size-64);
+      }
+
+      &[data-align='bottom'] {
+        margin-bottom: var(--base-size-64);
+      }
+    }
+
+    &[data-position-regular='left'] {
+      height: 100dvh;
+      max-height: unset;
+      border-radius: var(--borderRadius-large, var(--borderRadius-large));
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+
+      @media screen and (prefers-reduced-motion: no-preference) {
+        animation: Overlay--motion-slideInRight 0.25s cubic-bezier(0.33, 1, 0.68, 1) 1ms 1 normal none running;
+      }
+    }
+
+    &[data-position-regular='right'] {
+      height: 100dvh;
+      max-height: unset;
+      border-radius: var(--borderRadius-large, var(--borderRadius-large));
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+
+      @media screen and (prefers-reduced-motion: no-preference) {
+        animation: Overlay--motion-slideInLeft 0.25s cubic-bezier(0.33, 1, 0.68, 1) 0s 1 normal none running;
+      }
+    }
+
+    @media (max-width: 767px) {
+      &[data-position-narrow='center'] {
+        /* stylelint-disable-next-line primer/responsive-widths */
+        width: var(--dialog-width, 640px);
+        height: auto;
+        border-radius: var(--borderRadius-large, var(--borderRadius-large));
+
+        &:where([data-width='small']) {
+          width: 296px;
+        }
+
+        &:where([data-width='medium']) {
+          width: 320px;
+        }
+
+        &:where([data-width='large']) {
+          /* stylelint-disable-next-line primer/responsive-widths */
+          width: 480px;
+        }
+
+        &:where([data-height='small']) {
+          height: 480px;
+        }
+
+        &:where([data-height='large']) {
+          height: 640px;
+        }
+      }
+
+      @media (max-height: 280px) {
+        max-height: calc(100dvh - 12px);
+        max-width: calc(100dvw - 12px);
+      }
+
+      &[data-position-narrow='bottom'] {
+        width: 100dvw;
+        max-width: 100dvw;
+        height: auto;
+        max-height: calc(100dvh - 64px);
+        border-radius: var(--borderRadius-large, var(--borderRadius-large));
+        border-bottom-right-radius: 0;
+        border-bottom-left-radius: 0;
+
+        /* reset align margins since position wins at narrow */
+        &[data-align] {
+          margin-top: 0;
+          margin-bottom: 0;
+        }
+
+        @media screen and (prefers-reduced-motion: no-preference) {
+          animation: Overlay--motion-slideUp 0.25s cubic-bezier(0.33, 1, 0.68, 1) 1ms 1 normal none running;
+        }
+      }
+
+      &[data-position-narrow='fullscreen'] {
+        width: 100%;
+        max-width: 100dvw;
+        height: 100%;
+        max-height: 100dvh;
+        border-radius: unset !important;
+        flex-grow: 1;
+
+        /* reset align margins since fullscreen wins at narrow */
+        &[data-align] {
+          margin-top: 0;
+          margin-bottom: 0;
+        }
+
+        @media screen and (prefers-reduced-motion: no-preference) {
+          animation: Overlay--motion-scaleFade 0.2s cubic-bezier(0.33, 1, 0.68, 1) 1ms 1 normal none running;
+        }
+      }
     }
   }
-}
 
-/*
- * PERFORMANCE OPTIMIZATION: Direct attribute on body - O(1) lookup
- */
-/* stylelint-disable-next-line selector-no-qualifying-type */
-body[data-dialog-scroll-disabled] {
-  /* stylelint-disable-next-line primer/spacing */
-  padding-right: var(--prc-dialog-scrollgutter) !important;
-  overflow: hidden !important;
-}
-
-.DialogOverflowWrapper {
-  flex-grow: 1;
-}
-
-/*
-Add a border between the body and footer if:
-- the dialog has a footer
-- the dialog has a body that can scroll
-- the browser supports the `animation-timeline` property and its `scroll()` function
-*/
-.Dialog[data-has-footer] {
-  --can-scroll: 0;
+  /*
+   * PERFORMANCE OPTIMIZATION: Direct attribute on body - O(1) lookup
+   */
+  /* stylelint-disable-next-line selector-no-qualifying-type */
+  body[data-dialog-scroll-disabled] {
+    /* stylelint-disable-next-line primer/spacing */
+    padding-right: var(--prc-dialog-scrollgutter) !important;
+    overflow: hidden !important;
+  }
 
   .DialogOverflowWrapper {
-    /* If the browser does not support the `animation-timeline` property, always show a border */
-    border-bottom: var(--borderWidth-default) solid var(--borderColor-default);
-    animation: detect-scroll;
-    animation-timeline: scroll(self);
+    flex-grow: 1;
+  }
 
-    @supports (animation-timeline: scroll(self)) {
-      border-bottom: calc(var(--borderWidth-thin) * var(--can-scroll)) solid var(--borderColor-default);
+  /*
+  Add a border between the body and footer if:
+  - the dialog has a footer
+  - the dialog has a body that can scroll
+  - the browser supports the `animation-timeline` property and its `scroll()` function
+  */
+  .Dialog[data-has-footer] {
+    --can-scroll: 0;
+
+    .DialogOverflowWrapper {
+      /* If the browser does not support the `animation-timeline` property, always show a border */
+      border-bottom: var(--borderWidth-default) solid var(--borderColor-default);
+      animation: detect-scroll;
+      animation-timeline: scroll(self);
+
+      @supports (animation-timeline: scroll(self)) {
+        border-bottom: calc(var(--borderWidth-thin) * var(--can-scroll)) solid var(--borderColor-default);
+      }
     }
   }
-}
 
-.Header {
-  z-index: 1;
-  max-height: 35vh;
-  padding: var(--base-size-8);
-  overflow-y: auto;
-  /* stylelint-disable-next-line primer/box-shadow */
-  box-shadow: 0 1px 0 var(--borderColor-default);
-  flex-shrink: 0;
-}
+  .Header {
+    z-index: 1;
+    max-height: 35vh;
+    padding: var(--base-size-8);
+    overflow-y: auto;
+    /* stylelint-disable-next-line primer/box-shadow */
+    box-shadow: 0 1px 0 var(--borderColor-default);
+    flex-shrink: 0;
+  }
 
-.HeaderInner {
-  display: flex;
-}
+  .HeaderInner {
+    display: flex;
+  }
 
-.HeaderContent {
-  display: flex;
-  padding-inline: var(--base-size-8);
-  padding-block: var(--base-size-6);
-  flex-direction: column;
-  flex-grow: 1;
-}
+  .HeaderContent {
+    display: flex;
+    padding-inline: var(--base-size-8);
+    padding-block: var(--base-size-6);
+    flex-direction: column;
+    flex-grow: 1;
+  }
 
-.Title {
-  margin: 0; /* override default margin */
-  font-size: var(--text-body-size-medium);
-  font-weight: var(--text-title-weight-large);
-}
+  .Title {
+    margin: 0; /* override default margin */
+    font-size: var(--text-body-size-medium);
+    font-weight: var(--text-title-weight-large);
+  }
 
-.Subtitle {
-  margin: 0; /* override default margin */
-  margin-top: var(--base-size-4);
-  font-size: var(--text-body-size-small);
-  font-weight: var(--base-text-weight-normal);
-  color: var(--fgColor-muted);
-}
+  .Subtitle {
+    margin: 0; /* override default margin */
+    margin-top: var(--base-size-4);
+    font-size: var(--text-body-size-small);
+    font-weight: var(--base-text-weight-normal);
+    color: var(--fgColor-muted);
+  }
 
-.Body {
-  padding: var(--base-size-16);
-  overflow: auto;
-  flex-grow: 1;
-}
+  .Body {
+    padding: var(--base-size-16);
+    overflow: auto;
+    flex-grow: 1;
+  }
 
-.Footer {
-  z-index: 1;
-  display: flex;
-  flex-flow: wrap;
-  justify-content: flex-end;
-  padding: var(--base-size-16);
-  gap: var(--base-size-8);
-  flex-shrink: 0;
-}
+  .Footer {
+    z-index: 1;
+    display: flex;
+    flex-flow: wrap;
+    justify-content: flex-end;
+    padding: var(--base-size-16);
+    gap: var(--base-size-8);
+    flex-shrink: 0;
+  }
 
-.Dialog[data-footer-button-layout='scroll'] .Footer {
-  flex-wrap: nowrap;
-  overflow-x: scroll;
-  flex-direction: row;
-  justify-content: unset;
+  .Dialog[data-footer-button-layout='scroll'] .Footer {
+    flex-wrap: nowrap;
+    overflow-x: scroll;
+    flex-direction: row;
+    justify-content: unset;
+  }
 }

--- a/packages/react/src/__tests__/css-layers.test.ts
+++ b/packages/react/src/__tests__/css-layers.test.ts
@@ -88,6 +88,17 @@ const allowlist = new Set([
   path.resolve(import.meta.dirname, '../ActionList/ActionList.module.css'),
   path.resolve(import.meta.dirname, '../ActionList/Group.module.css'),
   path.resolve(import.meta.dirname, '../ActionList/Heading.module.css'),
+  path.resolve(import.meta.dirname, '../AnchoredOverlay/AnchoredOverlay.module.css'),
+  path.resolve(import.meta.dirname, '../Autocomplete/AutocompleteMenu.module.css'),
+  path.resolve(import.meta.dirname, '../Autocomplete/AutocompleteOverlay.module.css'),
+  path.resolve(import.meta.dirname, '../Banner/Banner.module.css'),
+  path.resolve(import.meta.dirname, '../Blankslate/Blankslate.module.css'),
+  path.resolve(import.meta.dirname, '../Breadcrumbs/Breadcrumbs.module.css'),
+  path.resolve(import.meta.dirname, '../deprecated/DialogV1/Dialog.module.css'),
+  path.resolve(import.meta.dirname, '../Dialog/Dialog.module.css'),
+  path.resolve(import.meta.dirname, '../ActionMenu/ActionMenu.module.css'),
+  path.resolve(import.meta.dirname, '../ActionBar/ActionBar.module.css'),
+  path.resolve(import.meta.dirname, '../experimental/SelectPanel2/SelectPanel.module.css'),
 ])
 const files = Array.from(allowlist).map(file => {
   return [path.relative(path.resolve(import.meta.dirname, '..'), file), file]

--- a/packages/react/src/deprecated/DialogV1/Dialog.module.css
+++ b/packages/react/src/deprecated/DialogV1/Dialog.module.css
@@ -1,72 +1,74 @@
-.Overlay {
-  &::before {
+@layer primer.components.DeprecatedDialogV1 {
+  .Overlay {
+    &::before {
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 99;
+      display: block;
+      cursor: default;
+      content: ' ';
+      background: var(--overlay-backdrop-bgColor);
+    }
+  }
+
+  .CloseIcon {
+    position: absolute;
+    top: var(--base-size-8);
+    right: var(--base-size-16);
+  }
+
+  .Dialog {
     position: fixed;
     top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 99;
-    display: block;
-    cursor: default;
-    content: ' ';
-    background: var(--overlay-backdrop-bgColor);
-  }
-}
+    left: 50%;
+    z-index: 999;
+    max-height: 80vh;
+    margin: 10vh auto;
+    background-color: var(--bgColor-default);
+    border-radius: var(--borderRadius-medium);
+    outline: none;
+    box-shadow: var(--shadow-floating-large);
+    transform: translateX(-50%);
 
-.CloseIcon {
-  position: absolute;
-  top: var(--base-size-8);
-  right: var(--base-size-16);
-}
+    &:where([data-width='default']) {
+      /* stylelint-disable-next-line primer/responsive-widths */
+      width: 440px;
+    }
 
-.Dialog {
-  position: fixed;
-  top: 0;
-  left: 50%;
-  z-index: 999;
-  max-height: 80vh;
-  margin: 10vh auto;
-  background-color: var(--bgColor-default);
-  border-radius: var(--borderRadius-medium);
-  outline: none;
-  box-shadow: var(--shadow-floating-large);
-  transform: translateX(-50%);
+    &:where([data-width='narrow']) {
+      width: 320px;
+    }
 
-  &:where([data-width='default']) {
-    /* stylelint-disable-next-line primer/responsive-widths */
-    width: 440px;
+    &:where([data-width='wide']) {
+      /* stylelint-disable-next-line primer/responsive-widths */
+      width: 640px;
+    }
+
+    @media screen and (max-width: 750px) {
+      width: 100dvw;
+      height: 100dvh;
+      margin: 0;
+      border-radius: 0;
+    }
   }
 
-  &:where([data-width='narrow']) {
-    width: 320px;
+  .Header {
+    display: flex;
+    padding: var(--base-size-16);
+    background: var(--bgColor-muted);
+    border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
+    border-radius: var(--borderRadius-medium) var(--borderRadius-medium) 0 0;
+
+    @media screen and (max-width: 750px) {
+      border-radius: 0;
+    }
   }
 
-  &:where([data-width='wide']) {
-    /* stylelint-disable-next-line primer/responsive-widths */
-    width: 640px;
+  .HeaderChild {
+    font-size: var(--text-body-size-medium);
+    font-weight: var(--base-text-weight-semibold);
   }
-
-  @media screen and (max-width: 750px) {
-    width: 100dvw;
-    height: 100dvh;
-    margin: 0;
-    border-radius: 0;
-  }
-}
-
-.Header {
-  display: flex;
-  padding: var(--base-size-16);
-  background: var(--bgColor-muted);
-  border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
-  border-radius: var(--borderRadius-medium) var(--borderRadius-medium) 0 0;
-
-  @media screen and (max-width: 750px) {
-    border-radius: 0;
-  }
-}
-
-.HeaderChild {
-  font-size: var(--text-body-size-medium);
-  font-weight: var(--base-text-weight-semibold);
 }

--- a/packages/react/src/experimental/SelectPanel2/SelectPanel.module.css
+++ b/packages/react/src/experimental/SelectPanel2/SelectPanel.module.css
@@ -1,290 +1,292 @@
-.Overlay {
-  padding: 0;
-  color: var(--fgColor-default);
-  border: none;
+@layer primer.components.SelectPanel2 {
+  .Overlay {
+    padding: 0;
+    color: var(--fgColor-default);
+    border: none;
 
-  /* CSS variables values are passed in via styles */
-  --max-height: 0;
-  --position-top: 0;
-  --position-left: 0;
+    /* CSS variables values are passed in via styles */
+    --max-height: 0;
+    --position-top: 0;
+    --position-left: 0;
 
-  &:where([open]) {
-    display: flex; /* to fit children */
-  }
+    &:where([open]) {
+      display: flex; /* to fit children */
+    }
 
-  &:where([data-variant='anchored']),
-  &:where([data-variant='full-screen']) {
-    /* stylelint-disable-next-line primer/spacing */
-    top: var(--position-top);
-    /* stylelint-disable-next-line primer/spacing */
-    left: var(--position-left);
-    margin: 0;
+    &:where([data-variant='anchored']),
+    &:where([data-variant='full-screen']) {
+      /* stylelint-disable-next-line primer/spacing */
+      top: var(--position-top);
+      /* stylelint-disable-next-line primer/spacing */
+      left: var(--position-left);
+      margin: 0;
 
-    &::backdrop {
-      background-color: transparent;
+      &::backdrop {
+        background-color: transparent;
+      }
+    }
+
+    &:where([data-variant='modal']) {
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+
+    &:where([data-variant='modal'])::backdrop {
+      background-color: var(--overlay-backdrop-bgColor);
+    }
+
+    &:where([data-variant='full-screen']) {
+      top: 0;
+      left: 0;
+      width: 100%;
+      max-width: 100vw;
+      height: 100%;
+      max-height: 100vh;
+      margin: 0;
+      border-radius: unset;
+    }
+
+    &:where([data-variant='bottom-sheet']) {
+      top: auto;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      max-width: 100vw;
+      max-height: calc(100vh - 64px);
+      margin: 0;
+      border-bottom-right-radius: 0;
+      border-bottom-left-radius: 0;
     }
   }
 
-  &:where([data-variant='modal']) {
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-  }
-
-  &:where([data-variant='modal'])::backdrop {
-    background-color: var(--overlay-backdrop-bgColor);
-  }
-
-  &:where([data-variant='full-screen']) {
-    top: 0;
-    left: 0;
+  .Form {
+    display: flex;
     width: 100%;
-    max-width: 100vw;
+    flex-direction: column;
+  }
+
+  .Container {
+    display: flex;
+    overflow: hidden;
+    flex-direction: column;
+    flex-shrink: 1;
+    flex-grow: 1;
+    justify-content: space-between;
+
+    ul {
+      overflow-y: auto;
+      flex-grow: 1;
+    }
+
+    /* Allow the browser to skip rendering for off-screen items, reducing style recalc and layout costs in long lists.
+       Exclude items that show the active indicator line, as content-visibility: auto applies paint containment
+       which clips the absolutely-positioned ::after pseudo-element that renders outside the item bounds. */
+    /* stylelint-disable-next-line selector-no-qualifying-type */
+    li:not(:focus, [data-is-active-descendant], [data-active]) {
+      content-visibility: auto;
+      contain-intrinsic-size: auto 32px;
+    }
+  }
+
+  .HeaderContent {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0;
+
+    &:where([data-description]) {
+      align-items: flex-start;
+    }
+
+    &:where([data-search-input]) {
+      margin-bottom: var(--base-size-8);
+    }
+  }
+
+  .TitleWrapper {
+    margin-top: 0;
+    margin-left: var(--base-size-8);
+
+    &:where([data-description]) {
+      /* stylelint-disable-next-line primer/spacing */
+      margin-top: 2px;
+    }
+
+    &:where([data-on-back]) {
+      margin-left: var(--base-size-4);
+    }
+  }
+
+  .TextInput {
+    padding-left: var(--base-size-8) !important;
+
+    /* stylelint-disable-next-line selector-class-pattern, selector-no-qualifying-type, selector-pseudo-class-disallowed-list -- :has() scoped to CSS Module, audited (github/github-ui#17224) */
+    &:has(input:placeholder-shown) :global(.TextInput-action) {
+      display: none;
+    }
+  }
+
+  .Checkbox {
+    margin-top: 0;
+  }
+
+  .FlexBox {
+    display: flex;
+  }
+
+  .Title {
+    font-size: var(--text-body-size-medium);
+    font-weight: var(--base-text-weight-semibold);
+  }
+
+  .Description {
+    display: block;
+    font-size: var(--text-body-size-small);
+    color: var(--fgColor-muted);
+  }
+
+  .ClearAction {
+    color: var(--fgColor-muted);
+    background: none;
+  }
+
+  .Footer {
+    display: flex;
+    min-height: 44px;
+    padding: var(--base-size-16);
+    border-top: var(--borderWidth-thin) solid;
+    border-top-color: var(--borderColor-default);
+    justify-content: space-between;
+    align-items: center;
+    flex-shrink: 0;
+
+    &:where([data-hide-primary-actions]) {
+      padding: var(--base-size-8);
+    }
+  }
+
+  .FooterContent {
+    flex-grow: 0;
+
+    &:where([data-hide-primary-actions]) {
+      flex-grow: 1;
+    }
+  }
+
+  .FooterActions {
+    display: flex;
+    gap: var(--stack-gap-condensed);
+  }
+
+  .SecondaryCheckbox {
+    display: flex;
+    align-items: center;
+    gap: var(--stack-gap-condensed);
+  }
+
+  .SmallText {
+    font-size: var(--text-body-size-small);
+  }
+
+  .SelectPanelLoading {
+    display: flex;
     height: 100%;
-    max-height: 100vh;
-    margin: 0;
-    border-radius: unset;
+
+    /* maxHeight of dialog - (header & footer) */
+    min-height: min(calc(var(--max-height) - 150px), 324px);
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: var(--stack-gap-normal);
   }
 
-  &:where([data-variant='bottom-sheet']) {
-    top: auto;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    max-width: 100vw;
-    max-height: calc(100vh - 64px);
-    margin: 0;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+  .LoadingText {
+    font-size: var(--text-body-size-medium);
+    color: var(--fgColor-muted);
   }
-}
 
-.Form {
-  display: flex;
-  width: 100%;
-  flex-direction: column;
-}
+  .MessageFull {
+    display: flex;
+    height: 100%;
 
-.Container {
-  display: flex;
-  overflow: hidden;
-  flex-direction: column;
-  flex-shrink: 1;
-  flex-grow: 1;
-  justify-content: space-between;
-
-  ul {
-    overflow-y: auto;
+    /* maxHeight of dialog - (header & footer) */
+    min-height: min(calc(var(--max-height) - 150px), 324px);
+    padding-right: var(--base-size-24);
+    padding-left: var(--base-size-24);
+    text-align: center;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
     flex-grow: 1;
+    gap: var(--base-size-4);
+
+    a {
+      color: inherit;
+      text-decoration: underline;
+    }
   }
 
-  /* Allow the browser to skip rendering for off-screen items, reducing style recalc and layout costs in long lists.
-     Exclude items that show the active indicator line, as content-visibility: auto applies paint containment
-     which clips the absolutely-positioned ::after pseudo-element that renders outside the item bounds. */
-  /* stylelint-disable-next-line selector-no-qualifying-type */
-  li:not(:focus, [data-is-active-descendant], [data-active]) {
-    content-visibility: auto;
-    contain-intrinsic-size: auto 32px;
-  }
-}
-
-.HeaderContent {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0;
-
-  &:where([data-description]) {
-    align-items: flex-start;
-  }
-
-  &:where([data-search-input]) {
+  .Octicon {
     margin-bottom: var(--base-size-8);
-  }
-}
 
-.TitleWrapper {
-  margin-top: 0;
-  margin-left: var(--base-size-8);
+    &.Error {
+      color: var(--fgColor-danger);
+    }
 
-  &:where([data-description]) {
-    /* stylelint-disable-next-line primer/spacing */
-    margin-top: 2px;
+    &.Warning {
+      color: var(--fgColor-attention);
+    }
   }
 
-  &:where([data-on-back]) {
-    margin-left: var(--base-size-4);
+  .MessageTitle {
+    font-size: var(--text-body-size-medium);
+    font-weight: var(--base-text-weight-medium);
   }
-}
 
-.TextInput {
-  padding-left: var(--base-size-8) !important;
-
-  /* stylelint-disable-next-line selector-class-pattern, selector-no-qualifying-type, selector-pseudo-class-disallowed-list -- :has() scoped to CSS Module, audited (github/github-ui#17224) */
-  &:has(input:placeholder-shown) :global(.TextInput-action) {
-    display: none;
+  .MessageContent {
+    display: flex;
+    font-size: var(--text-body-size-medium);
+    color: var(--fgColor-muted);
+    flex-direction: column;
+    gap: var(--stack-gap-condensed);
+    align-items: center;
   }
-}
 
-.Checkbox {
-  margin-top: 0;
-}
+  .MessageInline {
+    display: flex;
+    padding-top: var(--base-size-12);
+    padding-right: var(--base-size-16);
+    padding-bottom: var(--base-size-12);
+    padding-left: var(--base-size-16);
+    font-size: var(--text-body-size-small);
+    border-bottom: var(--borderWidth-thin) solid;
+    gap: var(--stack-gap-condensed);
 
-.FlexBox {
-  display: flex;
-}
+    a {
+      color: inherit;
+      text-decoration: underline;
+    }
 
-.Title {
-  font-size: var(--text-body-size-medium);
-  font-weight: var(--base-text-weight-semibold);
-}
+    &:where([data-variant='error']) {
+      color: var(--fgColor-danger);
+      background-color: var(--bgColor-danger-muted);
+      border-color: var(--borderColor-danger-muted);
+    }
 
-.Description {
-  display: block;
-  font-size: var(--text-body-size-small);
-  color: var(--fgColor-muted);
-}
+    &:where([data-variant='warning']) {
+      color: var(--fgColor-attention);
+      background-color: var(--bgColor-attention-muted);
+      border-color: var(--borderColor-attention-muted);
+    }
+  }
 
-.ClearAction {
-  color: var(--fgColor-muted);
-  background: none;
-}
-
-.Footer {
-  display: flex;
-  min-height: 44px;
-  padding: var(--base-size-16);
-  border-top: var(--borderWidth-thin) solid;
-  border-top-color: var(--borderColor-default);
-  justify-content: space-between;
-  align-items: center;
-  flex-shrink: 0;
-
-  &:where([data-hide-primary-actions]) {
+  .Header {
+    display: flex;
     padding: var(--base-size-8);
+    flex-direction: column;
+    border-bottom: var(--borderWidth-thin) solid;
+    border-bottom-color: var(--borderColor-default);
   }
-}
-
-.FooterContent {
-  flex-grow: 0;
-
-  &:where([data-hide-primary-actions]) {
-    flex-grow: 1;
-  }
-}
-
-.FooterActions {
-  display: flex;
-  gap: var(--stack-gap-condensed);
-}
-
-.SecondaryCheckbox {
-  display: flex;
-  align-items: center;
-  gap: var(--stack-gap-condensed);
-}
-
-.SmallText {
-  font-size: var(--text-body-size-small);
-}
-
-.SelectPanelLoading {
-  display: flex;
-  height: 100%;
-
-  /* maxHeight of dialog - (header & footer) */
-  min-height: min(calc(var(--max-height) - 150px), 324px);
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: var(--stack-gap-normal);
-}
-
-.LoadingText {
-  font-size: var(--text-body-size-medium);
-  color: var(--fgColor-muted);
-}
-
-.MessageFull {
-  display: flex;
-  height: 100%;
-
-  /* maxHeight of dialog - (header & footer) */
-  min-height: min(calc(var(--max-height) - 150px), 324px);
-  padding-right: var(--base-size-24);
-  padding-left: var(--base-size-24);
-  text-align: center;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  flex-grow: 1;
-  gap: var(--base-size-4);
-
-  a {
-    color: inherit;
-    text-decoration: underline;
-  }
-}
-
-.Octicon {
-  margin-bottom: var(--base-size-8);
-
-  &.Error {
-    color: var(--fgColor-danger);
-  }
-
-  &.Warning {
-    color: var(--fgColor-attention);
-  }
-}
-
-.MessageTitle {
-  font-size: var(--text-body-size-medium);
-  font-weight: var(--base-text-weight-medium);
-}
-
-.MessageContent {
-  display: flex;
-  font-size: var(--text-body-size-medium);
-  color: var(--fgColor-muted);
-  flex-direction: column;
-  gap: var(--stack-gap-condensed);
-  align-items: center;
-}
-
-.MessageInline {
-  display: flex;
-  padding-top: var(--base-size-12);
-  padding-right: var(--base-size-16);
-  padding-bottom: var(--base-size-12);
-  padding-left: var(--base-size-16);
-  font-size: var(--text-body-size-small);
-  border-bottom: var(--borderWidth-thin) solid;
-  gap: var(--stack-gap-condensed);
-
-  a {
-    color: inherit;
-    text-decoration: underline;
-  }
-
-  &:where([data-variant='error']) {
-    color: var(--fgColor-danger);
-    background-color: var(--bgColor-danger-muted);
-    border-color: var(--borderColor-danger-muted);
-  }
-
-  &:where([data-variant='warning']) {
-    color: var(--fgColor-attention);
-    background-color: var(--bgColor-attention-muted);
-    border-color: var(--borderColor-attention-muted);
-  }
-}
-
-.Header {
-  display: flex;
-  padding: var(--base-size-8);
-  flex-direction: column;
-  border-bottom: var(--borderWidth-thin) solid;
-  border-bottom-color: var(--borderColor-default);
 }


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/6275

Migrates AnchoredOverlay, Autocomplete, Banner, Blankslate, Breadcrumbs, Dialog, ActionMenu, ActionBar, and SelectPanel2 styles into named Primer component CSS layers.

### Changelog

#### New

- Adds CSS layer coverage for AnchoredOverlay, Autocomplete, Banner, Blankslate, Breadcrumbs, Dialog, ActionMenu, ActionBar, and SelectPanel2.

#### Changed

- Wraps AnchoredOverlay, Autocomplete, Banner, Blankslate, Breadcrumbs, Dialog, ActionMenu, ActionBar, and SelectPanel2 CSS module styles in named `@layer primer.components.*` layers.

#### Removed

- None

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- Run `cd packages/react && npx vitest run src/__tests__/css-layers.test.ts --config vitest.config.mts`.
- Review this PR as part of the CSS layers stack; this entry covers AnchoredOverlay, Autocomplete, Banner, Blankslate, Breadcrumbs, Dialog, ActionMenu, ActionBar, and SelectPanel2.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

