### PR TITLE
chore(npm): add allowScripts for npm v12 migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13726,6 +13726,8 @@
     },
     "node_modules/core-js": {
       "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT"
@@ -14856,6 +14858,8 @@
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -122,5 +122,10 @@
       "running": false
     }
   ],
-  "packageManager": "npm@11.16.0+sha512.03be172fc3b199c7a06433163e459be5b110a6983c1dd6305b7ac10f6b0fa12e1440755a8df6b1064ab2ccb789df0474919fb9c684e322dc57685ede21752ccb"
+  "packageManager": "npm@11.16.0+sha512.03be172fc3b199c7a06433163e459be5b110a6983c1dd6305b7ac10f6b0fa12e1440755a8df6b1064ab2ccb789df0474919fb9c684e322dc57685ede21752ccb",
+  "allowScripts": {
+    "sharp@0.34.4": true,
+    "core-js@2.6.12": true,
+    "esbuild@0.25.5": true
+  }
 }


### PR DESCRIPTION
With our move to Node.js v26, `npm` is updated to `11.16.0`. This introduces a new behavior, `allowScripts`, that will default to off in v12 of `npm`. As a result, this PR opts us into package scripts that we would like to run to support the project.