### PR TITLE
feat: add CSS Layer support to navigation composites

### DIFF
--- a/.changeset/css-layers-navigation-composites.md
+++ b/.changeset/css-layers-navigation-composites.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+LabelGroup, NavList, SegmentedControl, TreeView, UnderlineNav: Improve custom class override behavior for component styles

--- a/.changeset/css-layers-navigation-composites.md
+++ b/.changeset/css-layers-navigation-composites.md
@@ -2,4 +2,4 @@
 '@primer/react': patch
 ---
 
-LabelGroup, NavList, SegmentedControl, TreeView, UnderlineNav: Improve custom class override behavior for component styles
+LabelGroup, NavList, SegmentedControl, TreeView, UnderlineNav: Add CSS layer support for component styles

--- a/packages/react/src/LabelGroup/LabelGroup.module.css
+++ b/packages/react/src/LabelGroup/LabelGroup.module.css
@@ -1,52 +1,54 @@
-.Container {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: var(--base-size-4);
-  /* stylelint-disable-next-line primer/typography */
-  line-height: 1;
-  max-width: 100%;
-  overflow: hidden;
+@layer primer.components.LabelGroup {
+  .Container {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: var(--base-size-4);
+    /* stylelint-disable-next-line primer/typography */
+    line-height: 1;
+    max-width: 100%;
+    overflow: hidden;
 
-  &:where([data-overflow='inline']) {
+    &:where([data-overflow='inline']) {
+      flex-wrap: wrap;
+    }
+
+    &:where([data-list]) {
+      padding-inline-start: 0;
+      margin-block-start: 0;
+      margin-block-end: 0;
+      list-style-type: none;
+    }
+  }
+
+  .ItemWrapper {
+    display: flex;
+    align-items: center;
+    /* This min-height matches the height of the expand/collapse button.
+       Without it, the labels/tokens will do a slight layout shift when expanded.
+       This is because the height of the first row will match the token sizes,
+       but the height of the second row will be the height of the collapse button.
+    */
+    min-height: 28px;
+  }
+
+  .ItemWrapper--hidden {
+    order: 9999;
+    pointer-events: none;
+    visibility: hidden;
+  }
+
+  .OverlayContainer {
+    align-items: flex-start;
+    display: flex;
+  }
+
+  .OverlayInner {
+    display: flex;
     flex-wrap: wrap;
+    gap: var(--base-size-4);
   }
 
-  &:where([data-list]) {
-    padding-inline-start: 0;
-    margin-block-start: 0;
-    margin-block-end: 0;
-    list-style-type: none;
+  .CloseButton {
+    flex-shrink: 0;
   }
-}
-
-.ItemWrapper {
-  display: flex;
-  align-items: center;
-  /* This min-height matches the height of the expand/collapse button.
-     Without it, the labels/tokens will do a slight layout shift when expanded.
-     This is because the height of the first row will match the token sizes,
-     but the height of the second row will be the height of the collapse button.
-  */
-  min-height: 28px;
-}
-
-.ItemWrapper--hidden {
-  order: 9999;
-  pointer-events: none;
-  visibility: hidden;
-}
-
-.OverlayContainer {
-  align-items: flex-start;
-  display: flex;
-}
-
-.OverlayInner {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--base-size-4);
-}
-
-.CloseButton {
-  flex-shrink: 0;
 }

--- a/packages/react/src/NavList/NavList.module.css
+++ b/packages/react/src/NavList/NavList.module.css
@@ -1,8 +1,10 @@
-.GroupHeading > a {
-  color: var(--fgColor-default);
-  text-decoration: inherit;
-}
+@layer primer.components.NavList {
+  .GroupHeading > a {
+    color: var(--fgColor-default);
+    text-decoration: inherit;
+  }
 
-.GroupHeading > a:hover {
-  text-decoration: underline;
+  .GroupHeading > a:hover {
+    text-decoration: underline;
+  }
 }

--- a/packages/react/src/SegmentedControl/SegmentedControl.module.css
+++ b/packages/react/src/SegmentedControl/SegmentedControl.module.css
@@ -1,352 +1,354 @@
-.SegmentedControl {
-  /* TODO: use primitive `control.medium.size` when it is available instead of '32px' */
-  --segmented-control-icon-width: 32px;
-
-  display: inline-flex;
-
-  /* TODO: use primitive `control.{small|medium}.size` when it is available */
-  height: 32px;
-  padding: 0;
-  margin: 0;
-  font-size: var(--text-body-size-medium);
-  background-color: var(--controlTrack-bgColor-rest);
-  border: var(--borderWidth-thin) solid var(--controlTrack-borderColor-rest, transparent);
-  border-radius: var(--borderRadius-medium);
-
-  /* Responsive full-width */
-  &[data-full-width='true'] {
-    display: flex;
-    width: 100%;
-
-    --segmented-control-icon-width: 100%;
-  }
-
-  &[data-full-width='false'] {
-    display: inline-flex;
-    width: auto;
-
+@layer primer.components.SegmentedControl {
+  .SegmentedControl {
+    /* TODO: use primitive `control.medium.size` when it is available instead of '32px' */
     --segmented-control-icon-width: 32px;
-  }
 
-  @media (--viewportRange-narrow) {
-    &[data-full-width-narrow='true'] {
-      display: flex;
-      width: 100%;
+    display: inline-flex;
 
-      --segmented-control-icon-width: 100%;
-    }
-
-    &[data-full-width-narrow='false'] {
-      display: inline-flex;
-      width: auto;
-
-      --segmented-control-icon-width: 32px;
-    }
-  }
-
-  @media (--viewportRange-regular) {
-    &[data-full-width-regular='true'] {
-      display: flex;
-      width: 100%;
-
-      --segmented-control-icon-width: 100%;
-    }
-
-    &[data-full-width-regular='false'] {
-      display: inline-flex;
-      width: auto;
-
-      --segmented-control-icon-width: 32px;
-    }
-  }
-
-  @media (--viewportRange-wide) {
-    &[data-full-width-wide='true'] {
-      display: flex;
-      width: 100%;
-
-      --segmented-control-icon-width: 100%;
-    }
-
-    &[data-full-width-wide='false'] {
-      display: inline-flex;
-      width: auto;
-
-      --segmented-control-icon-width: 32px;
-    }
-
-    &[data-full-width-regular='true']:not([data-full-width-wide='true']) {
-      display: inline-flex;
-      width: auto;
-
-      --segmented-control-icon-width: 32px;
-    }
-  }
-
-  /* Hide when dropdown variant is active */
-  &[data-variant='dropdown'] {
-    display: none;
-  }
-
-  /* Handle hideLabels variant - hide button text */
-  &[data-variant='hideLabels'] .Text {
-    display: none;
-  }
-
-  @media (--viewportRange-narrow) {
-    &[data-variant-narrow='dropdown'] {
-      display: none;
-    }
-
-    &[data-variant-narrow='hideLabels'] .Text {
-      display: none;
-    }
-  }
-
-  @media (--viewportRange-regular) {
-    &[data-variant-regular='dropdown'] {
-      display: none;
-    }
-
-    &[data-variant-regular='hideLabels'] .Text {
-      display: none;
-    }
-  }
-
-  @media (--viewportRange-wide) {
-    &[data-variant-wide='dropdown'] {
-      display: none;
-    }
-
-    &[data-variant-wide='hideLabels'] .Text {
-      display: none;
-    }
-  }
-
-  &:where([data-size='small']) {
     /* TODO: use primitive `control.{small|medium}.size` when it is available */
-    height: 28px;
-    font-size: var(--text-body-size-small);
+    height: 32px;
+    padding: 0;
+    margin: 0;
+    font-size: var(--text-body-size-medium);
+    background-color: var(--controlTrack-bgColor-rest);
+    border: var(--borderWidth-thin) solid var(--controlTrack-borderColor-rest, transparent);
+    border-radius: var(--borderRadius-medium);
+
+    /* Responsive full-width */
+    &[data-full-width='true'] {
+      display: flex;
+      width: 100%;
+
+      --segmented-control-icon-width: 100%;
+    }
+
+    &[data-full-width='false'] {
+      display: inline-flex;
+      width: auto;
+
+      --segmented-control-icon-width: 32px;
+    }
+
+    @media (--viewportRange-narrow) {
+      &[data-full-width-narrow='true'] {
+        display: flex;
+        width: 100%;
+
+        --segmented-control-icon-width: 100%;
+      }
+
+      &[data-full-width-narrow='false'] {
+        display: inline-flex;
+        width: auto;
+
+        --segmented-control-icon-width: 32px;
+      }
+    }
+
+    @media (--viewportRange-regular) {
+      &[data-full-width-regular='true'] {
+        display: flex;
+        width: 100%;
+
+        --segmented-control-icon-width: 100%;
+      }
+
+      &[data-full-width-regular='false'] {
+        display: inline-flex;
+        width: auto;
+
+        --segmented-control-icon-width: 32px;
+      }
+    }
+
+    @media (--viewportRange-wide) {
+      &[data-full-width-wide='true'] {
+        display: flex;
+        width: 100%;
+
+        --segmented-control-icon-width: 100%;
+      }
+
+      &[data-full-width-wide='false'] {
+        display: inline-flex;
+        width: auto;
+
+        --segmented-control-icon-width: 32px;
+      }
+
+      &[data-full-width-regular='true']:not([data-full-width-wide='true']) {
+        display: inline-flex;
+        width: auto;
+
+        --segmented-control-icon-width: 32px;
+      }
+    }
+
+    /* Hide when dropdown variant is active */
+    &[data-variant='dropdown'] {
+      display: none;
+    }
+
+    /* Handle hideLabels variant - hide button text */
+    &[data-variant='hideLabels'] .Text {
+      display: none;
+    }
+
+    @media (--viewportRange-narrow) {
+      &[data-variant-narrow='dropdown'] {
+        display: none;
+      }
+
+      &[data-variant-narrow='hideLabels'] .Text {
+        display: none;
+      }
+    }
+
+    @media (--viewportRange-regular) {
+      &[data-variant-regular='dropdown'] {
+        display: none;
+      }
+
+      &[data-variant-regular='hideLabels'] .Text {
+        display: none;
+      }
+    }
+
+    @media (--viewportRange-wide) {
+      &[data-variant-wide='dropdown'] {
+        display: none;
+      }
+
+      &[data-variant-wide='hideLabels'] .Text {
+        display: none;
+      }
+    }
+
+    &:where([data-size='small']) {
+      /* TODO: use primitive `control.{small|medium}.size` when it is available */
+      height: 28px;
+      font-size: var(--text-body-size-small);
+    }
   }
-}
 
-.DropdownContainer {
-  display: none;
+  .DropdownContainer {
+    display: none;
 
-  /* Show when dropdown variant is active */
-  &[data-variant='dropdown'] {
+    /* Show when dropdown variant is active */
+    &[data-variant='dropdown'] {
+      display: block;
+    }
+
+    @media (--viewportRange-narrow) {
+      &[data-variant-narrow='dropdown'] {
+        display: block;
+      }
+    }
+
+    @media (--viewportRange-regular) {
+      &[data-variant-regular='dropdown'] {
+        display: block;
+      }
+    }
+
+    @media (--viewportRange-wide) {
+      &[data-variant-wide='dropdown'] {
+        display: block;
+      }
+    }
+  }
+
+  .Item {
+    position: relative;
     display: block;
-  }
-
-  @media (--viewportRange-narrow) {
-    &[data-variant-narrow='dropdown'] {
-      display: block;
-    }
-  }
-
-  @media (--viewportRange-regular) {
-    &[data-variant-regular='dropdown'] {
-      display: block;
-    }
-  }
-
-  @media (--viewportRange-wide) {
-    &[data-variant-wide='dropdown'] {
-      display: block;
-    }
-  }
-}
-
-.Item {
-  position: relative;
-  display: block;
-  /* stylelint-disable-next-line primer/spacing */
-  margin-top: -1px;
-  /* stylelint-disable-next-line primer/spacing */
-  margin-bottom: -1px;
-  flex-grow: 1;
-
-  &:not(:last-child) {
     /* stylelint-disable-next-line primer/spacing */
-    margin-right: 1px;
+    margin-top: -1px;
+    /* stylelint-disable-next-line primer/spacing */
+    margin-bottom: -1px;
+    flex-grow: 1;
 
-    &::after {
-      position: absolute;
-      top: var(--base-size-8);
-      right: calc(-1 * var(--base-size-2));
-      bottom: var(--base-size-8);
-      width: 1px;
-      content: '';
-      /* stylelint-disable-next-line primer/colors */
-      background-color: var(--borderColor-default);
+    &:not(:last-child) {
+      /* stylelint-disable-next-line primer/spacing */
+      margin-right: 1px;
+
+      &::after {
+        position: absolute;
+        top: var(--base-size-8);
+        right: calc(-1 * var(--base-size-2));
+        bottom: var(--base-size-8);
+        width: 1px;
+        content: '';
+        /* stylelint-disable-next-line primer/colors */
+        background-color: var(--borderColor-default);
+      }
+
+      /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- scoped to CSS Module, audited (github/github-ui#17224) */
+      &:has(+ [data-selected])::after,
+      &:where([data-selected])::after {
+        background-color: transparent;
+      }
     }
 
     /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- scoped to CSS Module, audited (github/github-ui#17224) */
-    &:has(+ [data-selected])::after,
-    &:where([data-selected])::after {
+    &:focus-within:has(:focus-visible) {
       background-color: transparent;
     }
+
+    &:first-child {
+      /* stylelint-disable-next-line primer/spacing */
+      margin-left: -1px;
+    }
+
+    &:last-child {
+      /* stylelint-disable-next-line primer/spacing */
+      margin-right: -1px;
+    }
+
+    .Counter {
+      margin-inline-start: var(--base-size-8);
+      display: flex;
+      align-items: center;
+    }
   }
 
-  /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- scoped to CSS Module, audited (github/github-ui#17224) */
-  &:focus-within:has(:focus-visible) {
+  .Button {
+    /* TODO: use primitive `primer.control.medium.paddingInline.normal` when it is available */
+    --segmented-control-button-inner-padding: 12px;
+    --segmented-control-button-bg-inset: 4px;
+    --segmented-control-outer-radius: var(--borderRadius-medium);
+
+    width: 100%;
+    height: 100%;
+    /* stylelint-disable-next-line primer/spacing */
+    padding: var(--segmented-control-button-bg-inset);
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: var(--base-text-weight-normal);
+    color: currentColor;
+    cursor: pointer;
     background-color: transparent;
-  }
-
-  &:first-child {
-    /* stylelint-disable-next-line primer/spacing */
-    margin-left: -1px;
-  }
-
-  &:last-child {
-    /* stylelint-disable-next-line primer/spacing */
-    margin-right: -1px;
-  }
-
-  .Counter {
-    margin-inline-start: var(--base-size-8);
-    display: flex;
-    align-items: center;
-  }
-}
-
-.Button {
-  /* TODO: use primitive `primer.control.medium.paddingInline.normal` when it is available */
-  --segmented-control-button-inner-padding: 12px;
-  --segmented-control-button-bg-inset: 4px;
-  --segmented-control-outer-radius: var(--borderRadius-medium);
-
-  width: 100%;
-  height: 100%;
-  /* stylelint-disable-next-line primer/spacing */
-  padding: var(--segmented-control-button-bg-inset);
-  font-family: inherit;
-  font-size: inherit;
-  font-weight: var(--base-text-weight-normal);
-  color: currentColor;
-  cursor: pointer;
-  background-color: transparent;
-  border-color: transparent;
-  border-width: 0;
-  /* stylelint-disable-next-line primer/borders */
-  border-radius: var(--segmented-control-outer-radius);
-
-  & svg {
-    fill: var(--fgColor-muted);
-    color: var(--fgColor-muted);
-  }
-
-  /* fallback :focus state */
-  &:focus:not(:disabled) {
-    outline: var(--base-size-2) solid var(--fgColor-accent);
-    outline-offset: -1px;
-    box-shadow: none;
-
-    /* remove fallback :focus if :focus-visible is supported */
-    &:not(:focus-visible) {
-      outline: solid 1px transparent;
-    }
-  }
-
-  /* default focus state */
-  &:focus-visible:not(:disabled) {
-    outline: var(--base-size-2) solid var(--fgColor-accent);
-    outline-offset: -1px;
-    box-shadow: none;
-  }
-
-  /* stylelint-disable-next-line selector-max-specificity */
-  &:focus:focus-visible:not(:last-child)::after {
-    /* fixes an issue where the focus outline shows over the pseudo-element */
-    width: 0;
-  }
-
-  &[aria-disabled='true']:not([aria-current='true']) {
-    cursor: not-allowed;
-    color: var(--fgColor-disabled);
-    background-color: transparent;
-
-    & svg {
-      fill: var(--fgColor-disabled);
-      color: var(--fgColor-disabled);
-    }
-  }
-
-  @media (pointer: coarse) {
-    &::before {
-      position: absolute;
-      top: 50%;
-      right: 0;
-      left: 0;
-      min-height: 44px;
-      content: '';
-      transform: translateY(-50%);
-    }
-  }
-}
-
-.IconButton {
-  width: var(--segmented-control-icon-width, 32px);
-}
-
-.Content {
-  display: flex;
-  height: 100%;
-  /* stylelint-disable-next-line primer/spacing */
-  padding-right: calc(var(--segmented-control-button-inner-padding) - var(--segmented-control-button-bg-inset));
-  /* stylelint-disable-next-line primer/spacing */
-  padding-left: calc(var(--segmented-control-button-inner-padding) - var(--segmented-control-button-bg-inset));
-  border-color: transparent;
-  border-style: solid;
-  border-width: var(--borderWidth-thin);
-
-  /*
-    innerRadius = outerRadius - distance/2
-    https://stackoverflow.com/questions/2932146/math-problem-determine-the-corner-radius-of-an-inner-border-based-on-outer-corn
-  */
-  /* stylelint-disable-next-line primer/borders */
-  border-radius: calc(var(--segmented-control-outer-radius) - var(--segmented-control-button-bg-inset) / 2);
-  align-items: center;
-  justify-content: center;
-}
-
-.Button[aria-current='true'] {
-  padding: 0;
-  font-weight: var(--base-text-weight-semibold);
-
-  .Content {
-    /* stylelint-disable-next-line primer/spacing */
-    padding-right: var(--segmented-control-button-inner-padding);
-    /* stylelint-disable-next-line primer/spacing */
-    padding-left: var(--segmented-control-button-inner-padding);
-    background-color: var(--controlKnob-bgColor-rest);
-    border-color: var(--controlKnob-borderColor-rest);
+    border-color: transparent;
+    border-width: 0;
     /* stylelint-disable-next-line primer/borders */
     border-radius: var(--segmented-control-outer-radius);
+
+    & svg {
+      fill: var(--fgColor-muted);
+      color: var(--fgColor-muted);
+    }
+
+    /* fallback :focus state */
+    &:focus:not(:disabled) {
+      outline: var(--base-size-2) solid var(--fgColor-accent);
+      outline-offset: -1px;
+      box-shadow: none;
+
+      /* remove fallback :focus if :focus-visible is supported */
+      &:not(:focus-visible) {
+        outline: solid 1px transparent;
+      }
+    }
+
+    /* default focus state */
+    &:focus-visible:not(:disabled) {
+      outline: var(--base-size-2) solid var(--fgColor-accent);
+      outline-offset: -1px;
+      box-shadow: none;
+    }
+
+    /* stylelint-disable-next-line selector-max-specificity */
+    &:focus:focus-visible:not(:last-child)::after {
+      /* fixes an issue where the focus outline shows over the pseudo-element */
+      width: 0;
+    }
+
+    &[aria-disabled='true']:not([aria-current='true']) {
+      cursor: not-allowed;
+      color: var(--fgColor-disabled);
+      background-color: transparent;
+
+      & svg {
+        fill: var(--fgColor-disabled);
+        color: var(--fgColor-disabled);
+      }
+    }
+
+    @media (pointer: coarse) {
+      &::before {
+        position: absolute;
+        top: 50%;
+        right: 0;
+        left: 0;
+        min-height: 44px;
+        content: '';
+        transform: translateY(-50%);
+      }
+    }
   }
-}
 
-.Button:not([aria-current='true'], [aria-disabled='true']) {
-  &:hover .Content {
-    background-color: var(--controlTrack-bgColor-hover);
+  .IconButton {
+    width: var(--segmented-control-icon-width, 32px);
   }
 
-  &:active .Content {
-    background-color: var(--controlTrack-bgColor-active);
+  .Content {
+    display: flex;
+    height: 100%;
+    /* stylelint-disable-next-line primer/spacing */
+    padding-right: calc(var(--segmented-control-button-inner-padding) - var(--segmented-control-button-bg-inset));
+    /* stylelint-disable-next-line primer/spacing */
+    padding-left: calc(var(--segmented-control-button-inner-padding) - var(--segmented-control-button-bg-inset));
+    border-color: transparent;
+    border-style: solid;
+    border-width: var(--borderWidth-thin);
+
+    /*
+      innerRadius = outerRadius - distance/2
+      https://stackoverflow.com/questions/2932146/math-problem-determine-the-corner-radius-of-an-inner-border-based-on-outer-corn
+    */
+    /* stylelint-disable-next-line primer/borders */
+    border-radius: calc(var(--segmented-control-outer-radius) - var(--segmented-control-button-bg-inset) / 2);
+    align-items: center;
+    justify-content: center;
   }
-}
 
-.Text::after {
-  display: block;
-  height: 0;
-  overflow: hidden;
-  font-weight: var(--base-text-weight-semibold);
-  pointer-events: none;
-  visibility: hidden;
-  content: attr(data-text);
-  user-select: none;
-}
+  .Button[aria-current='true'] {
+    padding: 0;
+    font-weight: var(--base-text-weight-semibold);
 
-.LeadingIcon {
-  margin-right: var(--base-size-4);
+    .Content {
+      /* stylelint-disable-next-line primer/spacing */
+      padding-right: var(--segmented-control-button-inner-padding);
+      /* stylelint-disable-next-line primer/spacing */
+      padding-left: var(--segmented-control-button-inner-padding);
+      background-color: var(--controlKnob-bgColor-rest);
+      border-color: var(--controlKnob-borderColor-rest);
+      /* stylelint-disable-next-line primer/borders */
+      border-radius: var(--segmented-control-outer-radius);
+    }
+  }
+
+  .Button:not([aria-current='true'], [aria-disabled='true']) {
+    &:hover .Content {
+      background-color: var(--controlTrack-bgColor-hover);
+    }
+
+    &:active .Content {
+      background-color: var(--controlTrack-bgColor-active);
+    }
+  }
+
+  .Text::after {
+    display: block;
+    height: 0;
+    overflow: hidden;
+    font-weight: var(--base-text-weight-semibold);
+    pointer-events: none;
+    visibility: hidden;
+    content: attr(data-text);
+    user-select: none;
+  }
+
+  .LeadingIcon {
+    margin-right: var(--base-size-4);
+  }
 }

--- a/packages/react/src/TreeView/TreeView.module.css
+++ b/packages/react/src/TreeView/TreeView.module.css
@@ -1,291 +1,293 @@
-.TreeViewRootUlStyles {
-  padding: 0;
-  margin: 0;
-  list-style: none;
+@layer primer.components.TreeView {
+  .TreeViewRootUlStyles {
+    padding: 0;
+    margin: 0;
+    list-style: none;
 
-  /*
-   * WARNING: This is a performance optimization.
-   *
-   * We define styles for the tree items at the root level of the tree
-   * to avoid recomputing the styles for each item when the tree updates.
-   * We're sacrificing maintainability for performance because TreeView
-   * needs to be performant enough to handle large trees (thousands of items).
-   *
-   * This is intended to be a temporary solution until we can improve the
-   * performance of our styling patterns.
-   *
-   * Do NOT copy this pattern without understanding the tradeoffs.
-   */
-  .TreeViewItem {
     /*
-     * `overflow-clip-margin` extends the paint clip edge by 8px so the current-item indicator
-     * (positioned at `left: -8px` of the row container) remains visible when a consumer applies
-     * `contain: paint` (or `contain: strict`, or `content-visibility: auto`) to this `<li>`. Has
-     * no effect when no paint containment is active, so default rendering is unchanged.
+     * WARNING: This is a performance optimization.
+     *
+     * We define styles for the tree items at the root level of the tree
+     * to avoid recomputing the styles for each item when the tree updates.
+     * We're sacrificing maintainability for performance because TreeView
+     * needs to be performant enough to handle large trees (thousands of items).
+     *
+     * This is intended to be a temporary solution until we can improve the
+     * performance of our styling patterns.
+     *
+     * Do NOT copy this pattern without understanding the tradeoffs.
      */
-    overflow-clip-margin: var(--base-size-8);
-    outline: none;
-
-    &:focus-visible > div,
-    &:global(.focus-visible) > div {
-      box-shadow: var(--boxShadow-thick) var(--fgColor-accent);
-
-      @media (forced-colors: active) {
-        outline: 2px solid HighlightText;
-        outline-offset: -2px;
-      }
-    }
-
-    &[data-has-leading-action] {
-      --has-leading-action: 1;
-    }
-  }
-
-  .TreeViewItemContainer {
-    --level: 1;
-    --toggle-width: 1rem;
-    --min-item-height: 2rem;
-
-    position: relative;
-    display: grid;
-    width: 100%;
-    /*
-     * Mirrors the `overflow-clip-margin` on `.TreeViewItem` so the indicator also stays
-     * visible when `containIntrinsicSize` is set on this row (which sets
-     * `content-visibility: auto` on this container and implies paint containment).
-     */
-    overflow-clip-margin: var(--base-size-8);
-    font-size: var(--text-body-size-medium);
-    color: var(--fgColor-default);
-    cursor: pointer;
-    border-radius: var(--borderRadius-medium);
-    grid-template-columns: var(--spacer-width) var(--leading-action-width) var(--toggle-width) 1fr auto;
-    grid-template-areas: 'spacer leadingAction toggle content trailingAction';
-
-    --leading-action-width: calc(var(--has-leading-action, 0) * 1.5rem);
-    --spacer-width: calc(calc(var(--level) - 1) * (var(--toggle-width) / 2));
-
-    &:hover {
-      background-color: var(--control-transparent-bgColor-hover);
-
-      @media (forced-colors: active) {
-        outline: 2px solid transparent;
-        outline-offset: -2px;
-      }
-    }
-
-    @media (pointer: coarse) {
-      --toggle-width: 1.5rem;
-      --min-item-height: 2.75rem;
-    }
-  }
-
-  &:where([data-omit-spacer='true']) .TreeViewItemContainer {
-    grid-template-columns: 0 0 0 1fr auto;
-  }
-
-  /*
-   * Suppress hover affordances on rows being used as skeleton loading placeholders.
-   * Marked positively via `data-loading` from `LoadingItem` so we avoid the broad
-   * invalidation cost of `:has(.TreeViewItemSkeleton)` across every row in large trees.
-   */
-  .TreeViewItem:where([data-loading]) > .TreeViewItemContainer:hover {
-    cursor: default;
-    background-color: transparent;
-
-    @media (forced-colors: active) {
-      outline: none;
-    }
-  }
-
-  .TreeViewItem[aria-current='true'] > .TreeViewItemContainer {
-    background-color: var(--control-transparent-bgColor-selected);
-
-    /* Current item indicator */
-    /* stylelint-disable-next-line selector-max-specificity */
-    &::after {
-      position: absolute;
-      top: calc(50% - var(--base-size-12));
-      left: calc(-1 * var(--base-size-8));
-      width: 0.25rem;
-      height: 1.5rem;
-      content: '';
-
+    .TreeViewItem {
       /*
-       * Use fgColor accent for consistency across all themes. Using the "correct" variable,
-       * --bgColor-accent-emphasis, causes vrt failures for dark high contrast mode
+       * `overflow-clip-margin` extends the paint clip edge by 8px so the current-item indicator
+       * (positioned at `left: -8px` of the row container) remains visible when a consumer applies
+       * `contain: paint` (or `contain: strict`, or `content-visibility: auto`) to this `<li>`. Has
+       * no effect when no paint containment is active, so default rendering is unchanged.
        */
-      /* stylelint-disable-next-line primer/colors */
-      background-color: var(--fgColor-accent);
-      border-radius: var(--borderRadius-medium);
+      overflow-clip-margin: var(--base-size-8);
+      outline: none;
 
-      @media (forced-colors: active) {
-        background-color: HighlightText;
+      &:focus-visible > div,
+      &:global(.focus-visible) > div {
+        box-shadow: var(--boxShadow-thick) var(--fgColor-accent);
+
+        @media (forced-colors: active) {
+          outline: 2px solid HighlightText;
+          outline-offset: -2px;
+        }
+      }
+
+      &[data-has-leading-action] {
+        --has-leading-action: 1;
       }
     }
-  }
 
-  .TreeViewItemToggle {
-    display: flex;
-    height: 100%;
+    .TreeViewItemContainer {
+      --level: 1;
+      --toggle-width: 1rem;
+      --min-item-height: 2rem;
 
-    /* The toggle should appear vertically centered for single-line items, but remain at the top for items that wrap
-    across more lines. */
-    /* stylelint-disable-next-line primer/spacing */
-    padding-top: calc(var(--min-item-height) / 2 - var(--base-size-12) / 2);
-    color: var(--fgColor-muted);
-    grid-area: toggle;
-    justify-content: center;
-    align-items: flex-start;
-  }
+      position: relative;
+      display: grid;
+      width: 100%;
+      /*
+       * Mirrors the `overflow-clip-margin` on `.TreeViewItem` so the indicator also stays
+       * visible when `containIntrinsicSize` is set on this row (which sets
+       * `content-visibility: auto` on this container and implies paint containment).
+       */
+      overflow-clip-margin: var(--base-size-8);
+      font-size: var(--text-body-size-medium);
+      color: var(--fgColor-default);
+      cursor: pointer;
+      border-radius: var(--borderRadius-medium);
+      grid-template-columns: var(--spacer-width) var(--leading-action-width) var(--toggle-width) 1fr auto;
+      grid-template-areas: 'spacer leadingAction toggle content trailingAction';
 
-  .TreeViewItemToggleHover:hover {
-    background-color: var(--control-transparent-bgColor-hover);
-  }
+      --leading-action-width: calc(var(--has-leading-action, 0) * 1.5rem);
+      --spacer-width: calc(calc(var(--level) - 1) * (var(--toggle-width) / 2));
 
-  .TreeViewItemToggleEnd {
-    border-top-left-radius: var(--borderRadius-medium);
-    border-bottom-left-radius: var(--borderRadius-medium);
-  }
+      &:hover {
+        background-color: var(--control-transparent-bgColor-hover);
 
-  .TreeViewItemContent {
-    display: flex;
-    height: 100%;
-    padding: 0 var(--base-size-8);
+        @media (forced-colors: active) {
+          outline: 2px solid transparent;
+          outline-offset: -2px;
+        }
+      }
 
-    /* The dynamic top and bottom padding to maintain the minimum item height for single line items */
-    /* stylelint-disable-next-line primer/spacing */
-    padding-top: calc((var(--min-item-height) - var(--custom-line-height, 1.3rem)) / 2);
-    /* stylelint-disable-next-line primer/spacing */
-    padding-bottom: calc((var(--min-item-height) - var(--custom-line-height, 1.3rem)) / 2);
-    line-height: var(--custom-line-height, var(--text-body-lineHeight-medium, 1.4285));
-    grid-area: content;
-    gap: var(--stack-gap-condensed);
-  }
+      @media (pointer: coarse) {
+        --toggle-width: 1.5rem;
+        --min-item-height: 2.75rem;
+      }
+    }
 
-  .TreeViewItemContentText {
-    flex: 1 1 auto;
-    width: 0;
-  }
+    &:where([data-omit-spacer='true']) .TreeViewItemContainer {
+      grid-template-columns: 0 0 0 1fr auto;
+    }
 
-  &:where([data-truncate-text='true']) .TreeViewItemContentText {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+    /*
+     * Suppress hover affordances on rows being used as skeleton loading placeholders.
+     * Marked positively via `data-loading` from `LoadingItem` so we avoid the broad
+     * invalidation cost of `:has(.TreeViewItemSkeleton)` across every row in large trees.
+     */
+    .TreeViewItem:where([data-loading]) > .TreeViewItemContainer:hover {
+      cursor: default;
+      background-color: transparent;
 
-  &:where([data-truncate-text='false']) .TreeViewItemContentText {
-    /* stylelint-disable-next-line declaration-property-value-keyword-no-deprecated */
-    word-break: break-word;
-  }
+      @media (forced-colors: active) {
+        outline: none;
+      }
+    }
 
-  .TreeViewItemVisual {
-    display: flex;
+    .TreeViewItem[aria-current='true'] > .TreeViewItemContainer {
+      background-color: var(--control-transparent-bgColor-selected);
 
-    /* The visual icons should appear vertically centered for single-line items, but remain at the top for items that wrap
-    across more lines. */
-    height: var(--custom-line-height, 1.3rem);
-    color: var(--fgColor-muted);
-    align-items: center;
-  }
+      /* Current item indicator */
+      /* stylelint-disable-next-line selector-max-specificity */
+      &::after {
+        position: absolute;
+        top: calc(50% - var(--base-size-12));
+        left: calc(-1 * var(--base-size-8));
+        width: 0.25rem;
+        height: 1.5rem;
+        content: '';
 
-  .TreeViewItemLeadingAction {
-    display: flex;
-    color: var(--fgColor-muted);
-    grid-area: leadingAction;
+        /*
+         * Use fgColor accent for consistency across all themes. Using the "correct" variable,
+         * --bgColor-accent-emphasis, causes vrt failures for dark high contrast mode
+         */
+        /* stylelint-disable-next-line primer/colors */
+        background-color: var(--fgColor-accent);
+        border-radius: var(--borderRadius-medium);
 
-    & > button {
+        @media (forced-colors: active) {
+          background-color: HighlightText;
+        }
+      }
+    }
+
+    .TreeViewItemToggle {
+      display: flex;
+      height: 100%;
+
+      /* The toggle should appear vertically centered for single-line items, but remain at the top for items that wrap
+      across more lines. */
+      /* stylelint-disable-next-line primer/spacing */
+      padding-top: calc(var(--min-item-height) / 2 - var(--base-size-12) / 2);
+      color: var(--fgColor-muted);
+      grid-area: toggle;
+      justify-content: center;
+      align-items: flex-start;
+    }
+
+    .TreeViewItemToggleHover:hover {
+      background-color: var(--control-transparent-bgColor-hover);
+    }
+
+    .TreeViewItemToggleEnd {
+      border-top-left-radius: var(--borderRadius-medium);
+      border-bottom-left-radius: var(--borderRadius-medium);
+    }
+
+    .TreeViewItemContent {
+      display: flex;
+      height: 100%;
+      padding: 0 var(--base-size-8);
+
+      /* The dynamic top and bottom padding to maintain the minimum item height for single line items */
+      /* stylelint-disable-next-line primer/spacing */
+      padding-top: calc((var(--min-item-height) - var(--custom-line-height, 1.3rem)) / 2);
+      /* stylelint-disable-next-line primer/spacing */
+      padding-bottom: calc((var(--min-item-height) - var(--custom-line-height, 1.3rem)) / 2);
+      line-height: var(--custom-line-height, var(--text-body-lineHeight-medium, 1.4285));
+      grid-area: content;
+      gap: var(--stack-gap-condensed);
+    }
+
+    .TreeViewItemContentText {
+      flex: 1 1 auto;
+      width: 0;
+    }
+
+    &:where([data-truncate-text='true']) .TreeViewItemContentText {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    &:where([data-truncate-text='false']) .TreeViewItemContentText {
+      /* stylelint-disable-next-line declaration-property-value-keyword-no-deprecated */
+      word-break: break-word;
+    }
+
+    .TreeViewItemVisual {
+      display: flex;
+
+      /* The visual icons should appear vertically centered for single-line items, but remain at the top for items that wrap
+      across more lines. */
+      height: var(--custom-line-height, 1.3rem);
+      color: var(--fgColor-muted);
+      align-items: center;
+    }
+
+    .TreeViewItemLeadingAction {
+      display: flex;
+      color: var(--fgColor-muted);
+      grid-area: leadingAction;
+
+      & > button {
+        flex-shrink: 1;
+      }
+    }
+
+    .TreeViewItemTrailingAction {
+      display: flex;
+      color: var(--fgColor-muted);
+      grid-area: trailingAction;
+    }
+
+    .TreeViewItemTrailingActionButton {
       flex-shrink: 1;
     }
-  }
 
-  .TreeViewItemTrailingAction {
-    display: flex;
-    color: var(--fgColor-muted);
-    grid-area: trailingAction;
-  }
+    .TreeViewItemLevelLine {
+      width: 100%;
+      height: 100%;
+      border-right: var(--borderWidth-thin) solid;
 
-  .TreeViewItemTrailingActionButton {
-    flex-shrink: 1;
-  }
+      /*
+       * `--tree-line-color` is set on the root `<ul>` and inherited down. On coarse pointers it
+       * stays unset and falls back to `muted` (lines always visible). On hover-capable devices it
+       * is initialized to `transparent` on the root and flipped to `muted` while the tree is
+       * hovered or focused, so the browser only has to propagate a single inherited custom
+       * property instead of re-matching `.TreeViewItemLevelLine` descendant selectors on every
+       * hover/focus change inside large trees.
+       */
+      /* stylelint-disable-next-line primer/colors -- private custom property, defaults to a Primer token */
+      border-color: var(--tree-line-color, var(--borderColor-muted));
+    }
 
-  .TreeViewItemLevelLine {
-    width: 100%;
-    height: 100%;
-    border-right: var(--borderWidth-thin) solid;
+    @media (hover: hover) {
+      --tree-line-color: transparent;
 
-    /*
-     * `--tree-line-color` is set on the root `<ul>` and inherited down. On coarse pointers it
-     * stays unset and falls back to `muted` (lines always visible). On hover-capable devices it
-     * is initialized to `transparent` on the root and flipped to `muted` while the tree is
-     * hovered or focused, so the browser only has to propagate a single inherited custom
-     * property instead of re-matching `.TreeViewItemLevelLine` descendant selectors on every
-     * hover/focus change inside large trees.
-     */
-    /* stylelint-disable-next-line primer/colors -- private custom property, defaults to a Primer token */
-    border-color: var(--tree-line-color, var(--borderColor-muted));
-  }
+      &:hover,
+      &:focus-within {
+        --tree-line-color: var(--borderColor-muted);
+      }
+    }
 
-  @media (hover: hover) {
-    --tree-line-color: transparent;
+    .TreeViewDirectoryIcon {
+      display: grid;
+      color: var(--treeViewItem-leadingVisual-iconColor-rest);
+    }
 
-    &:hover,
-    &:focus-within {
-      --tree-line-color: var(--borderColor-muted);
+    .TreeViewVisuallyHidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      /* stylelint-disable-next-line primer/spacing */
+      margin: -1px;
+      overflow: hidden;
+      /* stylelint-disable-next-line property-no-deprecated */
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border-width: 0;
     }
   }
 
-  .TreeViewDirectoryIcon {
-    display: grid;
-    color: var(--treeViewItem-leadingVisual-iconColor-rest);
+  .TreeViewSkeletonItemContainerStyle {
+    display: flex;
+    align-items: center;
+    column-gap: 0.5rem;
+    height: 2rem;
+
+    @media (pointer: coarse) {
+      height: 2.75rem;
+    }
+
+    &:nth-of-type(5n + 1) {
+      --tree-item-loading-width: 67%;
+    }
+
+    &:nth-of-type(5n + 2) {
+      --tree-item-loading-width: 47%;
+    }
+
+    &:nth-of-type(5n + 3) {
+      --tree-item-loading-width: 73%;
+    }
+
+    &:nth-of-type(5n + 4) {
+      --tree-item-loading-width: 64%;
+    }
+
+    &:nth-of-type(5n + 5) {
+      --tree-item-loading-width: 50%;
+    }
   }
 
-  .TreeViewVisuallyHidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    /* stylelint-disable-next-line primer/spacing */
-    margin: -1px;
-    overflow: hidden;
-    /* stylelint-disable-next-line property-no-deprecated */
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border-width: 0;
+  .TreeItemSkeletonTextStyles {
+    width: var(--tree-item-loading-width, 67%);
   }
-}
-
-.TreeViewSkeletonItemContainerStyle {
-  display: flex;
-  align-items: center;
-  column-gap: 0.5rem;
-  height: 2rem;
-
-  @media (pointer: coarse) {
-    height: 2.75rem;
-  }
-
-  &:nth-of-type(5n + 1) {
-    --tree-item-loading-width: 67%;
-  }
-
-  &:nth-of-type(5n + 2) {
-    --tree-item-loading-width: 47%;
-  }
-
-  &:nth-of-type(5n + 3) {
-    --tree-item-loading-width: 73%;
-  }
-
-  &:nth-of-type(5n + 4) {
-    --tree-item-loading-width: 64%;
-  }
-
-  &:nth-of-type(5n + 5) {
-    --tree-item-loading-width: 50%;
-  }
-}
-
-.TreeItemSkeletonTextStyles {
-  width: var(--tree-item-loading-width, 67%);
 }

--- a/packages/react/src/UnderlineNav/UnderlineNav.module.css
+++ b/packages/react/src/UnderlineNav/UnderlineNav.module.css
@@ -1,22 +1,24 @@
-.MenuItemContent {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
+@layer primer.components.UnderlineNav {
+  .MenuItemContent {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
 
-/* More button styles migrated from styles.ts (was moreBtnStyles) */
-.MoreButton {
-  margin: 0; /* reset Safari extra margin */
-  border: 0;
-  background: transparent;
-  font-weight: var(--base-text-weight-normal);
-  box-shadow: none;
-  padding-top: var(--base-size-4);
-  padding-bottom: var(--base-size-4);
-  padding-left: var(--base-size-8);
-  padding-right: var(--base-size-8);
+  /* More button styles migrated from styles.ts (was moreBtnStyles) */
+  .MoreButton {
+    margin: 0; /* reset Safari extra margin */
+    border: 0;
+    background: transparent;
+    font-weight: var(--base-text-weight-normal);
+    box-shadow: none;
+    padding-top: var(--base-size-4);
+    padding-bottom: var(--base-size-4);
+    padding-left: var(--base-size-8);
+    padding-right: var(--base-size-8);
 
-  & > [data-component='trailingVisual'] {
-    margin-left: 0;
+    & > [data-component='trailingVisual'] {
+      margin-left: 0;
+    }
   }
 }

--- a/packages/react/src/UnderlineNav/UnderlineNavItem.module.css
+++ b/packages/react/src/UnderlineNav/UnderlineNavItem.module.css
@@ -1,5 +1,7 @@
-.UnderlineNavItem {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+@layer primer.components.UnderlineNav {
+  .UnderlineNavItem {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
 }

--- a/packages/react/src/__tests__/css-layers.test.ts
+++ b/packages/react/src/__tests__/css-layers.test.ts
@@ -1,118 +1,37 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import {sync as glob} from 'fast-glob'
 import {generate, parse} from 'css-tree'
 import type {StyleSheet} from 'css-tree'
 import {describe, expect, test} from 'vitest'
 
-const allowlist = new Set([
-  path.resolve(import.meta.dirname, '../Avatar/Avatar.module.css'),
-  path.resolve(import.meta.dirname, '../AvatarStack/AvatarStack.module.css'),
-  path.resolve(import.meta.dirname, '../BaseStyles.module.css'),
-  path.resolve(import.meta.dirname, '../BranchName/BranchName.module.css'),
-  path.resolve(import.meta.dirname, '../ButtonGroup/ButtonGroup.module.css'),
-  path.resolve(import.meta.dirname, '../Card/Card.module.css'),
-  path.resolve(import.meta.dirname, '../Checkbox/Checkbox.module.css'),
-  path.resolve(import.meta.dirname, '../Checkbox/shared.module.css'),
-  path.resolve(import.meta.dirname, '../CircleBadge/CircleBadge.module.css'),
-  path.resolve(import.meta.dirname, '../deprecated/FilteredSearch/FilteredSearch.module.css'),
-  path.resolve(import.meta.dirname, '../deprecated/UnderlineNav/UnderlineNav.module.css'),
-  path.resolve(import.meta.dirname, '../Details/Details.module.css'),
-  path.resolve(import.meta.dirname, '../experimental/CSSComponent/component.module.css'),
-  path.resolve(import.meta.dirname, '../experimental/UnderlinePanels/UnderlinePanels.module.css'),
-  path.resolve(import.meta.dirname, '../Flash/Flash.module.css'),
-  path.resolve(import.meta.dirname, '../Header/Header.module.css'),
-  path.resolve(import.meta.dirname, '../Heading/Heading.module.css'),
-  path.resolve(import.meta.dirname, '../Hidden/Hidden.module.css'),
-  path.resolve(import.meta.dirname, '../InlineMessage/InlineMessage.module.css'),
-  path.resolve(import.meta.dirname, '../internal/components/ButtonReset.module.css'),
-  path.resolve(import.meta.dirname, '../internal/components/Caret.module.css'),
-  path.resolve(import.meta.dirname, '../internal/components/InputLabel.module.css'),
-  path.resolve(import.meta.dirname, '../internal/components/InputValidation.module.css'),
-  path.resolve(import.meta.dirname, '../internal/components/TextInputInnerAction.module.css'),
-  path.resolve(import.meta.dirname, '../internal/components/TextInputInnerVisualSlot.module.css'),
-  path.resolve(import.meta.dirname, '../internal/components/TextInputWrapper.module.css'),
-  path.resolve(import.meta.dirname, '../internal/components/UnderlineTabbedInterface.module.css'),
-  path.resolve(import.meta.dirname, '../internal/components/UnstyledTextInput.module.css'),
-  path.resolve(import.meta.dirname, '../internal/components/ValidationAnimationContainer.module.css'),
-  path.resolve(import.meta.dirname, '../Label/Label.module.css'),
-  path.resolve(import.meta.dirname, '../Link/Link.module.css'),
-  path.resolve(import.meta.dirname, '../Overlay/Overlay.module.css'),
-  path.resolve(import.meta.dirname, '../Pagehead/Pagehead.module.css'),
-  path.resolve(import.meta.dirname, '../PageHeader/PageHeader.module.css'),
-  path.resolve(import.meta.dirname, '../Pagination/Pagination.module.css'),
-  path.resolve(import.meta.dirname, '../Placeholder.module.css'),
-  path.resolve(import.meta.dirname, '../Popover/Popover.module.css'),
-  path.resolve(import.meta.dirname, '../ProgressBar/ProgressBar.module.css'),
-  path.resolve(import.meta.dirname, '../Radio/Radio.module.css'),
-  path.resolve(import.meta.dirname, '../PageLayout/PageLayout.module.css'),
-  path.resolve(import.meta.dirname, '../ScrollableRegion/ScrollableRegion.module.css'),
-  path.resolve(import.meta.dirname, '../Select/Select.module.css'),
-  path.resolve(import.meta.dirname, '../SideNav.module.css'),
-  path.resolve(import.meta.dirname, '../Skeleton/SkeletonBox.module.css'),
-  path.resolve(import.meta.dirname, '../SkeletonAvatar/SkeletonAvatar.module.css'),
-  path.resolve(import.meta.dirname, '../SkeletonText/SkeletonText.module.css'),
-  path.resolve(import.meta.dirname, '../Stack/Stack.module.css'),
-  path.resolve(import.meta.dirname, '../StateLabel/StateLabel.module.css'),
-  path.resolve(import.meta.dirname, '../SubNav/SubNav.module.css'),
-  path.resolve(import.meta.dirname, '../TabNav/TabNav.module.css'),
-  path.resolve(import.meta.dirname, '../Text/Text.module.css'),
-  path.resolve(import.meta.dirname, '../Timeline/Timeline.module.css'),
-  path.resolve(import.meta.dirname, '../Tooltip/Tooltip.module.css'),
-  path.resolve(import.meta.dirname, '../TopicTag/TopicTag.module.css'),
-  path.resolve(import.meta.dirname, '../TopicTag/TopicTagGroup.module.css'),
-  path.resolve(import.meta.dirname, '../Truncate/Truncate.module.css'),
-  path.resolve(import.meta.dirname, '../deprecated/ActionList/Divider.module.css'),
-  path.resolve(import.meta.dirname, '../deprecated/ActionList/Header.module.css'),
-  path.resolve(import.meta.dirname, '../deprecated/ActionList/Item.module.css'),
-  path.resolve(import.meta.dirname, '../deprecated/ActionList/List.module.css'),
-  path.resolve(import.meta.dirname, '../VisuallyHidden/VisuallyHidden.module.css'),
-  path.resolve(import.meta.dirname, '../_VisuallyHidden.module.css'),
-  path.resolve(import.meta.dirname, '../CounterLabel/CounterLabel.module.css'),
-  path.resolve(import.meta.dirname, '../DataTable/Pagination.module.css'),
-  path.resolve(import.meta.dirname, '../DataTable/Table.module.css'),
-  path.resolve(import.meta.dirname, '../internal/components/CheckboxOrRadioGroup/CheckboxOrRadioGroup.module.css'),
-  path.resolve(import.meta.dirname, '../KeybindingHint/KeybindingHint.module.css'),
-  path.resolve(import.meta.dirname, '../KeybindingHint/components/Chord.module.css'),
-  path.resolve(import.meta.dirname, '../Spinner/Spinner.module.css'),
-  path.resolve(import.meta.dirname, '../Textarea/TextArea.module.css'),
-  path.resolve(import.meta.dirname, '../TextInput/TextInput.module.css'),
-  path.resolve(import.meta.dirname, '../ToggleSwitch/ToggleSwitch.module.css'),
-  path.resolve(import.meta.dirname, '../Token/IssueLabelToken.module.css'),
-  path.resolve(import.meta.dirname, '../Token/Token.module.css'),
-  path.resolve(import.meta.dirname, '../Token/TokenBase.module.css'),
-  path.resolve(import.meta.dirname, '../Token/_RemoveTokenButton.module.css'),
-  path.resolve(import.meta.dirname, '../Token/_TokenTextContainer.module.css'),
-  path.resolve(import.meta.dirname, '../TextInputWithTokens/TextInputWithTokens.module.css'),
-  path.resolve(import.meta.dirname, '../TooltipV2/Tooltip.module.css'),
-  path.resolve(import.meta.dirname, '../Button/ButtonBase.module.css'),
-  path.resolve(import.meta.dirname, '../ActionList/ActionList.module.css'),
-  path.resolve(import.meta.dirname, '../ActionList/Group.module.css'),
-  path.resolve(import.meta.dirname, '../ActionList/Heading.module.css'),
-  path.resolve(import.meta.dirname, '../AnchoredOverlay/AnchoredOverlay.module.css'),
-  path.resolve(import.meta.dirname, '../Autocomplete/AutocompleteMenu.module.css'),
-  path.resolve(import.meta.dirname, '../Autocomplete/AutocompleteOverlay.module.css'),
-  path.resolve(import.meta.dirname, '../Banner/Banner.module.css'),
-  path.resolve(import.meta.dirname, '../Blankslate/Blankslate.module.css'),
-  path.resolve(import.meta.dirname, '../Breadcrumbs/Breadcrumbs.module.css'),
-  path.resolve(import.meta.dirname, '../deprecated/DialogV1/Dialog.module.css'),
-  path.resolve(import.meta.dirname, '../Dialog/Dialog.module.css'),
-  path.resolve(import.meta.dirname, '../ActionMenu/ActionMenu.module.css'),
-  path.resolve(import.meta.dirname, '../ActionBar/ActionBar.module.css'),
-  path.resolve(import.meta.dirname, '../experimental/SelectPanel2/SelectPanel.module.css'),
-  path.resolve(import.meta.dirname, '../FilteredActionList/FilteredActionList.module.css'),
-  path.resolve(import.meta.dirname, '../FilteredActionList/FilteredActionListLoaders.module.css'),
-  path.resolve(import.meta.dirname, '../FormControl/FormControl.module.css'),
-  path.resolve(import.meta.dirname, '../FormControl/FormControlCaption.module.css'),
-  path.resolve(import.meta.dirname, '../FormControl/FormControlLeadingVisual.module.css'),
-  path.resolve(import.meta.dirname, '../SelectPanel/SelectPanel.module.css'),
-])
-const files = Array.from(allowlist).map(file => {
-  return [path.relative(path.resolve(import.meta.dirname, '..'), file), file]
+const CSS_LAYER_REGEX = /^primer\.components\.[A-Z][A-Za-z0-9]+$/
+const SRC_DIR = path.resolve(import.meta.dirname, '..')
+
+const CSS_MODULE_IGNORE_PATTERNS = [
+  '**/*.dev.module.css',
+  '**/*.examples.stories.module.css',
+  '**/*.features.module.css',
+  '**/*.figma.module.css',
+  '**/*.stories.module.css',
+  '**/*.test.module.css',
+  '**/*StoryWrapper.module.css',
+  'utils/StressTest.module.css',
+]
+
+const files = glob('**/*.module.css', {
+  absolute: true,
+  cwd: SRC_DIR,
+  ignore: CSS_MODULE_IGNORE_PATTERNS,
+}).map(file => {
+  return [path.relative(SRC_DIR, file), file]
 })
 
-const CSS_LAYER_REGEX = /^primer\.components\.[A-Z][A-Za-z0-9]+$/
-
 describe('CSS Layers', () => {
+  test('discovers migrated CSS Modules', () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
   describe.each(files)('%s', (_name, filename) => {
     const contents = fs.readFileSync(filename, 'utf8')
     const ast = parse(contents, {


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/6275

Migrates LabelGroup, NavList, SegmentedControl, TreeView, and UnderlineNav styles into named Primer component CSS layers.

### Changelog

#### New

- Adds CSS layer coverage for LabelGroup, NavList, SegmentedControl, TreeView, and UnderlineNav.

#### Changed

- Wraps LabelGroup, NavList, SegmentedControl, TreeView, and UnderlineNav CSS module styles in named Primer component layers.
- Switches the CSS layer test to discover migrated runtime CSS modules by glob while excluding story, dev, feature, example, and test CSS modules.

#### Removed

- None

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- Run `cd packages/react && npx vitest run src/__tests__/css-layers.test.ts --config vitest.config.mts`.
- Review this PR as part of the CSS layers stack; this entry covers LabelGroup, NavList, SegmentedControl, TreeView, and UnderlineNav.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))

