### PR TITLE
Add NavList.Heading slot for accessible section-nav headings

### DIFF
--- a/.changeset/navlist-heading-slot.md
+++ b/.changeset/navlist-heading-slot.md
@@ -1,0 +1,9 @@
+---
+'@primer/react': minor
+---
+
+Add a `NavList.Heading` slot that names the navigation region. It renders an `h2`
+by default (configurable to `h3` via `as`), supports a `visuallyHidden` variant,
+labels the `nav` landmark via `aria-labelledby`, and makes `NavList.Group`
+headings default to one level deeper (`h3`, or `h4` under an `h3` heading) for a
+correct heading hierarchy.

--- a/packages/react/src/NavList/NavList.docs.json
+++ b/packages/react/src/NavList/NavList.docs.json
@@ -72,6 +72,11 @@
           "description": "The text rendered as the NavList's heading."
         },
         {
+          "name": "id",
+          "type": "string",
+          "description": "Custom id for the heading element. When set, it is used as the `aria-labelledby` target that names the `nav` landmark; otherwise a generated id is used."
+        },
+        {
           "name": "className",
           "type": "string",
           "description": "Custom CSS class name."

--- a/packages/react/src/NavList/NavList.docs.json
+++ b/packages/react/src/NavList/NavList.docs.json
@@ -49,6 +49,41 @@
   ],
   "subcomponents": [
     {
+      "name": "NavList.Heading",
+      "props": [
+        {
+          "name": "as",
+          "type": "'h2' | 'h3'",
+          "defaultValue": "\"h2\"",
+          "required": false,
+          "description": "Semantic heading level for the NavList. Also sets the default level for child group headings, which render one level deeper (h3 under an h2, h4 under an h3). Constrained to h2/h3 so the hierarchy stays shallow."
+        },
+        {
+          "name": "visuallyHidden",
+          "type": "boolean",
+          "defaultValue": "false",
+          "required": false,
+          "description": "Visually hide the heading while keeping it available to assistive technology and as the accessible name for the `nav` landmark."
+        },
+        {
+          "name": "children",
+          "type": "ReactNode",
+          "required": true,
+          "description": "The text rendered as the NavList's heading."
+        },
+        {
+          "name": "className",
+          "type": "string",
+          "description": "Custom CSS class name."
+        },
+        {
+          "name": "style",
+          "type": "React.CSSProperties",
+          "description": "Custom CSS styles."
+        }
+      ]
+    },
+    {
       "name": "NavList.Item",
       "props": [
         {
@@ -194,10 +229,9 @@
         },
         {
           "name": "as",
-          "description": "Heading level for the group heading. Sets the semantic heading tag.",
+          "description": "Heading level for the group heading. Sets the semantic heading tag. Defaults to one level below a `NavList.Heading` (h3 under an h2, h4 under an h3), or `h3` when there is no `NavList.Heading`.",
           "required": false,
-          "type": "'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'",
-          "defaultValue": "\"h3\""
+          "type": "'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'"
         }
       ]
     },

--- a/packages/react/src/NavList/NavList.features.stories.tsx
+++ b/packages/react/src/NavList/NavList.features.stories.tsx
@@ -667,8 +667,6 @@ export const WithHeading: StoryFn = () => (
   </PageLayout>
 )
 
-WithHeading.storyName = 'With Heading'
-
 export const WithVisuallyHiddenHeading: StoryFn = () => (
   <PageLayout>
     <PageLayout.Pane position="start">

--- a/packages/react/src/NavList/NavList.features.stories.tsx
+++ b/packages/react/src/NavList/NavList.features.stories.tsx
@@ -646,4 +646,50 @@ export const WithItemGap: StoryFn = () => (
 
 WithItemGap.storyName = 'With gap between items (behind feature flag)'
 
+export const WithHeading: StoryFn = () => (
+  <PageLayout>
+    <PageLayout.Pane position="start">
+      <NavList>
+        <NavList.Heading>Settings</NavList.Heading>
+        <NavList.Group title="Account">
+          <NavList.Item href="#" aria-current="page">
+            Profile
+          </NavList.Item>
+          <NavList.Item href="#">Appearance</NavList.Item>
+        </NavList.Group>
+        <NavList.Group title="Security">
+          <NavList.Item href="#">Password and authentication</NavList.Item>
+          <NavList.Item href="#">Sessions</NavList.Item>
+        </NavList.Group>
+      </NavList>
+    </PageLayout.Pane>
+    <PageLayout.Content></PageLayout.Content>
+  </PageLayout>
+)
+
+WithHeading.storyName = 'With Heading'
+
+export const WithVisuallyHiddenHeading: StoryFn = () => (
+  <PageLayout>
+    <PageLayout.Pane position="start">
+      <NavList>
+        <NavList.Heading visuallyHidden>Settings</NavList.Heading>
+        <NavList.Group title="Account">
+          <NavList.Item href="#" aria-current="page">
+            Profile
+          </NavList.Item>
+          <NavList.Item href="#">Appearance</NavList.Item>
+        </NavList.Group>
+        <NavList.Group title="Security">
+          <NavList.Item href="#">Password and authentication</NavList.Item>
+          <NavList.Item href="#">Sessions</NavList.Item>
+        </NavList.Group>
+      </NavList>
+    </PageLayout.Pane>
+    <PageLayout.Content></PageLayout.Content>
+  </PageLayout>
+)
+
+WithVisuallyHiddenHeading.storyName = 'With Heading (hidden)'
+
 export default meta

--- a/packages/react/src/NavList/NavList.module.css
+++ b/packages/react/src/NavList/NavList.module.css
@@ -1,3 +1,9 @@
+.Heading {
+  margin-block-end: var(--base-size-8);
+  /* stylelint-disable-next-line primer/spacing */
+  margin-inline-start: calc(var(--control-medium-paddingInline-condensed) + var(--base-size-8));
+}
+
 .GroupHeading > a {
   color: var(--fgColor-default);
   text-decoration: inherit;

--- a/packages/react/src/NavList/NavList.test.tsx
+++ b/packages/react/src/NavList/NavList.test.tsx
@@ -619,4 +619,122 @@ describe('NavList.ShowMoreItem with pages', () => {
       expect(getComputedStyle(subGroup as HTMLElement).marginBlockStart).toBe('0px')
     })
   })
+
+  describe('NavList.Heading', () => {
+    it('renders an h2 heading by default', () => {
+      const {getByRole} = render(
+        <NavList>
+          <NavList.Heading>Settings</NavList.Heading>
+          <NavList.Item href="#">Item 1</NavList.Item>
+        </NavList>,
+      )
+
+      expect(getByRole('heading', {level: 2, name: 'Settings'})).toBeInTheDocument()
+    })
+
+    it('respects an explicit heading level via the `as` prop', () => {
+      const {getByRole} = render(
+        <NavList>
+          <NavList.Heading as="h3">Settings</NavList.Heading>
+          <NavList.Item href="#">Item 1</NavList.Item>
+        </NavList>,
+      )
+
+      expect(getByRole('heading', {level: 3, name: 'Settings'})).toBeInTheDocument()
+    })
+
+    it('labels the nav landmark with the heading', () => {
+      const {getByRole} = render(
+        <NavList>
+          <NavList.Heading>Settings</NavList.Heading>
+          <NavList.Item href="#">Item 1</NavList.Item>
+        </NavList>,
+      )
+
+      const nav = getByRole('navigation', {name: 'Settings'})
+      const heading = getByRole('heading', {name: 'Settings'})
+      expect(nav).toHaveAttribute('aria-labelledby', heading.id)
+    })
+
+    it('does not override a consumer-supplied aria-label', () => {
+      const {getByRole} = render(
+        <NavList aria-label="Custom label">
+          <NavList.Heading>Settings</NavList.Heading>
+          <NavList.Item href="#">Item 1</NavList.Item>
+        </NavList>,
+      )
+
+      const nav = getByRole('navigation', {name: 'Custom label'})
+      expect(nav).not.toHaveAttribute('aria-labelledby')
+    })
+
+    it('defaults group headings to one level below the NavList.Heading', () => {
+      const {getByRole} = render(
+        <NavList>
+          <NavList.Heading>Settings</NavList.Heading>
+          <NavList.Group title="Account">
+            <NavList.Item href="#">Profile</NavList.Item>
+          </NavList.Group>
+        </NavList>,
+      )
+
+      expect(getByRole('heading', {level: 2, name: 'Settings'})).toBeInTheDocument()
+      expect(getByRole('heading', {level: 3, name: 'Account'})).toBeInTheDocument()
+    })
+
+    it('derives group headings to h4 when the NavList.Heading is an h3', () => {
+      const {getByRole} = render(
+        <NavList>
+          <NavList.Heading as="h3">Settings</NavList.Heading>
+          <NavList.Group title="Account">
+            <NavList.Item href="#">Profile</NavList.Item>
+          </NavList.Group>
+        </NavList>,
+      )
+
+      expect(getByRole('heading', {level: 3, name: 'Settings'})).toBeInTheDocument()
+      expect(getByRole('heading', {level: 4, name: 'Account'})).toBeInTheDocument()
+    })
+
+    it('keeps the h3 group heading default when there is no NavList.Heading', () => {
+      const {getByRole} = render(
+        <NavList>
+          <NavList.Group title="Account">
+            <NavList.Item href="#">Profile</NavList.Item>
+          </NavList.Group>
+        </NavList>,
+      )
+
+      expect(getByRole('heading', {level: 3, name: 'Account'})).toBeInTheDocument()
+    })
+
+    it('lets group headings override their computed level with `as`', () => {
+      const {getByRole} = render(
+        <NavList>
+          <NavList.Heading>Settings</NavList.Heading>
+          <NavList.Group>
+            <NavList.GroupHeading as="h4">Account</NavList.GroupHeading>
+            <NavList.Item href="#">Profile</NavList.Item>
+          </NavList.Group>
+        </NavList>,
+      )
+
+      expect(getByRole('heading', {level: 4, name: 'Account'})).toBeInTheDocument()
+    })
+
+    it('keeps a visually hidden heading in the accessibility tree', () => {
+      const {getByRole} = render(
+        <NavList>
+          <NavList.Heading visuallyHidden>Settings</NavList.Heading>
+          <NavList.Item href="#">Item 1</NavList.Item>
+        </NavList>,
+      )
+
+      const heading = getByRole('heading', {level: 2, name: 'Settings'})
+      expect(heading).toBeInTheDocument()
+      expect(getByRole('navigation', {name: 'Settings'})).toBeInTheDocument()
+      // The visually-hidden styles are applied to the heading itself, not a wrapping element.
+      expect(heading.parentElement?.tagName).not.toBe('SPAN')
+    })
+  })
 })

--- a/packages/react/src/NavList/NavList.test.tsx
+++ b/packages/react/src/NavList/NavList.test.tsx
@@ -736,5 +736,20 @@ describe('NavList.ShowMoreItem with pages', () => {
       // The visually-hidden styles are applied to the heading itself, not a wrapping element.
       expect(heading.parentElement?.tagName).not.toBe('SPAN')
     })
+
+    it('forwards standard HTML attributes to the heading element', () => {
+      const {getByRole} = render(
+        <NavList>
+          <NavList.Heading data-testid="nav-heading" title="Section navigation">
+            Settings
+          </NavList.Heading>
+          <NavList.Item href="#">Item 1</NavList.Item>
+        </NavList>,
+      )
+
+      const heading = getByRole('heading', {level: 2, name: 'Settings'})
+      expect(heading).toHaveAttribute('data-testid', 'nav-heading')
+      expect(heading).toHaveAttribute('title', 'Section navigation')
+    })
   })
 })

--- a/packages/react/src/NavList/NavList.tsx
+++ b/packages/react/src/NavList/NavList.tsx
@@ -19,6 +19,31 @@ import navListClasses from './NavList.module.css'
 import {flushSync} from 'react-dom'
 import {useSlots} from '../hooks/useSlots'
 import {fixedForwardRef, type PolymorphicProps} from '../utils/modern-polymorphic'
+import HeadingComponent from '../Heading'
+import visuallyHiddenClasses from '../_VisuallyHidden.module.css'
+import type {FCWithSlotMarker} from '../utils/types/Slots'
+
+type HeadingLevels = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+
+// NavList establishes a shallow hierarchy: the NavList itself is named by a
+// heading (h2 or h3) and its groups render one level deeper (h3 or h4). We don't
+// expose an h1 (that's the page title) and we don't go deeper than h4.
+type NavListHeadingLevels = 'h2' | 'h3'
+
+// Publishes the resolved numeric level of a NavList.Heading (e.g. 2 for an h2) so
+// NavList.Group/NavList.GroupHeading can default to one level deeper. `null` when
+// there is no NavList.Heading, in which case groups keep their historical h3 default.
+const NavListHeadingLevelContext = React.createContext<number | null>(null)
+
+function headingTagToLevel(as: NavListHeadingLevels): number {
+  return Number.parseInt(as.slice(1), 10)
+}
+
+function levelToHeadingTag(level: number): HeadingLevels {
+  // Clamp to h4 so group headings never go deeper than the supported hierarchy.
+  const clamped = Math.min(Math.max(level, 1), 4)
+  return `h${clamped}` as HeadingLevels
+}
 
 // ----------------------------------------------------------------------------
 // NavList
@@ -27,21 +52,81 @@ export type NavListProps = {
   children: React.ReactNode
 } & React.ComponentProps<'nav'>
 
-const Root = React.forwardRef<HTMLElement, NavListProps>(({children, ...props}, ref) => {
-  return (
-    <nav {...props} ref={ref} data-component="NavList">
-      <ActionListContainerContext.Provider
-        value={{
-          container: 'NavList',
-        }}
-      >
-        <ActionList>{children}</ActionList>
-      </ActionListContainerContext.Provider>
-    </nav>
-  )
-})
+const Root = React.forwardRef<HTMLElement, NavListProps>(
+  ({children, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledby, ...props}, ref) => {
+    const [slots, childrenWithoutHeading] = useSlots(children, {
+      heading: Heading,
+    })
+
+    const fallbackHeadingId = useId()
+    const heading = slots.heading
+    const headingId = heading ? (heading.props.id ?? fallbackHeadingId) : undefined
+    const headingLevel = heading ? headingTagToLevel(heading.props.as ?? 'h2') : null
+
+    // Don't override a consumer-supplied accessible name; otherwise label the
+    // <nav> landmark with the heading so it gets an accessible name automatically.
+    const navLabelledby = ariaLabelledby ?? (ariaLabel ? undefined : headingId)
+
+    return (
+      <nav {...props} aria-label={ariaLabel} aria-labelledby={navLabelledby} ref={ref} data-component="NavList">
+        <NavListHeadingLevelContext.Provider value={headingLevel}>
+          {heading ? React.cloneElement(heading, {id: headingId}) : null}
+          <ActionListContainerContext.Provider
+            value={{
+              container: 'NavList',
+            }}
+          >
+            <ActionList>{childrenWithoutHeading}</ActionList>
+          </ActionListContainerContext.Provider>
+        </NavListHeadingLevelContext.Provider>
+      </nav>
+    )
+  },
+)
 
 Root.displayName = 'NavList'
+
+// ----------------------------------------------------------------------------
+// NavList.Heading
+
+export type NavListHeadingProps = {
+  /** Semantic heading level for the NavList. Also sets the default level for child group headings, which render one level deeper. */
+  as?: NavListHeadingLevels
+  /** Visually hide the heading while keeping it available to assistive technology. */
+  visuallyHidden?: boolean
+  children: React.ReactNode
+  className?: string
+  id?: string
+  style?: React.CSSProperties
+}
+
+const Heading: FCWithSlotMarker<NavListHeadingProps> = ({
+  as = 'h2',
+  visuallyHidden = false,
+  className,
+  children,
+  ...props
+}) => {
+  return (
+    <HeadingComponent
+      as={as}
+      variant="small"
+      className={clsx(
+        // Apply the visually-hidden styles directly to the heading rather than wrapping
+        // it in a span (a heading isn't valid phrasing content inside a span).
+        visuallyHidden ? visuallyHiddenClasses.InternalVisuallyHidden : navListClasses.Heading,
+        className,
+      )}
+      data-component="NavList.Heading"
+      {...props}
+    >
+      {children}
+    </HeadingComponent>
+  )
+}
+
+Heading.displayName = 'NavList.Heading'
+Heading.__SLOT__ = Symbol('NavList.Heading')
 
 // ----------------------------------------------------------------------------
 // NavList.Item
@@ -285,13 +370,17 @@ export type NavListGroupProps = React.HTMLAttributes<HTMLLIElement> & {
 }
 
 const Group: React.FC<NavListGroupProps> = ({title, children, ...props}) => {
+  const headingLevel = React.useContext(NavListHeadingLevelContext)
+  // Default the group heading to one level below the NavList.Heading (h3 under an
+  // h2, h4 under an h3), falling back to h3 when there is no NavList.Heading. To
+  // use a different level, pass NavList.GroupHeading with an explicit `as` instead.
+  const groupHeadingAs = headingLevel ? levelToHeadingTag(headingLevel + 1) : 'h3'
   return (
     <>
       <ActionList.Divider />
       <ActionList.Group {...props}>
-        {/* Setting up the default value for the heading level. TODO: API update to give flexibility to NavList.Group title's heading level */}
         {title ? (
-          <ActionList.GroupHeading as="h3" data-component="ActionList.GroupHeading">
+          <ActionList.GroupHeading as={groupHeadingAs} data-component="ActionList.GroupHeading">
             {title}
           </ActionList.GroupHeading>
         ) : null}
@@ -409,10 +498,12 @@ export type NavListGroupHeadingProps = ActionListGroupHeadingProps
  * This is an alternative to the `title` prop on `NavList.Group`.
  * It was primarily added to allow links in group headings.
  */
-const GroupHeading: React.FC<NavListGroupHeadingProps> = ({as = 'h3', className, ...rest}) => {
+const GroupHeading: React.FC<NavListGroupHeadingProps> = ({as, className, ...rest}) => {
+  const headingLevel = React.useContext(NavListHeadingLevelContext)
+  const resolvedAs = as ?? (headingLevel ? levelToHeadingTag(headingLevel + 1) : 'h3')
   return (
     <ActionList.GroupHeading
-      as={as}
+      as={resolvedAs}
       className={clsx(navListClasses.GroupHeading, className)}
       data-component="NavList.GroupHeading"
       headingWrapElement="li"
@@ -426,6 +517,7 @@ const GroupHeading: React.FC<NavListGroupHeadingProps> = ({as = 'h3', className,
 
 export const NavList = Object.assign(Root, {
   Description: ActionList.Description,
+  Heading,
   Item,
   SubNav,
   LeadingVisual,

--- a/packages/react/src/NavList/NavList.tsx
+++ b/packages/react/src/NavList/NavList.tsx
@@ -94,11 +94,7 @@ export type NavListHeadingProps = {
   as?: NavListHeadingLevels
   /** Visually hide the heading while keeping it available to assistive technology. */
   visuallyHidden?: boolean
-  children: React.ReactNode
-  className?: string
-  id?: string
-  style?: React.CSSProperties
-}
+} & React.ComponentPropsWithoutRef<'h2'>
 
 const Heading: FCWithSlotMarker<NavListHeadingProps> = ({
   as = 'h2',


### PR DESCRIPTION
## Overview

Many GitHub pages built with `NavList` — user settings, repository settings, and similar — end up with a confusing or broken page heading structure. This PR adds an optional `NavList.Heading` slot that gives the whole navigation region a single heading, names the `<nav>` landmark, and automatically keeps group headings nested correctly beneath it.

### Why this is needed

Today, `NavList.Group` headings default to `h3` (and some are hand-tweaked to `h2`). On a typical settings page that means a *subset of the left-hand section-navigation links* is exposed at the **same heading level** as the main page-content sections. For someone navigating by heading with a screen reader, the navigation links and the page content look like siblings in the document outline, which misrepresents the actual hierarchy and makes the page slower to understand and move through.

What usually makes more sense is:

- an `h2` heading for the `NavList` as a whole, with
- `h3` subheadings for each `NavList.Group`.

That produces a correct `h2 → h3` outline, lets screen reader users jump straight to the navigation region, and makes the visual/content hierarchy match the semantic one.

Right now teams have to wire all of this up by hand — add an accessible name to the `<nav>`, pick heading levels for each group, and remember to keep them consistent. It's easy to forget and easy to get wrong. This PR makes the correct structure the easy, built-in path.

### How it works

- **`NavList.Heading`** is a new slot. Add it as a child of `NavList` and it renders the heading for the region. It defaults to `h2`.
- It **labels the `<nav>` landmark** automatically via `aria-labelledby`, so the navigation gets an accessible name without extra work. If you already pass your own `aria-label`/`aria-labelledby`, yours wins — we don't override it.
- It supports a **`visuallyHidden`** variant for pages where the heading shouldn't be shown visually but should still exist for assistive tech and as the landmark's name.
- **Group headings auto-nest.** When a `NavList.Heading` is present, `NavList.Group` (and `NavList.GroupHeading`) default to one level deeper than the heading — `h3` under an `h2`, `h4` under an `h3`. With no `NavList.Heading`, groups keep today's `h3` default, so nothing changes for existing usage.
- The heading level is intentionally constrained to `h2` or `h3` (no `h1` — that's the page title — and group headings never go deeper than `h4`), keeping the outline shallow. If you need a specific level on a single group, pass `NavList.GroupHeading as={...}` as an explicit override.

```tsx
<NavList>
  <NavList.Heading>Settings</NavList.Heading>          {/* h2, names the <nav> */}
  <NavList.Group title="Account">                      {/* auto h3 */}
    <NavList.Item href="#" aria-current="page">Profile</NavList.Item>
    <NavList.Item href="#">Appearance</NavList.Item>
  </NavList.Group>
  <NavList.Group title="Security">                     {/* auto h3 */}
    <NavList.Item href="#">Password and authentication</NavList.Item>
  </NavList.Group>
</NavList>
```

### Implementation notes

- `NavList` already wraps its children in `ActionList`, which has a heading slot. The new work is a NavList-level slot that (a) names the `<nav>` landmark and (b) coordinates heading levels with groups via a small internal context. It's mostly wiring rather than net-new machinery.
- For the `visuallyHidden` variant, the visually-hidden styles are applied **directly to the heading element** (reusing the existing `_VisuallyHidden` CSS) rather than wrapping it in a `<span>` — a heading isn't valid phrasing content inside a span.
- A follow-up is noted for `ActionList.Heading`, which currently has the same span-wrapping pattern; it's intentionally left out of this PR to keep the scope tight.

### Changelog

#### New

- `NavList.Heading` slot: names the navigation region, labels the `<nav>` landmark via `aria-labelledby`, supports a `visuallyHidden` variant, and defaults to `h2` (configurable to `h3`).
- `NavList.Group` / `NavList.GroupHeading` now default their heading level to one below a `NavList.Heading` (e.g. `h3` under an `h2`).
- Storybook stories: "With Heading" and "With Heading (hidden)".

#### Changed

- When a `NavList.Heading` is present, `NavList.Group` title headings derive their level from it instead of always rendering `h3`. With no `NavList.Heading`, the `h3` default is unchanged.

#### Removed

- Nothing.

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

Purely additive. Existing `NavList` usage that doesn't include a `NavList.Heading` renders exactly as before.

### Testing & Reviewing

- Unit tests cover: default `h2` heading, `as="h3"` override, `<nav>` labelled by the heading, consumer `aria-label` not being overridden, group headings deriving `h3`/`h4`, the `h3` fallback with no heading, `NavList.GroupHeading as` override, and the visually-hidden heading staying in the a11y tree without a wrapping span.
- In Storybook see **Components → NavList → Features → "With Heading"** and **"With Heading (hidden)"**. Inspect the accessibility tree to confirm the `h2 → h3` outline and that the `<nav>` is named by the heading.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui

