### PR TITLE
feat: add support for compiling :is() selectors

### DIFF
--- a/.changeset/huge-mangos-call.md
+++ b/.changeset/huge-mangos-call.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Update CSS build options to compile down :is() selectors

--- a/package-lock.json
+++ b/package-lock.json
@@ -29238,6 +29238,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@csstools/postcss-global-data": "^2.1.1",
+        "@csstools/postcss-is-pseudo-class": "^5.0.1",
         "@github/browserslist-config": "^1.0.0",
         "@primer/primitives": "10.x || 11.x",
         "glob": "^11.1.0",

--- a/packages/postcss-preset-primer/package.json
+++ b/packages/postcss-preset-primer/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@csstools/postcss-global-data": "^2.1.1",
+    "@csstools/postcss-is-pseudo-class": "^5.0.1",
     "@github/browserslist-config": "^1.0.0",
     "@primer/primitives": "10.x || 11.x",
     "glob": "^11.1.0",

--- a/packages/postcss-preset-primer/src/index.js
+++ b/packages/postcss-preset-primer/src/index.js
@@ -104,8 +104,8 @@ const postcssPresetPrimer = () => {
           },
         }),
       ),
-      ...plugins(cssnano()),
       isPseudoClass(),
+      ...plugins(cssnano()),
     ],
   }
 }

--- a/packages/postcss-preset-primer/src/index.js
+++ b/packages/postcss-preset-primer/src/index.js
@@ -10,6 +10,7 @@ import cssnano from 'cssnano'
 import customPropertiesFallback from 'postcss-custom-properties-fallback'
 // @ts-expect-error this plugin does not have a declaration file
 import browsers from '@github/browserslist-config'
+import isPseudoClass from '@csstools/postcss-is-pseudo-class'
 
 const filepath = fileURLToPath(import.meta.url)
 const {root: ROOT_DIR} = path.parse(filepath)
@@ -98,15 +99,13 @@ const postcssPresetPrimer = () => {
           browsers,
           // https://preset-env.cssdb.org/features/#stage-2
           features: {
-            'nesting-rules': {
-              noIsPseudoSelector: true,
-            },
             'focus-visible-pseudo-class': false,
             'logical-properties-and-values': false,
           },
         }),
       ),
       ...plugins(cssnano()),
+      isPseudoClass(),
     ],
   }
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

I'm not sure when this was introduced, but it seems like in the latest edition of the postcss-nesting plugin the `:is()` selector can no longer be compiled out like we originally had in our config: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-nesting#2024-02-default

This PR adds in a plugin to compile down this selector so that we don't see broad `:is()` selectors being generated.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

<!-- List of things added in this PR -->

#### Changed

<!-- List of things changed in this PR -->

- Add `@csstools/postcss-is-pseudo-class` to compile away the generated `:is()` selectors from postcss-nesting

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Minor release
