### PR TITLE
feat: add React Compiler support for hooks

### DIFF
--- a/.changeset/react-compiler-hooks.md
+++ b/.changeset/react-compiler-hooks.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Hooks: Improve rendering performance with React Compiler support

--- a/packages/react/script/react-compiler.mjs
+++ b/packages/react/script/react-compiler.mjs
@@ -30,16 +30,7 @@ const unsupportedPatterns = [
   'src/SideNav.tsx',
   'src/UnderlineNav/**/*.tsx',
   'src/experimental/SelectPanel2/**/*.tsx',
-  'src/hooks/useAnchoredPosition.ts',
-  'src/hooks/useFocusTrap.ts',
-  'src/hooks/useFocusZone.ts',
-  'src/hooks/useMenuInitialFocus.ts',
-  'src/hooks/useOnEscapePress.ts',
-  'src/hooks/useResizeObserver.ts',
-  'src/hooks/useSafeTimeout.ts',
-  'src/hooks/useScrollFlash.ts',
   'src/internal/components/CheckboxOrRadioGroup/**/*.tsx',
-  'src/hooks/useMergedRefs.ts',
   'src/TooltipV2/**/*.tsx',
 ]
 

--- a/packages/react/src/SelectPanel/SelectPanel.test.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.test.tsx
@@ -1673,11 +1673,10 @@ for (const usingRemoveActiveDescendant of [false, true]) {
         const input = screen.getByPlaceholderText('Filter items')
         const options = screen.getAllByRole('option')
 
-        // Wait a tick for the effect to run
-        await new Promise(resolve => setTimeout(resolve, 0))
-
-        // aria-activedescendant should be set to the first item
-        expect(input.getAttribute('aria-activedescendant')).toBe(options[0].id)
+        await waitFor(() => {
+          // aria-activedescendant should be set to the first item
+          expect(input.getAttribute('aria-activedescendant')).toBe(options[0].id)
+        })
       })
 
       it('should not set aria-activedescendant on mouse hover until after first interaction when setInitialFocus is true', async () => {


### PR DESCRIPTION
Closes #

Adds React Compiler support for the remaining ignored shared hooks by removing them from the compiler unsupported list.

### Changelog

#### New

- React Compiler support for shared hooks

#### Changed

- None

#### Removed

- Removed the remaining shared hooks from the React Compiler unsupported list

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- `npx eslint --no-cache packages/react/src/hooks/useAnchoredPosition.ts packages/react/src/hooks/useFocusTrap.ts packages/react/src/hooks/useFocusZone.ts packages/react/src/hooks/useMenuInitialFocus.ts packages/react/src/hooks/useOnEscapePress.ts packages/react/src/hooks/useResizeObserver.ts packages/react/src/hooks/useSafeTimeout.ts packages/react/src/hooks/useScrollFlash.ts packages/react/src/hooks/useMergedRefs.ts`
- `npm test -- --run packages/react/src/hooks/__tests__/useAnchoredPosition.test.tsx packages/react/src/hooks/__tests__/useMenuInitialFocus.test.tsx packages/react/src/hooks/__tests__/useMergedRefs.test.tsx packages/react/src/hooks/__tests__/useOnEscapePress.test.tsx packages/react/src/hooks/__tests__/useSafeTimeout.test.tsx`
- `npm run build && npm test -- --run && npm run type-check && npm run lint && npm run lint:css && npm run format:diff`

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
