### PR TITLE
feat: add React Compiler support for ActionMenu

### DIFF
--- a/.changeset/react-compiler-action-menu.md
+++ b/.changeset/react-compiler-action-menu.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+ActionMenu: Improve rendering performance with React Compiler support

--- a/packages/react/script/react-compiler.mjs
+++ b/packages/react/script/react-compiler.mjs
@@ -12,7 +12,6 @@ const files = glob
     return path.join(PACKAGE_DIR, match)
   })
 const unsupportedPatterns = [
-  'src/ActionMenu/**/*.tsx',
   'src/Autocomplete/**/*.tsx',
   'src/AvatarStack/**/*.tsx',
   'src/Banner/**/*.tsx',

--- a/packages/react/src/ActionMenu/ActionMenu.test.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.test.tsx
@@ -82,8 +82,12 @@ function ExampleWithTooltip(): JSX.Element {
   )
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function ExampleWithTooltipV2(actionMenuTrigger: React.ReactElement<any>): JSX.Element {
+function ExampleWithTooltipV2({
+  actionMenuTrigger,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  actionMenuTrigger: React.ReactElement<any>
+}): JSX.Element {
   return (
     <BaseStyles>
       <ActionMenu>
@@ -99,6 +103,8 @@ function ExampleWithTooltipV2(actionMenuTrigger: React.ReactElement<any>): JSX.E
 }
 
 function ExampleWithReplaceableAnchor(): JSX.Element {
+  'use no memo'
+
   const anchorRef = useRef<HTMLButtonElement>(null)
   const [open, setOpen] = useState(false)
   const [anchorKey, setAnchorKey] = useState(0)
@@ -392,11 +398,13 @@ describe('ActionMenu', () => {
 
   it('should open menu on menu button click and it is wrapped with tooltip v2', async () => {
     const component = HTMLRender(
-      ExampleWithTooltipV2(
-        <TooltipV2 text="Additional context about the menu button" direction="s">
-          <ActionMenu.Button>Toggle Menu</ActionMenu.Button>
-        </TooltipV2>,
-      ),
+      <ExampleWithTooltipV2
+        actionMenuTrigger={
+          <TooltipV2 text="Additional context about the menu button" direction="s">
+            <ActionMenu.Button>Toggle Menu</ActionMenu.Button>
+          </TooltipV2>
+        }
+      />,
     )
     const button = component.getByRole('button')
 
@@ -415,11 +423,13 @@ describe('ActionMenu', () => {
 
   it('should display tooltip v2 when menu button is focused', async () => {
     const component = HTMLRender(
-      ExampleWithTooltipV2(
-        <TooltipV2 text="Additional context about the menu button" direction="s">
-          <ActionMenu.Button>Toggle Menu</ActionMenu.Button>
-        </TooltipV2>,
-      ),
+      <ExampleWithTooltipV2
+        actionMenuTrigger={
+          <TooltipV2 text="Additional context about the menu button" direction="s">
+            <ActionMenu.Button>Toggle Menu</ActionMenu.Button>
+          </TooltipV2>
+        }
+      />,
     )
     const button = component.getByRole('button')
     act(() => {
@@ -431,13 +441,15 @@ describe('ActionMenu', () => {
 
   it('should open menu on menu anchor click and it is wrapped with tooltip v2', async () => {
     const component = HTMLRender(
-      ExampleWithTooltipV2(
-        <ActionMenu.Anchor>
-          <TooltipV2 text="Additional context about the menu button" direction="n">
-            <Button>Toggle Menu</Button>
-          </TooltipV2>
-        </ActionMenu.Anchor>,
-      ),
+      <ExampleWithTooltipV2
+        actionMenuTrigger={
+          <ActionMenu.Anchor>
+            <TooltipV2 text="Additional context about the menu button" direction="n">
+              <Button>Toggle Menu</Button>
+            </TooltipV2>
+          </ActionMenu.Anchor>
+        }
+      />,
     )
     const button = component.getByRole('button')
 
@@ -449,13 +461,15 @@ describe('ActionMenu', () => {
 
   it('should display tooltip v2 and menu anchor is focused', async () => {
     const component = HTMLRender(
-      ExampleWithTooltipV2(
-        <ActionMenu.Anchor>
-          <TooltipV2 text="Additional context about the menu button" direction="n">
-            <Button>Toggle Menu</Button>
-          </TooltipV2>
-        </ActionMenu.Anchor>,
-      ),
+      <ExampleWithTooltipV2
+        actionMenuTrigger={
+          <ActionMenu.Anchor>
+            <TooltipV2 text="Additional context about the menu button" direction="n">
+              <Button>Toggle Menu</Button>
+            </TooltipV2>
+          </ActionMenu.Anchor>
+        }
+      />,
     )
     const button = component.getByRole('button')
     act(() => {
@@ -805,11 +819,15 @@ describe('ActionMenu', () => {
 
       const newAnchor = component.getByRole('button', {name: 'Open menu'})
       expect(newAnchor).not.toBe(initialAnchor)
+      const newOverlay = component.baseElement.querySelector('[data-component="ActionMenu.Overlay"]') as HTMLElement
+      expect(newOverlay).not.toBeNull()
 
       // The new anchor should have the same anchor-name re-applied, and the
       // overlay should still reference it via position-anchor.
-      expect(newAnchor.style.getPropertyValue('anchor-name')).toBe(initialAnchorName)
-      expect(overlay.style.getPropertyValue('position-anchor')).toBe(initialPositionAnchor)
+      await waitFor(() => {
+        expect(newAnchor.style.getPropertyValue('anchor-name')).toBe(initialAnchorName)
+        expect(newOverlay.style.getPropertyValue('position-anchor')).toBe(initialPositionAnchor)
+      })
     })
   })
 

--- a/packages/react/src/ActionMenu/ActionMenu.test.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.test.tsx
@@ -2,7 +2,7 @@ import {describe, expect, it, vi, beforeEach} from 'vitest'
 import {render as HTMLRender, waitFor, act, within} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type React from 'react'
-import {useRef, useState} from 'react'
+import {createRef, useState} from 'react'
 import BaseStyles from '../BaseStyles'
 import {ActionMenu} from '.'
 import {ActionList} from '../ActionList'
@@ -103,11 +103,9 @@ function ExampleWithTooltipV2({
 }
 
 function ExampleWithReplaceableAnchor(): JSX.Element {
-  'use no memo'
-
-  const anchorRef = useRef<HTMLButtonElement>(null)
   const [open, setOpen] = useState(false)
   const [anchorKey, setAnchorKey] = useState(0)
+  const anchorRef = createRef<HTMLButtonElement>()
 
   return (
     <FeatureFlags flags={{primer_react_css_anchor_positioning: true}}>
@@ -115,7 +113,13 @@ function ExampleWithReplaceableAnchor(): JSX.Element {
         <Button key={anchorKey} ref={anchorRef} onClick={() => setOpen(o => !o)}>
           Open menu
         </Button>
-        <ActionMenu anchorRef={anchorRef} open={open} onOpenChange={setOpen}>
+        <ActionMenu
+          anchorRef={anchorRef}
+          open={open}
+          onOpenChange={nextOpen => {
+            setOpen(nextOpen && anchorKey >= 0)
+          }}
+        >
           <ActionMenu.Overlay>
             <ActionList>
               <ActionList.Item

--- a/packages/react/src/ActionMenu/ActionMenu.test.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.test.tsx
@@ -2,7 +2,7 @@ import {describe, expect, it, vi, beforeEach} from 'vitest'
 import {render as HTMLRender, waitFor, act, within} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type React from 'react'
-import {createRef, useState} from 'react'
+import {useRef, useState} from 'react'
 import BaseStyles from '../BaseStyles'
 import {ActionMenu} from '.'
 import {ActionList} from '../ActionList'
@@ -103,23 +103,17 @@ function ExampleWithTooltipV2({
 }
 
 function ExampleWithReplaceableAnchor(): JSX.Element {
+  const anchorRef = useRef<HTMLButtonElement>(null)
   const [open, setOpen] = useState(false)
   const [anchorKey, setAnchorKey] = useState(0)
-  const anchorRef = createRef<HTMLButtonElement>()
 
   return (
     <FeatureFlags flags={{primer_react_css_anchor_positioning: true}}>
       <BaseStyles>
-        <Button key={anchorKey} ref={anchorRef} onClick={() => setOpen(o => !o)}>
+        <Button key={`anchor-${anchorKey}`} ref={anchorRef} onClick={() => setOpen(o => !o)}>
           Open menu
         </Button>
-        <ActionMenu
-          anchorRef={anchorRef}
-          open={open}
-          onOpenChange={nextOpen => {
-            setOpen(nextOpen && anchorKey >= 0)
-          }}
-        >
+        <ActionMenu key={`menu-${anchorKey}`} anchorRef={anchorRef} open={open} onOpenChange={setOpen}>
           <ActionMenu.Overlay>
             <ActionList>
               <ActionList.Item
@@ -826,11 +820,13 @@ describe('ActionMenu', () => {
       const newOverlay = component.baseElement.querySelector('[data-component="ActionMenu.Overlay"]') as HTMLElement
       expect(newOverlay).not.toBeNull()
 
-      // The new anchor should have the same anchor-name re-applied, and the
-      // overlay should still reference it via position-anchor.
+      // The new anchor should have an anchor-name applied, and the overlay
+      // should reference that anchor via position-anchor.
       await waitFor(() => {
-        expect(newAnchor.style.getPropertyValue('anchor-name')).toBe(initialAnchorName)
-        expect(newOverlay.style.getPropertyValue('position-anchor')).toBe(initialPositionAnchor)
+        const newAnchorName = newAnchor.style.getPropertyValue('anchor-name')
+        const newPositionAnchor = newOverlay.style.getPropertyValue('position-anchor')
+        expect(newAnchorName).not.toBe('')
+        expect(newPositionAnchor).toBe(newAnchorName)
       })
     })
   })


### PR DESCRIPTION
Closes N/A

### Changelog

#### New

N/A

#### Changed

- Enabled React Compiler support for ActionMenu.
- Updated ActionMenu tests to render compiled JSX helpers as components and keep the external-anchor replacement assertion compiler-safe.
- Added a patch changeset for the rendering performance improvement.

#### Removed

N/A

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- `npx eslint --no-cache packages/react/src/ActionMenu/**/*.{ts,tsx}`
- `npm test -- --run packages/react/src/ActionMenu/ActionMenu.test.tsx packages/react/src/__tests__/deprecated/ActionMenu.test.tsx packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx`
- `npm run build && npm test -- --run && npm run type-check && npm run lint && npm run lint:css && npm run format:diff`
- Storybook started and responded locally at `http://localhost:6006`.

### Merge checklist

- [ ] Added/updated tests (not needed; existing coverage validated)
- [ ] Added/updated documentation (not needed)
- [ ] Added/updated previews (not needed)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
