### PR TITLE
feat: add React Compiler support for SelectPanel

### DIFF
--- a/.changeset/react-compiler-select-panel.md
+++ b/.changeset/react-compiler-select-panel.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+SelectPanel: Improve rendering performance with React Compiler support

--- a/packages/react/script/react-compiler.mjs
+++ b/packages/react/script/react-compiler.mjs
@@ -26,7 +26,6 @@ const unsupportedPatterns = [
   'src/PageLayout/**/*.tsx',
   'src/Pagination/**/*.tsx',
   'src/Portal/**/*.tsx',
-  'src/SelectPanel/**/*.tsx',
   'src/SideNav.tsx',
   'src/UnderlineNav/**/*.tsx',
   'src/experimental/SelectPanel2/**/*.tsx',

--- a/packages/react/src/SelectPanel/SelectPanel.test.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.test.tsx
@@ -602,13 +602,12 @@ for (const usingRemoveActiveDescendant of [false, true]) {
     function NoItemAvailableSelectPanel() {
       const [selected, setSelected] = React.useState<SelectPanelProps['items']>([])
       const [filter, setFilter] = React.useState('')
+      const [items, setItems] = React.useState<SelectPanelProps['items']>([])
       const [open, setOpen] = React.useState(false)
 
       const onSelectedChange = (selected: SelectPanelProps['items']) => {
         setSelected(selected)
       }
-
-      const items: SelectPanelProps['items'] = []
 
       return (
         <SelectPanel
@@ -622,6 +621,7 @@ for (const usingRemoveActiveDescendant of [false, true]) {
           filterValue={filter}
           onFilterChange={value => {
             setFilter(value)
+            setItems([])
           }}
           open={open}
           onOpenChange={isOpen => {
@@ -940,8 +940,8 @@ for (const usingRemoveActiveDescendant of [false, true]) {
 
         renderWithProp(<NoItemAvailableSelectPanel />, usingRemoveActiveDescendant)
 
-        await waitFor(async () => {
-          await user.click(screen.getByText('Select items'))
+        await user.click(screen.getByText('Select items'))
+        await waitFor(() => {
           expect(screen.getByText('No items available')).toBeInTheDocument()
         })
       })


### PR DESCRIPTION
Closes #

Adds React Compiler support for SelectPanel by removing it from the compiler unsupported list. Updates the empty-state test fixture so it models an async empty load completing under compiler-enabled tests.

### Changelog

#### New

- React Compiler support for SelectPanel

#### Changed

- Updated SelectPanel empty-state test coverage to be compatible with React Compiler

#### Removed

- Removed SelectPanel from the React Compiler unsupported list

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- `npx eslint --no-cache packages/react/src/SelectPanel/**/*.{ts,tsx}`
- `npm test -- --run packages/react/src/SelectPanel/SelectPanel.test.tsx packages/react/src/SelectPanel/SelectPanel.types.test.tsx`
- `npm run build && npm test -- --run && npm run type-check && npm run lint && npm run lint:css && npm run format:diff`
- Verified Storybook responds locally

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
