### PR TITLE
test(vitest-config): update config to fail on late-emitted logs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ The primary workspace is `packages/react` which contains the `@primer/react` pac
 **Run tests:**
 
 - `npm test` -- runs unit tests. NEVER CANCEL. Takes 75 seconds. Set timeout to 90+ minutes. Runs 1500+ tests using Vitest in both node and chromium environments.
-- Vitest console enforcement is enabled by default. For local debugging, temporarily opt out with `VITEST_FAIL_ON_CONSOLE=false npm test`.
+- Vitest console enforcement is enabled by default in CI. For local debugging, it is disabled unless you opt in with `VITEST_FAIL_ON_CONSOLE=true npm test`.
 - `npm run type-check` -- runs TypeScript type checking across all packages. Takes 42 seconds. Set timeout to 60+ minutes.
 
 **Development workflow:**

--- a/contributor-docs/testing.md
+++ b/contributor-docs/testing.md
@@ -86,7 +86,7 @@ We are slowly moving away from using snapshots as a way to test visual changes o
 | Run a specific test | `npm test ComponentName` |
 | Update snapshots    | `npm test -- -u`         |
 
-By default, Vitest fails when tests emit unexpected console output. For local debugging, you can temporarily disable this enforcement with `VITEST_FAIL_ON_CONSOLE=false`.
+By default, Vitest fails when tests emit unexpected console output in CI. For local debugging, it is disabled unless you opt in with `VITEST_FAIL_ON_CONSOLE=true`.
 
 ## Interaction Tests
 

--- a/packages/react/config/vitest/browser/setup.ts
+++ b/packages/react/config/vitest/browser/setup.ts
@@ -19,11 +19,11 @@ import '@primer/primitives/dist/css/functional/themes/light.css'
 import '@primer/primitives/dist/css/functional/typography/typography.css'
 import './global.css'
 
-import {beforeEach} from 'vitest'
+import {afterEach} from 'vitest'
 import {cleanup} from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
-beforeEach(() => {
+afterEach(() => {
   cleanup()
 })
 

--- a/packages/react/src/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/packages/react/src/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -1,5 +1,5 @@
 import Breadcrumbs from '..'
-import {fireEvent, render as HTMLRender, screen, waitFor, within} from '@testing-library/react'
+import {act, fireEvent, render as HTMLRender, screen, waitFor, within} from '@testing-library/react'
 import {describe, expect, it, vi} from 'vitest'
 import userEvent from '@testing-library/user-event'
 import {FeatureFlags} from '../../FeatureFlags'
@@ -290,11 +290,14 @@ describe('Breadcrumbs', () => {
 
     // Simulate a wide container resize
     if (resizeCallback) {
-      resizeCallback([
-        {
-          contentRect: {width: 800, height: 40},
-        } as ResizeObserverEntry,
-      ])
+      const callback = resizeCallback
+      act(() => {
+        callback([
+          {
+            contentRect: {width: 800, height: 40},
+          } as ResizeObserverEntry,
+        ])
+      })
     }
 
     // Should still have overflow menu for 6 items (>5 rule)
@@ -302,11 +305,14 @@ describe('Breadcrumbs', () => {
 
     // Simulate a narrow container resize
     if (resizeCallback) {
-      resizeCallback([
-        {
-          contentRect: {width: 250, height: 40},
-        } as ResizeObserverEntry,
-      ])
+      const callback = resizeCallback
+      act(() => {
+        callback([
+          {
+            contentRect: {width: 250, height: 40},
+          } as ResizeObserverEntry,
+        ])
+      })
     }
 
     // Should maintain overflow menu for narrow container
@@ -373,11 +379,14 @@ describe('Breadcrumbs', () => {
 
     // Simulate a very narrow container resize that would affect overflow calculation
     if (resizeCallback) {
-      resizeCallback([
-        {
-          contentRect: {width: 200, height: 40},
-        } as ResizeObserverEntry,
-      ])
+      const callback = resizeCallback
+      act(() => {
+        callback([
+          {
+            contentRect: {width: 200, height: 40},
+          } as ResizeObserverEntry,
+        ])
+      })
     }
 
     // Menu button should still be present
@@ -385,11 +394,14 @@ describe('Breadcrumbs', () => {
 
     // Simulate a very wide container resize
     if (resizeCallback) {
-      resizeCallback([
-        {
-          contentRect: {width: 1200, height: 40},
-        } as ResizeObserverEntry,
-      ])
+      const callback = resizeCallback
+      act(() => {
+        callback([
+          {
+            contentRect: {width: 1200, height: 40},
+          } as ResizeObserverEntry,
+        ])
+      })
     }
 
     // Menu button should still be present (7 items > 5)
@@ -547,7 +559,9 @@ describe('Breadcrumbs', () => {
       const menuButton = screen.getByRole('button', {name: /more breadcrumb items/i})
 
       // Focus the menu button
-      menuButton.focus()
+      act(() => {
+        menuButton.focus()
+      })
       expect(menuButton).toHaveFocus()
 
       // Open menu with Enter key

--- a/packages/react/src/ConfirmationDialog/ConfirmationDialog.test.tsx
+++ b/packages/react/src/ConfirmationDialog/ConfirmationDialog.test.tsx
@@ -1,5 +1,5 @@
 import {render, fireEvent} from '@testing-library/react'
-import {describe, it, expect, vi} from 'vitest'
+import {afterEach, beforeEach, describe, it, expect, vi} from 'vitest'
 import type React from 'react'
 import {useCallback, useRef, useState} from 'react'
 
@@ -11,6 +11,14 @@ import {useConfirm} from './useConfirm'
 import {Stack} from '../Stack'
 import {implementsClassName} from '../utils/testing'
 import dialogClasses from '../Dialog/Dialog.module.css'
+
+const originalResizeObserver = globalThis.ResizeObserver
+
+class NoopResizeObserver implements ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
 
 const Basic = ({
   confirmButtonType,
@@ -119,6 +127,14 @@ const LoadingStates = ({
 }
 
 describe('ConfirmationDialog', () => {
+  beforeEach(() => {
+    globalThis.ResizeObserver = NoopResizeObserver
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver
+  })
+
   it('renders data-component attribute', () => {
     const {getByRole} = render(
       <BaseStyles>

--- a/packages/vitest-config/src/config.ts
+++ b/packages/vitest-config/src/config.ts
@@ -2,7 +2,10 @@ import {defineConfig as vitestDefineConfig, mergeConfig, type ViteUserConfig} fr
 
 export const defaultConfig: ViteUserConfig = {
   define: {
-    __VITEST_FAIL_ON_CONSOLE__: JSON.stringify(process.env.VITEST_FAIL_ON_CONSOLE === 'true'),
+    __VITEST_FAIL_ON_CONSOLE__: JSON.stringify(
+      process.env.VITEST_FAIL_ON_CONSOLE === 'true' ||
+        (process.env.VITEST_FAIL_ON_CONSOLE !== 'false' && process.env.CI === 'true'),
+    ),
   },
   test: {
     setupFiles: ['@primer/vitest-config/setup'],

--- a/packages/vitest-config/src/setup.ts
+++ b/packages/vitest-config/src/setup.ts
@@ -1,9 +1,13 @@
+import {afterEach, vi} from 'vitest'
+
 declare const __VITEST_FAIL_ON_CONSOLE__: boolean
 
 const failOnConsoleEnabled =
-  typeof __VITEST_FAIL_ON_CONSOLE__ === 'undefined'
-    ? typeof process !== 'undefined' && process.env.VITEST_FAIL_ON_CONSOLE === 'true'
-    : __VITEST_FAIL_ON_CONSOLE__
+  typeof __VITEST_FAIL_ON_CONSOLE__ === 'boolean'
+    ? __VITEST_FAIL_ON_CONSOLE__
+    : typeof process !== 'undefined' &&
+      (process.env.VITEST_FAIL_ON_CONSOLE === 'true' ||
+        (process.env.VITEST_FAIL_ON_CONSOLE !== 'false' && process.env.CI === 'true'))
 
 if (failOnConsoleEnabled) {
   const {default: failOnConsole} = await import('vitest-fail-on-console')
@@ -15,5 +19,10 @@ if (failOnConsoleEnabled) {
     shouldFailOnInfo: true,
     shouldFailOnLog: true,
     shouldFailOnWarn: true,
+    afterEachDelay: 1,
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 }


### PR DESCRIPTION
Import our vitest config to fail on logs that are emitted after a test completes (there were a few asynchronous ones we didn't catch before). This also makes it so that this is on by default in CI and off locally