### PR TITLE
test: fix async console warnings

### DIFF
--- a/.changeset/fix-anchored-overlay-popover-target.md
+++ b/.changeset/fix-anchored-overlay-popover-target.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+AnchoredOverlay: Render the popover target attribute correctly for popover anchors

--- a/packages/react/src/ActionMenu/ActionMenu.test.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.test.tsx
@@ -353,9 +353,7 @@ describe('ActionMenu', () => {
     const button = component.getByRole('button')
 
     const user = userEvent.setup()
-    await act(async () => {
-      await user.click(button)
-    })
+    await user.click(button)
 
     expect(component.queryByRole('menu')).toBeInTheDocument()
     const menuItems = component.getAllByRole('menuitem')
@@ -368,13 +366,11 @@ describe('ActionMenu', () => {
     await user.keyboard('{ArrowDown}')
     expect(menuItems[1]).toEqual(document.activeElement)
 
-    await act(async () => {
-      // TODO: Removed one ArrowDown to account for the focus trap starting at the second element
-      // await user.keyboard('{ArrowDown}')
-      await user.keyboard('{ArrowDown}')
-      await user.keyboard('{ArrowDown}')
-      await user.keyboard('{ArrowDown}')
-    })
+    // TODO: Removed one ArrowDown to account for the focus trap starting at the second element
+    // await user.keyboard('{ArrowDown}')
+    await user.keyboard('{ArrowDown}')
+    await user.keyboard('{ArrowDown}')
+    await user.keyboard('{ArrowDown}')
     expect(menuItems[menuItems.length - 1]).toEqual(document.activeElement) // last elememt
 
     await user.keyboard('{ArrowDown}')

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
@@ -1,7 +1,7 @@
-import {act, createRef, useCallback, useRef, useState} from 'react'
+import {createRef, useCallback, useRef, useState} from 'react'
 import {describe, expect, it, vi} from 'vitest'
-import {render} from '@testing-library/react'
-import {userEvent} from 'vitest/browser'
+import {act, fireEvent, render} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {AnchoredOverlay} from '../AnchoredOverlay'
 import {Button} from '../Button'
 import BaseStyles from '../BaseStyles'
@@ -105,9 +105,7 @@ describe.each([true, false])(
         />,
       )
       const anchor = anchoredOverlay.baseElement.querySelector('[aria-haspopup="true"]')!
-      await act(async () => {
-        await userEvent.click(anchor)
-      })
+      await userEvent.click(anchor)
 
       expect(mockOpenCallback).toHaveBeenCalledTimes(1)
       expect(mockOpenCallback).toHaveBeenCalledWith('anchor-click')
@@ -125,9 +123,7 @@ describe.each([true, false])(
         />,
       )
       const anchor = anchoredOverlay.baseElement.querySelector('[aria-haspopup="true"]')!
-      await act(async () => {
-        await userEvent.type(anchor, '{Space}')
-      })
+      fireEvent.keyDown(anchor, {key: ' '})
 
       expect(mockOpenCallback).toHaveBeenCalledTimes(1)
       expect(mockOpenCallback).toHaveBeenCalledWith('anchor-key-press')
@@ -145,9 +141,7 @@ describe.each([true, false])(
           withCSSAnchorPositioningFeatureFlag={withCSSAnchorPositioningFeatureFlag}
         />,
       )
-      await act(async () => {
-        await userEvent.click(anchoredOverlay.baseElement)
-      })
+      await userEvent.click(anchoredOverlay.baseElement)
 
       expect(mockOpenCallback).toHaveBeenCalledTimes(0)
       expect(mockCloseCallback).toHaveBeenCalledTimes(1)
@@ -167,9 +161,7 @@ describe.each([true, false])(
         />,
       )
 
-      await act(async () => {
-        await userEvent.keyboard('{Escape}')
-      })
+      await userEvent.keyboard('{Escape}')
 
       expect(mockOpenCallback).toHaveBeenCalledTimes(0)
       expect(mockCloseCallback).toHaveBeenCalledTimes(1)
@@ -186,9 +178,7 @@ describe.each([true, false])(
         />,
       )
 
-      await act(async () => {
-        await userEvent.keyboard('{Escape}')
-      })
+      await userEvent.keyboard('{Escape}')
 
       expect(mockPositionChangeCallback).toHaveBeenCalled()
       expect(mockPositionChangeCallback).toHaveBeenCalledWith({

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -407,7 +407,7 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
           tabIndex: 0,
           onClick: onAnchorClick,
           onKeyDown: onAnchorKeyDown,
-          ...(shouldRenderAsPopover ? {popoverTarget: popoverId} : {}),
+          ...(shouldRenderAsPopover ? {popovertarget: popoverId} : {}),
         })}
       {open ? (
         <Overlay

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -16,6 +16,7 @@ import classes from './AnchoredOverlay.module.css'
 import {clsx} from 'clsx'
 import {useFeatureFlag} from '../FeatureFlags'
 import {widthMap} from '../Overlay/constants'
+import {reactMajorVersion} from '../utils/environment'
 
 interface AnchoredOverlayPropsWithAnchor {
   /**
@@ -291,6 +292,11 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
   })
 
   const popoverId = useId()
+  const popoverTargetProps = shouldRenderAsPopover
+    ? reactMajorVersion >= 19
+      ? {popoverTarget: popoverId}
+      : {popovertarget: popoverId}
+    : {}
   const id = popoverId.replaceAll(':', '_') // popoverId can contain colons which are invalid in CSS custom property names, so we replace them with underscores
   const anchorName = `--anchored-overlay-anchor-${id}`
 
@@ -407,7 +413,7 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
           tabIndex: 0,
           onClick: onAnchorClick,
           onKeyDown: onAnchorKeyDown,
-          ...(shouldRenderAsPopover ? {popovertarget: popoverId} : {}),
+          ...popoverTargetProps,
         })}
       {open ? (
         <Overlay

--- a/packages/react/src/DataTable/__tests__/Pagination.test.tsx
+++ b/packages/react/src/DataTable/__tests__/Pagination.test.tsx
@@ -1,7 +1,7 @@
 import {page} from 'vitest/browser'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {Pagination} from '../Pagination'
-import {render, screen} from '@testing-library/react'
+import {act, render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 describe('Table.Pagination', () => {
@@ -100,9 +100,12 @@ describe('Table.Pagination', () => {
       expect(getCurrentPage()).toEqual(getPage(0))
       expect(getPageRange()).toEqual('1 through 25 of 25')
 
-      rerender(
-        <Pagination onChange={onChange} aria-label="Test label" defaultPageIndex={2} pageSize={5} totalCount={300} />,
-      )
+      await act(async () => {
+        rerender(
+          <Pagination onChange={onChange} aria-label="Test label" defaultPageIndex={2} pageSize={5} totalCount={300} />,
+        )
+        await Promise.resolve()
+      })
       expect(getPageRange()).toEqual('11 through 15 of 300')
       expect(getCurrentPage()).toEqual(getPage(2))
       expect(getInvalidPages()).toHaveLength(0)
@@ -293,9 +296,12 @@ describe('Table.Pagination', () => {
       expect(getCurrentPage()).toEqual(getPage(1))
       expect(getPageRange()).toEqual('26 through 50 of 50')
 
-      rerender(
-        <Pagination aria-label="Test label" onChange={onChange} defaultPageIndex={0} pageSize={5} totalCount={300} />,
-      )
+      await act(async () => {
+        rerender(
+          <Pagination aria-label="Test label" onChange={onChange} defaultPageIndex={0} pageSize={5} totalCount={300} />,
+        )
+        await Promise.resolve()
+      })
       expect(getPageRange()).toEqual('1 through 5 of 300')
       expect(getCurrentPage()).toEqual(getPage(0))
       expect(getInvalidPages()).toHaveLength(0)
@@ -358,9 +364,12 @@ describe('Table.Pagination', () => {
     expect(getCurrentPage()).toEqual(getPage(1))
     expect(getPageRange()).toEqual('11 through 20 of 1000')
 
-    rerender(
-      <Pagination aria-label="Test label" onChange={onChange} defaultPageIndex={0} pageSize={5} totalCount={300} />,
-    )
+    await act(async () => {
+      rerender(
+        <Pagination aria-label="Test label" onChange={onChange} defaultPageIndex={0} pageSize={5} totalCount={300} />,
+      )
+      await Promise.resolve()
+    })
     expect(getPageRange()).toEqual('1 through 5 of 300')
     expect(getFirstPage()).toEqual(getCurrentPage())
     expect(getInvalidPages()).toHaveLength(0)

--- a/packages/react/src/PageLayout/usePaneWidth.test.ts
+++ b/packages/react/src/PageLayout/usePaneWidth.test.ts
@@ -717,12 +717,10 @@ describe('usePaneWidth', () => {
       // Shrink viewport (crosses 1280 breakpoint, diff switches to 511)
       vi.stubGlobal('innerWidth', 1000)
 
-      // Fire resize - with throttle, first update happens immediately (if THROTTLE_MS passed)
-      window.dispatchEvent(new Event('resize'))
-
       // Since Date.now() starts at 0 and lastUpdateTime is 0, first update should happen immediately
       // but it's in rAF, so we need to advance through rAF
       await act(async () => {
+        window.dispatchEvent(new Event('resize'))
         await vi.runAllTimersAsync()
       })
 
@@ -753,11 +751,9 @@ describe('usePaneWidth', () => {
       // Shrink viewport (crosses 1280 breakpoint, diff switches to 511)
       vi.stubGlobal('innerWidth', 900)
 
-      // Fire resize - with throttle, update happens via rAF
-      window.dispatchEvent(new Event('resize'))
-
       // Wait for rAF to complete
       await act(async () => {
+        window.dispatchEvent(new Event('resize'))
         await vi.runAllTimersAsync()
       })
 
@@ -789,10 +785,10 @@ describe('usePaneWidth', () => {
 
       // Fire resize events rapidly
       vi.stubGlobal('innerWidth', 1100)
-      window.dispatchEvent(new Event('resize'))
 
       // With throttle, CSS should update immediately or via rAF
       await act(async () => {
+        window.dispatchEvent(new Event('resize'))
         await vi.runAllTimersAsync()
       })
 
@@ -803,13 +799,11 @@ describe('usePaneWidth', () => {
       setPropertySpy.mockClear()
 
       // Fire more resize events rapidly (within throttle window)
-      for (let i = 0; i < 3; i++) {
-        vi.stubGlobal('innerWidth', 1000 - i * 50)
-        window.dispatchEvent(new Event('resize'))
-      }
-
-      // Should schedule via rAF
       await act(async () => {
+        for (let i = 0; i < 3; i++) {
+          vi.stubGlobal('innerWidth', 1000 - i * 50)
+          window.dispatchEvent(new Event('resize'))
+        }
         await vi.runAllTimersAsync()
       })
 
@@ -840,10 +834,10 @@ describe('usePaneWidth', () => {
 
       // Shrink viewport (crosses 1280 breakpoint, diff switches to 511)
       vi.stubGlobal('innerWidth', 800)
-      window.dispatchEvent(new Event('resize'))
 
       // After throttle (via rAF), state updated via startTransition
       await act(async () => {
+        window.dispatchEvent(new Event('resize'))
         await vi.runAllTimersAsync()
       })
 
@@ -874,8 +868,8 @@ describe('usePaneWidth', () => {
       expect(result.current.maxPaneWidth).toBe(389)
 
       // Dispatch resize without changing viewport (same max = same value)
-      window.dispatchEvent(new Event('resize'))
       await act(async () => {
+        window.dispatchEvent(new Event('resize'))
         await vi.runAllTimersAsync()
       })
 
@@ -947,7 +941,9 @@ describe('usePaneWidth', () => {
 
       // Fire resize
       vi.stubGlobal('innerWidth', 1000)
-      window.dispatchEvent(new Event('resize'))
+      act(() => {
+        window.dispatchEvent(new Event('resize'))
+      })
 
       // Attribute should be applied immediately on first resize
       expect(refs.paneRef.current?.hasAttribute('data-dragging')).toBe(true)
@@ -955,7 +951,9 @@ describe('usePaneWidth', () => {
 
       // Fire another resize event immediately (simulating continuous resize)
       vi.stubGlobal('innerWidth', 900)
-      window.dispatchEvent(new Event('resize'))
+      act(() => {
+        window.dispatchEvent(new Event('resize'))
+      })
 
       // Attribute should still be present (containment stays on during continuous resize)
       expect(refs.paneRef.current?.hasAttribute('data-dragging')).toBe(true)
@@ -990,7 +988,9 @@ describe('usePaneWidth', () => {
 
       // Fire resize
       vi.stubGlobal('innerWidth', 1000)
-      window.dispatchEvent(new Event('resize'))
+      act(() => {
+        window.dispatchEvent(new Event('resize'))
+      })
 
       // Attribute should be applied
       expect(refs.paneRef.current?.hasAttribute('data-dragging')).toBe(true)
@@ -1028,9 +1028,9 @@ describe('usePaneWidth', () => {
 
       // Shrink viewport (crosses 1280 breakpoint, diff switches to 511)
       vi.stubGlobal('innerWidth', 800)
-      window.dispatchEvent(new Event('resize'))
 
       await act(async () => {
+        window.dispatchEvent(new Event('resize'))
         await vi.runAllTimersAsync()
       })
 

--- a/packages/react/src/SelectPanel/SelectPanel.test.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.test.tsx
@@ -44,11 +44,14 @@ export function getLiveRegion(): LiveRegionElement {
   throw new Error('No live-region found')
 }
 
-const renderWithProp = (element: React.ReactElement, flag?: boolean) => {
+const getFocusManagement = (flag?: boolean) => {
   // true = 'use roving tabindex'
   // false = 'use aria-activedescendant'
-  const focusManagement = flag ? 'roving-tabindex' : 'active-descendant'
-  return render(React.cloneElement(element, {_PrivateFocusManagement: focusManagement}))
+  return flag ? 'roving-tabindex' : 'active-descendant'
+}
+
+const renderWithProp = (element: React.ReactElement, flag?: boolean) => {
+  return render(React.cloneElement(element, {_PrivateFocusManagement: getFocusManagement(flag)}))
 }
 
 const items: SelectPanelProps['items'] = [
@@ -160,12 +163,11 @@ for (const usingRemoveActiveDescendant of [false, true]) {
     it('should close the select panel when clicking outside of the select panel', async () => {
       const user = userEvent.setup()
 
-      renderWithProp(
+      render(
         <>
           <button type="button">outer button</button>
-          <BasicSelectPanel />
+          <BasicSelectPanel _PrivateFocusManagement={getFocusManagement(usingRemoveActiveDescendant)} />
         </>,
-        usingRemoveActiveDescendant,
       )
 
       await user.click(screen.getByText('Select items'))

--- a/packages/react/src/TopicTag/TopicTag.test.tsx
+++ b/packages/react/src/TopicTag/TopicTag.test.tsx
@@ -1,6 +1,5 @@
-import {render, screen} from '@testing-library/react'
+import {fireEvent, render, screen} from '@testing-library/react'
 import {describe, test, expect, vi} from 'vitest'
-import {userEvent} from 'vitest/browser'
 import {TopicTag} from '../TopicTag'
 import {implementsClassName} from '../utils/testing'
 import classes from './TopicTag.module.css'
@@ -22,7 +21,7 @@ describe('TopicTag', () => {
       </TopicTag>,
     )
 
-    await userEvent.click(screen.getByRole('button', {name: 'test'}))
+    fireEvent.click(screen.getByRole('button', {name: 'test'}))
     expect(onClick).toHaveBeenCalled()
   })
 

--- a/packages/react/src/experimental/Tabs/Tabs.test.tsx
+++ b/packages/react/src/experimental/Tabs/Tabs.test.tsx
@@ -1,5 +1,5 @@
 import {render, screen, fireEvent, act} from '@testing-library/react'
-import {userEvent} from 'vitest/browser'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import {describe, test, expect, vi} from 'vitest'
 import {Tabs, TabList, Tab, TabPanel} from './Tabs'


### PR DESCRIPTION
Closes: N/A

Fixes remaining async interaction tests so updates from focus, resize, rerender, and keyboard interactions do not emit act warnings. Also corrects AnchoredOverlay's popover target attribute casing for popover anchors.

### Changelog

#### New

- N/A

#### Changed

- AnchoredOverlay now renders the popover target attribute correctly for popover anchors.

#### Removed

- N/A

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Validated as part of the final stack with build, tests, type-check, lint, CSS lint, and format checks. Includes a patch changeset.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/primer/react/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
