### PR TITLE
IconButton: add `hasTriangleDownIcon` prop for dropdown affordance

### DIFF
--- a/.changeset/icon-button-triangle-down.md
+++ b/.changeset/icon-button-triangle-down.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+IconButton: Add `hasTriangleDownIcon` to render a `TriangleDownIcon` after the icon, indicating the button opens a dropdown or menu

--- a/packages/react/src/Button/ButtonBase.module.css
+++ b/packages/react/src/Button/ButtonBase.module.css
@@ -89,6 +89,35 @@
     &:where([data-size='large']) {
       width: var(--control-large-size);
     }
+
+    /* Dropdown affordance: the icon is followed by a TriangleDownIcon, so the
+       button is no longer a fixed square. */
+    &:where([data-has-triangle-down-icon]) {
+      width: auto;
+      grid-auto-flow: column;
+      align-items: center;
+      gap: var(--control-medium-gap);
+      /* stylelint-disable-next-line primer/spacing */
+      padding-inline: var(--control-medium-paddingInline-condensed);
+
+      &:where([data-size='small']) {
+        gap: var(--control-small-gap);
+        /* stylelint-disable-next-line primer/spacing */
+        padding-inline: var(--control-small-paddingInline-condensed);
+      }
+
+      &:where([data-size='large']) {
+        gap: var(--control-large-gap);
+        /* stylelint-disable-next-line primer/spacing */
+        padding-inline: var(--control-large-paddingInline-condensed);
+      }
+
+      & :where([data-component='triangleDownIcon']) {
+        /* Pull the caret slightly tighter to the icon, matching the
+           `trailingAction` treatment on text buttons. */
+        margin-inline-start: calc(var(--base-size-4) * -1);
+      }
+    }
   }
 
   /* LinkButton */

--- a/packages/react/src/Button/ButtonBase.tsx
+++ b/packages/react/src/Button/ButtonBase.tsx
@@ -11,6 +11,7 @@ import {AriaStatus} from '../live-region'
 import {clsx} from 'clsx'
 import classes from './ButtonBase.module.css'
 import {isElement} from 'react-is'
+import {TriangleDownIcon} from '@primer/octicons-react'
 
 const renderModuleVisual = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -36,6 +37,7 @@ const ButtonBase = forwardRef(({children, as: Component = 'button', ...props}, f
     ['aria-labelledby']: ariaLabelledBy,
     count,
     icon: Icon,
+    hasTriangleDownIcon,
     id,
     variant = 'default',
     size = 'medium',
@@ -99,6 +101,7 @@ const ButtonBase = forwardRef(({children, as: Component = 'button', ...props}, f
         data-variant={variant}
         data-label-wrap={labelWrap}
         data-has-count={count !== undefined ? true : undefined}
+        data-has-triangle-down-icon={Icon && hasTriangleDownIcon ? true : undefined}
         data-icon-only-counter={count !== undefined && LeadingVisual && !children ? true : undefined}
         aria-describedby={ariaDescribedByIds.filter(descriptionID => Boolean(descriptionID)).join(' ') || undefined}
         // aria-labelledby is needed because the accessible name becomes unset when the button is in a loading state.
@@ -114,10 +117,11 @@ const ButtonBase = forwardRef(({children, as: Component = 'button', ...props}, f
         {Icon ? (
           loading ? (
             <Spinner size="small" />
-          ) : isElement(Icon) ? (
-            Icon
           ) : (
-            <Icon />
+            <>
+              {isElement(Icon) ? Icon : <Icon />}
+              {hasTriangleDownIcon ? <TriangleDownIcon data-component="triangleDownIcon" /> : null}
+            </>
           )
         ) : (
           <>

--- a/packages/react/src/Button/IconButton.dev.stories.tsx
+++ b/packages/react/src/Button/IconButton.dev.stories.tsx
@@ -61,3 +61,13 @@ export const IconButtonWithinFlexContainer = () => (
     <IconButton icon={BoldIcon} aria-label="Icon button" />
   </Stack>
 )
+
+export const WithTriangleDownIcon = () => (
+  <Stack direction="horizontal" align="center">
+    <IconButton icon={BoldIcon} aria-label="Formatting options" hasTriangleDownIcon size="small" />
+    <IconButton icon={BoldIcon} aria-label="Formatting options" hasTriangleDownIcon />
+    <IconButton icon={BoldIcon} aria-label="Formatting options" hasTriangleDownIcon size="large" />
+    <IconButton icon={BoldIcon} aria-label="Formatting options" hasTriangleDownIcon variant="primary" />
+    <IconButton icon={BoldIcon} aria-label="Formatting options" hasTriangleDownIcon variant="invisible" />
+  </Stack>
+)

--- a/packages/react/src/Button/IconButton.docs.json
+++ b/packages/react/src/Button/IconButton.docs.json
@@ -93,6 +93,12 @@
       "description": "provide an octicon. It will be placed in the center of the button"
     },
     {
+      "name": "hasTriangleDownIcon",
+      "type": "boolean",
+      "defaultValue": "false",
+      "description": "Whether to render a `TriangleDownIcon` after the icon to indicate the button opens a dropdown or menu."
+    },
+    {
       "name": "aria-label",
       "type": "string",
       "defaultValue": "",

--- a/packages/react/src/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/Button/__tests__/Button.test.tsx
@@ -317,6 +317,14 @@ describe('Button', () => {
     const triggerEl = getByRole('button', {name: 'Heart'})
     expect(triggerEl).toHaveAccessibleDescription('Love is all around (command h)')
   })
+  it('should render a TriangleDownIcon when hasTriangleDownIcon is passed', () => {
+    const {container} = render(<IconButton icon={HeartIcon} aria-label="Heart" hasTriangleDownIcon />)
+    expect(container.querySelector('[data-component="triangleDownIcon"]')).toBeInTheDocument()
+  })
+  it('should not render a TriangleDownIcon by default', () => {
+    const {container} = render(<IconButton icon={HeartIcon} aria-label="Heart" />)
+    expect(container.querySelector('[data-component="triangleDownIcon"]')).not.toBeInTheDocument()
+  })
 })
 
 describe('data-component attributes', () => {
@@ -387,6 +395,21 @@ describe('data-component attributes', () => {
     it('should have data-component="IconButton" on the button element', () => {
       const {container} = render(<IconButton icon={SearchIcon} aria-label="Search" />)
       expect(container.querySelector('[data-component="IconButton"]')).toBeInTheDocument()
+    })
+
+    it('should set data-has-triangle-down-icon when hasTriangleDownIcon is passed', () => {
+      const {container} = render(<IconButton icon={SearchIcon} aria-label="Search" hasTriangleDownIcon />)
+      expect(container.querySelector('[data-component="IconButton"]')).toHaveAttribute(
+        'data-has-triangle-down-icon',
+        'true',
+      )
+    })
+
+    it('should not set data-has-triangle-down-icon by default', () => {
+      const {container} = render(<IconButton icon={SearchIcon} aria-label="Search" />)
+      expect(container.querySelector('[data-component="IconButton"]')).not.toHaveAttribute(
+        'data-has-triangle-down-icon',
+      )
     })
   })
 

--- a/packages/react/src/Button/types.ts
+++ b/packages/react/src/Button/types.ts
@@ -82,12 +82,23 @@ export type ButtonProps = {
   children?: React.ReactNode
 
   count?: number | string
+
+  /**
+   * Whether to render a `TriangleDownIcon` after the icon to indicate the button opens a
+   * dropdown or menu. Only has an effect on `IconButton`.
+   */
+  hasTriangleDownIcon?: boolean
 } & ButtonBaseProps
 
 export type IconButtonProps = ButtonA11yProps & {
   icon: React.ElementType
   unsafeDisableTooltip?: boolean
   description?: string
+  /**
+   * Whether to render a `TriangleDownIcon` after the icon to indicate the button opens a
+   * dropdown or menu.
+   */
+  hasTriangleDownIcon?: boolean
   tooltipDirection?: TooltipDirection
   /** @deprecated Use `keybindingHint` instead. */
   keyshortcuts?: string


### PR DESCRIPTION
Closes #

Adds a first-class prop to `IconButton` so an icon-only button can show a `TriangleDownIcon` caret indicating it opens a dropdown/menu. Today `IconButton` renders a single, square icon — `ButtonBase` short-circuits to render only the `icon` and ignores `trailingAction`/children — so there was no sanctioned way to add a caret. This introduces one deliberately rather than composing two glyphs into a custom `icon`.

> [!NOTE]
> `hasTriangleDownIcon` is a **working prop name** to be discussed with Primer design before stabilising. By design, the only available trailing glyph is `TriangleDownIcon`. This PR is a draft to support that conversation.

### Changelog

#### New

- `IconButton` now accepts `hasTriangleDownIcon?: boolean`. When `true`, a `TriangleDownIcon` is rendered after the icon.

#### Changed

- When `hasTriangleDownIcon` is set, the `IconButton` switches from a fixed square to an auto-width layout (token-based `gap` and `padding-inline` per size). A `data-has-triangle-down-icon` attribute on the button drives the styling; the caret carries `data-component="triangleDownIcon"`.

#### Removed

- N/A

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- New unit tests cover that the caret renders only when `hasTriangleDownIcon` is set and that `data-has-triangle-down-icon` is applied accordingly.
- New `IconButton/Dev` story **WithTriangleDownIcon** demonstrates the three sizes and the `primary`/`invisible` variants.
- Open consideration for review: whether the prop should also wire `aria-haspopup`/`aria-expanded` automatically, or leave that to the consumer (as `ActionMenu` does today).

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui