### PR TITLE
test(vitest): enable console enforcement and document env override

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,7 @@ The primary workspace is `packages/react` which contains the `@primer/react` pac
 **Run tests:**
 
 - `npm test` -- runs unit tests. NEVER CANCEL. Takes 75 seconds. Set timeout to 90+ minutes. Runs 1500+ tests using Vitest in both node and chromium environments.
+- Vitest console enforcement is enabled by default. For local debugging, temporarily opt out with `VITEST_FAIL_ON_CONSOLE=false npm test`.
 - `npm run type-check` -- runs TypeScript type checking across all packages. Takes 42 seconds. Set timeout to 60+ minutes.
 
 **Development workflow:**

--- a/contributor-docs/testing.md
+++ b/contributor-docs/testing.md
@@ -86,6 +86,8 @@ We are slowly moving away from using snapshots as a way to test visual changes o
 | Run a specific test | `npm test ComponentName` |
 | Update snapshots    | `npm test -- -u`         |
 
+By default, Vitest fails when tests emit unexpected console output. For local debugging, you can temporarily disable this enforcement with `VITEST_FAIL_ON_CONSOLE=false`.
+
 ## Interaction Tests
 
 ### As A Part Of Unit Tests


### PR DESCRIPTION
Enables the shared Vitest console enforcement by default for every Vitest project, and documents the `VITEST_FAIL_ON_CONSOLE=false` local debugging override in contributor docs and agent instructions.

### Changelog

#### New

- N/A

#### Changed

- Vitest now fails by default when tests emit unexpected console output.
- Added documentation for the fail-on-console environment variable helper in:
  - `contributor-docs/testing.md`
  - `.github/copilot-instructions.md`

#### Removed

- N/A

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; test infrastructure + documentation updates only.

### Testing & Reviewing

Validated with build, tests, type-check, lint, CSS lint, and format checks before the docs follow-up.  
Validated docs follow-up with `npm run lint` and `npm run format:diff`.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))