### PR TITLE
refactor: update build config for @primer/styled-react to rolldown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29433,7 +29433,6 @@
         "@primer/primitives": "10.x || 11.x",
         "@primer/react": "^38.26.0",
         "@rolldown/plugin-babel": "^0.2.3",
-        "@rollup/plugin-babel": "^6.1.0",
         "@storybook/react-vite": "^10.4.2",
         "@types/babel__core": "^7.20.5",
         "@types/react": "18.3.11",
@@ -29448,8 +29447,7 @@
         "react-compiler-runtime": "^1.0.0",
         "react-dom": "18.3.1",
         "rimraf": "^6.0.1",
-        "rollup": "4.59.0",
-        "rollup-plugin-typescript2": "^0.36.0",
+        "rolldown": "^1.1.2",
         "styled-components": "5.3.11",
         "typescript": "^6.0.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29448,6 +29448,7 @@
         "react-dom": "18.3.1",
         "rimraf": "^6.0.1",
         "rolldown": "^1.1.2",
+        "rolldown-plugin-dts": "^0.26.0",
         "styled-components": "5.3.11",
         "typescript": "^6.0.3"
       },

--- a/packages/styled-react/package.json
+++ b/packages/styled-react/package.json
@@ -59,6 +59,7 @@
     "react-dom": "18.3.1",
     "rimraf": "^6.0.1",
     "rolldown": "^1.1.2",
+    "rolldown-plugin-dts": "^0.26.0",
     "styled-components": "5.3.11",
     "typescript": "^6.0.3"
   },

--- a/packages/styled-react/package.json
+++ b/packages/styled-react/package.json
@@ -44,7 +44,6 @@
     "@primer/primitives": "10.x || 11.x",
     "@primer/react": "^38.26.0",
     "@rolldown/plugin-babel": "^0.2.3",
-    "@rollup/plugin-babel": "^6.1.0",
     "@storybook/react-vite": "^10.4.2",
     "@types/babel__core": "^7.20.5",
     "@types/react": "18.3.11",
@@ -59,8 +58,7 @@
     "react-compiler-runtime": "^1.0.0",
     "react-dom": "18.3.1",
     "rimraf": "^6.0.1",
-    "rollup": "4.59.0",
-    "rollup-plugin-typescript2": "^0.36.0",
+    "rolldown": "^1.1.2",
     "styled-components": "5.3.11",
     "typescript": "^6.0.3"
   },

--- a/packages/styled-react/rolldown.config.js
+++ b/packages/styled-react/rolldown.config.js
@@ -1,9 +1,6 @@
-import babel from '@rollup/plugin-babel'
-import nodeResolve from '@rollup/plugin-node-resolve'
-import {defineConfig} from 'rollup'
-import typescript from 'rollup-plugin-typescript2'
+import babel from '@rolldown/plugin-babel'
+import {defineConfig, RolldownMagicString as MagicString} from 'rolldown'
 import packageJson from './package.json' with {type: 'json'}
-import MagicString from 'magic-string'
 
 const dependencies = [
   ...Object.keys(packageJson.peerDependencies ?? {}),
@@ -19,18 +16,13 @@ export default defineConfig({
   input: ['src/index.tsx'],
   external: dependencies.map(createPackageRegex),
   plugins: [
-    typescript({
-      tsconfig: 'tsconfig.build.json',
-    }),
-    nodeResolve({extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']}),
     babel({
       presets: ['@babel/preset-typescript', ['@babel/preset-react', {runtime: 'automatic'}]],
       plugins: ['babel-plugin-styled-components'],
-      extensions: ['.ts', '.tsx'],
-      babelHelpers: 'bundled',
+      include: /\.(?:ts|tsx)$/,
     }),
     /**
-     * This custom rollup plugin allows us to preserve directives in source
+     * This custom Rolldown plugin allows us to preserve directives in source
      * code, such as "use client", in order to support React Server Components.
      *
      * The source for this plugin is inspired by:

--- a/packages/styled-react/rolldown.config.js
+++ b/packages/styled-react/rolldown.config.js
@@ -96,12 +96,9 @@ export default defineConfig({
           if (chunkHasClientDirective) {
             const transformed = new MagicString(code)
             transformed.prepend(`"use client";\n`)
-            const sourcemap = transformed.generateMap({
-              includeContent: true,
-            })
             return {
               code: transformed.toString(),
-              map: sourcemap,
+              map: null,
             }
           }
 

--- a/packages/styled-react/rolldown.config.js
+++ b/packages/styled-react/rolldown.config.js
@@ -1,5 +1,6 @@
 import babel from '@rolldown/plugin-babel'
 import {defineConfig, RolldownMagicString as MagicString} from 'rolldown'
+import {dts} from 'rolldown-plugin-dts'
 import packageJson from './package.json' with {type: 'json'}
 
 const dependencies = [
@@ -12,118 +13,156 @@ function createPackageRegex(name) {
   return new RegExp(`^${name}(/.*)?`)
 }
 
-export default defineConfig({
-  input: ['src/index.tsx'],
-  external: dependencies.map(createPackageRegex),
-  plugins: [
-    babel({
-      presets: ['@babel/preset-typescript', ['@babel/preset-react', {runtime: 'automatic'}]],
-      plugins: ['babel-plugin-styled-components'],
-      include: /\.(?:ts|tsx)$/,
-    }),
-    /**
-     * This custom Rolldown plugin allows us to preserve directives in source
-     * code, such as "use client", in order to support React Server Components.
-     *
-     * The source for this plugin is inspired by:
-     * https://github.com/Ephem/rollup-plugin-preserve-directives
-     */
-    {
-      name: 'preserve-directives',
-      transform(code) {
-        const ast = this.parse(code)
-        if (ast.type !== 'Program' || !ast.body) {
-          return {
-            code,
-            ast,
-            map: null,
-          }
-        }
+const external = dependencies.map(createPackageRegex)
 
-        let hasClientDirective = false
+const declarationInput = {
+  index: 'src/index.tsx',
+  sx: 'src/sx.ts',
+  'theme-get': 'src/theme-get.ts',
+  'styled-props': 'src/styled-props.ts',
+  polymorphic: 'src/polymorphic.ts',
+  'components/BaseStyles': 'src/components/BaseStyles.tsx',
+  'components/FeatureFlaggedTheming': 'src/components/FeatureFlaggedTheming.tsx',
+  'components/ThemeContext': 'src/components/ThemeContext.ts',
+  'components/ThemeProvider': 'src/components/ThemeProvider.tsx',
+  'components/useFeatureFlaggedTheme': 'src/components/useFeatureFlaggedTheme.ts',
+  'components/useTheme': 'src/components/useTheme.ts',
+}
 
-        for (const node of ast.body) {
-          if (!node) {
-            continue
-          }
+function hasClientDirective(ast) {
+  if (ast.type !== 'Program' || !ast.body) {
+    return false
+  }
 
-          if (node.type !== 'ExpressionStatement') {
-            continue
-          }
+  for (const node of ast.body) {
+    if (!node) {
+      continue
+    }
 
-          if (node.directive === 'use client') {
-            hasClientDirective = true
-            break
-          }
-        }
+    if (node.type !== 'ExpressionStatement') {
+      continue
+    }
 
-        if (hasClientDirective) {
-          return {
-            code,
-            ast,
-            map: null,
-            meta: {
-              hasClientDirective: true,
-            },
-          }
-        }
+    if (node.directive === 'use client') {
+      return true
+    }
+  }
 
-        return {
-          code,
-          ast,
-          map: null,
-        }
-      },
-      renderChunk: {
-        order: 'post',
-        handler(code, chunk, options) {
-          // If `preserveModules` is not set to true, we can't be sure if the client
-          // directive corresponds to the whole chunk or just a part of it.
-          if (!options.preserveModules) {
-            return undefined
-          }
+  return false
+}
 
-          let chunkHasClientDirective = false
+export default defineConfig([
+  {
+    input: ['src/index.tsx'],
+    external,
+    plugins: [
+      babel({
+        presets: ['@babel/preset-typescript', ['@babel/preset-react', {runtime: 'automatic'}]],
+        plugins: ['babel-plugin-styled-components'],
+        include: /\.(?:ts|tsx)$/,
+      }),
+      /**
+       * This custom Rolldown plugin allows us to preserve directives in source
+       * code, such as "use client", in order to support React Server Components.
+       *
+       * The source for this plugin is inspired by:
+       * https://github.com/Ephem/rollup-plugin-preserve-directives
+       */
+      {
+        name: 'preserve-directives',
+        transform(code) {
+          const ast = this.parse(code)
 
-          for (const moduleId of Object.keys(chunk.modules)) {
-            const hasClientDirective = this.getModuleInfo(moduleId)?.meta?.hasClientDirective
-            if (hasClientDirective) {
-              chunkHasClientDirective = true
-              break
-            }
-          }
-
-          if (chunkHasClientDirective) {
-            const transformed = new MagicString(code)
-            transformed.prepend(`"use client";\n`)
+          if (hasClientDirective(ast)) {
             return {
-              code: transformed.toString(),
+              code,
+              ast,
               map: null,
+              meta: {
+                hasClientDirective: true,
+              },
             }
           }
 
-          return null
+          return {
+            code,
+            ast,
+            map: null,
+          }
+        },
+        renderChunk: {
+          order: 'post',
+          handler(code, chunk, options) {
+            // If `preserveModules` is not set to true, we can't be sure if the client
+            // directive corresponds to the whole chunk or just a part of it.
+            if (!options.preserveModules) {
+              return undefined
+            }
+
+            let chunkHasClientDirective = false
+
+            for (const moduleId of Object.keys(chunk.modules)) {
+              const hasClientDirective = this.getModuleInfo(moduleId)?.meta?.hasClientDirective
+              if (hasClientDirective) {
+                chunkHasClientDirective = true
+                break
+              }
+            }
+
+            if (chunkHasClientDirective) {
+              const ast = this.parse(code)
+              if (hasClientDirective(ast)) {
+                return null
+              }
+
+              const transformed = new MagicString(code)
+              transformed.prepend(`"use client";\n`)
+              return {
+                code: transformed.toString(),
+                map: null,
+              }
+            }
+
+            return null
+          },
         },
       },
+    ],
+    onwarn(warning, defaultHandler) {
+      // Dependencies or modules may use "use client" as an indicator for React
+      // Server Components that this module should only be loaded on the client.
+      if (warning.code === 'MODULE_LEVEL_DIRECTIVE' && warning.message.includes('use client')) {
+        return
+      }
+
+      if (warning.code === 'CIRCULAR_DEPENDENCY') {
+        throw warning
+      }
+
+      defaultHandler(warning)
     },
-  ],
-  onwarn(warning, defaultHandler) {
-    // Dependencies or modules may use "use client" as an indicator for React
-    // Server Components that this module should only be loaded on the client.
-    if (warning.code === 'MODULE_LEVEL_DIRECTIVE' && warning.message.includes('use client')) {
-      return
-    }
-
-    if (warning.code === 'CIRCULAR_DEPENDENCY') {
-      throw warning
-    }
-
-    defaultHandler(warning)
+    output: {
+      dir: 'dist',
+      format: 'esm',
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+    },
   },
-  output: {
-    dir: 'dist',
-    format: 'esm',
-    preserveModules: true,
-    preserveModulesRoot: 'src',
+  {
+    input: declarationInput,
+    external,
+    plugins: [
+      dts({
+        emitDtsOnly: true,
+        sourcemap: true,
+        tsconfig: './tsconfig.build.json',
+      }),
+    ],
+    output: {
+      dir: 'dist',
+      format: 'esm',
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+    },
   },
-})
+])

--- a/packages/styled-react/script/build
+++ b/packages/styled-react/script/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Build the package
-npx rollup -c
+npx rolldown -c
 
 # Generate type declarations
 npx tsc --project tsconfig.build.json

--- a/packages/styled-react/script/build
+++ b/packages/styled-react/script/build
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Build the package
 npx rolldown -c
 

--- a/packages/styled-react/script/build
+++ b/packages/styled-react/script/build
@@ -5,8 +5,5 @@ set -e
 # Build the package
 npx rolldown -c
 
-# Generate type declarations
-npx tsc --project tsconfig.build.json
-
 # Generate components.json
 ./script/generate-components-json


### PR DESCRIPTION
Closes #

N/A

### Changelog

#### New

N/A

#### Changed

- Updated `@primer/styled-react` to build JavaScript with Rolldown and emit declarations with TypeScript.

#### Removed

- Removed the package Rollup build config and Rollup build dependencies.

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; build tooling-only change with no public runtime API change

### Testing & Reviewing

Validated as part of the stack with `npm run build`, `npm run type-check`, `npm run lint`, `npm run lint:css`, `npm run format:diff`, and `npm test -- --run`.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
