### PR TITLE
Add eslint-plugin-react-you-might-not-need-an-effect

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ import storybook from 'eslint-plugin-storybook'
 import react from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefreshPlugin from 'eslint-plugin-react-refresh'
+import reactYouMightNotNeedAnEffect from 'eslint-plugin-react-you-might-not-need-an-effect'
 import {unsupportedPatterns as reactCompilerUnsupported} from './packages/react/script/react-compiler.mjs'
 import playwright from 'eslint-plugin-playwright'
 import prettierRecommended from 'eslint-plugin-prettier/recommended'
@@ -114,6 +115,9 @@ const config = defineConfig([
       '@eslint-react/no-useless-forward-ref': 'error',
     },
   },
+
+  // eslint-plugin-react-you-might-not-need-an-effect
+  reactYouMightNotNeedAnEffect.configs.recommended,
 
   {
     extends: fixupConfigRules(compat.extends('plugin:clsx/recommended', 'plugin:ssr-friendly/recommended')),

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-plugin-react": "^7.35.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "eslint-plugin-react-you-might-not-need-an-effect": "1.0.1",
         "eslint-plugin-ssr-friendly": "1.3.0",
         "eslint-plugin-storybook": "^10.4.2",
         "eslint-plugin-testing-library": "^7.16.0",
@@ -83,7 +84,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@primer/react": "38.27.0",
+        "@primer/react": "38.28.0",
         "@primer/styled-react": "1.1.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
@@ -97,7 +98,7 @@
       "name": "example-nextjs",
       "version": "0.0.0",
       "dependencies": {
-        "@primer/react": "38.27.0",
+        "@primer/react": "38.28.0",
         "@primer/styled-react": "1.1.0",
         "next": "^16.1.7",
         "react": "^19.2.0",
@@ -140,7 +141,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@primer/octicons-react": "^19.21.0",
-        "@primer/react": "38.27.0",
+        "@primer/react": "38.28.0",
         "@primer/styled-react": "1.1.0",
         "clsx": "^2.1.1",
         "next": "^16.1.7",
@@ -15133,6 +15134,25 @@
         }
       }
     },
+    "node_modules/eslint-plugin-react-you-might-not-need-an-effect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-you-might-not-need-an-effect/-/eslint-plugin-react-you-might-not-need-an-effect-1.0.1.tgz",
+      "integrity": "sha512-oOhQTYhor88Xp8RVytq25tvBfiAjU0r9SCDC51Qop+3Wg5BR1xGMAkM+/dV4MZbcMhdaU1L9bkv6LC95JmiTig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^16.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/nickjvandyke"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "2.1.0",
       "dev": true,
@@ -28427,13 +28447,13 @@
     },
     "packages/mcp": {
       "name": "@primer/mcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@modelcontextprotocol/sdk": "^1.24.0",
         "@primer/octicons": "^19.15.5",
         "@primer/primitives": "10.x || 11.x",
-        "@primer/react": "^38.20.0",
+        "@primer/react": "^38.28.0",
         "cheerio": "^1.0.0",
         "turndown": "^7.2.0",
         "zod": "^4.3.5"
@@ -28585,7 +28605,7 @@
     },
     "packages/react": {
       "name": "@primer/react",
-      "version": "38.27.0",
+      "version": "38.28.0",
       "license": "MIT",
       "dependencies": {
         "@github/mini-throttle": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-ssr-friendly": "1.3.0",
     "eslint-plugin-storybook": "^10.4.2",
     "eslint-plugin-testing-library": "^7.16.0",
+    "eslint-plugin-react-you-might-not-need-an-effect": "1.0.1",
     "fast-glob": "^3.3.3",
     "globals": "^16.2.0",
     "markdownlint-cli2": "^0.19.0",

--- a/packages/react/src/ActionList/Description.tsx
+++ b/packages/react/src/ActionList/Description.tsx
@@ -35,9 +35,11 @@ export const Description: FCWithSlotMarker<React.PropsWithChildren<ActionListDes
 
   // Extract text content from rendered DOM for tooltip
   React.useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (truncate && containerRef.current) {
       const el = containerRef.current
       const textContent = el.textContent || ''
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
       setComputedTitle(textContent)
       if (setTruncatedText) {
         setTruncatedText(

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -273,6 +273,7 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
 
   useEffect(() => {
     // ensure overlay ref gets cleared when closed, so position can reset between closing/re-opening
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (!open && overlayRef.current) {
       updateOverlayRef(null)
     }

--- a/packages/react/src/Autocomplete/Autocomplete.features.stories.tsx
+++ b/packages/react/src/Autocomplete/Autocomplete.features.stories.tsx
@@ -556,6 +556,7 @@ export const InADialog = () => {
   useEffect(() => {
     if (outerContainerRef.current instanceof HTMLElement) {
       registerPortalRoot(outerContainerRef.current, 'outerContainer')
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-chain-state-updates
       setMounted(true)
     }
   }, [isDialogOpen])

--- a/packages/react/src/Autocomplete/AutocompleteInput.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteInput.tsx
@@ -151,6 +151,7 @@ const AutocompleteInput = React.forwardRef(
 
       if (
         isInputFocused &&
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
         highlightRemainingText &&
         autocompleteSuggestion &&
         (inputValue || isMenuDirectlyActivated)

--- a/packages/react/src/Autocomplete/AutocompleteMenu.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteMenu.tsx
@@ -316,6 +316,7 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
   useEffect(() => {
     // Use deferredInputValue to avoid running this effect on every keystroke
     // The Input component guards against stale suggestions
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-data-to-parent, react-you-might-not-need-an-effect/no-pass-live-state-to-parent
     if (highlightedItem?.text?.startsWith(deferredInputValue) && !selectedItemIds.includes(highlightedItem.id)) {
       setAutocompleteSuggestion(highlightedItem.text)
     } else {
@@ -331,15 +332,18 @@ function AutocompleteMenu<T extends AutocompleteItemProps>(props: AutocompleteMe
       itemIdSortResult.length === sortedItemIds.length &&
       itemIdSortResult.every((element, index) => element === sortedItemIds[index])
 
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (showMenu === false && !sortResultMatchesState) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-derived-state
       setSortedItemIds(itemIdSortResult)
     }
 
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-data-to-parent
     onOpenChange && onOpenChange(Boolean(showMenu))
   }, [showMenu, onOpenChange, selectedItemIds, sortOnCloseFn, sortedItemIds])
 
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (selectedItemIds.length) {
       setSelectedItemLength(selectedItemIds.length)
     }

--- a/packages/react/src/AvatarStack/AvatarStack.tsx
+++ b/packages/react/src/AvatarStack/AvatarStack.tsx
@@ -126,6 +126,7 @@ const AvatarStack = ({
       observer.observe(stackContainer.current, {childList: true})
 
       // Call on initial render, then call it again only if there's a mutation
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-initialize-state
       interactiveChildren()
 
       return () => {

--- a/packages/react/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react/src/Breadcrumbs/Breadcrumbs.tsx
@@ -271,14 +271,18 @@ function Breadcrumbs({className, children, style, overflow = 'wrap', variant = '
   useResizeObserver(handleResize, containerRef)
 
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if ((overflow === 'menu' || overflow === 'menu-with-root') && childArray.length > 5 && menuItems.length === 0) {
       const containerWidth = containerRef.current?.offsetWidth || 800
       const result = calculateOverflow(containerWidth)
 
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react-you-might-not-need-an-effect/no-chain-state-updates
       setVisibleItems(result.visibleItems)
 
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react-you-might-not-need-an-effect/no-chain-state-updates
       setMenuItems(result.menuItems)
 
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-chain-state-updates, react-you-might-not-need-an-effect/no-derived-state
       setEffectiveHideRoot(result.effectiveHideRoot)
     }
   }, [overflow, childArray, calculateOverflow, menuItems.length])

--- a/packages/react/src/DataTable/storybook/data.ts
+++ b/packages/react/src/DataTable/storybook/data.ts
@@ -109,9 +109,11 @@ export function useQuery<T>(
   React.useEffect(() => {
     const controller = new AbortController()
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
     setLoading(true)
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
     setError(null)
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
     setData(null)
 
     savedQueryFn

--- a/packages/react/src/Dialog/Dialog.features.stories.tsx
+++ b/packages/react/src/Dialog/Dialog.features.stories.tsx
@@ -213,6 +213,7 @@ export const ReproMultistepDialogWithConditionalFooter = ({width, height}: Dialo
   React.useEffect(() => {
     // focus the close button when the step changes
     const focusTarget = dialogRef.current?.querySelector('button[aria-label="Close"]') as HTMLButtonElement
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (step === 2) {
       focusTarget.focus()
     }

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -492,7 +492,7 @@ const Buttons: React.FC<React.PropsWithChildren<{buttons: DialogButtonProps[]}>>
     if (hasRendered === 1) {
       autoFocusRef.current?.focus()
     } else {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-derived-state
       setHasRendered(hasRendered + 1)
     }
   }, [autoFocusRef, hasRendered])

--- a/packages/react/src/FilteredActionList/FilteredActionList.tsx
+++ b/packages/react/src/FilteredActionList/FilteredActionList.tsx
@@ -281,6 +281,7 @@ export function FilteredActionList({
     [onListContainerRefChanged],
   )
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-data-to-parent
     onInputRefChanged?.(inputRef)
   }, [inputRef, onInputRefChanged])
 
@@ -369,6 +370,7 @@ export function FilteredActionList({
   }, [items, inputRef, scrollContainerRef, scrollBehavior])
 
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (usingRovingTabindex) {
       const inputAndListContainerElement = inputAndListContainerRef.current
       if (!inputAndListContainerElement) return
@@ -391,7 +393,9 @@ export function FilteredActionList({
   }, [items, inputRef, listContainerElement, usingRovingTabindex]) // Re-run when items change to update active indicators
 
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (usingRovingTabindex && !loading) {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
       setIsInputFocused(inputRef.current && inputRef.current === document.activeElement ? true : false)
     }
   }, [loading, inputRef, usingRovingTabindex])

--- a/packages/react/src/FilteredActionList/useAnnouncements.tsx
+++ b/packages/react/src/FilteredActionList/useAnnouncements.tsx
@@ -107,6 +107,7 @@ export const useAnnouncements = (
 
       liveRegion?.clear() // clear previous announcements
 
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (items.length === 0 && !loading) {
         announce(`${message?.title}. ${message?.description}`, {delayMs})
         return

--- a/packages/react/src/FormControl/FormControl.features.stories.tsx
+++ b/packages/react/src/FormControl/FormControl.features.stories.tsx
@@ -128,9 +128,11 @@ export const WithCustomInput = () => {
 
   React.useEffect(() => {
     if (doesValueContainSpaces(value)) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-chain-state-updates
       setValidationResult('noSpaces')
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     } else if (value) {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-chain-state-updates
       setValidationResult('validName')
     }
   }, [value])
@@ -241,9 +243,11 @@ export const ValidationExample = () => {
 
   React.useEffect(() => {
     if (doesValueContainSpaces(value)) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-chain-state-updates
       setValidationResult('noSpaces')
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     } else if (value) {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-chain-state-updates
       setValidationResult('validName')
     }
   }, [value])

--- a/packages/react/src/LabelGroup/LabelGroup.tsx
+++ b/packages/react/src/LabelGroup/LabelGroup.tsx
@@ -205,6 +205,7 @@ const LabelGroup: React.FC<React.PropsWithChildren<LabelGroupProps>> = ({
 
   React.useEffect(() => {
     // If we're not truncating, we don't need to run this useEffect.
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (!visibleChildCount || isOverflowShown) {
       return
     }
@@ -255,6 +256,7 @@ const LabelGroup: React.FC<React.PropsWithChildren<LabelGroupProps>> = ({
   // We need to keep track of this so we can focus the first hidden child when the overflow is shown inline.
   React.useEffect(() => {
     // If we're using an overlay, we don't need to keep track of the first hidden index.
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (overflowStyle === 'overlay') {
       return
     }
@@ -267,12 +269,14 @@ const LabelGroup: React.FC<React.PropsWithChildren<LabelGroupProps>> = ({
   // We need to keep track of this so we can focus the first hidden child when the overflow is shown inline.
   React.useEffect(() => {
     // If we're using an overlay, we don't need to focus the first child that was previously hidden.
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (overflowStyle === 'overlay') {
       return
     }
     const firstHiddenChildDOM = document.querySelector<HTMLElement>(`[data-index="${firstHiddenIndexRef.current}"]`)
     const focusableChild = firstHiddenChildDOM ? getFocusableChild(firstHiddenChildDOM) : null
 
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (isOverflowShown) {
       // If the first hidden child is focusable, focus it.
       // Otherwise, focus the collapse button.

--- a/packages/react/src/Overlay/Overlay.features.stories.tsx
+++ b/packages/react/src/Overlay/Overlay.features.stories.tsx
@@ -418,6 +418,7 @@ export const MemexIssueOverlay = ({role, open}: Args) => {
 
   React.useEffect(() => {
     // If we just started editing, focus the newly rendered input
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (editing) inputRef.current?.focus()
   }, [editing])
 

--- a/packages/react/src/Portal/Portal.features.stories.tsx
+++ b/packages/react/src/Portal/Portal.features.stories.tsx
@@ -30,6 +30,7 @@ export const CustomPortalRootByRegistration: React.FC<React.PropsWithChildren<Re
   React.useEffect(() => {
     if (outerContainerRef.current instanceof HTMLElement) {
       registerPortalRoot(outerContainerRef.current)
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-initialize-state
       setMounted(true)
     }
   }, [])
@@ -92,6 +93,7 @@ export const WithPortalContext = () => {
     if (customContainerRef.current instanceof HTMLElement && overrideContainerRef.current instanceof HTMLElement) {
       registerPortalRoot(customContainerRef.current, 'custom-portal')
       registerPortalRoot(overrideContainerRef.current, 'override-portal')
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-initialize-state
       setMounted(true)
     }
   }, [])

--- a/packages/react/src/SelectPanel/SelectPanel.dev.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.dev.stories.tsx
@@ -344,8 +344,10 @@ export const LotsOfItems = () => {
   }
 
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (open) {
       timeAfterOpen.current = performance.now()
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-chain-state-updates
       if (timeBeforeOpen.current) setTimeTakenToOpen(timeAfterOpen.current - timeBeforeOpen.current)
     }
   }, [open])

--- a/packages/react/src/SelectPanel/SelectPanel.examples.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.examples.stories.tsx
@@ -356,7 +356,7 @@ export const RepositionAfterLoading = () => {
   const [loading, setLoading] = useState(true)
 
   React.useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-chain-state-updates, react-you-might-not-need-an-effect/no-event-handler
     if (!open) setLoading(true)
     window.setTimeout(() => {
       if (open) {
@@ -368,8 +368,9 @@ export const RepositionAfterLoading = () => {
   }, [open])
 
   React.useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (!loading) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-chain-state-updates
       setFilteredItems(items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase())))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -405,7 +406,7 @@ export const SelectPanelRepositionInsideDialog = () => {
   const [loading, setLoading] = useState(true)
 
   React.useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-chain-state-updates, react-you-might-not-need-an-effect/no-event-handler
     if (!open) setLoading(true)
     window.setTimeout(() => {
       if (open) {
@@ -417,8 +418,9 @@ export const SelectPanelRepositionInsideDialog = () => {
   }, [open])
 
   React.useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (!loading) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-chain-state-updates
       setFilteredItems(items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase())))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -534,8 +536,10 @@ export const RenderMoreOnScroll = () => {
 
   useEffect(
     function measureTimeAfterOpen() {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (open) {
         timeAfterOpen.current = performance.now()
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-chain-state-updates
         if (timeBeforeOpen.current) setTimeTakenToOpen(timeAfterOpen.current - timeBeforeOpen.current)
       }
     },
@@ -616,8 +620,10 @@ export const VirtualizedConsumerSide = () => {
   }
   useEffect(
     function measureTimeAfterOpen() {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (open) {
         timeAfterOpen.current = performance.now()
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-chain-state-updates
         if (timeBeforeOpen.current) setTimeTakenToOpen(timeAfterOpen.current - timeBeforeOpen.current)
       }
     },
@@ -757,8 +763,10 @@ export const VirtualizedBuiltIn = () => {
   }
   useEffect(
     function measureA() {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (openA) {
         timeAfterOpenA.current = performance.now()
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-chain-state-updates
         if (timeBeforeOpenA.current) setTimeTakenA(timeAfterOpenA.current - timeBeforeOpenA.current)
       }
     },
@@ -776,8 +784,10 @@ export const VirtualizedBuiltIn = () => {
   }
   useEffect(
     function measureB() {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (openB) {
         timeAfterOpenB.current = performance.now()
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-chain-state-updates
         if (timeBeforeOpenB.current) setTimeTakenB(timeAfterOpenB.current - timeBeforeOpenB.current)
       }
     },

--- a/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.features.stories.tsx
@@ -753,7 +753,7 @@ export const WithOnCancel = () => {
 
   const [open, setOpen] = useState(false)
   React.useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-derived-state, react-you-might-not-need-an-effect/no-event-handler
     if (!open) setInitialSelection(selected) // set initialSelection for next time
   }, [open, selected])
 
@@ -792,7 +792,7 @@ export const MultiSelectModal = () => {
   React.useEffect(() => {
     // Sync initialSelection with the last committed selection after the modal closes.
     // onCancel uses initialSelection to discard unsaved changes made while the modal is open.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-derived-state, react-you-might-not-need-an-effect/no-event-handler
     if (!open) setInitialSelection(selected)
   }, [open, selected])
 
@@ -953,7 +953,7 @@ export const WithMessage = () => {
   const filteredItems = itemsToShow.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-chain-state-updates
     setFilter('')
   }, [messageVariant])
 

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -243,7 +243,7 @@ function Panel({
 
   // Reset the intermediate selected item when the panel is open/closed
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-derived-state
     setIntermediateSelected(isSingleSelectModal ? selected : undefined)
   }, [isSingleSelectModal, open, selected])
 
@@ -365,6 +365,7 @@ function Panel({
 
   // disable body scroll when the panel is open in modal mode or on narrow screens
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (open && (variant === 'modal' || (isNarrowScreenSize && usingFullScreenOnNarrow))) {
       const bodyOverflowStyle = document.body.style.overflow || ''
       // If the body is already set to overflow: hidden, it likely means
@@ -383,24 +384,32 @@ function Panel({
   }, [isNarrowScreenSize, open, usingFullScreenOnNarrow, variant])
 
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (open) {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (items.length === 0 && !(isLoading || loading)) {
         // we need to wait for the listContainerElement to disappear before announcing no items, otherwise it will be interrupted
-        // eslint-disable-next-line react-hooks/set-state-in-effect
+        // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
         setNeedsNoItemsAnnouncement(true)
       }
     }
 
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (loadingManagedExternally) {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (items.length > 0) {
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
         setDataLoadedOnce(true)
       }
 
       return
     }
 
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (isLoading || items.length > 0) {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
       setIsLoading(false)
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
       setDataLoadedOnce(true)
     }
 
@@ -413,12 +422,14 @@ function Panel({
   }, [items])
 
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (inputRef?.current) {
       const ref = inputRef.current
 
       // We would normally expect AnchoredOverlay's focus trap to automatically focus the input,
       // but for some reason the ref isn't populated until _after_ the panel is open, which is
       // too late. So, we focus manually here.
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (open) {
         ref.focus()
       }
@@ -427,6 +438,7 @@ function Panel({
 
   // Manage loading announcements when loadingManagedExternally
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (loadingManagedExternally) {
       if (isLoading) {
         // Delay the announcement a bit, just in case the loading is quick
@@ -444,14 +456,18 @@ function Panel({
 
   // Populate panel with items on first open
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (loadingManagedExternally) return
 
     // If data was already loaded once, do nothing
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (dataLoadedOnce) return
 
     // Only load data when the panel is open
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (open) {
       // Only trigger filter change event if there are no items
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (items.length === 0) {
         // Trigger filter event to populate panel on first open
         // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -512,6 +528,7 @@ function Panel({
       })
     }
 
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (open && notice) {
       announceNotice()
     }
@@ -697,7 +714,9 @@ function Panel({
   // Track previous items and reset sort when items first load
   const prevItemsRef = useRef(items)
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (prevItemsRef.current !== items) {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (prevItemsRef.current.length === 0 && items.length > 0) {
         resetSort()
       }
@@ -708,6 +727,7 @@ function Panel({
   // Reset sort when panel opens
   const prevOpenRef = useRef(open)
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (prevOpenRef.current !== open) {
       resetSort()
       prevOpenRef.current = open

--- a/packages/react/src/Spinner/Spinner.tsx
+++ b/packages/react/src/Spinner/Spinner.tsx
@@ -48,6 +48,7 @@ function Spinner({
   }))
 
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (delay) {
       const delayDuration = typeof delay === 'number' ? delay : delay === 'short' ? 300 : 1000
       const timeoutId = setTimeout(() => {

--- a/packages/react/src/Textarea/Textarea.tsx
+++ b/packages/react/src/Textarea/Textarea.tsx
@@ -97,6 +97,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 
     // Initialize character counter
     useEffect(() => {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (characterLimit) {
         characterCounterRef.current = new CharacterCounter({
           onCountUpdate: (count, overLimit, message) => {
@@ -116,6 +117,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 
     // Update character count when value changes
     useEffect(() => {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (characterLimit && characterCounterRef.current) {
         const currentValue =
           value !== undefined ? String(value) : defaultValue !== undefined ? String(defaultValue) : ''

--- a/packages/react/src/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/react/src/ToggleSwitch/ToggleSwitch.tsx
@@ -125,8 +125,9 @@ const ToggleSwitch = React.forwardRef<HTMLButtonElement, ToggleSwitchProps>(func
 
   useEffect(() => {
     if (!loading && isLoadingLabelVisible) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-chain-state-updates
       setIsLoadingLabelVisible(false)
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     } else if (loading && !isLoadingLabelVisible) {
       safeSetTimeout(() => {
         setIsLoadingLabelVisible(true)

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -239,6 +239,7 @@ export const Tooltip: ForwardRefExoticComponent<
         'The `Tooltip` component expects a single React element that contains interactive content. Consider using a `<button>` or equivalent interactive element instead.',
       )
       // If the tooltip is used for labelling the interactive element, the trigger element or any of its children should not have aria-label
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (type === 'label') {
         const hasAriaLabel = triggerRef.current.hasAttribute('aria-label')
         const hasAriaLabelInChildren = Array.from(triggerRef.current.childNodes).some(

--- a/packages/react/src/TreeView/TreeView.tsx
+++ b/packages/react/src/TreeView/TreeView.tsx
@@ -527,7 +527,7 @@ const SubTree: FCWithSlotMarker<TreeViewSubTreeProps> = ({count, state, children
     const parentElement = document.getElementById(itemId)
     if (!parentElement) return
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-chain-state-updates
     setSubTreeLabel(getAccessibleName(parentElement))
     if (previousState === 'loading' && state === 'done') {
       // Announce update to screen readers
@@ -541,6 +541,7 @@ const SubTree: FCWithSlotMarker<TreeViewSubTreeProps> = ({count, state, children
 
       // Move focus to the first child if the loading indicator
       // was focused when the async items finished loading
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (loadingFocused) {
         const firstChild = getFirstChildElement(parentElement)
 
@@ -554,6 +555,7 @@ const SubTree: FCWithSlotMarker<TreeViewSubTreeProps> = ({count, state, children
           })
         }
 
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-chain-state-updates
         setLoadingFocused(false)
       }
     } else if (state === 'loading') {

--- a/packages/react/src/experimental/SelectPanel2/SelectPanel.examples.stories.tsx
+++ b/packages/react/src/experimental/SelectPanel2/SelectPanel.examples.stories.tsx
@@ -544,7 +544,7 @@ export const WithFilterButtons = () => {
 
   React.useEffect(
     function updateSearchResults() {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-derived-state
       setSearchResults(query, selectedFilter)
     },
     [query, selectedFilter],

--- a/packages/react/src/experimental/SelectPanel2/SelectPanel.tsx
+++ b/packages/react/src/experimental/SelectPanel2/SelectPanel.tsx
@@ -216,6 +216,7 @@ const Panel: React.FC<SelectPanelProps> = ({
   // but not for dialogs, so we have to do it
   React.useEffect(
     function initialFocus() {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (internalOpen) {
         const searchInput = document.querySelector('dialog[open] input') as HTMLInputElement | undefined
         if (searchInput) searchInput.focus()

--- a/packages/react/src/hooks/useControllableState.ts
+++ b/packages/react/src/hooks/useControllableState.ts
@@ -73,6 +73,7 @@ export function useControllableState<T>({
 
     // Uncontrolled -> Controlled
     // If the component prop is uncontrolled, the prop value should be undefined
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (controlled.current === false && controlledValue) {
       warning(
         true,
@@ -87,6 +88,7 @@ export function useControllableState<T>({
 
     // Controlled -> Uncontrolled
     // If the component prop is controlled, the prop value should be defined
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (controlled.current === true && !controlledValue) {
       warning(
         true,

--- a/packages/react/src/hooks/useDetails.tsx
+++ b/packages/react/src/hooks/useDetails.tsx
@@ -29,6 +29,7 @@ function useDetails({ref, closeOnOutsideClick, defaultOpen, onClickOutside}: Use
 
   // handles the overlay behavior - closing the menu when clicking outside of it
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (open && closeOnOutsideClick) {
       document.addEventListener('click', onClickOutsideInternal)
       return () => {

--- a/packages/react/src/hooks/useDialog.ts
+++ b/packages/react/src/hooks/useDialog.ts
@@ -46,6 +46,7 @@ function useDialog({
   )
 
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (isOpen) {
       document.addEventListener('click', onClickOutside)
       return () => {
@@ -55,9 +56,11 @@ function useDialog({
   }, [isOpen, onClickOutside])
 
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (isOpen) {
       if (initialFocusRef && initialFocusRef.current) {
         initialFocusRef.current.focus()
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       } else if (closeButtonRef && closeButtonRef.current) {
         closeButtonRef.current.focus()
       }

--- a/packages/react/src/hooks/useFocusZone.ts
+++ b/packages/react/src/hooks/useFocusZone.ts
@@ -51,6 +51,7 @@ export function useFocusZone(
     () => {
       if (
         containerRef.current instanceof HTMLElement &&
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
         (!useActiveDescendant || activeDescendantControlRef.current instanceof HTMLElement)
       ) {
         if (!disabled) {

--- a/packages/react/src/hooks/useMedia.ts
+++ b/packages/react/src/hooks/useMedia.ts
@@ -68,7 +68,7 @@ export function useMedia(mediaQueryString: string, defaultState?: boolean) {
     }
 
     // Make sure the media query list is in sync with the matches state
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-external-store-subscription
     setMatches(mediaQueryList.matches)
 
     return () => {

--- a/packages/react/src/hooks/useMenuInitialFocus.ts
+++ b/packages/react/src/hooks/useMenuInitialFocus.ts
@@ -46,6 +46,7 @@ export const useMenuInitialFocus = (
    */
   React.useEffect(
     function moveFocusOnOpen() {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (!open || !containerRef?.current) return // wait till the menu is open
 
       const iterable = iterateFocusableElements(containerRef.current)

--- a/packages/react/src/hooks/useMnemonics.ts
+++ b/packages/react/src/hooks/useMnemonics.ts
@@ -13,6 +13,7 @@ export const useMnemonics = (open: boolean, providedRef?: React.RefObject<HTMLEl
 
   React.useEffect(
     function addAriaKeyshortcuts() {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (!open || !containerRef.current) return
       const container = containerRef.current
 

--- a/packages/react/src/internal/components/ValidationAnimationContainer.tsx
+++ b/packages/react/src/internal/components/ValidationAnimationContainer.tsx
@@ -10,7 +10,7 @@ const ValidationAnimationContainer: React.FC<React.PropsWithChildren<Props>> = (
   const [shouldRender, setRender] = useState(show)
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-derived-state, react-you-might-not-need-an-effect/no-event-handler
     if (show) setRender(true)
   }, [show])
 

--- a/packages/react/src/utils/StressTest.tsx
+++ b/packages/react/src/utils/StressTest.tsx
@@ -67,12 +67,17 @@ export const StressTest: React.FC<StressTestProps> = ({
   }
 
   useEffect(() => {
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (count === totalIterations - 1) {
       // Get the median of the duration when the test is done
       const durations = observer.current?.data ?? []
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react-you-might-not-need-an-effect/no-chain-state-updates
       setMedian(durations.sort((a, b) => a - b)[Math.floor(durations.length / 2)])
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react-you-might-not-need-an-effect/no-chain-state-updates
       setAverage(durations.reduce((a, b) => a + b, 0) / durations.length)
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react-you-might-not-need-an-effect/no-chain-state-updates
       setMin(Math.min(...durations))
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react-you-might-not-need-an-effect/no-chain-state-updates
       setMax(Math.max(...durations))
     }
   }, [count, totalIterations])

--- a/packages/react/src/utils/descendant-registry.tsx
+++ b/packages/react/src/utils/descendant-registry.tsx
@@ -145,6 +145,7 @@ export function createDescendantRegistry<T>() {
         const setEntries = Array.from(workingRegistryRef.current.entries()).filter(
           (entry): entry is [string, T] => entry[1] !== unsetValue,
         )
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-data-to-parent
         setRegistry(new Map(setEntries))
         workingRegistryRef.current = 'idle'
       }


### PR DESCRIPTION
Closes #

## What

Adds [`eslint-plugin-react-you-might-not-need-an-effect`](https://github.com/NickvanDyke/eslint-plugin-react-you-might-not-need-an-effect) and wires it into our flat ESLint config via its `recommended` preset. The plugin flags `useEffect` usage that the React docs describe under ["You Might Not Need an Effect"](https://react.dev/learn/you-might-not-need-an-effect) — storing derived state, running event-handler logic, chaining state updates, resetting/adjusting state on prop changes, passing data up to parents, subscribing to external stores, and initializing state in an effect.

Because the codebase already contains effects that trip these rules, the **pre-existing** violations are suppressed **inline** with `// eslint-disable-next-line` comments (107 sites across 37 files) rather than disabling the rules globally. New code is linted immediately; each legacy case is individually marked so it can be revisited and removed over time.

## Why

- The "You Might Not Need an Effect" anti-patterns are a recurring source of bugs — extra renders, stale state, and render loops — and they make components harder to reason about. Catching them at lint time keeps **new** code on the rails.
- Suppressing with inline disables (instead of a config-level ignore list) keeps every remaining case **visible at its call site** and discoverable via grep/code search, so the backlog can be burned down incrementally. A central ignore list would hide the debt and silently swallow new violations in those files.

## How

- `eslint.config.mjs`: import the plugin and add `reactYouMightNotNeedAnEffect.configs.recommended` (enables all 9 rules as warnings across JS/TS files).
- Suppression uses per-line `// eslint-disable-next-line` comments — the repo's `eslint-comments/no-use` rule **bans** whole-file `/* eslint-disable */` blocks, and per-line directives are the convention already used throughout the repo.
- Where a line already had a directive (e.g. `react-hooks/set-state-in-effect`), the new rule id was **merged** into the existing comment rather than added on a separate line, to avoid "unused directive" errors (lint runs with `--max-warnings=0`).
- No runtime/source logic changed — every code edit is an added or merged lint comment.

### Changelog

#### New

- Dev dependency `eslint-plugin-react-you-might-not-need-an-effect` and its recommended ESLint configuration.

#### Changed

- Suppressed pre-existing unnecessary-effect violations inline across 37 files. No behavior changes.

#### Removed

- N/A

### Rollout strategy

- [x] None; this is dev-only lint tooling. There are no changes to the published `@primer/react` package, so no changeset is required (the `skip changeset` label is applied).

### Testing & Reviewing

- `npm run lint` passes with `--max-warnings=0` — zero remaining plugin violations and zero unused disable directives.
- Since no source logic changed, the diff should be reviewable as purely additive lint comments. The interesting file is `eslint.config.mjs`; everything else is `// eslint-disable-next-line` annotations.
- Follow-up: the inline disables mark a backlog of effects that are good candidates for refactoring away.

### Merge checklist

- [ ] Added/updated tests — N/A (tooling only)
- [ ] Added/updated documentation — N/A
- [ ] Added/updated previews (Storybook) — N/A
- [x] Changes are SSR compatible (no runtime changes)
- [ ] Tested in Chrome / Firefox / Safari / Edge — N/A (no runtime changes)