### PR TITLE
feat: remove private flag from @primer/react-canvas

### DIFF
--- a/packages/canvas/package.json
+++ b/packages/canvas/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@primer/react-canvas",
-  "private": true,
   "version": "0.0.2",
   "type": "module",
   "exports": {


### PR DESCRIPTION
With the discussion up: https://github.com/github/planning-tracking/discussions/3426 it seems like this package is in a good shape to allow us to publish it when `@primer/react` itself is published 🥳 

This removes the private flag so that in the future when it receives changes it will be published as a part of our regular workflow.

Note: this does not include a changeset because `0.0.2` is already published