### PR TITLE
feat: add CSS Layer support to form and select panel components

### DIFF
--- a/.changeset/css-layers-filtered-form-select-panel.md
+++ b/.changeset/css-layers-filtered-form-select-panel.md
@@ -2,4 +2,4 @@
 '@primer/react': patch
 ---
 
-FilteredActionList, FormControl, SelectPanel: Improve custom class override behavior for component styles
+FilteredActionList, FormControl, SelectPanel: Add CSS layer support for component styles

--- a/.changeset/css-layers-filtered-form-select-panel.md
+++ b/.changeset/css-layers-filtered-form-select-panel.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+FilteredActionList, FormControl, SelectPanel: Improve custom class override behavior for component styles

--- a/packages/react/src/FilteredActionList/FilteredActionList.module.css
+++ b/packages/react/src/FilteredActionList/FilteredActionList.module.css
@@ -1,82 +1,84 @@
-.Root {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.Header {
-  /* stylelint-disable-next-line primer/box-shadow */
-  box-shadow: 0 1px 0 var(--borderColor-default);
-  z-index: 1;
-}
-
-.Container {
-  display: flex;
-  height: 100%;
-  overflow: auto;
-  flex-grow: 1;
-
-  /* Allow the browser to skip rendering for off-screen items, reducing style recalc and layout costs in long lists.
-     Exclude items that show the active indicator line, as content-visibility: auto applies paint containment
-     which clips the absolutely-positioned ::after pseudo-element that renders outside the item bounds. */
-  & .ActionListItem:not(:focus, [data-is-active-descendant], [data-active], [data-input-focused]) {
-    content-visibility: auto;
-    contain-intrinsic-size: auto 32px;
+@layer primer.components.FilteredActionList {
+  .Root {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
   }
 
-  /* When showDividers is enabled, divider ::before pseudo-elements on ActionListSubContent are
-     positioned outside the item bounds (top: -7px). content-visibility: auto applies paint containment
-     which clips these, so we must disable it for items in lists with dividers. */
-  & [data-dividers='true'] .ActionListItem {
-    content-visibility: visible;
+  .Header {
+    /* stylelint-disable-next-line primer/box-shadow */
+    box-shadow: 0 1px 0 var(--borderColor-default);
+    z-index: 1;
   }
-}
 
-.ActionList {
-  flex-grow: 1;
-}
+  .Container {
+    display: flex;
+    height: 100%;
+    overflow: auto;
+    flex-grow: 1;
 
-.ActionListItem:focus {
-  background: var(--control-transparent-bgColor-selected);
+    /* Allow the browser to skip rendering for off-screen items, reducing style recalc and layout costs in long lists.
+       Exclude items that show the active indicator line, as content-visibility: auto applies paint containment
+       which clips the absolutely-positioned ::after pseudo-element that renders outside the item bounds. */
+    & .ActionListItem:not(:focus, [data-is-active-descendant], [data-active], [data-input-focused]) {
+      content-visibility: auto;
+      contain-intrinsic-size: auto 32px;
+    }
 
-  &::after {
-    @mixin activeIndicatorLine;
-  }
-}
-
-.ActionListItem:where([data-input-focused]):where([data-first-child]) {
-  background: var(--control-transparent-bgColor-selected);
-
-  &::after {
-    @mixin activeIndicatorLine;
-  }
-}
-
-.FullScreenTextInput {
-  @media screen and (--viewportRange-narrow) {
-    /* Ensures inputs don't zoom on mobile iPhone but are body-font size on iPad */
-    @supports (-webkit-touch-callout: none) {
-      font-size: var(--text-title-size-small);
+    /* When showDividers is enabled, divider ::before pseudo-elements on ActionListSubContent are
+       positioned outside the item bounds (top: -7px). content-visibility: auto applies paint containment
+       which clips these, so we must disable it for items in lists with dividers. */
+    & [data-dividers='true'] .ActionListItem {
+      content-visibility: visible;
     }
   }
-}
 
-.SelectAllContainer {
-  display: flex;
-  align-items: center;
-  padding-block: var(--base-size-4);
-  padding-inline: var(--base-size-16);
-  background: var(--bgColor-muted);
-  border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
-}
+  .ActionList {
+    flex-grow: 1;
+  }
 
-.SelectAllCheckbox {
-  /* -1px hack to offset 1px border-bottom causing uneven alignment */
-  /* stylelint-disable-next-line primer/spacing */
-  margin: var(--base-size-4) var(--base-size-8) calc(var(--base-size-4) - 1px) 0;
-}
+  .ActionListItem:focus {
+    background: var(--control-transparent-bgColor-selected);
 
-.SelectAllLabel {
-  font-size: var(--text-body-size-medium);
-  color: var(--fgColor-muted);
+    &::after {
+      @mixin activeIndicatorLine;
+    }
+  }
+
+  .ActionListItem:where([data-input-focused]):where([data-first-child]) {
+    background: var(--control-transparent-bgColor-selected);
+
+    &::after {
+      @mixin activeIndicatorLine;
+    }
+  }
+
+  .FullScreenTextInput {
+    @media screen and (--viewportRange-narrow) {
+      /* Ensures inputs don't zoom on mobile iPhone but are body-font size on iPad */
+      @supports (-webkit-touch-callout: none) {
+        font-size: var(--text-title-size-small);
+      }
+    }
+  }
+
+  .SelectAllContainer {
+    display: flex;
+    align-items: center;
+    padding-block: var(--base-size-4);
+    padding-inline: var(--base-size-16);
+    background: var(--bgColor-muted);
+    border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
+  }
+
+  .SelectAllCheckbox {
+    /* -1px hack to offset 1px border-bottom causing uneven alignment */
+    /* stylelint-disable-next-line primer/spacing */
+    margin: var(--base-size-4) var(--base-size-8) calc(var(--base-size-4) - 1px) 0;
+  }
+
+  .SelectAllLabel {
+    font-size: var(--text-body-size-medium);
+    color: var(--fgColor-muted);
+  }
 }

--- a/packages/react/src/FilteredActionList/FilteredActionListLoaders.module.css
+++ b/packages/react/src/FilteredActionList/FilteredActionListLoaders.module.css
@@ -1,19 +1,21 @@
-.LoadingSkeleton {
-  /* stylelint-disable-next-line primer/borders */
-  border-radius: 4px;
-}
+@layer primer.components.FilteredActionList {
+  .LoadingSkeleton {
+    /* stylelint-disable-next-line primer/borders */
+    border-radius: 4px;
+  }
 
-.LoadingSpinner {
-  padding: var(--base-size-16);
-  flex-grow: 1;
-  align-content: center;
-  text-align: center;
-  height: 100%;
-}
+  .LoadingSpinner {
+    padding: var(--base-size-16);
+    flex-grow: 1;
+    align-content: center;
+    text-align: center;
+    height: 100%;
+  }
 
-.LoadingSkeletonContainer {
-  padding: var(--base-size-8);
-  display: flex;
-  flex-grow: 1;
-  flex-direction: column;
+  .LoadingSkeletonContainer {
+    padding: var(--base-size-8);
+    display: flex;
+    flex-grow: 1;
+    flex-direction: column;
+  }
 }

--- a/packages/react/src/FormControl/FormControl.module.css
+++ b/packages/react/src/FormControl/FormControl.module.css
@@ -1,57 +1,59 @@
-.ControlHorizontalLayout {
-  display: flex;
+@layer primer.components.FormControl {
+  .ControlHorizontalLayout {
+    display: flex;
 
-  &:where([data-has-leading-visual]) {
-    align-items: center;
-  }
-}
-
-.ControlVerticalLayout {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-
-  & > *:not(label) + * {
-    margin-top: var(--base-size-4);
+    &:where([data-has-leading-visual]) {
+      align-items: center;
+    }
   }
 
-  &[data-has-label] > * + * {
-    margin-top: var(--base-size-4);
-  }
-}
+  .ControlVerticalLayout {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
 
-.ControlChoiceInputs > input {
-  margin-right: 0;
-  margin-left: 0;
-}
+    & > *:not(label) + * {
+      margin-top: var(--base-size-4);
+    }
 
-.LabelContainer {
-  > * {
-    /* stylelint-disable-next-line primer/spacing */
-    padding-left: var(--stack-gap-condensed);
+    &[data-has-label] > * + * {
+      margin-top: var(--base-size-4);
+    }
   }
 
-  > label {
-    font-weight: var(--base-text-weight-normal);
-  }
-}
-
-.LeadingVisual {
-  margin-left: var(--base-size-8);
-  color: var(--fgColor-muted);
-
-  &:where([data-disabled]) {
-    color: var(--control-fgColor-disabled);
+  .ControlChoiceInputs > input {
+    margin-right: 0;
+    margin-left: 0;
   }
 
-  > * {
-    min-width: var(--text-body-size-large);
-    min-height: var(--text-body-size-large);
-    fill: currentColor;
+  .LabelContainer {
+    > * {
+      /* stylelint-disable-next-line primer/spacing */
+      padding-left: var(--stack-gap-condensed);
+    }
+
+    > label {
+      font-weight: var(--base-text-weight-normal);
+    }
   }
 
-  > *:where([data-has-caption]) {
-    min-width: var(--base-size-24);
-    min-height: var(--base-size-24);
+  .LeadingVisual {
+    margin-left: var(--base-size-8);
+    color: var(--fgColor-muted);
+
+    &:where([data-disabled]) {
+      color: var(--control-fgColor-disabled);
+    }
+
+    > * {
+      min-width: var(--text-body-size-large);
+      min-height: var(--text-body-size-large);
+      fill: currentColor;
+    }
+
+    > *:where([data-has-caption]) {
+      min-width: var(--base-size-24);
+      min-height: var(--base-size-24);
+    }
   }
 }

--- a/packages/react/src/FormControl/FormControlCaption.module.css
+++ b/packages/react/src/FormControl/FormControlCaption.module.css
@@ -1,9 +1,11 @@
-.Caption {
-  display: block;
-  font-size: var(--text-body-size-small);
-  color: var(--fgColor-muted);
+@layer primer.components.FormControl {
+  .Caption {
+    display: block;
+    font-size: var(--text-body-size-small);
+    color: var(--fgColor-muted);
 
-  &:where([data-control-disabled]) {
-    color: var(--control-fgColor-disabled);
+    &:where([data-control-disabled]) {
+      color: var(--control-fgColor-disabled);
+    }
   }
 }

--- a/packages/react/src/FormControl/FormControlLeadingVisual.module.css
+++ b/packages/react/src/FormControl/FormControlLeadingVisual.module.css
@@ -1,21 +1,23 @@
-.LeadingVisual {
-  --leadingVisual-size: 16px;
+@layer primer.components.FormControl {
+  .LeadingVisual {
+    --leadingVisual-size: 16px;
 
-  color: var(--fgColor-default);
-  display: flex;
-  align-items: center;
+    color: var(--fgColor-default);
+    display: flex;
+    align-items: center;
 
-  &:where([data-control-disabled]) {
-    color: var(--control-fgColor-disabled);
-  }
+    &:where([data-control-disabled]) {
+      color: var(--control-fgColor-disabled);
+    }
 
-  & > * {
-    min-width: var(--leadingVisual-size);
-    min-height: var(--leadingVisual-size);
-    fill: currentColor;
-  }
+    & > * {
+      min-width: var(--leadingVisual-size);
+      min-height: var(--leadingVisual-size);
+      fill: currentColor;
+    }
 
-  &:where([data-has-caption]) {
-    --leadingVisual-size: 24px;
+    &:where([data-has-caption]) {
+      --leadingVisual-size: 24px;
+    }
   }
 }

--- a/packages/react/src/SelectPanel/SelectPanel.module.css
+++ b/packages/react/src/SelectPanel/SelectPanel.module.css
@@ -1,236 +1,238 @@
-.Overlay {
-  /* CSS variables values are passed in via styles */
-  --max-height: 0;
-}
-
-.Wrapper {
-  display: flex;
-  height: inherit;
-  max-height: inherit;
-  flex-direction: column;
-}
-
-.Header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  padding-top: var(--base-size-8);
-  padding-right: var(--base-size-8);
-  padding-left: var(--base-size-8);
-
-  &:where([data-variant='fullscreen']) {
-    min-height: 40px;
-    flex-shrink: 0;
+@layer primer.components.SelectPanel {
+  .Overlay {
+    /* CSS variables values are passed in via styles */
+    --max-height: 0;
   }
-}
 
-.Title {
-  margin-left: var(--base-size-8);
-  font-size: var(--text-body-size-medium);
-}
+  .Wrapper {
+    display: flex;
+    height: inherit;
+    max-height: inherit;
+    flex-direction: column;
+  }
 
-.Wrapper[data-variant='modal'] .Title {
-  margin-top: var(--base-size-8);
-  /* styling specific to the modal variant */
-}
+  .Header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding-top: var(--base-size-8);
+    padding-right: var(--base-size-8);
+    padding-left: var(--base-size-8);
 
-/*
- * Align SelectPanel header text with AnchoredOverlay close button
- * 
- * Ensures the title properly aligns with the close button position
- * in anchor variant on narrow viewports.
- */
-.Wrapper[data-variant='anchored'] .Title {
-  @media screen and (--viewportRange-narrow) {
+    &:where([data-variant='fullscreen']) {
+      min-height: 40px;
+      flex-shrink: 0;
+    }
+  }
+
+  .Title {
+    margin-left: var(--base-size-8);
+    font-size: var(--text-body-size-medium);
+  }
+
+  .Wrapper[data-variant='modal'] .Title {
     margin-top: var(--base-size-8);
+    /* styling specific to the modal variant */
   }
-}
 
-.Subtitle {
-  margin-left: var(--base-size-8);
-  font-size: var(--text-body-size-small);
-  color: var(--fgColor-muted);
-}
+  /*
+   * Align SelectPanel header text with AnchoredOverlay close button
+   * 
+   * Ensures the title properly aligns with the close button position
+   * in anchor variant on narrow viewports.
+   */
+  .Wrapper[data-variant='anchored'] .Title {
+    @media screen and (--viewportRange-narrow) {
+      margin-top: var(--base-size-8);
+    }
+  }
 
-.Notice {
-  margin-top: var(--base-size-4);
-  margin-right: var(--base-size-8);
-  margin-left: var(--base-size-8);
-}
+  .Subtitle {
+    margin-left: var(--base-size-8);
+    font-size: var(--text-body-size-small);
+    color: var(--fgColor-muted);
+  }
 
-.Notice a {
-  color: inherit;
-  text-decoration: underline;
-}
+  .Notice {
+    margin-top: var(--base-size-4);
+    margin-right: var(--base-size-8);
+    margin-left: var(--base-size-8);
+  }
 
-.Notice:where([data-variant='info']) {
-  color: var(--fgColor-accent);
-  background-color: var(--bgColor-accent-muted);
-  border-color: var(--borderColor-accent-muted);
-}
-
-.Notice:where([data-variant='warning']) {
-  color: var(--fgColor-attention);
-  background-color: var(--bgColor-attention-muted);
-  border-color: var(--borderColor-attention-muted);
-}
-
-.Notice:where([data-variant='critical']) {
-  color: var(--fgColor-danger);
-  background-color: var(--bgColor-danger-muted);
-  border-color: var(--borderColor-danger-muted);
-}
-
-.Footer {
-  display: flex;
-  padding: var(--base-size-8);
-  border-top: var(--borderWidth-thin) solid;
-  border-top-color: var(--borderColor-default);
-}
-
-.FilteredActionList {
-  /* inheriting height and maxHeight ensures that the FilteredActionList is never taller
-     than the Overlay (which would break scrolling the items) */
-  height: inherit;
-  max-height: inherit;
-}
-
-.Message {
-  display: flex;
-  height: 100%;
-  padding: var(--base-size-24);
-  text-align: center;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  flex-grow: 1;
-  gap: var(--base-size-4);
-
-  a {
+  .Notice a {
     color: inherit;
     text-decoration: underline;
   }
-}
 
-.MessageTitle {
-  font-size: var(--text-body-size-medium);
-  font-weight: var(--base-text-weight-semibold);
-}
+  .Notice:where([data-variant='info']) {
+    color: var(--fgColor-accent);
+    background-color: var(--bgColor-accent-muted);
+    border-color: var(--borderColor-accent-muted);
+  }
 
-.MessageBody {
-  font-size: var(--text-body-size-small);
-  color: var(--fgColor-muted);
-  align-items: center;
-  gap: var(--stack-gap-condensed);
-}
+  .Notice:where([data-variant='warning']) {
+    color: var(--fgColor-attention);
+    background-color: var(--bgColor-attention-muted);
+    border-color: var(--borderColor-attention-muted);
+  }
 
-.MessageIcon {
-  margin-bottom: var(--base-size-8);
-  color: var(--fgColor-attention);
-
-  &:where([data-variant='error']) {
+  .Notice:where([data-variant='critical']) {
     color: var(--fgColor-danger);
+    background-color: var(--bgColor-danger-muted);
+    border-color: var(--borderColor-danger-muted);
   }
-}
 
-.MessageAction {
-  margin-top: var(--base-size-8);
-}
-
-.ResponsiveCloseButton {
-  display: inline-grid;
-}
-
-.ResponsiveFooter {
-  display: none;
-  align-items: center;
-  padding: var(--base-size-8);
-  justify-content: center;
-
-  &:where([data-display-footer='always']) {
+  .Footer {
     display: flex;
+    padding: var(--base-size-8);
+    border-top: var(--borderWidth-thin) solid;
+    border-top-color: var(--borderColor-default);
   }
 
-  &:where([data-display-footer='only-small']) {
-    @media screen and (--viewportRange-narrow) {
+  .FilteredActionList {
+    /* inheriting height and maxHeight ensures that the FilteredActionList is never taller
+       than the Overlay (which would break scrolling the items) */
+    height: inherit;
+    max-height: inherit;
+  }
+
+  .Message {
+    display: flex;
+    height: 100%;
+    padding: var(--base-size-24);
+    text-align: center;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    flex-grow: 1;
+    gap: var(--base-size-4);
+
+    a {
+      color: inherit;
+      text-decoration: underline;
+    }
+  }
+
+  .MessageTitle {
+    font-size: var(--text-body-size-medium);
+    font-weight: var(--base-text-weight-semibold);
+  }
+
+  .MessageBody {
+    font-size: var(--text-body-size-small);
+    color: var(--fgColor-muted);
+    align-items: center;
+    gap: var(--stack-gap-condensed);
+  }
+
+  .MessageIcon {
+    margin-bottom: var(--base-size-8);
+    color: var(--fgColor-attention);
+
+    &:where([data-variant='error']) {
+      color: var(--fgColor-danger);
+    }
+  }
+
+  .MessageAction {
+    margin-top: var(--base-size-8);
+  }
+
+  .ResponsiveCloseButton {
+    display: inline-grid;
+  }
+
+  .ResponsiveFooter {
+    display: none;
+    align-items: center;
+    padding: var(--base-size-8);
+    justify-content: center;
+
+    &:where([data-display-footer='always']) {
       display: flex;
     }
-  }
 
-  &[data-stretch-secondary-action='never'] {
-    justify-content: space-between;
-  }
+    &:where([data-display-footer='only-small']) {
+      @media screen and (--viewportRange-narrow) {
+        display: flex;
+      }
+    }
 
-  &:where([data-stretch-secondary-action='only-big']) {
-    @media screen and (--viewportRange-narrow) {
+    &[data-stretch-secondary-action='never'] {
       justify-content: space-between;
     }
-  }
 
-  &:where([data-stretch-save-button='only-small']) {
-    justify-content: space-between;
+    &:where([data-stretch-secondary-action='only-big']) {
+      @media screen and (--viewportRange-narrow) {
+        justify-content: space-between;
+      }
+    }
 
-    @media screen and (--viewportRange-narrow) {
-      justify-content: center;
+    &:where([data-stretch-save-button='only-small']) {
+      justify-content: space-between;
+
+      @media screen and (--viewportRange-narrow) {
+        justify-content: center;
+      }
     }
   }
-}
 
-.SecondaryAction {
-  flex-grow: 1;
-  align-items: stretch;
-  display: flex;
-  justify-content: center;
+  .SecondaryAction {
+    flex-grow: 1;
+    align-items: stretch;
+    display: flex;
+    justify-content: center;
 
-  &[data-stretch-secondary-action='never'] {
-    flex-grow: 0;
-    align-items: flex-start;
-  }
-
-  &:where([data-stretch-secondary-action='only-big']) {
-    @media screen and (--viewportRange-narrow) {
+    &[data-stretch-secondary-action='never'] {
       flex-grow: 0;
       align-items: flex-start;
     }
+
+    &:where([data-stretch-secondary-action='only-big']) {
+      @media screen and (--viewportRange-narrow) {
+        flex-grow: 0;
+        align-items: flex-start;
+      }
+    }
   }
-}
 
-.CancelSaveButtons {
-  display: flex;
-  gap: var(--stack-gap-condensed);
-  justify-content: flex-end;
-}
-
-.ResponsiveCancelSaveButtons {
-  display: none;
-
-  @media screen and (--viewportRange-narrow) {
+  .CancelSaveButtons {
     display: flex;
     gap: var(--stack-gap-condensed);
     justify-content: flex-end;
   }
-}
 
-.ResponsiveSaveButton {
-  display: none;
+  .ResponsiveCancelSaveButtons {
+    display: none;
 
-  @media screen and (--viewportRange-narrow) {
-    display: flex;
-  }
-
-  &:where([data-stretch-save-button='only-small']) {
     @media screen and (--viewportRange-narrow) {
-      flex-grow: 1;
+      display: flex;
+      gap: var(--stack-gap-condensed);
+      justify-content: flex-end;
     }
   }
-}
 
-.Backdrop {
-  position: fixed;
-  inset: 0;
-  background-color: var(--overlay-backdrop-bgColor);
-}
+  .ResponsiveSaveButton {
+    display: none;
 
-.TextInput {
-  margin: var(--base-size-8);
+    @media screen and (--viewportRange-narrow) {
+      display: flex;
+    }
+
+    &:where([data-stretch-save-button='only-small']) {
+      @media screen and (--viewportRange-narrow) {
+        flex-grow: 1;
+      }
+    }
+  }
+
+  .Backdrop {
+    position: fixed;
+    inset: 0;
+    background-color: var(--overlay-backdrop-bgColor);
+  }
+
+  .TextInput {
+    margin: var(--base-size-8);
+  }
 }

--- a/packages/react/src/SelectPanel/SelectPanel.module.css
+++ b/packages/react/src/SelectPanel/SelectPanel.module.css
@@ -37,7 +37,7 @@
 
   /*
    * Align SelectPanel header text with AnchoredOverlay close button
-   * 
+   *
    * Ensures the title properly aligns with the close button position
    * in anchor variant on narrow viewports.
    */

--- a/packages/react/src/__tests__/css-layers.test.ts
+++ b/packages/react/src/__tests__/css-layers.test.ts
@@ -99,6 +99,12 @@ const allowlist = new Set([
   path.resolve(import.meta.dirname, '../ActionMenu/ActionMenu.module.css'),
   path.resolve(import.meta.dirname, '../ActionBar/ActionBar.module.css'),
   path.resolve(import.meta.dirname, '../experimental/SelectPanel2/SelectPanel.module.css'),
+  path.resolve(import.meta.dirname, '../FilteredActionList/FilteredActionList.module.css'),
+  path.resolve(import.meta.dirname, '../FilteredActionList/FilteredActionListLoaders.module.css'),
+  path.resolve(import.meta.dirname, '../FormControl/FormControl.module.css'),
+  path.resolve(import.meta.dirname, '../FormControl/FormControlCaption.module.css'),
+  path.resolve(import.meta.dirname, '../FormControl/FormControlLeadingVisual.module.css'),
+  path.resolve(import.meta.dirname, '../SelectPanel/SelectPanel.module.css'),
 ])
 const files = Array.from(allowlist).map(file => {
   return [path.relative(path.resolve(import.meta.dirname, '..'), file), file]


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/6275

Migrates FilteredActionList, FormControl, and SelectPanel styles into named Primer component CSS layers.

### Changelog

#### New

- Adds CSS layer coverage for FilteredActionList, FormControl, and SelectPanel.

#### Changed

- Wraps FilteredActionList, FormControl, and SelectPanel CSS module styles in named `@layer primer.components.*` layers.

#### Removed

- None

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- Run `cd packages/react && npx vitest run src/__tests__/css-layers.test.ts --config vitest.config.mts`.
- Review this PR as part of the CSS layers stack; this entry covers FilteredActionList, FormControl, and SelectPanel.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

