### PR TITLE
Add scenario patterns to MCP pattern tools

### DIFF
--- a/.changeset/mcp-scenario-patterns.md
+++ b/.changeset/mcp-scenario-patterns.md
@@ -1,0 +1,5 @@
+---
+'@primer/mcp': minor
+---
+
+MCP server: Add the Copy, Delete, Filter and Search scenario patterns to the `list_patterns` and `get_pattern` tools, served from the scenario patterns documentation. Scenario patterns are resolved first so they take precedence over UI patterns when a name matches.

--- a/.changeset/mcp-scenario-patterns.md
+++ b/.changeset/mcp-scenario-patterns.md
@@ -2,4 +2,4 @@
 '@primer/mcp': minor
 ---
 
-MCP server: Add the Copy, Delete, Filter and Search scenario patterns to the `list_patterns` and `get_pattern` tools, served from the scenario patterns documentation. Scenario patterns are resolved first so they take precedence over UI patterns when a name matches.
+MCP server: Add Copy, Delete, Filter and Search scenario patterns to the `list_patterns` and `get_pattern` tools. Scenario patterns take precedence over UI patterns when a name matches.

--- a/packages/mcp/src/primer.ts
+++ b/packages/mcp/src/primer.ts
@@ -40,48 +40,81 @@ function listComponents(): Array<Component> {
 type Pattern = {
   id: string
   name: string
+  // 'scenario' maps to the /product/scenario-patterns/ base path, 'ui' to /product/ui-patterns/
+  category: 'scenario' | 'ui'
 }
 
+// Scenario patterns are listed first so name resolution favours them over UI patterns.
 const patterns: Array<Pattern> = [
+  {
+    id: 'copy',
+    name: 'Copy',
+    category: 'scenario',
+  },
+  {
+    id: 'delete',
+    name: 'Delete',
+    category: 'scenario',
+  },
+  {
+    id: 'filter',
+    name: 'Filter',
+    category: 'scenario',
+  },
+  {
+    id: 'search',
+    name: 'Search',
+    category: 'scenario',
+  },
   {
     id: 'data-visualization',
     name: 'Data Visualization',
+    category: 'ui',
   },
   {
     id: 'degraded-experiences',
     name: 'Degraded Experiences',
+    category: 'ui',
   },
   {
     id: 'empty-states',
     name: 'Empty States',
+    category: 'ui',
   },
   {
     id: 'feature-onboarding',
     name: 'Feature Onboarding',
+    category: 'ui',
   },
   {
     id: 'forms',
     name: 'Forms',
+    category: 'ui',
   },
   {
     id: 'loading',
     name: 'Loading',
+    category: 'ui',
   },
   {
     id: 'navigation',
     name: 'Navigation',
+    category: 'ui',
   },
   {
     id: 'notification-messaging',
     name: 'Notification message',
+    category: 'ui',
   },
   {
     id: 'progressive-disclosure',
     name: 'Progressive disclosure',
+    category: 'ui',
   },
   {
     id: 'saving',
     name: 'Saving',
+    category: 'ui',
   },
 ]
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -372,18 +372,28 @@ ${text}`,
 // -----------------------------------------------------------------------------
 server.registerTool(
   'list_patterns',
-  {description: 'List all of the patterns available from Primer React', annotations: {readOnlyHint: true}},
+  {
+    description:
+      'List all of the patterns available from Primer React. Scenario patterns describe specific user tasks (copy, delete, filter, search). Prefer a scenario pattern when one fits the task, and fall back to the more generic UI patterns otherwise.',
+    annotations: {readOnlyHint: true},
+  },
   async () => {
-    const patterns = listPatterns().map(pattern => {
-      return `- ${pattern.name}`
-    })
+    const all = listPatterns()
+    const scenario = all.filter(pattern => pattern.category === 'scenario').map(pattern => `- ${pattern.name}`)
+    const ui = all.filter(pattern => pattern.category === 'ui').map(pattern => `- ${pattern.name}`)
     return {
       content: [
         {
           type: 'text',
-          text: `The following patterns are available in the @primer/react in TypeScript projects:
+          text: `The following patterns are available in the @primer/react in TypeScript projects. Scenario patterns describe specific user tasks. Prefer a scenario pattern when one fits the task, and fall back to the UI patterns otherwise.
 
-${patterns.join('\n')}`,
+## Scenario patterns
+
+${scenario.join('\n')}
+
+## UI patterns
+
+${ui.join('\n')}`,
         },
       ],
     }
@@ -393,7 +403,8 @@ ${patterns.join('\n')}`,
 server.registerTool(
   'get_pattern',
   {
-    description: 'Get a specific pattern by name',
+    description:
+      'Get a specific pattern by name. Scenario patterns describe specific user tasks (copy, delete, filter, search). Prefer a scenario pattern when one fits the task, and fall back to the more generic UI patterns otherwise.',
     inputSchema: {
       name: z.string().describe('The name of the pattern to retrieve'),
     },
@@ -401,9 +412,10 @@ server.registerTool(
   },
   async ({name}) => {
     const patterns = listPatterns()
-    const match = patterns.find(pattern => {
-      return pattern.name === name
-    })
+    // Resolve scenario patterns first so a name clash favours the scenario pattern.
+    const match =
+      patterns.find(pattern => pattern.category === 'scenario' && pattern.name === name) ??
+      patterns.find(pattern => pattern.name === name)
     if (!match) {
       return {
         content: [
@@ -415,7 +427,8 @@ server.registerTool(
       }
     }
 
-    const url = new URL(`/product/ui-patterns/${match.id}`, 'https://primer.style')
+    const basePath = match.category === 'scenario' ? 'scenario-patterns' : 'ui-patterns'
+    const url = new URL(`/product/${basePath}/${match.id}`, 'https://primer.style')
     const response = await fetch(url)
     if (!response.ok) {
       throw new Error(`Failed to fetch ${url} - ${response.statusText}`)

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -385,7 +385,7 @@ server.registerTool(
       content: [
         {
           type: 'text',
-          text: `The following patterns are available in the @primer/react in TypeScript projects. Scenario patterns describe specific user tasks. Prefer a scenario pattern when one fits the task, and fall back to the UI patterns otherwise.
+          text: `The following patterns are available from \`@primer/react\` for use in TypeScript projects. Scenario patterns describe specific user tasks. Prefer a scenario pattern when one fits the task, and fall back to the UI patterns otherwise.
 
 ## Scenario patterns
 


### PR DESCRIPTION
Closes github/core-ux#2814

The Primer MCP server already lets an agent list and fetch UI patterns (forms, navigation, empty states, and so on). This adds four scenario patterns to those same tools: Copy, Delete, Filter, and Search. Scenario patterns describe a specific user task rather than a generic building block, so when one fits the job an agent should reach for it first. The tools now say so, and resolve scenario patterns ahead of UI patterns.

The scrape-and-convert mechanism is unchanged but two other things do change. The URL is now built from the pattern's category, so scenario patterns resolve to `https://primer.style/product/scenario-patterns/{slug}/` while UI patterns keep `/product/ui-patterns/{slug}/`. Name resolution now prefers a scenario pattern when one matches. The four new pages are then scraped and converted exactly as before.

This is part 2 of github/core-ux#2795 brought forward. It is decoupled from the llms.txt route decision in that issue and relies only on the existing rendered-page scraping mechanism.

### Changelog

#### New

- MCP server: Copy, Delete, Filter, and Search scenario patterns available through `list_patterns` and `get_pattern`.

#### Changed

- MCP server: `get_pattern` derives the documentation base path from a pattern's category; scenario patterns take precedence over UI patterns on a name match.
- MCP server: `list_patterns` groups patterns under scenario and UI headings.

#### Removed

- N/A

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

The `@primer/mcp` package has no unit test suite (consistent with how the tools were originally added). The change was validated by:

- Running the edited server end to end through an in-memory MCP client and calling the tools against the live docs. `list_patterns` returns the scenario-first grouping; `get_pattern` for `Copy` and `Search` resolves the `scenario-patterns` base path and returns real converted content; `get_pattern` for `Forms` still uses `ui-patterns` (no regression); an unknown name falls back to the not-found message.
- Confirming all four scenario pages resolve with HTTP 200 and return content (they redirect to a trailing-slash URL, which `fetch` follows by default).
- Checking that the do/don't guidance blocks on the scenario pages survive the scrape. The `DosAndDonts` component (shared with UI pattern pages) converts to legible markdown: each `Do` and `Don't` label is preserved as its own line immediately before its guidance statement, and the do/don't pairing is kept by document order. No change was needed for an agent to read these correctly.
- An isolated TypeScript check of the edited source. The edited regions produce no type errors.

To review manually, run the MCP server and call `list_patterns` (scenario patterns should appear first under their own heading) and `get_pattern` with `Copy`, `Delete`, `Filter`, or `Search`.

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui