### PR TITLE
docs: migrate ActionBar ts docs status

### DIFF
--- a/packages/react/src/ActionBar/ActionBar.docs.json
+++ b/packages/react/src/ActionBar/ActionBar.docs.json
@@ -12,44 +12,32 @@
   "props": [
     {
       "name": "aria-label",
-      "type": "string",
       "derive": true
     },
     {
       "name": "aria-labelledby",
-      "type": "string",
       "derive": true
     },
     {
       "name": "children",
-      "type": "ReactNode",
-      "required": false,
-      "description": "Buttons in the action bar",
-      "defaultValue": ""
+      "derive": true,
+      "required": true
     },
     {
       "name": "size",
-      "type": "'small' | 'large' | 'medium'",
       "derive": true
     },
     {
       "name": "flush",
-      "derive": true,
-      "type": "boolean"
+      "derive": true
     },
     {
       "name": "className",
-      "type": "string",
-      "required": false,
-      "description": "Custom className",
-      "defaultValue": ""
+      "derive": true
     },
     {
       "name": "gap",
-      "type": "'none' | 'condensed'",
-      "required": false,
-      "defaultValue": "'condensed'",
-      "description": "Horizontal gap scale between items (restricted to none or condensed)."
+      "derive": true
     }
   ],
   "subcomponents": [
@@ -57,28 +45,84 @@
       "name": "ActionBar.IconButton",
       "props": [
         {
-          "name": "children",
-          "type": "React.ReactNode",
-          "defaultValue": "",
-          "required": true,
-          "description": "This will be the Button description."
+          "name": "aria-label",
+          "type": "string",
+          "description": "Use an aria label to describe the functionality of the button. Please refer to [our guidance on alt text](https://primer.style/guides/accessibility/alternative-text-for-images) for tips on writing good alternative text."
+        },
+        {
+          "name": "aria-labelledby",
+          "type": "string",
+          "description": "ID of the element that labels the button."
+        },
+        {
+          "name": "variant",
+          "type": "VariantType",
+          "description": "Determines the styles on a button, one of 'default' | 'primary' | 'invisible' | 'danger' | 'link'"
+        },
+        {
+          "name": "size",
+          "type": "Size",
+          "description": "Size of the button and fontSize of the text in the button"
+        },
+        {
+          "name": "block",
+          "type": "boolean",
+          "description": "Allow a button to fill its container horizontally"
+        },
+        {
+          "name": "loading",
+          "type": "boolean",
+          "description": "Specify whether the button is in a loading state"
+        },
+        {
+          "name": "loadingAnnouncement",
+          "type": "string",
+          "description": "The content to announce to screen readers when loading"
+        },
+        {
+          "name": "inactive",
+          "type": "boolean",
+          "description": "Whether the button looks visually disabled, but can still accept all the same interactions as an enabled button."
+        },
+        {
+          "name": "labelWrap",
+          "type": "boolean",
+          "description": "Whether the button label should wrap to multiple lines if it is longer than the button width"
         },
         {
           "name": "icon",
-          "type": "Component",
-          "defaultValue": "",
-          "description": "Provide an octicon. It will be placed in the center of the button"
+          "type": "ElementType<any, keyof IntrinsicElements>",
+          "required": true,
+          "description": "Icon rendered inside the button."
         },
         {
-          "name": "aria-label",
+          "name": "unsafeDisableTooltip",
+          "type": "boolean",
+          "description": "Disable the default tooltip for the icon button."
+        },
+        {
+          "name": "description",
           "type": "string",
-          "defaultValue": "",
-          "description": "Use an aria label to describe the functionality of the button. Please refer to [our guidance on alt text](https://primer.style/guides/accessibility/alternative-text-for-images) for tips on writing good alternative text."
+          "description": "Text used as the icon button's tooltip description."
+        },
+        {
+          "name": "tooltipDirection",
+          "type": "TooltipDirection",
+          "description": "Direction for the icon button tooltip."
+        },
+        {
+          "name": "keyshortcuts",
+          "type": "string",
+          "deprecated": true
+        },
+        {
+          "name": "keybindingHint",
+          "type": "string | string[]",
+          "description": "Keybinding hint rendered in the icon button tooltip."
         },
         {
           "name": "disabled",
           "type": "boolean",
-          "defaultValue": "",
           "description": "Provides a disabled state for the button. The button will remain focusable, and have `aria-disabled` applied."
         }
       ],
@@ -96,14 +140,78 @@
       "props": [
         {
           "name": "children",
-          "type": "React.ReactNode",
-          "defaultValue": ""
+          "type": "React.ReactElement[]"
         }
       ]
     },
     {
       "name": "ActionBar.Menu",
       "props": [
+        {
+          "name": "variant",
+          "type": "VariantType",
+          "description": "Determines the styles on a button, one of 'default' | 'primary' | 'invisible' | 'danger' | 'link'"
+        },
+        {
+          "name": "size",
+          "type": "Size",
+          "description": "Size of the button and fontSize of the text in the button"
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "description": "Disables a button. Avoid disabling buttons because it will make them inaccessible to users who rely on keyboard navigation. Buttons that are disabled cannot be clicked, selected, or navigated through."
+        },
+        {
+          "name": "block",
+          "type": "boolean",
+          "description": "Allow a button to fill its container horizontally"
+        },
+        {
+          "name": "loading",
+          "type": "boolean",
+          "description": "Specify whether the button is in a loading state"
+        },
+        {
+          "name": "loadingAnnouncement",
+          "type": "string",
+          "description": "The content to announce to screen readers when loading"
+        },
+        {
+          "name": "inactive",
+          "type": "boolean",
+          "description": "Whether the button looks visually disabled, but can still accept all the same interactions as an enabled button."
+        },
+        {
+          "name": "labelWrap",
+          "type": "boolean",
+          "description": "Whether the button label should wrap to multiple lines if it is longer than the button width"
+        },
+        {
+          "name": "unsafeDisableTooltip",
+          "type": "boolean",
+          "description": "Disable the default tooltip for the icon button."
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "description": "Text used as the icon button's tooltip description."
+        },
+        {
+          "name": "tooltipDirection",
+          "type": "TooltipDirection",
+          "description": "Direction for the icon button tooltip."
+        },
+        {
+          "name": "keyshortcuts",
+          "type": "string",
+          "deprecated": true
+        },
+        {
+          "name": "keybindingHint",
+          "type": "string | string[]",
+          "description": "Keybinding hint rendered in the icon button tooltip."
+        },
         {
           "name": "aria-label",
           "type": "string",
@@ -112,7 +220,7 @@
         },
         {
           "name": "icon",
-          "type": "Component",
+          "type": "ElementType<any, keyof IntrinsicElements>",
           "required": true,
           "description": "Icon for the menu button."
         },
@@ -120,19 +228,17 @@
           "name": "items",
           "type": "ActionBarMenuItemProps[]",
           "required": true,
-          "description": "Array of menu items to render in the menu. Each item can be an action, group, or divider."
+          "description": "Items to render in the menu."
         },
         {
           "name": "overflowIcon",
-          "type": "Component | 'none'",
-          "required": false,
+          "type": "\"none\" | ElementType<any, keyof IntrinsicElements>",
           "description": "Icon displayed when the menu item is within the overflow menu. If 'none' is provided, no icon will be shown in the overflow menu."
         },
         {
           "name": "returnFocusRef",
-          "type": "React.RefObject<HTMLElement>",
-          "required": false,
-          "description": "A ref to an element that should receive focus when the menu is closed."
+          "type": "RefObject<HTMLElement>",
+          "description": "Target element to return focus to when the menu is closed."
         }
       ]
     }

--- a/packages/react/src/ActionBar/ActionBar.tsx
+++ b/packages/react/src/ActionBar/ActionBar.tsx
@@ -84,6 +84,10 @@ export type ActionBarProps = {
 
 export type ActionBarIconButtonProps = {disabled?: boolean} & IconButtonProps
 
+type ActionBarGroupProps = {
+  children?: React.ReactNode
+}
+
 export type ActionBarMenuItemProps =
   | ({
       /**
@@ -127,6 +131,7 @@ export type ActionBarMenuProps = {
   'aria-label': string
   /** Icon for the menu button */
   icon: ActionBarIconButtonProps['icon']
+  /** Items to render in the menu */
   items: ActionBarMenuItemProps[]
   /**
    * Icon displayed when the menu item is overflowing.
@@ -137,7 +142,7 @@ export type ActionBarMenuProps = {
    * Target element to return focus to when the menu is closed.
    */
   returnFocusRef?: React.RefObject<HTMLElement>
-} & IconButtonProps
+} & Omit<IconButtonProps, 'aria-label' | 'aria-labelledby' | 'icon'>
 
 const ActionBarItemsRegistry = createDescendantRegistry<ChildProps | null>()
 
@@ -394,7 +399,7 @@ const ActionBarGroupContext = React.createContext<{
   isOverflowing: boolean
 } | null>(null)
 
-export const ActionBarGroup = forwardRef(({children}: React.PropsWithChildren, forwardedRef) => {
+export const ActionBarGroup = forwardRef<HTMLDivElement, ActionBarGroupProps>(({children}, forwardedRef) => {
   const backupRef = useRef<HTMLDivElement>(null)
   const ref = (forwardedRef ?? backupRef) as RefObject<HTMLDivElement>
   const {dataOverflowingAttr, isOverflowing} = useActionBarItem(

--- a/packages/react/src/Button/types.ts
+++ b/packages/react/src/Button/types.ts
@@ -9,8 +9,16 @@ export type Size = 'small' | 'medium' | 'large'
 export type AlignContent = 'start' | 'center'
 
 type ButtonA11yProps =
-  | {'aria-label': string; 'aria-labelledby'?: undefined}
-  | {'aria-label'?: undefined; 'aria-labelledby': string}
+  | {
+      /** Accessible label for the button. */
+      'aria-label': string
+      'aria-labelledby'?: undefined
+    }
+  | {
+      'aria-label'?: undefined
+      /** ID of the element that labels the button. */
+      'aria-labelledby': string
+    }
 
 export type ButtonBaseProps = {
   /**
@@ -38,7 +46,7 @@ export type ButtonBaseProps = {
    * The content to announce to screen readers when loading
    */
   loadingAnnouncement?: string
-  /*
+  /**
    * Whether the button looks visually disabled, but can still accept all the same
    * interactions as an enabled button.
    */
@@ -85,12 +93,27 @@ export type ButtonProps = {
 } & ButtonBaseProps
 
 export type IconButtonProps = ButtonA11yProps & {
+  /**
+   * Icon rendered inside the button.
+   */
   icon: React.ElementType
+  /**
+   * Disable the default tooltip for the icon button.
+   */
   unsafeDisableTooltip?: boolean
+  /**
+   * Text used as the icon button's tooltip description.
+   */
   description?: string
+  /**
+   * Direction for the icon button tooltip.
+   */
   tooltipDirection?: TooltipDirection
   /** @deprecated Use `keybindingHint` instead. */
   keyshortcuts?: string
+  /**
+   * Keybinding hint rendered in the icon button tooltip.
+   */
   keybindingHint?: string | string[]
 } & Omit<ButtonBaseProps, 'aria-label' | 'aria-labelledby'>
 

--- a/script/ts-docs-status.mts
+++ b/script/ts-docs-status.mts
@@ -57,9 +57,9 @@ for (const componentDocFile of componentDocsFiles) {
         // propResult.mismatchedType ||
         propResult.missingJSDoc
       ) {
-        subPassingProps.push(propName)
-      } else {
         subBrokenProps.push(propName)
+      } else {
+        subPassingProps.push(propName)
       }
     }
 


### PR DESCRIPTION
Closes N/A

### Changelog

#### New

N/A

#### Changed

- Migrated ActionBar docs metadata to match TypeScript-derived prop information.
- Fixed `script/ts-docs-status.mts` so subcomponent passing and broken props are reported in the correct buckets.

#### Removed

N/A

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; docs-status migration and reporting fix only, with no consumer-facing runtime change.

### Testing & Reviewing

- `SHOW_ALL=1 npx doc-gen validate packages/react/src/ActionBar --verbose`
- `node script/ts-docs-status.mts` reports zero broken ActionBar props
- `npm run build`
- `npm test -- --run`
- `npm run type-check`
- `npm run lint`
- `npm run lint:css`
- `npm run format:diff`

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
