### PR TITLE
Timeline: add Issue event stories (Phase 2)

### DIFF
--- a/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
@@ -72,18 +72,12 @@
   color: var(--fgColor-muted);
 }
 
-.ProjectIcon {
-  vertical-align: middle;
-  margin-right: var(--base-size-4);
-  color: var(--fgColor-muted);
-}
-
-/* Issue-version ProjectV2 reference (github-ui `ProjectV2.tsx`): an inline
-   default-colored TableIcon octicon followed by a regular-weight, default-color
-   link. The underline comes from the Link `inline` prop (always-on underline,
-   which also satisfies the high-contrast a11y rule). Mirrors live
-   `.projectLink { color: var(--fgColor-default) }`. NOTE: the PR (ERB) surface
-   renders this differently — see the EventProject group comment. */
+/* Issue-version ProjectV2 reference (github-ui `ProjectV2.tsx` + `ClosedEvent.tsx`):
+   an inline default-colored TableIcon octicon followed by a default-color link
+   (`.ProjectRefLink`). The underline comes from the Link `inline` prop (always-on
+   underline, which also satisfies the high-contrast a11y rule). Mirrors live
+   `.projectLink`/`.stateReasonLink` (both `color: var(--fgColor-default)`). NOTE:
+   the PR (ERB) surface renders this differently — see the EventProject group. */
 .ProjectRefIcon {
   vertical-align: middle;
   margin-right: var(--base-size-4);

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
@@ -1,0 +1,165 @@
+.RealisticTimeline {
+  /* GitHub renders the timeline at most 1012px wide in product surfaces. */
+  max-width: 1012px;
+}
+
+.LinkWithBoldStyle {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+  margin-right: var(--base-size-4);
+}
+
+.LinkWithBoldStyle:hover {
+  color: var(--fgColor-accent);
+}
+
+.InlineAvatar {
+  vertical-align: middle;
+  margin-right: var(--base-size-4);
+}
+
+.Timestamp {
+  text-decoration: underline;
+}
+
+.CommitSha {
+  font-family: var(--fontStack-monospace);
+  font-size: var(--text-body-size-small);
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+}
+
+/* Story-only scaffolding: a small caption per Timeline.Item so the variants
+   can be scanned like a Figma component set. Not part of the faithful event. */
+.VariantLabel {
+  display: block;
+  margin-bottom: var(--base-size-4);
+  font-size: var(--text-body-size-small);
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* IssueLink-style inline reference: state octicon + bold title + muted number. */
+.IssueLink {
+  color: var(--fgColor-default);
+  text-decoration: none;
+}
+
+.IssueLink:hover {
+  color: var(--fgColor-accent);
+  text-decoration: underline;
+}
+
+.IssueLinkIcon {
+  color: var(--fgColor-done);
+  vertical-align: middle;
+  margin-right: var(--base-size-4);
+}
+
+.IssueLinkTitle {
+  font-weight: var(--base-text-weight-semibold);
+}
+
+.IssueLinkNumber {
+  color: var(--fgColor-muted);
+}
+
+.ProjectIcon {
+  vertical-align: middle;
+  margin-right: var(--base-size-4);
+  color: var(--fgColor-muted);
+}
+
+/* Open (green) state icon variant for IssueLink references that point at an
+   open issue/PR (e.g. the canonical issue in a "marked as duplicate of" row). */
+.IssueLinkIconOpen {
+  color: var(--fgColor-open);
+  vertical-align: middle;
+  margin-right: var(--base-size-4);
+}
+
+/* Inline pull-request state icon rendered in the body text (References group),
+   mirroring github-ui's `sourceIcon('PullRequest', ...)` open-state coloring. */
+.PrStateIcon {
+  color: var(--fgColor-open);
+  vertical-align: middle;
+  margin: 0 var(--base-size-4);
+}
+
+/* Open (green) badge icon, used when the badge icon itself is a PR state icon
+   (References "removed a link to a pull request" → `leadingIcon={PullStateIcon}`). */
+.BadgeIconOpen {
+  color: var(--fgColor-open);
+}
+
+/* Wrapper around a colored issue-type Token so it sits inline with the copy,
+   matching github-ui's `IssueTypeEvent.module.css` `issueTypeTokenWrapper`. */
+.TokenWrapper {
+  display: inline-flex;
+  vertical-align: middle;
+  margin: 0 var(--base-size-4);
+}
+
+/* Simplified commit-reference card (github-ui's `ReferencedEventInner`): a
+   bordered row with a monospace commit message link and a trailing SHA. */
+.CommitRefBox {
+  margin-top: var(--base-size-8);
+  border: var(--borderWidth-thin) solid var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+}
+
+.CommitRefRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--base-size-8);
+  padding: var(--base-size-8) var(--base-size-12);
+}
+
+.CommitRefRow + .CommitRefRow {
+  border-top: var(--borderWidth-thin) solid var(--borderColor-muted);
+}
+
+.CommitRefMessage {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+}
+
+.CommitRefOid {
+  font-family: var(--fontStack-monospace);
+  font-size: var(--text-body-size-small);
+  color: var(--fgColor-muted);
+}
+
+/* Secondary reference list (github-ui Hierarchy/Dependency events render the
+   linked issues in a bordered `<ul>` Box below the main copy). Single vs
+   multiple differ only by item count + singular/plural leading copy. */
+.RefList {
+  margin-top: var(--base-size-8);
+  padding: 0;
+  list-style: none;
+  border: var(--borderWidth-thin) solid var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+}
+
+.RefListItem {
+  padding: var(--base-size-8) var(--base-size-12);
+}
+
+.RefListItem + .RefListItem {
+  border-top: var(--borderWidth-thin) solid var(--borderColor-muted);
+}
+
+/* IssueField event: the field name reads as semibold inline text, the value as
+   an inline link (github-ui's `IssueFieldEvent` `issueFieldTokenWrapper`). */
+.FieldName {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+  margin: 0 var(--base-size-4);
+}
+
+.FieldValue {
+  margin-left: var(--base-size-4);
+}

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
@@ -127,7 +127,7 @@
 }
 
 .CommitRefMessage {
-  font-weight: var(--base-text-weight-semibold);
+  font-size: var(--text-body-size-small);
   color: var(--fgColor-default);
 }
 

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
@@ -78,6 +78,21 @@
   color: var(--fgColor-muted);
 }
 
+/* Issue-version ProjectV2 reference (github-ui `ProjectV2.tsx`): an inline
+   default-colored TableIcon octicon followed by a regular-weight, default-color
+   link. The underline comes from the Link `inline` prop (always-on underline,
+   which also satisfies the high-contrast a11y rule). Mirrors live
+   `.projectLink { color: var(--fgColor-default) }`. NOTE: the PR (ERB) surface
+   renders this differently — see the EventProject group comment. */
+.ProjectRefIcon {
+  vertical-align: middle;
+  margin-right: var(--base-size-4);
+}
+
+.ProjectRefLink {
+  color: var(--fgColor-default);
+}
+
 /* Open (green) state icon variant for IssueLink references that point at an
    open issue/PR (e.g. the canonical issue in a "marked as duplicate of" row). */
 .IssueLinkIconOpen {

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
@@ -127,8 +127,9 @@
 }
 
 .CommitRefMessage {
+  font-family: var(--fontStack-monospace);
   font-size: var(--text-body-size-small);
-  color: var(--fgColor-default);
+  color: var(--fgColor-muted);
 }
 
 .CommitRefOid {

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
@@ -1,23 +1,3 @@
-.RealisticTimeline {
-  /* GitHub renders the timeline at most 1012px wide in product surfaces. */
-  max-width: 1012px;
-}
-
-.LinkWithBoldStyle {
-  font-weight: var(--base-text-weight-semibold);
-  color: var(--fgColor-default);
-  margin-right: var(--base-size-4);
-}
-
-.LinkWithBoldStyle:hover {
-  color: var(--fgColor-accent);
-}
-
-.InlineAvatar {
-  vertical-align: middle;
-  margin-right: var(--base-size-4);
-}
-
 .Timestamp {
   text-decoration: underline;
 }
@@ -27,24 +7,6 @@
   font-size: var(--text-body-size-small);
   font-weight: var(--base-text-weight-semibold);
   color: var(--fgColor-default);
-}
-
-/* Story-only scaffolding: each variant is wrapped in its own <section> with a
-   small caption heading ABOVE the event, so the event row itself (badge +
-   inline avatar + body) renders exactly as it would in product — the caption
-   never sits inside Timeline.Body. Variants stay scannable like a Figma
-   component set. Not part of the faithful event. */
-.Variant {
-  margin-bottom: var(--base-size-24);
-}
-
-.VariantLabel {
-  margin: 0 0 var(--base-size-4);
-  font-size: var(--text-body-size-small);
-  font-weight: var(--base-text-weight-semibold);
-  color: var(--fgColor-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 
 /* IssueLink-style inline reference: state octicon + bold title + muted number. */

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
@@ -29,11 +29,17 @@
   color: var(--fgColor-default);
 }
 
-/* Story-only scaffolding: a small caption per Timeline.Item so the variants
-   can be scanned like a Figma component set. Not part of the faithful event. */
+/* Story-only scaffolding: each variant is wrapped in its own <section> with a
+   small caption heading ABOVE the event, so the event row itself (badge +
+   inline avatar + body) renders exactly as it would in product — the caption
+   never sits inside Timeline.Body. Variants stay scannable like a Figma
+   component set. Not part of the faithful event. */
+.Variant {
+  margin-bottom: var(--base-size-24);
+}
+
 .VariantLabel {
-  display: block;
-  margin-bottom: var(--base-size-4);
+  margin: 0 0 var(--base-size-4);
   font-size: var(--text-body-size-small);
   font-weight: var(--base-text-weight-semibold);
   color: var(--fgColor-muted);
@@ -102,12 +108,15 @@
   margin: 0 var(--base-size-4);
 }
 
-/* Simplified commit-reference card (github-ui's `ReferencedEventInner`): a
-   bordered row with a monospace commit message link and a trailing SHA. */
+/* Commit reference (github-ui's `ReferencedEventInner`): NOT a bordered card on
+   live GitHub — `.referencedCommitContainer` is a plain flex column (`gap: 2px`)
+   with the monospace message on the left and the SHA on the right. Mirror that:
+   no border, no card background, no row dividers. */
 .CommitRefBox {
+  display: flex;
+  flex-direction: column;
+  gap: var(--base-size-4);
   margin-top: var(--base-size-8);
-  border: var(--borderWidth-thin) solid var(--borderColor-default);
-  border-radius: var(--borderRadius-medium);
 }
 
 .CommitRefRow {
@@ -115,11 +124,6 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--base-size-8);
-  padding: var(--base-size-8) var(--base-size-12);
-}
-
-.CommitRefRow + .CommitRefRow {
-  border-top: var(--borderWidth-thin) solid var(--borderColor-muted);
 }
 
 .CommitRefMessage {
@@ -134,22 +138,18 @@
 }
 
 /* Secondary reference list (github-ui Hierarchy/Dependency events render the
-   linked issues in a bordered `<ul>` Box below the main copy). Single vs
+   linked issues below the main copy). On live GitHub these are PLAIN, lightly
+   indented rows — state octicon + bold title + muted #number per line — with no
+   surrounding border, no card background, and no row dividers. Single vs
    multiple differ only by item count + singular/plural leading copy. */
 .RefList {
   margin-top: var(--base-size-8);
-  padding: 0;
+  padding-left: var(--base-size-4);
   list-style: none;
-  border: var(--borderWidth-thin) solid var(--borderColor-default);
-  border-radius: var(--borderRadius-medium);
-}
-
-.RefListItem {
-  padding: var(--base-size-8) var(--base-size-12);
 }
 
 .RefListItem + .RefListItem {
-  border-top: var(--borderWidth-thin) solid var(--borderColor-muted);
+  margin-top: var(--base-size-4);
 }
 
 /* IssueField event: the field name reads as semibold inline text, the value as

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.module.css
@@ -1,7 +1,3 @@
-.Timestamp {
-  text-decoration: underline;
-}
-
 .CommitSha {
   font-family: var(--fontStack-monospace);
   font-size: var(--text-body-size-small);

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -89,7 +89,7 @@ const Time = ({date}: {date: string}) => (
 )
 
 export default {
-  title: 'Components/Timeline/Issues Features',
+  title: 'Components/Timeline/Events/Issues',
   component: Timeline,
   subcomponents: {
     'Timeline.Item': Timeline.Item,

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -20,11 +20,18 @@ import {
   IssueTrackedByIcon,
   IssueTracksIcon,
   LinkExternalIcon,
+  LockIcon,
+  MilestoneIcon,
   NumberIcon,
+  PencilIcon,
+  PersonIcon,
   PinIcon,
   SingleSelectIcon,
   TableIcon,
+  TagIcon,
+  TrashIcon,
   TypographyIcon,
+  UnlockIcon,
 } from '@primer/octicons-react'
 import Avatar from '../Avatar'
 import {Button} from '../Button'
@@ -1896,6 +1903,633 @@ export const EventProject = () => (
               Roadmap
             </Link>{' '}
             <Time date="2022-07-24T16:42:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Labels event group — shared timeline events (Issue version).
+ *
+ * Sourced from live `LabeledEvent.tsx` / `UnlabeledEvent.tsx` (badge `TagIcon`).
+ * Copy is just "added {label}" / "removed {label}" (live `LABELS.timeline.added`
+ * / `removed`, then the `Label` pill — no "the"/"label" filler words). The
+ * rolled-up form (`RolledupLabeledEvent`) joins them: "added {…} and removed {…}".
+ *
+ * Labels render as colored pills; the color comes from the label in live code
+ * (`@github-ui/label-token` `LabelToken`). We compose the closest Primer
+ * equivalent with `Token` + the label's semantic color tokens (same pattern as
+ * the IssueTypes group).
+ *
+ * PR ERB source: `app/views/issues/events/_labeled_event.html.erb` — verify on
+ * the PR build (label pill markup is shared, copy is the same).
+ */
+export const EventLabels = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Label added */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Label added</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TagIcon} aria-label="Label added" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'added '}
+            <span className={classes.TokenWrapper}>
+              <Token
+                as="a"
+                href="#"
+                text="bug"
+                size="small"
+                style={{
+                  backgroundColor: 'var(--bgColor-danger-muted)',
+                  color: 'var(--fgColor-danger)',
+                  borderColor: 'var(--borderColor-danger-muted)',
+                }}
+              />
+            </span>{' '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Label removed */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Label removed</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TagIcon} aria-label="Label removed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'removed '}
+            <span className={classes.TokenWrapper}>
+              <Token
+                as="a"
+                href="#"
+                text="bug"
+                size="small"
+                style={{
+                  backgroundColor: 'var(--bgColor-danger-muted)',
+                  color: 'var(--fgColor-danger)',
+                  borderColor: 'var(--borderColor-danger-muted)',
+                }}
+              />
+            </span>{' '}
+            <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Added + removed (rollup) — RolledupLabeledEvent joins both renderings
+        with "and" between them. */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Labels added and removed</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TagIcon} aria-label="Labels added and removed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'added '}
+            <span className={classes.TokenWrapper}>
+              <Token
+                as="a"
+                href="#"
+                text="enhancement"
+                size="small"
+                style={{
+                  backgroundColor: 'var(--bgColor-accent-muted)',
+                  color: 'var(--fgColor-accent)',
+                  borderColor: 'var(--borderColor-accent-muted)',
+                }}
+              />
+            </span>
+            {' and removed '}
+            <span className={classes.TokenWrapper}>
+              <Token
+                as="a"
+                href="#"
+                text="bug"
+                size="small"
+                style={{
+                  backgroundColor: 'var(--bgColor-danger-muted)',
+                  color: 'var(--fgColor-danger)',
+                  borderColor: 'var(--borderColor-danger-muted)',
+                }}
+              />
+            </span>{' '}
+            <Time date="2022-07-24T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Title event group — shared timeline event (Issue version).
+ *
+ * Sourced from live `RenamedTitleEvent.tsx` (badge `PencilIcon`). Copy is
+ * "changed the title {old} {new}" where the OLD title is struck through (`<del>`,
+ * default color) and the NEW title is plain (default color, no underline). NOTE
+ * audit-vs-live DRIFT: the audit phrases this "changed the title from {old} to
+ * {new}", but live renders NO "from"/"to" words — just strikethrough old then
+ * new (`LABELS.timeline.renamedTitle` = "changed the title").
+ *
+ * PR ERB source: `app/views/issues/events/_renamed_event.html.erb` — verify on
+ * the PR build.
+ */
+export const EventTitle = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Title changed */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Title changed</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PencilIcon} aria-label="Title changed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'changed the title '}
+            <del>Fix the uplaod bug</del> Fix the upload bug <Time date="2022-07-23T11:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Milestones event group — shared timeline events (Issue version).
+ *
+ * Sourced from live `MilestonedEvent.tsx` / `DemilestonedEvent.tsx` (badge
+ * `MilestoneIcon`). Copy: "added this to the {milestone} milestone" /
+ * "removed this from the {milestone} milestone" (`LABELS.timeline.addedToMilestone`
+ * / `removedFromMilestone` + the milestone link + `milestone`). The milestone
+ * link is a regular-weight, default-color `<Link inline>` (live `.milestoneLink`
+ * = `color: var(--fgColor-default)`); the `inline` prop gives the always-on
+ * underline (also satisfies the high-contrast a11y rule).
+ *
+ * PR ERB source: `app/views/issues/events/_milestoned_event.html.erb` — verify
+ * on the PR build.
+ */
+export const EventMilestones = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Added to milestone */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Added to milestone</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={MilestoneIcon} aria-label="Added to milestone" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'added this to the '}
+            <Link href="#" inline className={classes.ProjectRefLink}>
+              v2.0
+            </Link>
+            {' milestone '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Removed from milestone */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Removed from milestone</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={MilestoneIcon} aria-label="Removed from milestone" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'removed this from the '}
+            <Link href="#" inline className={classes.ProjectRefLink}>
+              v2.0
+            </Link>
+            {' milestone '}
+            <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Assignments event group — shared timeline events (Issue version).
+ *
+ * Sourced from live `AssignedEvent.tsx` / `UnassignedEvent.tsx` (badge
+ * `PersonIcon`). Copy: self → "self-assigned this" / "removed their assignment"
+ * (no actor-name prefix); other → "assigned {user}" / "unassigned {user}";
+ * multiple → joined with "and". The assignee is a BOLD text link with NO avatar
+ * in the React Issue impl (`AssignmentEventAssignee` → `ProfileReference` inside
+ * a `<Link>`, no avatar element).
+ *
+ * PR/Dependabot DIVERGENCE: Dependabot's assignment events render the assignee
+ * via a different ActorComponent that DOES include an inline avatar (avatar +
+ * name), unlike this Issue impl (bold name only). Whoever builds the
+ * Dependabot/PR surface must use that ActorComponent, not this composition.
+ */
+export const EventAssignments = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Self-assigned */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Self-assigned</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PersonIcon} aria-label="Self-assigned" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'self-assigned this '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Assigned someone else — assignee is a bold link, no avatar. */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Assigned</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PersonIcon} aria-label="Assigned" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'assigned '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              hubot
+            </Link>{' '}
+            <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Assigned multiple — joined with "and". */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Assigned multiple</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PersonIcon} aria-label="Assigned multiple" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'assigned '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              hubot
+            </Link>
+            {' and '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              octocat
+            </Link>{' '}
+            <Time date="2022-07-24T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Self-unassigned */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Self-unassigned</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PersonIcon} aria-label="Self-unassigned" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'removed their assignment '}
+            <Time date="2022-07-23T11:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Unassigned someone else */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Unassigned</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PersonIcon} aria-label="Unassigned" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'unassigned '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              hubot
+            </Link>{' '}
+            <Time date="2022-07-22T14:20:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Unassigned multiple — joined with "and". */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Unassigned multiple</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PersonIcon} aria-label="Unassigned multiple" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'unassigned '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              hubot
+            </Link>
+            {' and '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              octocat
+            </Link>{' '}
+            <Time date="2022-07-21T08:30:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Lock/Unlock event group — shared timeline events (Issue version).
+ *
+ * Sourced from live `LockedEvent.tsx` / `UnlockedEvent.tsx`. Locked uses the
+ * `LockIcon` badge; UNLOCKED uses the `UnlockIcon` badge (badge DRIFT vs the
+ * single "LockIcon" family note — live `UnlockedEvent` passes
+ * `leadingIcon={UnlockIcon}`). Locked copy: "locked as {reason} and limited
+ * conversation to collaborators" (reason from `VALUES.lockedReasonStrings`:
+ * off topic / resolved / spam / too heated); with no reason: "locked and limited
+ * conversation to collaborators". Unlocked copy: "unlocked this conversation".
+ *
+ * PR ERB source: `app/views/issues/events/_locked_event.html.erb` — verify on
+ * the PR build.
+ */
+export const EventLockUnlock = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Locked with reason — one row per reason (off topic / resolved / spam /
+        too heated). */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Locked (with reason)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LockIcon} aria-label="Locked as off topic" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'locked as off topic and limited conversation to collaborators '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LockIcon} aria-label="Locked as resolved" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'locked as resolved and limited conversation to collaborators '}
+            <Time date="2022-07-26T11:47:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LockIcon} aria-label="Locked as spam" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'locked as spam and limited conversation to collaborators '}
+            <Time date="2022-07-26T11:48:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LockIcon} aria-label="Locked as too heated" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'locked as too heated and limited conversation to collaborators '}
+            <Time date="2022-07-26T11:49:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Locked (no reason) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Locked (no reason)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LockIcon} aria-label="Locked" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'locked and limited conversation to collaborators '}
+            <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Unlocked — UnlockIcon badge (not LockIcon). */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Unlocked</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={UnlockIcon} aria-label="Unlocked" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'unlocked this conversation '}
+            <Time date="2022-07-24T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Comment-deleted event group — shared timeline event (Issue version).
+ *
+ * Sourced from live `CommentDeletedEvent.tsx` (badge `TrashIcon`). Copy:
+ * "deleted a comment from {user}" (`LABELS.timeline.deletedACommentFrom` + the
+ * deleted comment author as an inline `<Link>` wrapping a `ProfileReference`).
+ * The author link uses the `inline` prop (always-on underline / high-contrast).
+ *
+ * PR ERB source: `app/views/issues/events/_comment_deleted_event.html.erb` —
+ * verify on the PR build.
+ */
+export const EventCommentDeleted = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Comment deleted */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Comment deleted</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TrashIcon} aria-label="Comment deleted" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'deleted a comment from '}
+            <Link href="#" inline>
+              octocat
+            </Link>{' '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Cross-references event group — shared timeline events (Issue version).
+ *
+ * Sourced from live `CrossReferencedEvent.tsx` + `IssueLink.tsx` (badge
+ * `LinkExternalIcon`). The body message is "mentioned this" (then timestamp);
+ * the closing-PR form is "linked a pull request that will close this issue";
+ * rolled-up forms read "mentioned this in {n} issues / pull requests". The
+ * referenced source is rendered in a Secondary slot as an `IssueLink` row:
+ * a state octicon (from `useIssueState().sourceIcon` — open issue green
+ * `IssueOpenedIcon`, open PR green `GitPullRequestIcon`) + the title + the
+ * abbreviated #number reference. We reuse the plain (borderless) `.RefList`.
+ *
+ * PR ERB source: `app/views/issues/events/_cross_referenced_event.html.erb` —
+ * verify on the PR build.
+ */
+export const EventCrossReferences = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Mentioned from an issue */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Mentioned in an issue</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LinkExternalIcon} aria-label="Mentioned in an issue" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'mentioned this '}
+            <Time date="2022-07-26T11:46:07Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} aria-label="Open" />
+                <Link href="#" inline className={classes.IssueLinkTitle}>
+                  Track flaky upload retries
+                </Link>
+                <span className={classes.IssueLinkNumber}> #128</span>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Mentioned from a pull request */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Mentioned in a pull request</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LinkExternalIcon} aria-label="Mentioned in a pull request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'mentioned this '}
+            <Time date="2022-07-25T09:12:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
+                <Link href="#" inline className={classes.IssueLinkTitle}>
+                  Add retry logic to the uploader
+                </Link>
+                <span className={classes.IssueLinkNumber}> #42</span>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Linked a closing pull request */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Linked a closing pull request</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LinkExternalIcon} aria-label="Linked a closing pull request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'linked a pull request that will close this issue '}
+            <Time date="2022-07-24T16:40:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
+                <Link href="#" inline className={classes.IssueLinkTitle}>
+                  Fix the upload retry race condition
+                </Link>
+                <span className={classes.IssueLinkNumber}> #57</span>
+              </li>
+            </ul>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -37,10 +37,9 @@ import {Button} from '../Button'
 import Label from '../Label'
 import Link from '../Link'
 import Octicon from '../Octicon'
-import RelativeTime from '../RelativeTime'
 import Token from '../Token'
 import classes from './Timeline.issues.features.stories.module.css'
-import {BoldLink, Examples, UserActor, VariantSection} from './internal/timelineStoryHelpers'
+import {BoldLink, Examples, MutedTime, UserActor, VariantSection} from './internal/timelineStoryHelpers'
 
 /**
  * Issue Timeline event examples (Phase 2 of github/primer#6663).
@@ -81,13 +80,6 @@ import {BoldLink, Examples, UserActor, VariantSection} from './internal/timeline
  *       </Timeline.Actions>
  *     </Timeline.Item>
  */
-
-// Muted underlined relative timestamp, mirroring github-ui's `Ago` deep-link.
-const Time = ({date}: {date: string}) => (
-  <Link href="#" className={classes.Timestamp} muted>
-    <RelativeTime date={new Date(date)} format="relative" />
-  </Link>
-)
 
 export default {
   title: 'Components/Timeline/Events/Issues',
@@ -136,7 +128,7 @@ export const EventClosed = () => (
             <Link href="#" inline>
               completed
             </Link>{' '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -164,7 +156,7 @@ export const EventClosed = () => (
             <Link href="#" inline>
               not planned
             </Link>{' '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -184,7 +176,7 @@ export const EventClosed = () => (
               completed
             </Link>
             {' in '}
-            <BoldLink href="#">#123</BoldLink> <Time date="2022-07-24T16:40:00Z" />
+            <BoldLink href="#">#123</BoldLink> <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -207,7 +199,7 @@ export const EventClosed = () => (
             <Link href="#" className={classes.CommitSha}>
               abc1234
             </Link>{' '}
-            <Time date="2022-07-23T11:05:00Z" />
+            <MutedTime date={new Date('2022-07-23T11:05:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -230,7 +222,7 @@ export const EventClosed = () => (
             </Link>
             {' by moving to Done in '}
             <Octicon icon={TableIcon} size={16} className={classes.ProjectRefIcon} />
-            <BoldLink href="#">Roadmap</BoldLink> <Time date="2022-07-22T14:20:00Z" />
+            <BoldLink href="#">Roadmap</BoldLink> <MutedTime date={new Date('2022-07-22T14:20:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -264,7 +256,7 @@ export const EventClosed = () => (
               <span className={classes.IssueLinkTitle}>Fix the flaky avatar test</span>{' '}
               <span className={classes.IssueLinkNumber}>#42</span>
             </Link>{' '}
-            <Time date="2022-07-21T08:30:00Z" />
+            <MutedTime date={new Date('2022-07-21T08:30:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -280,7 +272,7 @@ export const EventClosed = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'closed this '}
-            <Time date="2022-07-20T10:00:00Z" />
+            <MutedTime date={new Date('2022-07-20T10:00:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -308,7 +300,7 @@ export const EventState = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'reopened this '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -328,7 +320,7 @@ export const EventState = () => (
             <Link href="#" inline>
               octo-org/legacy-repo
             </Link>{' '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -344,7 +336,7 @@ export const EventState = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'pinned this issue '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -360,7 +352,7 @@ export const EventState = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'unpinned this issue '}
-            <Time date="2022-07-23T11:05:00Z" />
+            <MutedTime date={new Date('2022-07-23T11:05:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -377,7 +369,7 @@ export const EventState = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'converted this issue into a discussion '}
-            <BoldLink href="#">#123</BoldLink> <Time date="2022-07-22T14:20:00Z" />
+            <BoldLink href="#">#123</BoldLink> <MutedTime date={new Date('2022-07-22T14:20:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -393,7 +385,7 @@ export const EventState = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'converted this from a draft issue '}
-            <Time date="2022-07-21T08:30:00Z" />
+            <MutedTime date={new Date('2022-07-21T08:30:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -424,7 +416,8 @@ export const EventReferences = () => (
             {'linked a pull request that will close this issue '}
             <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
             <BoldLink href="#">Add retry logic to the uploader</BoldLink>
-            <span className={classes.IssueLinkNumber}>#42</span> <Time date="2022-07-26T11:46:07Z" />
+            <span className={classes.IssueLinkNumber}>#42</span>{' '}
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -447,7 +440,8 @@ export const EventReferences = () => (
             {'removed a link to a pull request '}
             <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
             <BoldLink href="#">Add retry logic to the uploader</BoldLink>
-            <span className={classes.IssueLinkNumber}>#42</span> <Time date="2022-07-25T09:12:00Z" />
+            <span className={classes.IssueLinkNumber}>#42</span>{' '}
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -464,7 +458,7 @@ export const EventReferences = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'added a commit that references this issue '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
             {/* Simplified ReferencedEventInner card (github-ui composes message +
               verification status + abbreviated OID per commit). */}
             <div className={classes.CommitRefBox}>
@@ -495,7 +489,7 @@ export const EventReferences = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'added 3 commits that reference this issue '}
-            <Time date="2022-07-23T11:05:00Z" />
+            <MutedTime date={new Date('2022-07-23T11:05:00Z')} href="#" />
             <div className={classes.CommitRefBox}>
               <div className={classes.CommitRefRow}>
                 <Link href="#" className={classes.CommitRefMessage} muted>
@@ -556,7 +550,7 @@ export const EventDuplicates = () => (
               <span className={classes.IssueLinkTitle}>Upload fails on large avatars</span>{' '}
               <span className={classes.IssueLinkNumber}>#42</span>
             </Link>{' '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
           <Timeline.Actions>
             <Button size="small">Undo</Button>
@@ -581,7 +575,7 @@ export const EventDuplicates = () => (
               <span className={classes.IssueLinkNumber}>#43</span>
             </Link>
             {' as a duplicate of this issue '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -602,7 +596,7 @@ export const EventDuplicates = () => (
               <span className={classes.IssueLinkTitle}>Upload fails on large avatars</span>{' '}
               <span className={classes.IssueLinkNumber}>#42</span>
             </Link>{' '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -624,7 +618,7 @@ export const EventDuplicates = () => (
               <span className={classes.IssueLinkNumber}>#43</span>
             </Link>
             {' as a duplicate of this issue '}
-            <Time date="2022-07-23T11:05:00Z" />
+            <MutedTime date={new Date('2022-07-23T11:05:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -651,7 +645,7 @@ export const EventModeration = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'blocked '}
-            <BoldLink href="#">six7</BoldLink> <Time date="2022-07-26T11:46:07Z" />
+            <BoldLink href="#">six7</BoldLink> <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -667,7 +661,7 @@ export const EventModeration = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'temporarily blocked '}
-            <BoldLink href="#">six7</BoldLink> <Time date="2022-07-25T09:12:00Z" />
+            <BoldLink href="#">six7</BoldLink> <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -686,7 +680,7 @@ export const EventModeration = () => (
             <Link href="#" inline>
               comment
             </Link>{' '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -705,7 +699,7 @@ export const EventModeration = () => (
             <Link href="#" inline>
               comment
             </Link>{' '}
-            <Time date="2022-07-23T11:05:00Z" />
+            <MutedTime date={new Date('2022-07-23T11:05:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -747,7 +741,7 @@ export const EventIssueTypes = () => (
               />
             </span>
             {' issue type '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -777,7 +771,7 @@ export const EventIssueTypes = () => (
               />
             </span>
             {' issue type '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -820,7 +814,7 @@ export const EventIssueTypes = () => (
                 }}
               />
             </span>{' '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -853,7 +847,7 @@ export const EventIssueHierarchy = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'added a sub-issue '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -878,7 +872,7 @@ export const EventIssueHierarchy = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'added sub-issues '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -910,7 +904,7 @@ export const EventIssueHierarchy = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'removed a sub-issue '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -935,7 +929,7 @@ export const EventIssueHierarchy = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'removed sub-issues '}
-            <Time date="2022-07-23T11:05:00Z" />
+            <MutedTime date={new Date('2022-07-23T11:05:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -967,7 +961,7 @@ export const EventIssueHierarchy = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'added a parent issue '}
-            <Time date="2022-07-22T14:20:00Z" />
+            <MutedTime date={new Date('2022-07-22T14:20:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -992,7 +986,7 @@ export const EventIssueHierarchy = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'added parent issues '}
-            <Time date="2022-07-21T08:30:00Z" />
+            <MutedTime date={new Date('2022-07-21T08:30:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -1024,7 +1018,7 @@ export const EventIssueHierarchy = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'removed a parent issue '}
-            <Time date="2022-07-20T10:00:00Z" />
+            <MutedTime date={new Date('2022-07-20T10:00:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -1049,7 +1043,7 @@ export const EventIssueHierarchy = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'removed parent issues '}
-            <Time date="2022-07-19T13:15:00Z" />
+            <MutedTime date={new Date('2022-07-19T13:15:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -1097,7 +1091,7 @@ export const EventDependencies = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'marked this as blocked '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -1122,7 +1116,7 @@ export const EventDependencies = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'marked this as blocked by 2 issues '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -1154,7 +1148,7 @@ export const EventDependencies = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'unmarked this as blocked '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -1179,7 +1173,7 @@ export const EventDependencies = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'unmarked this as blocked by 2 issues '}
-            <Time date="2022-07-23T11:05:00Z" />
+            <MutedTime date={new Date('2022-07-23T11:05:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -1211,7 +1205,7 @@ export const EventDependencies = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'marked this as blocking '}
-            <Time date="2022-07-22T14:20:00Z" />
+            <MutedTime date={new Date('2022-07-22T14:20:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -1236,7 +1230,7 @@ export const EventDependencies = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'marked this as blocking 2 issues '}
-            <Time date="2022-07-21T08:30:00Z" />
+            <MutedTime date={new Date('2022-07-21T08:30:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -1268,7 +1262,7 @@ export const EventDependencies = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'unmarked this as blocking '}
-            <Time date="2022-07-20T10:00:00Z" />
+            <MutedTime date={new Date('2022-07-20T10:00:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -1293,7 +1287,7 @@ export const EventDependencies = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'unmarked this as blocking 2 issues '}
-            <Time date="2022-07-19T13:15:00Z" />
+            <MutedTime date={new Date('2022-07-19T13:15:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Link href="#" className={classes.IssueLink}>
@@ -1350,7 +1344,7 @@ export const EventIssueFields = () => (
             <Link href="#" inline className={classes.FieldValue}>
               Identity
             </Link>{' '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1371,7 +1365,7 @@ export const EventIssueFields = () => (
             <Link href="#" inline className={classes.FieldValue}>
               5
             </Link>{' '}
-            <Time date="2022-07-25T15:30:00Z" />
+            <MutedTime date={new Date('2022-07-25T15:30:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1392,7 +1386,7 @@ export const EventIssueFields = () => (
             <Link href="#" inline className={classes.FieldValue}>
               Aug 1, 2022
             </Link>{' '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1426,7 +1420,7 @@ export const EventIssueFields = () => (
                 }}
               />
             </span>{' '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1447,7 +1441,7 @@ export const EventIssueFields = () => (
             <Link href="#" inline className={classes.FieldValue}>
               Platform
             </Link>{' '}
-            <Time date="2022-07-23T11:05:00Z" />
+            <MutedTime date={new Date('2022-07-23T11:05:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1468,7 +1462,7 @@ export const EventIssueFields = () => (
             <Link href="#" inline className={classes.FieldValue}>
               8
             </Link>{' '}
-            <Time date="2022-07-22T14:20:00Z" />
+            <MutedTime date={new Date('2022-07-22T14:20:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1489,7 +1483,7 @@ export const EventIssueFields = () => (
             <Link href="#" inline className={classes.FieldValue}>
               Aug 15, 2022
             </Link>{' '}
-            <Time date="2022-07-21T08:30:00Z" />
+            <MutedTime date={new Date('2022-07-21T08:30:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1520,7 +1514,7 @@ export const EventIssueFields = () => (
                 }}
               />
             </span>{' '}
-            <Time date="2022-07-20T10:00:00Z" />
+            <MutedTime date={new Date('2022-07-20T10:00:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1536,7 +1530,8 @@ export const EventIssueFields = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'cleared '}
-            <span className={classes.FieldName}>Team</span> <Time date="2022-07-19T13:15:00Z" />
+            <span className={classes.FieldName}>Team</span>{' '}
+            <MutedTime date={new Date('2022-07-19T13:15:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1552,7 +1547,8 @@ export const EventIssueFields = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'cleared '}
-            <span className={classes.FieldName}>Story Points</span> <Time date="2022-07-18T09:00:00Z" />
+            <span className={classes.FieldName}>Story Points</span>{' '}
+            <MutedTime date={new Date('2022-07-18T09:00:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1568,7 +1564,8 @@ export const EventIssueFields = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'cleared '}
-            <span className={classes.FieldName}>Target Date</span> <Time date="2022-07-17T12:00:00Z" />
+            <span className={classes.FieldName}>Target Date</span>{' '}
+            <MutedTime date={new Date('2022-07-17T12:00:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1584,7 +1581,8 @@ export const EventIssueFields = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'cleared '}
-            <span className={classes.FieldName}>Priority</span> <Time date="2022-07-16T08:30:00Z" />
+            <span className={classes.FieldName}>Priority</span>{' '}
+            <MutedTime date={new Date('2022-07-16T08:30:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1609,7 +1607,7 @@ export const EventIssueFields = () => (
             <Link href="#" inline className={classes.FieldValue}>
               8
             </Link>{' '}
-            <Time date="2022-07-15T10:00:00Z" />
+            <MutedTime date={new Date('2022-07-15T10:00:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1627,7 +1625,8 @@ export const EventIssueFields = () => (
             {'removed '}
             <span className={classes.FieldName}>Team</span>
             {' and '}
-            <span className={classes.FieldName}>Priority</span> <Time date="2022-07-14T10:00:00Z" />
+            <span className={classes.FieldName}>Priority</span>{' '}
+            <MutedTime date={new Date('2022-07-14T10:00:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1648,7 +1647,8 @@ export const EventIssueFields = () => (
               Platform
             </Link>
             {', and also removed '}
-            <span className={classes.FieldName}>Priority</span> <Time date="2022-07-13T10:00:00Z" />
+            <span className={classes.FieldName}>Priority</span>{' '}
+            <MutedTime date={new Date('2022-07-13T10:00:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1699,7 +1699,7 @@ export const EventProject = () => (
             <Link href="#" inline className={classes.ProjectRefLink}>
               Roadmap
             </Link>{' '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1719,7 +1719,7 @@ export const EventProject = () => (
             <Link href="#" inline className={classes.ProjectRefLink}>
               Roadmap
             </Link>{' '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1743,7 +1743,7 @@ export const EventProject = () => (
             <Link href="#" inline className={classes.ProjectRefLink}>
               Roadmap
             </Link>{' '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
         <Timeline.Item>
@@ -1757,7 +1757,7 @@ export const EventProject = () => (
             <Link href="#" inline className={classes.ProjectRefLink}>
               Roadmap
             </Link>{' '}
-            <Time date="2022-07-24T16:42:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:42:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1806,7 +1806,7 @@ export const EventLabels = () => (
                 }}
               />
             </span>{' '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1835,7 +1835,7 @@ export const EventLabels = () => (
                 }}
               />
             </span>{' '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1879,7 +1879,7 @@ export const EventLabels = () => (
                 }}
               />
             </span>{' '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1912,7 +1912,8 @@ export const EventTitle = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'changed the title '}
-            <del>Fix the uplaod bug</del> Fix the upload bug <Time date="2022-07-23T11:05:00Z" />
+            <del>Fix the uplaod bug</del> Fix the upload bug{' '}
+            <MutedTime date={new Date('2022-07-23T11:05:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1950,7 +1951,7 @@ export const EventMilestones = () => (
               v2.0
             </Link>
             {' milestone '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -1970,7 +1971,7 @@ export const EventMilestones = () => (
               v2.0
             </Link>
             {' milestone '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -2005,7 +2006,7 @@ export const EventAssignments = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'self-assigned this '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -2021,7 +2022,7 @@ export const EventAssignments = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'assigned '}
-            <BoldLink href="#">hubot</BoldLink> <Time date="2022-07-25T09:12:00Z" />
+            <BoldLink href="#">hubot</BoldLink> <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -2039,7 +2040,7 @@ export const EventAssignments = () => (
             {'assigned '}
             <BoldLink href="#">hubot</BoldLink>
             {' and '}
-            <BoldLink href="#">octocat</BoldLink> <Time date="2022-07-24T16:40:00Z" />
+            <BoldLink href="#">octocat</BoldLink> <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -2055,7 +2056,7 @@ export const EventAssignments = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'removed their assignment '}
-            <Time date="2022-07-23T11:05:00Z" />
+            <MutedTime date={new Date('2022-07-23T11:05:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -2071,7 +2072,7 @@ export const EventAssignments = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'unassigned '}
-            <BoldLink href="#">hubot</BoldLink> <Time date="2022-07-22T14:20:00Z" />
+            <BoldLink href="#">hubot</BoldLink> <MutedTime date={new Date('2022-07-22T14:20:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -2089,7 +2090,7 @@ export const EventAssignments = () => (
             {'unassigned '}
             <BoldLink href="#">hubot</BoldLink>
             {' and '}
-            <BoldLink href="#">octocat</BoldLink> <Time date="2022-07-21T08:30:00Z" />
+            <BoldLink href="#">octocat</BoldLink> <MutedTime date={new Date('2022-07-21T08:30:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -2124,7 +2125,7 @@ export const EventLockUnlock = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'locked as off topic and limited conversation to collaborators '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
         <Timeline.Item>
@@ -2134,7 +2135,7 @@ export const EventLockUnlock = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'locked as resolved and limited conversation to collaborators '}
-            <Time date="2022-07-26T11:47:00Z" />
+            <MutedTime date={new Date('2022-07-26T11:47:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
         <Timeline.Item>
@@ -2144,7 +2145,7 @@ export const EventLockUnlock = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'locked as spam and limited conversation to collaborators '}
-            <Time date="2022-07-26T11:48:00Z" />
+            <MutedTime date={new Date('2022-07-26T11:48:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
         <Timeline.Item>
@@ -2154,7 +2155,7 @@ export const EventLockUnlock = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'locked as too heated and limited conversation to collaborators '}
-            <Time date="2022-07-26T11:49:00Z" />
+            <MutedTime date={new Date('2022-07-26T11:49:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -2170,7 +2171,7 @@ export const EventLockUnlock = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'locked and limited conversation to collaborators '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -2186,7 +2187,7 @@ export const EventLockUnlock = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'unlocked this conversation '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -2220,7 +2221,7 @@ export const EventCommentDeleted = () => (
             <Link href="#" inline>
               octocat
             </Link>{' '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -2255,7 +2256,7 @@ export const EventCrossReferences = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'mentioned this '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} aria-label="Open" />
@@ -2280,7 +2281,7 @@ export const EventCrossReferences = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'mentioned this '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <MutedTime date={new Date('2022-07-25T09:12:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
@@ -2305,7 +2306,7 @@ export const EventCrossReferences = () => (
           <Timeline.Body>
             <UserActor href="#" muted />
             {'linked a pull request that will close this issue '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
             <ul className={classes.RefList}>
               <li className={classes.RefListItem}>
                 <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -249,7 +249,7 @@ export const EventClosed = () => (
               completed
             </Link>
             {' by moving to Done in '}
-            <Octicon icon={TableIcon} size={16} className={classes.ProjectIcon} />
+            <Octicon icon={TableIcon} size={16} className={classes.ProjectRefIcon} />
             <Link href="#" className={classes.LinkWithBoldStyle}>
               Roadmap
             </Link>{' '}

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -128,155 +128,181 @@ export const EventClosed = () => (
       if ((e.target as HTMLElement).closest('a')) e.preventDefault()
     }}
   >
-    <Timeline aria-label="Issue timeline">
-      {/* Closed as completed */}
-      <Timeline.Item>
-        <Timeline.Badge variant="done">
-          <Octicon icon={CheckCircleIcon} aria-label="Closed as completed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Closed as completed</span>
-          <Actor />
-          {'closed this as '}
-          <Link href="#" inline>
-            completed
-          </Link>{' '}
-          <Time date="2022-07-26T11:46:07Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Closed as completed */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as completed</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={CheckCircleIcon} aria-label="Closed as completed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'closed this as '}
+            <Link href="#" inline>
+              completed
+            </Link>{' '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Not planned — neutral (gray) badge. Timeline.Badge has no `neutral`
+    {/* Not planned — neutral (gray) badge. Timeline.Badge has no `neutral`
           variant, so drive the documented `--timelineBadge-bgColor` hook inline
           (portable for docs copy-paste; matches production `TimelineRow`). */}
-      <Timeline.Item>
-        <Timeline.Badge
-          style={
-            {
-              '--timelineBadge-bgColor': 'var(--bgColor-neutral-emphasis)',
-              color: 'var(--fgColor-onEmphasis)',
-            } as React.CSSProperties
-          }
-        >
-          <Octicon icon={CircleSlashIcon} aria-label="Closed as not planned" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Closed as not planned</span>
-          <Actor />
-          {'closed this as '}
-          <Link href="#" inline>
-            not planned
-          </Link>{' '}
-          <Time date="2022-07-25T09:12:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as not planned</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge
+            style={
+              {
+                '--timelineBadge-bgColor': 'var(--bgColor-neutral-emphasis)',
+                color: 'var(--fgColor-onEmphasis)',
+              } as React.CSSProperties
+            }
+          >
+            <Octicon icon={CircleSlashIcon} aria-label="Closed as not planned" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'closed this as '}
+            <Link href="#" inline>
+              not planned
+            </Link>{' '}
+            <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Closed via pull request */}
-      <Timeline.Item>
-        <Timeline.Badge variant="done">
-          <Octicon icon={CheckCircleIcon} aria-label="Closed via pull request" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Closed via pull request</span>
-          <Actor />
-          {'closed this as '}
-          <Link href="#" inline>
-            completed
-          </Link>
-          {' in '}
-          <Link href="#" className={classes.LinkWithBoldStyle}>
-            #123
-          </Link>{' '}
-          <Time date="2022-07-24T16:40:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Closed via pull request */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed via pull request</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={CheckCircleIcon} aria-label="Closed via pull request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'closed this as '}
+            <Link href="#" inline>
+              completed
+            </Link>
+            {' in '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              #123
+            </Link>{' '}
+            <Time date="2022-07-24T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Closed via commit */}
-      <Timeline.Item>
-        <Timeline.Badge variant="done">
-          <Octicon icon={CheckCircleIcon} aria-label="Closed via commit" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Closed via commit</span>
-          <Actor />
-          {'closed this as '}
-          <Link href="#" inline>
-            completed
-          </Link>
-          {' in '}
-          <Link href="#" className={classes.CommitSha}>
-            abc1234
-          </Link>{' '}
-          <Time date="2022-07-23T11:05:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Closed via commit */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed via commit</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={CheckCircleIcon} aria-label="Closed via commit" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'closed this as '}
+            <Link href="#" inline>
+              completed
+            </Link>
+            {' in '}
+            <Link href="#" className={classes.CommitSha}>
+              abc1234
+            </Link>{' '}
+            <Time date="2022-07-23T11:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Closed via project (ProjectV2 status change). github-ui composes
+    {/* Closed via project (ProjectV2 status change). github-ui composes
           the closer link as TableIcon + project title; there is no Primer
           equivalent for github-ui's `ProjectV2` closer link. */}
-      <Timeline.Item>
-        <Timeline.Badge variant="done">
-          <Octicon icon={CheckCircleIcon} aria-label="Closed via project" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Closed via project</span>
-          <Actor />
-          {'closed this as '}
-          <Link href="#" inline>
-            completed
-          </Link>
-          {' by moving to Done in '}
-          <Octicon icon={TableIcon} size={16} className={classes.ProjectIcon} />
-          <Link href="#" className={classes.LinkWithBoldStyle}>
-            Roadmap
-          </Link>{' '}
-          <Time date="2022-07-22T14:20:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed via project</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={CheckCircleIcon} aria-label="Closed via project" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'closed this as '}
+            <Link href="#" inline>
+              completed
+            </Link>
+            {' by moving to Done in '}
+            <Octicon icon={TableIcon} size={16} className={classes.ProjectIcon} />
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              Roadmap
+            </Link>{' '}
+            <Time date="2022-07-22T14:20:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Closed as duplicate — neutral (gray) badge (see note above). github-ui
+    {/* Closed as duplicate — neutral (gray) badge (see note above). github-ui
           renders an `IssueLink` (state icon + title + #number + hovercard);
           composed here from Primer primitives. */}
-      <Timeline.Item>
-        <Timeline.Badge
-          style={
-            {
-              '--timelineBadge-bgColor': 'var(--bgColor-neutral-emphasis)',
-              color: 'var(--fgColor-onEmphasis)',
-            } as React.CSSProperties
-          }
-        >
-          <Octicon icon={CircleSlashIcon} aria-label="Closed as duplicate" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Closed as duplicate</span>
-          <Actor />
-          {'closed this as a '}
-          <Link href="#" inline>
-            duplicate
-          </Link>
-          {' of '}
-          <Link href="#" className={classes.IssueLink}>
-            <Octicon icon={IssueClosedIcon} size={16} className={classes.IssueLinkIcon} />
-            <span className={classes.IssueLinkTitle}>Fix the flaky avatar test</span>{' '}
-            <span className={classes.IssueLinkNumber}>#42</span>
-          </Link>{' '}
-          <Time date="2022-07-21T08:30:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as duplicate</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge
+            style={
+              {
+                '--timelineBadge-bgColor': 'var(--bgColor-neutral-emphasis)',
+                color: 'var(--fgColor-onEmphasis)',
+              } as React.CSSProperties
+            }
+          >
+            <Octicon icon={CircleSlashIcon} aria-label="Closed as duplicate" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'closed this as a '}
+            <Link href="#" inline>
+              duplicate
+            </Link>
+            {' of '}
+            <Link href="#" className={classes.IssueLink}>
+              <Octicon icon={IssueClosedIcon} size={16} className={classes.IssueLinkIcon} />
+              <span className={classes.IssueLinkTitle}>Fix the flaky avatar test</span>{' '}
+              <span className={classes.IssueLinkNumber}>#42</span>
+            </Link>{' '}
+            <Time date="2022-07-21T08:30:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Closed with no state reason */}
-      <Timeline.Item>
-        <Timeline.Badge variant="done">
-          <Octicon icon={CheckCircleIcon} aria-label="Closed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Closed (no reason)</span>
-          <Actor />
-          {'closed this '}
-          <Time date="2022-07-20T10:00:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
-    </Timeline>
+    {/* Closed with no state reason */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed (no reason)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={CheckCircleIcon} aria-label="Closed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'closed this '}
+            <Time date="2022-07-20T10:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
   </div>
 )
 
@@ -295,93 +321,115 @@ export const EventState = () => (
       if ((e.target as HTMLElement).closest('a')) e.preventDefault()
     }}
   >
-    <Timeline aria-label="Issue timeline">
-      {/* Reopened — open (green) badge via useIssueState (ReopenedEvent.tsx) */}
-      <Timeline.Item>
-        <Timeline.Badge variant="open">
-          <Octicon icon={IssueReopenedIcon} aria-label="Reopened" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Reopened</span>
-          <Actor />
-          {'reopened this '}
-          <Time date="2022-07-26T11:46:07Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Reopened — open (green) badge via useIssueState (ReopenedEvent.tsx) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Reopened</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="open">
+            <Octicon icon={IssueReopenedIcon} aria-label="Reopened" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'reopened this '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Transferred — github-ui's TransferredEvent renders the source repo as a
+    {/* Transferred — github-ui's TransferredEvent renders the source repo as a
           plain inline Link (the audit shows it bold; live code is canonical). */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={LinkExternalIcon} aria-label="Transferred" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Transferred</span>
-          <Actor />
-          {'transferred this issue from '}
-          <Link href="#" inline>
-            octo-org/legacy-repo
-          </Link>{' '}
-          <Time date="2022-07-25T09:12:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Transferred</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LinkExternalIcon} aria-label="Transferred" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'transferred this issue from '}
+            <Link href="#" inline>
+              octo-org/legacy-repo
+            </Link>{' '}
+            <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Pinned */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={PinIcon} aria-label="Pinned" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Pinned</span>
-          <Actor />
-          {'pinned this issue '}
-          <Time date="2022-07-24T16:40:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Pinned */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Pinned</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PinIcon} aria-label="Pinned" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'pinned this issue '}
+            <Time date="2022-07-24T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Unpinned */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={PinIcon} aria-label="Unpinned" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Unpinned</span>
-          <Actor />
-          {'unpinned this issue '}
-          <Time date="2022-07-23T11:05:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Unpinned */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Unpinned</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PinIcon} aria-label="Unpinned" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'unpinned this issue '}
+            <Time date="2022-07-23T11:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Converted to discussion — github-ui's ConvertedToDiscussionEvent links
+    {/* Converted to discussion — github-ui's ConvertedToDiscussionEvent links
           the resulting discussion by number. */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={CommentDiscussionIcon} aria-label="Converted to discussion" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Converted to discussion</span>
-          <Actor />
-          {'converted this issue into a discussion '}
-          <Link href="#" className={classes.LinkWithBoldStyle}>
-            #123
-          </Link>{' '}
-          <Time date="2022-07-22T14:20:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Converted to discussion</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CommentDiscussionIcon} aria-label="Converted to discussion" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'converted this issue into a discussion '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              #123
+            </Link>{' '}
+            <Time date="2022-07-22T14:20:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Converted from draft */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueDraftIcon} aria-label="Converted from draft" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Converted from draft</span>
-          <Actor />
-          {'converted this from a draft issue '}
-          <Time date="2022-07-21T08:30:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
-    </Timeline>
+    {/* Converted from draft */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Converted from draft</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueDraftIcon} aria-label="Converted from draft" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'converted this from a draft issue '}
+            <Time date="2022-07-21T08:30:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
   </div>
 )
 
@@ -400,115 +448,129 @@ export const EventReferences = () => (
       if ((e.target as HTMLElement).closest('a')) e.preventDefault()
     }}
   >
-    <Timeline aria-label="Issue timeline">
-      {/* Linked pull request — ConnectedEvent.tsx (CrossReferenceIcon badge,
+    {/* Linked pull request — ConnectedEvent.tsx (CrossReferenceIcon badge,
           open PR state icon inline before the PR title). */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={CrossReferenceIcon} aria-label="Linked pull request" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Linked pull request</span>
-          <Actor />
-          {'linked a pull request that will close this issue '}
-          <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
-          <Link href="#" className={classes.LinkWithBoldStyle}>
-            Add retry logic to the uploader
-          </Link>
-          <span className={classes.IssueLinkNumber}>#42</span> <Time date="2022-07-26T11:46:07Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Linked pull request</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CrossReferenceIcon} aria-label="Linked pull request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'linked a pull request that will close this issue '}
+            <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              Add retry logic to the uploader
+            </Link>
+            <span className={classes.IssueLinkNumber}>#42</span> <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Unlinked pull request — DisconnectedEvent.tsx uses the PR state icon AS
+    {/* Unlinked pull request — DisconnectedEvent.tsx uses the PR state icon AS
           the badge icon (leadingIcon={PullStateIcon}), so the badge octicon is
           green (open) on a default badge. Verified the live render path is
           active (in TIMELINE_ITEMS[__typename], current useIssueState hook,
           story fixture is an OPEN PR) — the Figma audit's gray cross-reference
           icon is behind the live code here. */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={GitPullRequestIcon} className={classes.BadgeIconOpen} aria-label="Unlinked pull request" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Unlinked pull request</span>
-          <Actor />
-          {'removed a link to a pull request '}
-          <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
-          <Link href="#" className={classes.LinkWithBoldStyle}>
-            Add retry logic to the uploader
-          </Link>
-          <span className={classes.IssueLinkNumber}>#42</span> <Time date="2022-07-25T09:12:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Unlinked pull request</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={GitPullRequestIcon} className={classes.BadgeIconOpen} aria-label="Unlinked pull request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'removed a link to a pull request '}
+            <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              Add retry logic to the uploader
+            </Link>
+            <span className={classes.IssueLinkNumber}>#42</span> <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Single commit reference — ReferencedEvent.tsx. The timestamp renders
+    {/* Single commit reference — ReferencedEvent.tsx. The timestamp renders
           inline (showAgoTimestamp={false}) and the commit card is sub-content. */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={GitCommitIcon} aria-label="Commit reference" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Single commit reference</span>
-          <Actor />
-          {'added a commit that references this issue '}
-          <Time date="2022-07-24T16:40:00Z" />
-          {/* Simplified ReferencedEventInner card (github-ui composes message +
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Single commit reference</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={GitCommitIcon} aria-label="Commit reference" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'added a commit that references this issue '}
+            <Time date="2022-07-24T16:40:00Z" />
+            {/* Simplified ReferencedEventInner card (github-ui composes message +
               verification status + abbreviated OID per commit). */}
-          <div className={classes.CommitRefBox}>
-            <div className={classes.CommitRefRow}>
-              <Link href="#" className={classes.CommitRefMessage} muted>
-                Fix flaky avatar upload retry
-              </Link>
-              <span>
-                <Label variant="success">Verified</Label>{' '}
+            <div className={classes.CommitRefBox}>
+              <div className={classes.CommitRefRow}>
+                <Link href="#" className={classes.CommitRefMessage} muted>
+                  Fix flaky avatar upload retry
+                </Link>
+                <span>
+                  <Label variant="success">Verified</Label>{' '}
+                  <Link href="#" className={classes.CommitRefOid} muted>
+                    abc1234
+                  </Link>
+                </span>
+              </div>
+            </div>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Multiple commit references — same event, pluralized copy + N cards. */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Multiple commit references</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={GitCommitIcon} aria-label="Commit references" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'added 3 commits that reference this issue '}
+            <Time date="2022-07-23T11:05:00Z" />
+            <div className={classes.CommitRefBox}>
+              <div className={classes.CommitRefRow}>
+                <Link href="#" className={classes.CommitRefMessage} muted>
+                  Fix flaky avatar upload retry
+                </Link>
                 <Link href="#" className={classes.CommitRefOid} muted>
                   abc1234
                 </Link>
-              </span>
+              </div>
+              <div className={classes.CommitRefRow}>
+                <Link href="#" className={classes.CommitRefMessage} muted>
+                  Add regression test for retry path
+                </Link>
+                <Link href="#" className={classes.CommitRefOid} muted>
+                  def5678
+                </Link>
+              </div>
+              <div className={classes.CommitRefRow}>
+                <Link href="#" className={classes.CommitRefMessage} muted>
+                  Document the retry backoff
+                </Link>
+                <Link href="#" className={classes.CommitRefOid} muted>
+                  9a0b1c2
+                </Link>
+              </div>
             </div>
-          </div>
-        </Timeline.Body>
-      </Timeline.Item>
-
-      {/* Multiple commit references — same event, pluralized copy + N cards. */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={GitCommitIcon} aria-label="Commit references" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Multiple commit references</span>
-          <Actor />
-          {'added 3 commits that reference this issue '}
-          <Time date="2022-07-23T11:05:00Z" />
-          <div className={classes.CommitRefBox}>
-            <div className={classes.CommitRefRow}>
-              <Link href="#" className={classes.CommitRefMessage} muted>
-                Fix flaky avatar upload retry
-              </Link>
-              <Link href="#" className={classes.CommitRefOid} muted>
-                abc1234
-              </Link>
-            </div>
-            <div className={classes.CommitRefRow}>
-              <Link href="#" className={classes.CommitRefMessage} muted>
-                Add regression test for retry path
-              </Link>
-              <Link href="#" className={classes.CommitRefOid} muted>
-                def5678
-              </Link>
-            </div>
-            <div className={classes.CommitRefRow}>
-              <Link href="#" className={classes.CommitRefMessage} muted>
-                Document the retry backoff
-              </Link>
-              <Link href="#" className={classes.CommitRefOid} muted>
-                9a0b1c2
-              </Link>
-            </div>
-          </div>
-        </Timeline.Body>
-      </Timeline.Item>
-    </Timeline>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
   </div>
 )
 
@@ -527,86 +589,100 @@ export const EventDuplicates = () => (
       if ((e.target as HTMLElement).closest('a')) e.preventDefault()
     }}
   >
-    <Timeline aria-label="Issue timeline">
-      {/* Marked this as a duplicate of <canonical>. Right-controls "Undo" button
+    {/* Marked this as a duplicate of <canonical>. Right-controls "Undo" button
           (viewerCanUndo) → Timeline.Actions. The canonical issue is open, so its
           IssueLink uses the open (green) state icon. */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={DuplicateIcon} aria-label="Marked as duplicate" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Marked as duplicate</span>
-          <Actor />
-          {'marked this as a duplicate of '}
-          <Link href="#" className={classes.IssueLink}>
-            <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-            <span className={classes.IssueLinkTitle}>Upload fails on large avatars</span>{' '}
-            <span className={classes.IssueLinkNumber}>#42</span>
-          </Link>{' '}
-          <Time date="2022-07-26T11:46:07Z" />
-        </Timeline.Body>
-        <Timeline.Actions>
-          <Button size="small">Undo</Button>
-        </Timeline.Actions>
-      </Timeline.Item>
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Marked as duplicate</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={DuplicateIcon} aria-label="Marked as duplicate" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'marked this as a duplicate of '}
+            <Link href="#" className={classes.IssueLink}>
+              <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+              <span className={classes.IssueLinkTitle}>Upload fails on large avatars</span>{' '}
+              <span className={classes.IssueLinkNumber}>#42</span>
+            </Link>{' '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+          <Timeline.Actions>
+            <Button size="small">Undo</Button>
+          </Timeline.Actions>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Marked <canonical> as a duplicate of this issue — no right controls. */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={DuplicateIcon} aria-label="Marked as canonical" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Marked as canonical</span>
-          <Actor />
-          {'marked '}
-          <Link href="#" className={classes.IssueLink}>
-            <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-            <span className={classes.IssueLinkTitle}>Retry uploads on transient errors</span>{' '}
-            <span className={classes.IssueLinkNumber}>#43</span>
-          </Link>
-          {' as a duplicate of this issue '}
-          <Time date="2022-07-25T09:12:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Marked <canonical> as a duplicate of this issue — no right controls. */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Marked as canonical</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={DuplicateIcon} aria-label="Marked as canonical" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'marked '}
+            <Link href="#" className={classes.IssueLink}>
+              <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+              <span className={classes.IssueLinkTitle}>Retry uploads on transient errors</span>{' '}
+              <span className={classes.IssueLinkNumber}>#43</span>
+            </Link>
+            {' as a duplicate of this issue '}
+            <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Unmarked this as a duplicate of <canonical>. */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={DuplicateIcon} aria-label="Unmarked as duplicate" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Unmarked as duplicate</span>
-          <Actor />
-          {'unmarked this as a duplicate of '}
-          <Link href="#" className={classes.IssueLink}>
-            <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-            <span className={classes.IssueLinkTitle}>Upload fails on large avatars</span>{' '}
-            <span className={classes.IssueLinkNumber}>#42</span>
-          </Link>{' '}
-          <Time date="2022-07-24T16:40:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Unmarked this as a duplicate of <canonical>. */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Unmarked as duplicate</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={DuplicateIcon} aria-label="Unmarked as duplicate" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'unmarked this as a duplicate of '}
+            <Link href="#" className={classes.IssueLink}>
+              <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+              <span className={classes.IssueLinkTitle}>Upload fails on large avatars</span>{' '}
+              <span className={classes.IssueLinkNumber}>#42</span>
+            </Link>{' '}
+            <Time date="2022-07-24T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Unmarked <canonical> as a duplicate of this issue. */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={DuplicateIcon} aria-label="Unmarked as canonical" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Unmarked as canonical</span>
-          <Actor />
-          {'unmarked '}
-          <Link href="#" className={classes.IssueLink}>
-            <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-            <span className={classes.IssueLinkTitle}>Retry uploads on transient errors</span>{' '}
-            <span className={classes.IssueLinkNumber}>#43</span>
-          </Link>
-          {' as a duplicate of this issue '}
-          <Time date="2022-07-23T11:05:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
-    </Timeline>
+    {/* Unmarked <canonical> as a duplicate of this issue. */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Unmarked as canonical</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={DuplicateIcon} aria-label="Unmarked as canonical" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'unmarked '}
+            <Link href="#" className={classes.IssueLink}>
+              <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+              <span className={classes.IssueLinkTitle}>Retry uploads on transient errors</span>{' '}
+              <span className={classes.IssueLinkNumber}>#43</span>
+            </Link>
+            {' as a duplicate of this issue '}
+            <Time date="2022-07-23T11:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
   </div>
 )
 
@@ -624,71 +700,85 @@ export const EventModeration = () => (
       if ((e.target as HTMLElement).closest('a')) e.preventDefault()
     }}
   >
-    <Timeline aria-label="Issue timeline">
-      {/* User blocked (permanent) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={BlockedIcon} aria-label="User blocked" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>User blocked</span>
-          <Actor />
-          {'blocked '}
-          <Link href="#" className={classes.LinkWithBoldStyle}>
-            six7
-          </Link>{' '}
-          <Time date="2022-07-26T11:46:07Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* User blocked (permanent) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>User blocked</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={BlockedIcon} aria-label="User blocked" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'blocked '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              six7
+            </Link>{' '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* User temporarily blocked */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={BlockedIcon} aria-label="User temporarily blocked" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>User temporarily blocked</span>
-          <Actor />
-          {'temporarily blocked '}
-          <Link href="#" className={classes.LinkWithBoldStyle}>
-            six7
-          </Link>{' '}
-          <Time date="2022-07-25T09:12:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* User temporarily blocked */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>User temporarily blocked</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={BlockedIcon} aria-label="User temporarily blocked" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'temporarily blocked '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              six7
+            </Link>{' '}
+            <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Comment pinned — IssueCommentPinnedEvent.tsx links the pinned comment. */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={PinIcon} aria-label="Comment pinned" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Comment pinned</span>
-          <Actor />
-          {'pinned a '}
-          <Link href="#" inline>
-            comment
-          </Link>{' '}
-          <Time date="2022-07-24T16:40:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Comment pinned — IssueCommentPinnedEvent.tsx links the pinned comment. */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Comment pinned</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PinIcon} aria-label="Comment pinned" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'pinned a '}
+            <Link href="#" inline>
+              comment
+            </Link>{' '}
+            <Time date="2022-07-24T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Comment unpinned */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={PinIcon} aria-label="Comment unpinned" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Comment unpinned</span>
-          <Actor />
-          {'unpinned a '}
-          <Link href="#" inline>
-            comment
-          </Link>{' '}
-          <Time date="2022-07-23T11:05:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
-    </Timeline>
+    {/* Comment unpinned */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Comment unpinned</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PinIcon} aria-label="Comment unpinned" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'unpinned a '}
+            <Link href="#" inline>
+              comment
+            </Link>{' '}
+            <Time date="2022-07-23T11:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
   </div>
 )
 
@@ -707,101 +797,111 @@ export const EventIssueTypes = () => (
       if ((e.target as HTMLElement).closest('a')) e.preventDefault()
     }}
   >
-    <Timeline aria-label="Issue timeline">
-      {/* Type added */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueOpenedIcon} aria-label="Issue type added" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Issue type added</span>
-          <Actor />
-          {'added the '}
-          <span className={classes.TokenWrapper}>
-            <Token
-              as="a"
-              href="#"
-              text="Bug"
-              size="small"
-              style={{
-                backgroundColor: 'var(--bgColor-danger-muted)',
-                color: 'var(--fgColor-danger)',
-                borderColor: 'var(--borderColor-danger-muted)',
-              }}
-            />
-          </span>
-          {' issue type '}
-          <Time date="2022-07-26T11:46:07Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Type added */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Issue type added</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueOpenedIcon} aria-label="Issue type added" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'added the '}
+            <span className={classes.TokenWrapper}>
+              <Token
+                as="a"
+                href="#"
+                text="Bug"
+                size="small"
+                style={{
+                  backgroundColor: 'var(--bgColor-danger-muted)',
+                  color: 'var(--fgColor-danger)',
+                  borderColor: 'var(--borderColor-danger-muted)',
+                }}
+              />
+            </span>
+            {' issue type '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Type removed */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueOpenedIcon} aria-label="Issue type removed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Issue type removed</span>
-          <Actor />
-          {'removed the '}
-          <span className={classes.TokenWrapper}>
-            <Token
-              as="a"
-              href="#"
-              text="Bug"
-              size="small"
-              style={{
-                backgroundColor: 'var(--bgColor-danger-muted)',
-                color: 'var(--fgColor-danger)',
-                borderColor: 'var(--borderColor-danger-muted)',
-              }}
-            />
-          </span>
-          {' issue type '}
-          <Time date="2022-07-25T09:12:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Type removed */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Issue type removed</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueOpenedIcon} aria-label="Issue type removed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'removed the '}
+            <span className={classes.TokenWrapper}>
+              <Token
+                as="a"
+                href="#"
+                text="Bug"
+                size="small"
+                style={{
+                  backgroundColor: 'var(--bgColor-danger-muted)',
+                  color: 'var(--fgColor-danger)',
+                  borderColor: 'var(--borderColor-danger-muted)',
+                }}
+              />
+            </span>
+            {' issue type '}
+            <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Type changed */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueOpenedIcon} aria-label="Issue type changed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Issue type changed</span>
-          <Actor />
-          {'changed the issue type from '}
-          <span className={classes.TokenWrapper}>
-            <Token
-              as="a"
-              href="#"
-              text="Bug"
-              size="small"
-              style={{
-                backgroundColor: 'var(--bgColor-danger-muted)',
-                color: 'var(--fgColor-danger)',
-                borderColor: 'var(--borderColor-danger-muted)',
-              }}
-            />
-          </span>
-          {' to '}
-          <span className={classes.TokenWrapper}>
-            <Token
-              as="a"
-              href="#"
-              text="Feature"
-              size="small"
-              style={{
-                backgroundColor: 'var(--bgColor-accent-muted)',
-                color: 'var(--fgColor-accent)',
-                borderColor: 'var(--borderColor-accent-muted)',
-              }}
-            />
-          </span>{' '}
-          <Time date="2022-07-24T16:40:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
-    </Timeline>
+    {/* Type changed */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Issue type changed</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueOpenedIcon} aria-label="Issue type changed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'changed the issue type from '}
+            <span className={classes.TokenWrapper}>
+              <Token
+                as="a"
+                href="#"
+                text="Bug"
+                size="small"
+                style={{
+                  backgroundColor: 'var(--bgColor-danger-muted)',
+                  color: 'var(--fgColor-danger)',
+                  borderColor: 'var(--borderColor-danger-muted)',
+                }}
+              />
+            </span>
+            {' to '}
+            <span className={classes.TokenWrapper}>
+              <Token
+                as="a"
+                href="#"
+                text="Feature"
+                size="small"
+                style={{
+                  backgroundColor: 'var(--bgColor-accent-muted)',
+                  color: 'var(--fgColor-accent)',
+                  borderColor: 'var(--borderColor-accent-muted)',
+                }}
+              />
+            </span>{' '}
+            <Time date="2022-07-24T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
   </div>
 )
 
@@ -825,211 +925,241 @@ export const EventIssueHierarchy = () => (
       if ((e.target as HTMLElement).closest('a')) e.preventDefault()
     }}
   >
-    <Timeline aria-label="Issue timeline">
-      {/* Sub-issue added (single) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueTracksIcon} aria-label="Sub-issue added" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Sub-issue added (single)</span>
-          <Actor />
-          {'added a sub-issue '}
-          <Time date="2022-07-26T11:46:07Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
-                <span className={classes.IssueLinkNumber}>#42</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Sub-issue added (single) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Sub-issue added (single)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueTracksIcon} aria-label="Sub-issue added" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'added a sub-issue '}
+            <Time date="2022-07-26T11:46:07Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#42</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Sub-issue added (multiple) — plural copy + N reference rows */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueTracksIcon} aria-label="Sub-issues added" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Sub-issues added (multiple)</span>
-          <Actor />
-          {'added sub-issues '}
-          <Time date="2022-07-25T09:12:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
-                <span className={classes.IssueLinkNumber}>#42</span>
-              </Link>
-            </li>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueClosedIcon} size={16} className={classes.IssueLinkIcon} />
-                <span className={classes.IssueLinkTitle}>Document the retry backoff</span>{' '}
-                <span className={classes.IssueLinkNumber}>#43</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Sub-issue added (multiple) — plural copy + N reference rows */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Sub-issues added (multiple)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueTracksIcon} aria-label="Sub-issues added" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'added sub-issues '}
+            <Time date="2022-07-25T09:12:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#42</span>
+                </Link>
+              </li>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueClosedIcon} size={16} className={classes.IssueLinkIcon} />
+                  <span className={classes.IssueLinkTitle}>Document the retry backoff</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#43</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Sub-issue removed (single) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueTracksIcon} aria-label="Sub-issue removed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Sub-issue removed (single)</span>
-          <Actor />
-          {'removed a sub-issue '}
-          <Time date="2022-07-24T16:40:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
-                <span className={classes.IssueLinkNumber}>#42</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Sub-issue removed (single) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Sub-issue removed (single)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueTracksIcon} aria-label="Sub-issue removed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'removed a sub-issue '}
+            <Time date="2022-07-24T16:40:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#42</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Sub-issues removed (multiple) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueTracksIcon} aria-label="Sub-issues removed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Sub-issues removed (multiple)</span>
-          <Actor />
-          {'removed sub-issues '}
-          <Time date="2022-07-23T11:05:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
-                <span className={classes.IssueLinkNumber}>#42</span>
-              </Link>
-            </li>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueClosedIcon} size={16} className={classes.IssueLinkIcon} />
-                <span className={classes.IssueLinkTitle}>Document the retry backoff</span>{' '}
-                <span className={classes.IssueLinkNumber}>#43</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Sub-issues removed (multiple) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Sub-issues removed (multiple)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueTracksIcon} aria-label="Sub-issues removed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'removed sub-issues '}
+            <Time date="2022-07-23T11:05:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#42</span>
+                </Link>
+              </li>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueClosedIcon} size={16} className={classes.IssueLinkIcon} />
+                  <span className={classes.IssueLinkTitle}>Document the retry backoff</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#43</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Parent issue added (single) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueTrackedByIcon} aria-label="Parent issue added" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Parent issue added (single)</span>
-          <Actor />
-          {'added a parent issue '}
-          <Time date="2022-07-22T14:20:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
-                <span className={classes.IssueLinkNumber}>#7</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Parent issue added (single) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Parent issue added (single)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueTrackedByIcon} aria-label="Parent issue added" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'added a parent issue '}
+            <Time date="2022-07-22T14:20:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#7</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Parent issues added (multiple) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueTrackedByIcon} aria-label="Parent issues added" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Parent issues added (multiple)</span>
-          <Actor />
-          {'added parent issues '}
-          <Time date="2022-07-21T08:30:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
-                <span className={classes.IssueLinkNumber}>#7</span>
-              </Link>
-            </li>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Q3 reliability tracker</span>{' '}
-                <span className={classes.IssueLinkNumber}>#8</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Parent issues added (multiple) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Parent issues added (multiple)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueTrackedByIcon} aria-label="Parent issues added" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'added parent issues '}
+            <Time date="2022-07-21T08:30:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#7</span>
+                </Link>
+              </li>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Q3 reliability tracker</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#8</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Parent issue removed (single) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueTrackedByIcon} aria-label="Parent issue removed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Parent issue removed (single)</span>
-          <Actor />
-          {'removed a parent issue '}
-          <Time date="2022-07-20T10:00:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
-                <span className={classes.IssueLinkNumber}>#7</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Parent issue removed (single) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Parent issue removed (single)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueTrackedByIcon} aria-label="Parent issue removed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'removed a parent issue '}
+            <Time date="2022-07-20T10:00:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#7</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Parent issues removed (multiple) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={IssueTrackedByIcon} aria-label="Parent issues removed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Parent issues removed (multiple)</span>
-          <Actor />
-          {'removed parent issues '}
-          <Time date="2022-07-19T13:15:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
-                <span className={classes.IssueLinkNumber}>#7</span>
-              </Link>
-            </li>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Q3 reliability tracker</span>{' '}
-                <span className={classes.IssueLinkNumber}>#8</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
-    </Timeline>
+    {/* Parent issues removed (multiple) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Parent issues removed (multiple)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={IssueTrackedByIcon} aria-label="Parent issues removed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'removed parent issues '}
+            <Time date="2022-07-19T13:15:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#7</span>
+                </Link>
+              </li>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Q3 reliability tracker</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#8</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
   </div>
 )
 
@@ -1052,211 +1182,241 @@ export const EventDependencies = () => (
       if ((e.target as HTMLElement).closest('a')) e.preventDefault()
     }}
   >
-    <Timeline aria-label="Issue timeline">
-      {/* Blocked by (single) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={BlockedIcon} aria-label="Marked as blocked" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Blocked by (single)</span>
-          <Actor />
-          {'marked this as blocked '}
-          <Time date="2022-07-26T11:46:07Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
-                <span className={classes.IssueLinkNumber}>#51</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Blocked by (single) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Blocked by (single)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={BlockedIcon} aria-label="Marked as blocked" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'marked this as blocked '}
+            <Time date="2022-07-26T11:46:07Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#51</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Blocked by (multiple) — count in copy + N rows */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={BlockedIcon} aria-label="Marked as blocked by multiple issues" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Blocked by (multiple)</span>
-          <Actor />
-          {'marked this as blocked by 2 issues '}
-          <Time date="2022-07-25T09:12:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
-                <span className={classes.IssueLinkNumber}>#51</span>
-              </Link>
-            </li>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Add multipart upload support</span>{' '}
-                <span className={classes.IssueLinkNumber}>#52</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Blocked by (multiple) — count in copy + N rows */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Blocked by (multiple)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={BlockedIcon} aria-label="Marked as blocked by multiple issues" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'marked this as blocked by 2 issues '}
+            <Time date="2022-07-25T09:12:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#51</span>
+                </Link>
+              </li>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Add multipart upload support</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#52</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Blocked by removed (single) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={BlockedIcon} aria-label="Unmarked as blocked" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Blocked by removed (single)</span>
-          <Actor />
-          {'unmarked this as blocked '}
-          <Time date="2022-07-24T16:40:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
-                <span className={classes.IssueLinkNumber}>#51</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Blocked by removed (single) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Blocked by removed (single)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={BlockedIcon} aria-label="Unmarked as blocked" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'unmarked this as blocked '}
+            <Time date="2022-07-24T16:40:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#51</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Blocked by removed (multiple) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={BlockedIcon} aria-label="Unmarked as blocked by multiple issues" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Blocked by removed (multiple)</span>
-          <Actor />
-          {'unmarked this as blocked by 2 issues '}
-          <Time date="2022-07-23T11:05:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
-                <span className={classes.IssueLinkNumber}>#51</span>
-              </Link>
-            </li>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Add multipart upload support</span>{' '}
-                <span className={classes.IssueLinkNumber}>#52</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Blocked by removed (multiple) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Blocked by removed (multiple)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={BlockedIcon} aria-label="Unmarked as blocked by multiple issues" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'unmarked this as blocked by 2 issues '}
+            <Time date="2022-07-23T11:05:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#51</span>
+                </Link>
+              </li>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Add multipart upload support</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#52</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Blocking (single) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={BlockedIcon} aria-label="Marked as blocking" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Blocking (single)</span>
-          <Actor />
-          {'marked this as blocking '}
-          <Time date="2022-07-22T14:20:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
-                <span className={classes.IssueLinkNumber}>#60</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Blocking (single) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Blocking (single)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={BlockedIcon} aria-label="Marked as blocking" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'marked this as blocking '}
+            <Time date="2022-07-22T14:20:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#60</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Blocking (multiple) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={BlockedIcon} aria-label="Marked as blocking multiple issues" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Blocking (multiple)</span>
-          <Actor />
-          {'marked this as blocking 2 issues '}
-          <Time date="2022-07-21T08:30:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
-                <span className={classes.IssueLinkNumber}>#60</span>
-              </Link>
-            </li>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Roll out to mobile clients</span>{' '}
-                <span className={classes.IssueLinkNumber}>#61</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Blocking (multiple) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Blocking (multiple)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={BlockedIcon} aria-label="Marked as blocking multiple issues" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'marked this as blocking 2 issues '}
+            <Time date="2022-07-21T08:30:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#60</span>
+                </Link>
+              </li>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Roll out to mobile clients</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#61</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Blocking removed (single) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={BlockedIcon} aria-label="Unmarked as blocking" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Blocking removed (single)</span>
-          <Actor />
-          {'unmarked this as blocking '}
-          <Time date="2022-07-20T10:00:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
-                <span className={classes.IssueLinkNumber}>#60</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Blocking removed (single) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Blocking removed (single)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={BlockedIcon} aria-label="Unmarked as blocking" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'unmarked this as blocking '}
+            <Time date="2022-07-20T10:00:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#60</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Blocking removed (multiple) */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={BlockedIcon} aria-label="Unmarked as blocking multiple issues" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Blocking removed (multiple)</span>
-          <Actor />
-          {'unmarked this as blocking 2 issues '}
-          <Time date="2022-07-19T13:15:00Z" />
-          <ul className={classes.RefList}>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
-                <span className={classes.IssueLinkNumber}>#60</span>
-              </Link>
-            </li>
-            <li className={classes.RefListItem}>
-              <Link href="#" className={classes.IssueLink}>
-                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
-                <span className={classes.IssueLinkTitle}>Roll out to mobile clients</span>{' '}
-                <span className={classes.IssueLinkNumber}>#61</span>
-              </Link>
-            </li>
-          </ul>
-        </Timeline.Body>
-      </Timeline.Item>
-    </Timeline>
+    {/* Blocking removed (multiple) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Blocking removed (multiple)</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={BlockedIcon} aria-label="Unmarked as blocking multiple issues" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'unmarked this as blocking 2 issues '}
+            <Time date="2022-07-19T13:15:00Z" />
+            <ul className={classes.RefList}>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#60</span>
+                </Link>
+              </li>
+              <li className={classes.RefListItem}>
+                <Link href="#" className={classes.IssueLink}>
+                  <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                  <span className={classes.IssueLinkTitle}>Roll out to mobile clients</span>{' '}
+                  <span className={classes.IssueLinkNumber}>#61</span>
+                </Link>
+              </li>
+            </ul>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
   </div>
 )
 
@@ -1283,280 +1443,338 @@ export const EventIssueFields = () => (
       if ((e.target as HTMLElement).closest('a')) e.preventDefault()
     }}
   >
-    <Timeline aria-label="Issue timeline">
-      {/* Set text field */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={TypographyIcon} aria-label="Text field set" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Set · text</span>
-          <Actor />
-          {'set '}
-          <span className={classes.FieldName}>Team</span>
-          {' to '}
-          <Link href="#" inline className={classes.FieldValue}>
-            Identity
-          </Link>{' '}
-          <Time date="2022-07-26T11:46:07Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Set text field */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Set · text</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TypographyIcon} aria-label="Text field set" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'set '}
+            <span className={classes.FieldName}>Team</span>
+            {' to '}
+            <Link href="#" inline className={classes.FieldValue}>
+              Identity
+            </Link>{' '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Set number field */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={NumberIcon} aria-label="Number field set" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Set · number</span>
-          <Actor />
-          {'set '}
-          <span className={classes.FieldName}>Story Points</span>
-          {' to '}
-          <Link href="#" inline className={classes.FieldValue}>
-            5
-          </Link>{' '}
-          <Time date="2022-07-25T15:30:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Set number field */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Set · number</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={NumberIcon} aria-label="Number field set" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'set '}
+            <span className={classes.FieldName}>Story Points</span>
+            {' to '}
+            <Link href="#" inline className={classes.FieldValue}>
+              5
+            </Link>{' '}
+            <Time date="2022-07-25T15:30:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Set date field */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={CalendarIcon} aria-label="Date field set" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Set · date</span>
-          <Actor />
-          {'set '}
-          <span className={classes.FieldName}>Target Date</span>
-          {' to '}
-          <Link href="#" inline className={classes.FieldValue}>
-            Aug 1, 2022
-          </Link>{' '}
-          <Time date="2022-07-25T09:12:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Set date field */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Set · date</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CalendarIcon} aria-label="Date field set" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'set '}
+            <span className={classes.FieldName}>Target Date</span>
+            {' to '}
+            <Link href="#" inline className={classes.FieldValue}>
+              Aug 1, 2022
+            </Link>{' '}
+            <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Set single-select field — value is a colored token */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={SingleSelectIcon} aria-label="Single select field set" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Set · single select</span>
-          <Actor />
-          {'set '}
-          <span className={classes.FieldName}>Priority</span>
-          {' to '}
-          {/* github-ui renders an `IssueFieldSingleSelectValueToken` (colored
+    {/* Set single-select field — value is a colored token */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Set · single select</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={SingleSelectIcon} aria-label="Single select field set" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'set '}
+            <span className={classes.FieldName}>Priority</span>
+            {' to '}
+            {/* github-ui renders an `IssueFieldSingleSelectValueToken` (colored
               Primer Token) for select values; approximated with functional
               color tokens. */}
-          <span className={classes.TokenWrapper}>
-            <Token
-              as="a"
-              href="#"
-              text="High"
-              size="small"
-              style={{
-                backgroundColor: 'var(--bgColor-danger-muted)',
-                color: 'var(--fgColor-danger)',
-                borderColor: 'var(--borderColor-danger-muted)',
-              }}
-            />
-          </span>{' '}
-          <Time date="2022-07-24T16:40:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+            <span className={classes.TokenWrapper}>
+              <Token
+                as="a"
+                href="#"
+                text="High"
+                size="small"
+                style={{
+                  backgroundColor: 'var(--bgColor-danger-muted)',
+                  color: 'var(--fgColor-danger)',
+                  borderColor: 'var(--borderColor-danger-muted)',
+                }}
+              />
+            </span>{' '}
+            <Time date="2022-07-24T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Changed text field */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={TypographyIcon} aria-label="Text field changed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Changed · text</span>
-          <Actor />
-          {'changed '}
-          <span className={classes.FieldName}>Team</span>
-          {' to '}
-          <Link href="#" inline className={classes.FieldValue}>
-            Platform
-          </Link>{' '}
-          <Time date="2022-07-23T11:05:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Changed text field */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Changed · text</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TypographyIcon} aria-label="Text field changed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'changed '}
+            <span className={classes.FieldName}>Team</span>
+            {' to '}
+            <Link href="#" inline className={classes.FieldValue}>
+              Platform
+            </Link>{' '}
+            <Time date="2022-07-23T11:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Changed number field */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={NumberIcon} aria-label="Number field changed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Changed · number</span>
-          <Actor />
-          {'changed '}
-          <span className={classes.FieldName}>Story Points</span>
-          {' to '}
-          <Link href="#" inline className={classes.FieldValue}>
-            8
-          </Link>{' '}
-          <Time date="2022-07-22T14:20:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Changed number field */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Changed · number</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={NumberIcon} aria-label="Number field changed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'changed '}
+            <span className={classes.FieldName}>Story Points</span>
+            {' to '}
+            <Link href="#" inline className={classes.FieldValue}>
+              8
+            </Link>{' '}
+            <Time date="2022-07-22T14:20:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Changed date field */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={CalendarIcon} aria-label="Date field changed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Changed · date</span>
-          <Actor />
-          {'changed '}
-          <span className={classes.FieldName}>Target Date</span>
-          {' to '}
-          <Link href="#" inline className={classes.FieldValue}>
-            Aug 15, 2022
-          </Link>{' '}
-          <Time date="2022-07-21T08:30:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Changed date field */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Changed · date</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CalendarIcon} aria-label="Date field changed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'changed '}
+            <span className={classes.FieldName}>Target Date</span>
+            {' to '}
+            <Link href="#" inline className={classes.FieldValue}>
+              Aug 15, 2022
+            </Link>{' '}
+            <Time date="2022-07-21T08:30:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Changed single-select field */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={SingleSelectIcon} aria-label="Single select field changed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Changed · single select</span>
-          <Actor />
-          {'changed '}
-          <span className={classes.FieldName}>Priority</span>
-          {' to '}
-          <span className={classes.TokenWrapper}>
-            <Token
-              as="a"
-              href="#"
-              text="Low"
-              size="small"
-              style={{
-                backgroundColor: 'var(--bgColor-success-muted)',
-                color: 'var(--fgColor-success)',
-                borderColor: 'var(--borderColor-success-muted)',
-              }}
-            />
-          </span>{' '}
-          <Time date="2022-07-20T10:00:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Changed single-select field */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Changed · single select</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={SingleSelectIcon} aria-label="Single select field changed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'changed '}
+            <span className={classes.FieldName}>Priority</span>
+            {' to '}
+            <span className={classes.TokenWrapper}>
+              <Token
+                as="a"
+                href="#"
+                text="Low"
+                size="small"
+                style={{
+                  backgroundColor: 'var(--bgColor-success-muted)',
+                  color: 'var(--fgColor-success)',
+                  borderColor: 'var(--borderColor-success-muted)',
+                }}
+              />
+            </span>{' '}
+            <Time date="2022-07-20T10:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Cleared text field — no value */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={TypographyIcon} aria-label="Text field cleared" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Cleared · text</span>
-          <Actor />
-          {'cleared '}
-          <span className={classes.FieldName}>Team</span> <Time date="2022-07-19T13:15:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Cleared text field — no value */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Cleared · text</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TypographyIcon} aria-label="Text field cleared" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'cleared '}
+            <span className={classes.FieldName}>Team</span> <Time date="2022-07-19T13:15:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Cleared number field */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={NumberIcon} aria-label="Number field cleared" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Cleared · number</span>
-          <Actor />
-          {'cleared '}
-          <span className={classes.FieldName}>Story Points</span> <Time date="2022-07-18T09:00:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Cleared number field */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Cleared · number</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={NumberIcon} aria-label="Number field cleared" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'cleared '}
+            <span className={classes.FieldName}>Story Points</span> <Time date="2022-07-18T09:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Cleared date field */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={CalendarIcon} aria-label="Date field cleared" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Cleared · date</span>
-          <Actor />
-          {'cleared '}
-          <span className={classes.FieldName}>Target Date</span> <Time date="2022-07-17T12:00:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Cleared date field */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Cleared · date</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CalendarIcon} aria-label="Date field cleared" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'cleared '}
+            <span className={classes.FieldName}>Target Date</span> <Time date="2022-07-17T12:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Cleared single-select field */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={SingleSelectIcon} aria-label="Single select field cleared" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Cleared · single select</span>
-          <Actor />
-          {'cleared '}
-          <span className={classes.FieldName}>Priority</span> <Time date="2022-07-16T08:30:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Cleared single-select field */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Cleared · single select</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={SingleSelectIcon} aria-label="Single select field cleared" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'cleared '}
+            <span className={classes.FieldName}>Priority</span> <Time date="2022-07-16T08:30:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Rollup: updated only — multiple field updates collapsed into one row */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={TypographyIcon} aria-label="Fields updated" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Rollup · updated</span>
-          <Actor />
-          {'updated '}
-          <span className={classes.FieldName}>Team</span>
-          <Link href="#" inline className={classes.FieldValue}>
-            Platform
-          </Link>
-          {' and '}
-          <span className={classes.FieldName}>Story Points</span>
-          <Link href="#" inline className={classes.FieldValue}>
-            8
-          </Link>{' '}
-          <Time date="2022-07-15T10:00:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Rollup: updated only — multiple field updates collapsed into one row */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Rollup · updated</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TypographyIcon} aria-label="Fields updated" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'updated '}
+            <span className={classes.FieldName}>Team</span>
+            <Link href="#" inline className={classes.FieldValue}>
+              Platform
+            </Link>
+            {' and '}
+            <span className={classes.FieldName}>Story Points</span>
+            <Link href="#" inline className={classes.FieldValue}>
+              8
+            </Link>{' '}
+            <Time date="2022-07-15T10:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Rollup: removed only */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={TypographyIcon} aria-label="Fields removed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Rollup · removed</span>
-          <Actor />
-          {'removed '}
-          <span className={classes.FieldName}>Team</span>
-          {' and '}
-          <span className={classes.FieldName}>Priority</span> <Time date="2022-07-14T10:00:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
+    {/* Rollup: removed only */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Rollup · removed</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TypographyIcon} aria-label="Fields removed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'removed '}
+            <span className={classes.FieldName}>Team</span>
+            {' and '}
+            <span className={classes.FieldName}>Priority</span> <Time date="2022-07-14T10:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
 
-      {/* Rollup: updated and also removed — combined row joined by "and also" */}
-      <Timeline.Item>
-        <Timeline.Badge>
-          <Octicon icon={TypographyIcon} aria-label="Fields updated and removed" />
-        </Timeline.Badge>
-        <Timeline.Body>
-          <span className={classes.VariantLabel}>Rollup · updated and removed</span>
-          <Actor />
-          {'updated '}
-          <span className={classes.FieldName}>Team</span>
-          <Link href="#" inline className={classes.FieldValue}>
-            Platform
-          </Link>
-          {', and also removed '}
-          <span className={classes.FieldName}>Priority</span> <Time date="2022-07-13T10:00:00Z" />
-        </Timeline.Body>
-      </Timeline.Item>
-    </Timeline>
+    {/* Rollup: updated and also removed — combined row joined by "and also" */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Rollup · updated and removed</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TypographyIcon} aria-label="Fields updated and removed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'updated '}
+            <span className={classes.FieldName}>Team</span>
+            <Link href="#" inline className={classes.FieldValue}>
+              Platform
+            </Link>
+            {', and also removed '}
+            <span className={classes.FieldName}>Priority</span> <Time date="2022-07-13T10:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
   </div>
 )

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -102,6 +102,30 @@ const Time = ({date}: {date: string}) => (
   </Link>
 )
 
+// Shared wrapper for every event-group story. Renders the realistic timeline
+// surface and applies two story-only a11y/UX shims:
+//  - `data-a11y-link-underlines="true"`: Primer gates the inline-link underline
+//    on this ancestor attribute, which GitHub sets from the default-on "Show
+//    link underlines" user preference. Storybook never sets it, so without this
+//    the in-text `<Link inline>` links would render color-only (WCAG 1.4.1).
+//    Actor-name links use `<Link className={ActorName}>` WITHOUT `inline`, so
+//    they don't match the `[data-inline='true']` selector and stay un-underlined
+//    (avatar + semibold remain their cue).
+//  - onClick guard: prevents the placeholder `href="#"` links from navigating
+//    inside Storybook. Uses `instanceof Element` so a click on an SVG/octicon
+//    target (no `.closest`) doesn't throw.
+const Examples = ({children}: {children: React.ReactNode}) => (
+  <div
+    className={classes.RealisticTimeline}
+    data-a11y-link-underlines="true"
+    onClick={e => {
+      if (e.target instanceof Element && e.target.closest('a')) e.preventDefault()
+    }}
+  >
+    {children}
+  </div>
+)
+
 export default {
   title: 'Components/Timeline/Events/Issues',
   component: Timeline,
@@ -135,20 +159,14 @@ export default {
  * not-planned/duplicate -> CircleSlashIcon on `neutral` (gray).
  */
 export const EventClosed = () => (
-  <div
-    className={classes.RealisticTimeline}
-    // Prevent the placeholder `href="#"` links from navigating inside Storybook.
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Closed as completed */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Closed as completed</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={CheckCircleIcon} aria-label="Closed as completed" />
+            <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -177,7 +195,7 @@ export const EventClosed = () => (
               } as React.CSSProperties
             }
           >
-            <Octicon icon={CircleSlashIcon} aria-label="Closed as not planned" />
+            <Octicon icon={CircleSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -197,7 +215,7 @@ export const EventClosed = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={CheckCircleIcon} aria-label="Closed via pull request" />
+            <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -221,7 +239,7 @@ export const EventClosed = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={CheckCircleIcon} aria-label="Closed via commit" />
+            <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -247,7 +265,7 @@ export const EventClosed = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={CheckCircleIcon} aria-label="Closed via project" />
+            <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -281,7 +299,7 @@ export const EventClosed = () => (
               } as React.CSSProperties
             }
           >
-            <Octicon icon={CircleSlashIcon} aria-label="Closed as duplicate" />
+            <Octicon icon={CircleSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -307,7 +325,7 @@ export const EventClosed = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={CheckCircleIcon} aria-label="Closed" />
+            <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -317,7 +335,7 @@ export const EventClosed = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -329,19 +347,14 @@ export const EventClosed = () => (
  * structural events with a default (muted) badge.
  */
 export const EventState = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Reopened — open (green) badge via useIssueState (ReopenedEvent.tsx) */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Reopened</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="open">
-            <Octicon icon={IssueReopenedIcon} aria-label="Reopened" />
+            <Octicon icon={IssueReopenedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -359,7 +372,7 @@ export const EventState = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LinkExternalIcon} aria-label="Transferred" />
+            <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -379,7 +392,7 @@ export const EventState = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={PinIcon} aria-label="Pinned" />
+            <Octicon icon={PinIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -396,7 +409,7 @@ export const EventState = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={PinIcon} aria-label="Unpinned" />
+            <Octicon icon={PinIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -414,7 +427,7 @@ export const EventState = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CommentDiscussionIcon} aria-label="Converted to discussion" />
+            <Octicon icon={CommentDiscussionIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -434,7 +447,7 @@ export const EventState = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueDraftIcon} aria-label="Converted from draft" />
+            <Octicon icon={IssueDraftIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -444,7 +457,7 @@ export const EventState = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -456,12 +469,7 @@ export const EventState = () => (
  * references compose a simplified `ReferencedEventInner` card.
  */
 export const EventReferences = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Linked pull request — ConnectedEvent.tsx (CrossReferenceIcon badge,
           open PR state icon inline before the PR title). */}
     <section className={classes.Variant}>
@@ -469,7 +477,7 @@ export const EventReferences = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CrossReferenceIcon} aria-label="Linked pull request" />
+            <Octicon icon={CrossReferenceIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -495,7 +503,7 @@ export const EventReferences = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={GitPullRequestIcon} className={classes.BadgeIconOpen} aria-label="Unlinked pull request" />
+            <Octicon icon={GitPullRequestIcon} className={classes.BadgeIconOpen} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -517,7 +525,7 @@ export const EventReferences = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={GitCommitIcon} aria-label="Commit reference" />
+            <Octicon icon={GitCommitIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -549,7 +557,7 @@ export const EventReferences = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={GitCommitIcon} aria-label="Commit references" />
+            <Octicon icon={GitCommitIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -585,7 +593,7 @@ export const EventReferences = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -597,12 +605,7 @@ export const EventReferences = () => (
  * We map that to the `Timeline.Actions` slot (sibling of `Timeline.Body`).
  */
 export const EventDuplicates = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Marked this as a duplicate of <canonical>. Right-controls "Undo" button
           (viewerCanUndo) → Timeline.Actions. The canonical issue is open, so its
           IssueLink uses the open (green) state icon. */}
@@ -611,7 +614,7 @@ export const EventDuplicates = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={DuplicateIcon} aria-label="Marked as duplicate" />
+            <Octicon icon={DuplicateIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -636,7 +639,7 @@ export const EventDuplicates = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={DuplicateIcon} aria-label="Marked as canonical" />
+            <Octicon icon={DuplicateIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -659,7 +662,7 @@ export const EventDuplicates = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={DuplicateIcon} aria-label="Unmarked as duplicate" />
+            <Octicon icon={DuplicateIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -681,7 +684,7 @@ export const EventDuplicates = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={DuplicateIcon} aria-label="Unmarked as canonical" />
+            <Octicon icon={DuplicateIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -697,7 +700,7 @@ export const EventDuplicates = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -708,19 +711,14 @@ export const EventDuplicates = () => (
  * (no avatar) via `ProfileReference`.
  */
 export const EventModeration = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* User blocked (permanent) */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>User blocked</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={BlockedIcon} aria-label="User blocked" />
+            <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -740,7 +738,7 @@ export const EventModeration = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={BlockedIcon} aria-label="User temporarily blocked" />
+            <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -760,7 +758,7 @@ export const EventModeration = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={PinIcon} aria-label="Comment pinned" />
+            <Octicon icon={PinIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -780,7 +778,7 @@ export const EventModeration = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={PinIcon} aria-label="Comment unpinned" />
+            <Octicon icon={PinIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -793,7 +791,7 @@ export const EventModeration = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -805,19 +803,14 @@ export const EventModeration = () => (
  * functional color tokens.
  */
 export const EventIssueTypes = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Type added */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Issue type added</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueOpenedIcon} aria-label="Issue type added" />
+            <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -848,7 +841,7 @@ export const EventIssueTypes = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueOpenedIcon} aria-label="Issue type removed" />
+            <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -879,7 +872,7 @@ export const EventIssueTypes = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueOpenedIcon} aria-label="Issue type changed" />
+            <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -916,7 +909,7 @@ export const EventIssueTypes = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -933,19 +926,14 @@ export const EventIssueTypes = () => (
  * 'single' : 'multiple']` + `itemsToRender.map(...)`.)
  */
 export const EventIssueHierarchy = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Sub-issue added (single) */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Sub-issue added (single)</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueTracksIcon} aria-label="Sub-issue added" />
+            <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -971,7 +959,7 @@ export const EventIssueHierarchy = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueTracksIcon} aria-label="Sub-issues added" />
+            <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1004,7 +992,7 @@ export const EventIssueHierarchy = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueTracksIcon} aria-label="Sub-issue removed" />
+            <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1030,7 +1018,7 @@ export const EventIssueHierarchy = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueTracksIcon} aria-label="Sub-issues removed" />
+            <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1063,7 +1051,7 @@ export const EventIssueHierarchy = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueTrackedByIcon} aria-label="Parent issue added" />
+            <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1089,7 +1077,7 @@ export const EventIssueHierarchy = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueTrackedByIcon} aria-label="Parent issues added" />
+            <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1122,7 +1110,7 @@ export const EventIssueHierarchy = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueTrackedByIcon} aria-label="Parent issue removed" />
+            <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1148,7 +1136,7 @@ export const EventIssueHierarchy = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={IssueTrackedByIcon} aria-label="Parent issues removed" />
+            <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1174,7 +1162,7 @@ export const EventIssueHierarchy = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -1190,19 +1178,14 @@ export const EventIssueHierarchy = () => (
  * .multiple(count)`, and the secondary list grows from 1 to N rows.
  */
 export const EventDependencies = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Blocked by (single) */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Blocked by (single)</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={BlockedIcon} aria-label="Marked as blocked" />
+            <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1228,7 +1211,7 @@ export const EventDependencies = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={BlockedIcon} aria-label="Marked as blocked by multiple issues" />
+            <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1261,7 +1244,7 @@ export const EventDependencies = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={BlockedIcon} aria-label="Unmarked as blocked" />
+            <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1287,7 +1270,7 @@ export const EventDependencies = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={BlockedIcon} aria-label="Unmarked as blocked by multiple issues" />
+            <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1320,7 +1303,7 @@ export const EventDependencies = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={BlockedIcon} aria-label="Marked as blocking" />
+            <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1346,7 +1329,7 @@ export const EventDependencies = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={BlockedIcon} aria-label="Marked as blocking multiple issues" />
+            <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1379,7 +1362,7 @@ export const EventDependencies = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={BlockedIcon} aria-label="Unmarked as blocking" />
+            <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1405,7 +1388,7 @@ export const EventDependencies = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={BlockedIcon} aria-label="Unmarked as blocking multiple issues" />
+            <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1431,7 +1414,7 @@ export const EventDependencies = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -1451,19 +1434,14 @@ export const EventDependencies = () => (
  * only the rendered variants, not the timing.)
  */
 export const EventIssueFields = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Set text field */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Set · text</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TypographyIcon} aria-label="Text field set" />
+            <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1485,7 +1463,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={NumberIcon} aria-label="Number field set" />
+            <Octicon icon={NumberIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1507,7 +1485,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CalendarIcon} aria-label="Date field set" />
+            <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1529,7 +1507,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={SingleSelectIcon} aria-label="Single select field set" />
+            <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1564,7 +1542,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TypographyIcon} aria-label="Text field changed" />
+            <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1586,7 +1564,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={NumberIcon} aria-label="Number field changed" />
+            <Octicon icon={NumberIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1608,7 +1586,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CalendarIcon} aria-label="Date field changed" />
+            <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1630,7 +1608,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={SingleSelectIcon} aria-label="Single select field changed" />
+            <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1662,7 +1640,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TypographyIcon} aria-label="Text field cleared" />
+            <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1679,7 +1657,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={NumberIcon} aria-label="Number field cleared" />
+            <Octicon icon={NumberIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1696,7 +1674,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CalendarIcon} aria-label="Date field cleared" />
+            <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1713,7 +1691,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={SingleSelectIcon} aria-label="Single select field cleared" />
+            <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1730,7 +1708,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TypographyIcon} aria-label="Fields updated" />
+            <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1756,7 +1734,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TypographyIcon} aria-label="Fields removed" />
+            <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1775,7 +1753,7 @@ export const EventIssueFields = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TypographyIcon} aria-label="Fields updated and removed" />
+            <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1790,7 +1768,7 @@ export const EventIssueFields = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -1820,19 +1798,14 @@ export const EventIssueFields = () => (
  * must use the ERB spec above, not this Issue composition.
  */
 export const EventProject = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Added to project */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Added to project</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TableIcon} aria-label="Added to project" />
+            <Octicon icon={TableIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1854,7 +1827,7 @@ export const EventProject = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TableIcon} aria-label="Removed from project" />
+            <Octicon icon={TableIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1879,7 +1852,7 @@ export const EventProject = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TableIcon} aria-label="Project status changed" />
+            <Octicon icon={TableIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1893,7 +1866,7 @@ export const EventProject = () => (
         </Timeline.Item>
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TableIcon} aria-label="Project status changed" />
+            <Octicon icon={TableIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1907,7 +1880,7 @@ export const EventProject = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -1927,19 +1900,14 @@ export const EventProject = () => (
  * the PR build (label pill markup is shared, copy is the same).
  */
 export const EventLabels = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Label added */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Label added</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TagIcon} aria-label="Label added" />
+            <Octicon icon={TagIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -1969,7 +1937,7 @@ export const EventLabels = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TagIcon} aria-label="Label removed" />
+            <Octicon icon={TagIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2000,7 +1968,7 @@ export const EventLabels = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TagIcon} aria-label="Labels added and removed" />
+            <Octicon icon={TagIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2037,7 +2005,7 @@ export const EventLabels = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -2054,19 +2022,14 @@ export const EventLabels = () => (
  * the PR build.
  */
 export const EventTitle = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Title changed */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Title changed</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={PencilIcon} aria-label="Title changed" />
+            <Octicon icon={PencilIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2076,7 +2039,7 @@ export const EventTitle = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -2094,19 +2057,14 @@ export const EventTitle = () => (
  * on the PR build.
  */
 export const EventMilestones = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Added to milestone */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Added to milestone</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={MilestoneIcon} aria-label="Added to milestone" />
+            <Octicon icon={MilestoneIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2127,7 +2085,7 @@ export const EventMilestones = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={MilestoneIcon} aria-label="Removed from milestone" />
+            <Octicon icon={MilestoneIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2141,7 +2099,7 @@ export const EventMilestones = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -2160,19 +2118,14 @@ export const EventMilestones = () => (
  * Dependabot/PR surface must use that ActorComponent, not this composition.
  */
 export const EventAssignments = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Self-assigned */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Self-assigned</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={PersonIcon} aria-label="Self-assigned" />
+            <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2189,7 +2142,7 @@ export const EventAssignments = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={PersonIcon} aria-label="Assigned" />
+            <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2209,7 +2162,7 @@ export const EventAssignments = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={PersonIcon} aria-label="Assigned multiple" />
+            <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2233,7 +2186,7 @@ export const EventAssignments = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={PersonIcon} aria-label="Self-unassigned" />
+            <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2250,7 +2203,7 @@ export const EventAssignments = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={PersonIcon} aria-label="Unassigned" />
+            <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2270,7 +2223,7 @@ export const EventAssignments = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={PersonIcon} aria-label="Unassigned multiple" />
+            <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2287,7 +2240,7 @@ export const EventAssignments = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -2305,12 +2258,7 @@ export const EventAssignments = () => (
  * the PR build.
  */
 export const EventLockUnlock = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Locked with reason — one row per reason (off topic / resolved / spam /
         too heated). */}
     <section className={classes.Variant}>
@@ -2318,7 +2266,7 @@ export const EventLockUnlock = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LockIcon} aria-label="Locked as off topic" />
+            <Octicon icon={LockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2328,7 +2276,7 @@ export const EventLockUnlock = () => (
         </Timeline.Item>
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LockIcon} aria-label="Locked as resolved" />
+            <Octicon icon={LockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2338,7 +2286,7 @@ export const EventLockUnlock = () => (
         </Timeline.Item>
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LockIcon} aria-label="Locked as spam" />
+            <Octicon icon={LockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2348,7 +2296,7 @@ export const EventLockUnlock = () => (
         </Timeline.Item>
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LockIcon} aria-label="Locked as too heated" />
+            <Octicon icon={LockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2365,7 +2313,7 @@ export const EventLockUnlock = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LockIcon} aria-label="Locked" />
+            <Octicon icon={LockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2382,7 +2330,7 @@ export const EventLockUnlock = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={UnlockIcon} aria-label="Unlocked" />
+            <Octicon icon={UnlockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2392,7 +2340,7 @@ export const EventLockUnlock = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -2407,19 +2355,14 @@ export const EventLockUnlock = () => (
  * verify on the PR build.
  */
 export const EventCommentDeleted = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Comment deleted */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Comment deleted</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={TrashIcon} aria-label="Comment deleted" />
+            <Octicon icon={TrashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2432,7 +2375,7 @@ export const EventCommentDeleted = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -2451,19 +2394,14 @@ export const EventCommentDeleted = () => (
  * verify on the PR build.
  */
 export const EventCrossReferences = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Mentioned from an issue */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Mentioned in an issue</h3>
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LinkExternalIcon} aria-label="Mentioned in an issue" />
+            <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2489,7 +2427,7 @@ export const EventCrossReferences = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LinkExternalIcon} aria-label="Mentioned in a pull request" />
+            <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2515,7 +2453,7 @@ export const EventCrossReferences = () => (
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LinkExternalIcon} aria-label="Linked a closing pull request" />
+            <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <Actor />
@@ -2534,5 +2472,5 @@ export const EventCrossReferences = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -43,6 +43,13 @@ import classes from './Timeline.issues.features.stories.module.css'
  * (`issue-timeline-events-for-figma.md`) and verified against the live React
  * implementation in `github/github-ui` (`packages/timeline-items`).
  *
+ * SCOPE: These are Storybook-only examples by design. They are intentionally
+ * NOT wired into components-json / the primer.style docs page (do NOT add this
+ * file to `Timeline.docs.json` or `build.ts`). Individual timeline events are not
+ * consumer-facing components — the primer.style Timeline page reflects the base
+ * `Timeline` component's own stories, and any docs-site representation is a
+ * Phase 3 consideration via base-component story changes, out of scope here.
+ *
  * FUTURE FILTERING (taxonomy still open — github/primer#6663): category
  * `data-*` attributes (e.g. `data-event-category="closed"`) will attach to each
  * `Timeline.Item` below so stories can be filtered/grouped by event family. We

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -33,7 +33,6 @@ import {
   TypographyIcon,
   UnlockIcon,
 } from '@primer/octicons-react'
-import Avatar from '../Avatar'
 import {Button} from '../Button'
 import Label from '../Label'
 import Link from '../Link'
@@ -41,6 +40,7 @@ import Octicon from '../Octicon'
 import RelativeTime from '../RelativeTime'
 import Token from '../Token'
 import classes from './Timeline.issues.features.stories.module.css'
+import {BoldLink, Examples, InlineAvatar, VariantSection} from './internal/timelineStoryHelpers'
 
 /**
  * Issue Timeline event examples (Phase 2 of github/primer#6663).
@@ -88,10 +88,10 @@ const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
 // (packages/timeline-items/components/row/EventActor.tsx) inline-avatar mode.
 const Actor = () => (
   <>
-    <Avatar src={MONALISA_AVATAR} size={20} alt="" className={classes.InlineAvatar} />
-    <Link href="#" className={classes.LinkWithBoldStyle} muted>
+    <InlineAvatar src={MONALISA_AVATAR} />
+    <BoldLink href="#" muted>
       monalisa
-    </Link>
+    </BoldLink>
   </>
 )
 
@@ -100,30 +100,6 @@ const Time = ({date}: {date: string}) => (
   <Link href="#" className={classes.Timestamp} muted>
     <RelativeTime date={new Date(date)} format="relative" />
   </Link>
-)
-
-// Shared wrapper for every event-group story. Renders the realistic timeline
-// surface and applies two story-only a11y/UX shims:
-//  - `data-a11y-link-underlines="true"`: Primer gates the inline-link underline
-//    on this ancestor attribute, which GitHub sets from the default-on "Show
-//    link underlines" user preference. Storybook never sets it, so without this
-//    the in-text `<Link inline>` links would render color-only (WCAG 1.4.1).
-//    Actor-name links use `<Link className={ActorName}>` WITHOUT `inline`, so
-//    they don't match the `[data-inline='true']` selector and stay un-underlined
-//    (avatar + semibold remain their cue).
-//  - onClick guard: prevents the placeholder `href="#"` links from navigating
-//    inside Storybook. Uses `instanceof Element` so a click on an SVG/octicon
-//    target (no `.closest`) doesn't throw.
-const Examples = ({children}: {children: React.ReactNode}) => (
-  <div
-    className={classes.RealisticTimeline}
-    data-a11y-link-underlines="true"
-    onClick={e => {
-      if (e.target instanceof Element && e.target.closest('a')) e.preventDefault()
-    }}
-  >
-    {children}
-  </div>
 )
 
 export default {
@@ -161,8 +137,7 @@ export default {
 export const EventClosed = () => (
   <Examples>
     {/* Closed as completed */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as completed</h3>
+    <VariantSection label="Closed as completed">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -178,13 +153,12 @@ export const EventClosed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Not planned — neutral (gray) badge. Timeline.Badge has no `neutral`
           variant, so drive the documented `--timelineBadge-bgColor` hook inline
           (portable for docs copy-paste; matches production `TimelineRow`). */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as not planned</h3>
+    <VariantSection label="Closed as not planned">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge
@@ -207,11 +181,10 @@ export const EventClosed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed via pull request */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed via pull request</h3>
+    <VariantSection label="Closed via pull request">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -224,18 +197,14 @@ export const EventClosed = () => (
               completed
             </Link>
             {' in '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              #123
-            </Link>{' '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <BoldLink href="#">#123</BoldLink> <Time date="2022-07-24T16:40:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed via commit */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed via commit</h3>
+    <VariantSection label="Closed via commit">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -255,13 +224,12 @@ export const EventClosed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed via project (ProjectV2 status change). github-ui composes
           the closer link as TableIcon + project title; there is no Primer
           equivalent for github-ui's `ProjectV2` closer link. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed via project</h3>
+    <VariantSection label="Closed via project">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -275,20 +243,16 @@ export const EventClosed = () => (
             </Link>
             {' by moving to Done in '}
             <Octicon icon={TableIcon} size={16} className={classes.ProjectRefIcon} />
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              Roadmap
-            </Link>{' '}
-            <Time date="2022-07-22T14:20:00Z" />
+            <BoldLink href="#">Roadmap</BoldLink> <Time date="2022-07-22T14:20:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed as duplicate — neutral (gray) badge (see note above). github-ui
           renders an `IssueLink` (state icon + title + #number + hovercard);
           composed here from Primer primitives. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as duplicate</h3>
+    <VariantSection label="Closed as duplicate">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge
@@ -317,11 +281,10 @@ export const EventClosed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed with no state reason */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed (no reason)</h3>
+    <VariantSection label="Closed (no reason)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -334,7 +297,7 @@ export const EventClosed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -349,8 +312,7 @@ export const EventClosed = () => (
 export const EventState = () => (
   <Examples>
     {/* Reopened — open (green) badge via useIssueState (ReopenedEvent.tsx) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Reopened</h3>
+    <VariantSection label="Reopened">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge variant="open">
@@ -363,12 +325,11 @@ export const EventState = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Transferred — github-ui's TransferredEvent renders the source repo as a
           plain inline Link (the audit shows it bold; live code is canonical). */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Transferred</h3>
+    <VariantSection label="Transferred">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -384,11 +345,10 @@ export const EventState = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Pinned */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Pinned</h3>
+    <VariantSection label="Pinned">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -401,11 +361,10 @@ export const EventState = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Unpinned */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Unpinned</h3>
+    <VariantSection label="Unpinned">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -418,12 +377,11 @@ export const EventState = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Converted to discussion — github-ui's ConvertedToDiscussionEvent links
           the resulting discussion by number. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Converted to discussion</h3>
+    <VariantSection label="Converted to discussion">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -432,18 +390,14 @@ export const EventState = () => (
           <Timeline.Body>
             <Actor />
             {'converted this issue into a discussion '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              #123
-            </Link>{' '}
-            <Time date="2022-07-22T14:20:00Z" />
+            <BoldLink href="#">#123</BoldLink> <Time date="2022-07-22T14:20:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Converted from draft */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Converted from draft</h3>
+    <VariantSection label="Converted from draft">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -456,7 +410,7 @@ export const EventState = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -472,8 +426,7 @@ export const EventReferences = () => (
   <Examples>
     {/* Linked pull request — ConnectedEvent.tsx (CrossReferenceIcon badge,
           open PR state icon inline before the PR title). */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Linked pull request</h3>
+    <VariantSection label="Linked pull request">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -483,14 +436,12 @@ export const EventReferences = () => (
             <Actor />
             {'linked a pull request that will close this issue '}
             <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              Add retry logic to the uploader
-            </Link>
+            <BoldLink href="#">Add retry logic to the uploader</BoldLink>
             <span className={classes.IssueLinkNumber}>#42</span> <Time date="2022-07-26T11:46:07Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Unlinked pull request — DisconnectedEvent.tsx uses the PR state icon AS
           the badge icon (leadingIcon={PullStateIcon}), so the badge octicon is
@@ -498,8 +449,7 @@ export const EventReferences = () => (
           active (in TIMELINE_ITEMS[__typename], current useIssueState hook,
           story fixture is an OPEN PR) — the Figma audit's gray cross-reference
           icon is behind the live code here. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Unlinked pull request</h3>
+    <VariantSection label="Unlinked pull request">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -509,19 +459,16 @@ export const EventReferences = () => (
             <Actor />
             {'removed a link to a pull request '}
             <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              Add retry logic to the uploader
-            </Link>
+            <BoldLink href="#">Add retry logic to the uploader</BoldLink>
             <span className={classes.IssueLinkNumber}>#42</span> <Time date="2022-07-25T09:12:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Single commit reference — ReferencedEvent.tsx. The timestamp renders
           inline (showAgoTimestamp={false}) and the commit card is sub-content. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Single commit reference</h3>
+    <VariantSection label="Single commit reference">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -549,11 +496,10 @@ export const EventReferences = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Multiple commit references — same event, pluralized copy + N cards. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Multiple commit references</h3>
+    <VariantSection label="Multiple commit references">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -592,7 +538,7 @@ export const EventReferences = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -609,8 +555,7 @@ export const EventDuplicates = () => (
     {/* Marked this as a duplicate of <canonical>. Right-controls "Undo" button
           (viewerCanUndo) → Timeline.Actions. The canonical issue is open, so its
           IssueLink uses the open (green) state icon. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Marked as duplicate</h3>
+    <VariantSection label="Marked as duplicate">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -631,11 +576,10 @@ export const EventDuplicates = () => (
           </Timeline.Actions>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Marked <canonical> as a duplicate of this issue — no right controls. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Marked as canonical</h3>
+    <VariantSection label="Marked as canonical">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -654,11 +598,10 @@ export const EventDuplicates = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Unmarked this as a duplicate of <canonical>. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Unmarked as duplicate</h3>
+    <VariantSection label="Unmarked as duplicate">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -676,11 +619,10 @@ export const EventDuplicates = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Unmarked <canonical> as a duplicate of this issue. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Unmarked as canonical</h3>
+    <VariantSection label="Unmarked as canonical">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -699,7 +641,7 @@ export const EventDuplicates = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -713,8 +655,7 @@ export const EventDuplicates = () => (
 export const EventModeration = () => (
   <Examples>
     {/* User blocked (permanent) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>User blocked</h3>
+    <VariantSection label="User blocked">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -723,18 +664,14 @@ export const EventModeration = () => (
           <Timeline.Body>
             <Actor />
             {'blocked '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              six7
-            </Link>{' '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <BoldLink href="#">six7</BoldLink> <Time date="2022-07-26T11:46:07Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* User temporarily blocked */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>User temporarily blocked</h3>
+    <VariantSection label="User temporarily blocked">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -743,18 +680,14 @@ export const EventModeration = () => (
           <Timeline.Body>
             <Actor />
             {'temporarily blocked '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              six7
-            </Link>{' '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <BoldLink href="#">six7</BoldLink> <Time date="2022-07-25T09:12:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Comment pinned — IssueCommentPinnedEvent.tsx links the pinned comment. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Comment pinned</h3>
+    <VariantSection label="Comment pinned">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -770,11 +703,10 @@ export const EventModeration = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Comment unpinned */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Comment unpinned</h3>
+    <VariantSection label="Comment unpinned">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -790,7 +722,7 @@ export const EventModeration = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -805,8 +737,7 @@ export const EventModeration = () => (
 export const EventIssueTypes = () => (
   <Examples>
     {/* Type added */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Issue type added</h3>
+    <VariantSection label="Issue type added">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -833,11 +764,10 @@ export const EventIssueTypes = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Type removed */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Issue type removed</h3>
+    <VariantSection label="Issue type removed">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -864,11 +794,10 @@ export const EventIssueTypes = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Type changed */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Issue type changed</h3>
+    <VariantSection label="Issue type changed">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -908,7 +837,7 @@ export const EventIssueTypes = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -928,8 +857,7 @@ export const EventIssueTypes = () => (
 export const EventIssueHierarchy = () => (
   <Examples>
     {/* Sub-issue added (single) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Sub-issue added (single)</h3>
+    <VariantSection label="Sub-issue added (single)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -951,11 +879,10 @@ export const EventIssueHierarchy = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Sub-issue added (multiple) — plural copy + N reference rows */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Sub-issues added (multiple)</h3>
+    <VariantSection label="Sub-issues added (multiple)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -984,11 +911,10 @@ export const EventIssueHierarchy = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Sub-issue removed (single) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Sub-issue removed (single)</h3>
+    <VariantSection label="Sub-issue removed (single)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1010,11 +936,10 @@ export const EventIssueHierarchy = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Sub-issues removed (multiple) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Sub-issues removed (multiple)</h3>
+    <VariantSection label="Sub-issues removed (multiple)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1043,11 +968,10 @@ export const EventIssueHierarchy = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Parent issue added (single) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Parent issue added (single)</h3>
+    <VariantSection label="Parent issue added (single)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1069,11 +993,10 @@ export const EventIssueHierarchy = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Parent issues added (multiple) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Parent issues added (multiple)</h3>
+    <VariantSection label="Parent issues added (multiple)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1102,11 +1025,10 @@ export const EventIssueHierarchy = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Parent issue removed (single) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Parent issue removed (single)</h3>
+    <VariantSection label="Parent issue removed (single)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1128,11 +1050,10 @@ export const EventIssueHierarchy = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Parent issues removed (multiple) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Parent issues removed (multiple)</h3>
+    <VariantSection label="Parent issues removed (multiple)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1161,7 +1082,7 @@ export const EventIssueHierarchy = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -1180,8 +1101,7 @@ export const EventIssueHierarchy = () => (
 export const EventDependencies = () => (
   <Examples>
     {/* Blocked by (single) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Blocked by (single)</h3>
+    <VariantSection label="Blocked by (single)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1203,11 +1123,10 @@ export const EventDependencies = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Blocked by (multiple) — count in copy + N rows */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Blocked by (multiple)</h3>
+    <VariantSection label="Blocked by (multiple)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1236,11 +1155,10 @@ export const EventDependencies = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Blocked by removed (single) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Blocked by removed (single)</h3>
+    <VariantSection label="Blocked by removed (single)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1262,11 +1180,10 @@ export const EventDependencies = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Blocked by removed (multiple) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Blocked by removed (multiple)</h3>
+    <VariantSection label="Blocked by removed (multiple)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1295,11 +1212,10 @@ export const EventDependencies = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Blocking (single) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Blocking (single)</h3>
+    <VariantSection label="Blocking (single)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1321,11 +1237,10 @@ export const EventDependencies = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Blocking (multiple) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Blocking (multiple)</h3>
+    <VariantSection label="Blocking (multiple)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1354,11 +1269,10 @@ export const EventDependencies = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Blocking removed (single) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Blocking removed (single)</h3>
+    <VariantSection label="Blocking removed (single)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1380,11 +1294,10 @@ export const EventDependencies = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Blocking removed (multiple) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Blocking removed (multiple)</h3>
+    <VariantSection label="Blocking removed (multiple)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1413,7 +1326,7 @@ export const EventDependencies = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -1436,8 +1349,7 @@ export const EventDependencies = () => (
 export const EventIssueFields = () => (
   <Examples>
     {/* Set text field */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Set · text</h3>
+    <VariantSection label="Set · text">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1455,11 +1367,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Set number field */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Set · number</h3>
+    <VariantSection label="Set · number">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1477,11 +1388,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Set date field */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Set · date</h3>
+    <VariantSection label="Set · date">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1499,11 +1409,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Set single-select field — value is a colored token */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Set · single select</h3>
+    <VariantSection label="Set · single select">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1534,11 +1443,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Changed text field */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Changed · text</h3>
+    <VariantSection label="Changed · text">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1556,11 +1464,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Changed number field */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Changed · number</h3>
+    <VariantSection label="Changed · number">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1578,11 +1485,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Changed date field */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Changed · date</h3>
+    <VariantSection label="Changed · date">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1600,11 +1506,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Changed single-select field */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Changed · single select</h3>
+    <VariantSection label="Changed · single select">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1632,11 +1537,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Cleared text field — no value */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Cleared · text</h3>
+    <VariantSection label="Cleared · text">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1649,11 +1553,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Cleared number field */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Cleared · number</h3>
+    <VariantSection label="Cleared · number">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1666,11 +1569,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Cleared date field */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Cleared · date</h3>
+    <VariantSection label="Cleared · date">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1683,11 +1585,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Cleared single-select field */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Cleared · single select</h3>
+    <VariantSection label="Cleared · single select">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1700,11 +1601,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Rollup: updated only — multiple field updates collapsed into one row */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Rollup · updated</h3>
+    <VariantSection label="Rollup · updated">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1726,11 +1626,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Rollup: removed only */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Rollup · removed</h3>
+    <VariantSection label="Rollup · removed">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1745,11 +1644,10 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Rollup: updated and also removed — combined row joined by "and also" */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Rollup · updated and removed</h3>
+    <VariantSection label="Rollup · updated and removed">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1767,7 +1665,7 @@ export const EventIssueFields = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -1800,8 +1698,7 @@ export const EventIssueFields = () => (
 export const EventProject = () => (
   <Examples>
     {/* Added to project */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Added to project</h3>
+    <VariantSection label="Added to project">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1819,11 +1716,10 @@ export const EventProject = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Removed from project */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Removed from project</h3>
+    <VariantSection label="Removed from project">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1840,15 +1736,14 @@ export const EventProject = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Project status changed. Two forms per live
         `ProjectV2ItemStatusChangedEvent.tsx`: with no previous status,
         "moved this to {status} in {project}"; with a previous status,
         "moved this from {previousStatus} to {status} in {project}". Status
         strings are PLAIN TEXT (not bold). Both forms shown under one caption. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Project status changed</h3>
+    <VariantSection label="Project status changed">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1879,7 +1774,7 @@ export const EventProject = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -1902,8 +1797,7 @@ export const EventProject = () => (
 export const EventLabels = () => (
   <Examples>
     {/* Label added */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Label added</h3>
+    <VariantSection label="Label added">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1929,11 +1823,10 @@ export const EventLabels = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Label removed */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Label removed</h3>
+    <VariantSection label="Label removed">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -1959,12 +1852,11 @@ export const EventLabels = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Added + removed (rollup) — RolledupLabeledEvent joins both renderings
         with "and" between them. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Labels added and removed</h3>
+    <VariantSection label="Labels added and removed">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2004,7 +1896,7 @@ export const EventLabels = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -2024,8 +1916,7 @@ export const EventLabels = () => (
 export const EventTitle = () => (
   <Examples>
     {/* Title changed */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Title changed</h3>
+    <VariantSection label="Title changed">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2038,7 +1929,7 @@ export const EventTitle = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -2059,8 +1950,7 @@ export const EventTitle = () => (
 export const EventMilestones = () => (
   <Examples>
     {/* Added to milestone */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Added to milestone</h3>
+    <VariantSection label="Added to milestone">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2077,11 +1967,10 @@ export const EventMilestones = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Removed from milestone */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Removed from milestone</h3>
+    <VariantSection label="Removed from milestone">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2098,7 +1987,7 @@ export const EventMilestones = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -2120,8 +2009,7 @@ export const EventMilestones = () => (
 export const EventAssignments = () => (
   <Examples>
     {/* Self-assigned */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Self-assigned</h3>
+    <VariantSection label="Self-assigned">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2134,11 +2022,10 @@ export const EventAssignments = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Assigned someone else — assignee is a bold link, no avatar. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Assigned</h3>
+    <VariantSection label="Assigned">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2147,18 +2034,14 @@ export const EventAssignments = () => (
           <Timeline.Body>
             <Actor />
             {'assigned '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              hubot
-            </Link>{' '}
-            <Time date="2022-07-25T09:12:00Z" />
+            <BoldLink href="#">hubot</BoldLink> <Time date="2022-07-25T09:12:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Assigned multiple — joined with "and". */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Assigned multiple</h3>
+    <VariantSection label="Assigned multiple">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2167,22 +2050,16 @@ export const EventAssignments = () => (
           <Timeline.Body>
             <Actor />
             {'assigned '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              hubot
-            </Link>
+            <BoldLink href="#">hubot</BoldLink>
             {' and '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              octocat
-            </Link>{' '}
-            <Time date="2022-07-24T16:40:00Z" />
+            <BoldLink href="#">octocat</BoldLink> <Time date="2022-07-24T16:40:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Self-unassigned */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Self-unassigned</h3>
+    <VariantSection label="Self-unassigned">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2195,11 +2072,10 @@ export const EventAssignments = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Unassigned someone else */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Unassigned</h3>
+    <VariantSection label="Unassigned">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2208,18 +2084,14 @@ export const EventAssignments = () => (
           <Timeline.Body>
             <Actor />
             {'unassigned '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              hubot
-            </Link>{' '}
-            <Time date="2022-07-22T14:20:00Z" />
+            <BoldLink href="#">hubot</BoldLink> <Time date="2022-07-22T14:20:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Unassigned multiple — joined with "and". */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Unassigned multiple</h3>
+    <VariantSection label="Unassigned multiple">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2228,18 +2100,13 @@ export const EventAssignments = () => (
           <Timeline.Body>
             <Actor />
             {'unassigned '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              hubot
-            </Link>
+            <BoldLink href="#">hubot</BoldLink>
             {' and '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              octocat
-            </Link>{' '}
-            <Time date="2022-07-21T08:30:00Z" />
+            <BoldLink href="#">octocat</BoldLink> <Time date="2022-07-21T08:30:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -2261,8 +2128,7 @@ export const EventLockUnlock = () => (
   <Examples>
     {/* Locked with reason — one row per reason (off topic / resolved / spam /
         too heated). */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Locked (with reason)</h3>
+    <VariantSection label="Locked (with reason)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2305,11 +2171,10 @@ export const EventLockUnlock = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Locked (no reason) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Locked (no reason)</h3>
+    <VariantSection label="Locked (no reason)">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2322,11 +2187,10 @@ export const EventLockUnlock = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Unlocked — UnlockIcon badge (not LockIcon). */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Unlocked</h3>
+    <VariantSection label="Unlocked">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2339,7 +2203,7 @@ export const EventLockUnlock = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -2357,8 +2221,7 @@ export const EventLockUnlock = () => (
 export const EventCommentDeleted = () => (
   <Examples>
     {/* Comment deleted */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Comment deleted</h3>
+    <VariantSection label="Comment deleted">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2374,7 +2237,7 @@ export const EventCommentDeleted = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -2396,8 +2259,7 @@ export const EventCommentDeleted = () => (
 export const EventCrossReferences = () => (
   <Examples>
     {/* Mentioned from an issue */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Mentioned in an issue</h3>
+    <VariantSection label="Mentioned in an issue">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2419,11 +2281,10 @@ export const EventCrossReferences = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Mentioned from a pull request */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Mentioned in a pull request</h3>
+    <VariantSection label="Mentioned in a pull request">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2445,11 +2306,10 @@ export const EventCrossReferences = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Linked a closing pull request */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Linked a closing pull request</h3>
+    <VariantSection label="Linked a closing pull request">
       <Timeline aria-label="Issue timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -2471,6 +2331,6 @@ export const EventCrossReferences = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -40,7 +40,7 @@ import Octicon from '../Octicon'
 import RelativeTime from '../RelativeTime'
 import Token from '../Token'
 import classes from './Timeline.issues.features.stories.module.css'
-import {BoldLink, Examples, InlineAvatar, VariantSection} from './internal/timelineStoryHelpers'
+import {BoldLink, Examples, UserActor, VariantSection} from './internal/timelineStoryHelpers'
 
 /**
  * Issue Timeline event examples (Phase 2 of github/primer#6663).
@@ -81,19 +81,6 @@ import {BoldLink, Examples, InlineAvatar, VariantSection} from './internal/timel
  *       </Timeline.Actions>
  *     </Timeline.Item>
  */
-
-const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
-
-// Inline 20px avatar + bold username link, matching github-ui's `EventActor`
-// (packages/timeline-items/components/row/EventActor.tsx) inline-avatar mode.
-const Actor = () => (
-  <>
-    <InlineAvatar src={MONALISA_AVATAR} />
-    <BoldLink href="#" muted>
-      monalisa
-    </BoldLink>
-  </>
-)
 
 // Muted underlined relative timestamp, mirroring github-ui's `Ago` deep-link.
 const Time = ({date}: {date: string}) => (
@@ -144,7 +131,7 @@ export const EventClosed = () => (
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'closed this as '}
             <Link href="#" inline>
               completed
@@ -172,7 +159,7 @@ export const EventClosed = () => (
             <Octicon icon={CircleSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'closed this as '}
             <Link href="#" inline>
               not planned
@@ -191,7 +178,7 @@ export const EventClosed = () => (
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'closed this as '}
             <Link href="#" inline>
               completed
@@ -211,7 +198,7 @@ export const EventClosed = () => (
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'closed this as '}
             <Link href="#" inline>
               completed
@@ -236,7 +223,7 @@ export const EventClosed = () => (
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'closed this as '}
             <Link href="#" inline>
               completed
@@ -266,7 +253,7 @@ export const EventClosed = () => (
             <Octicon icon={CircleSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'closed this as a '}
             <Link href="#" inline>
               duplicate
@@ -291,7 +278,7 @@ export const EventClosed = () => (
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'closed this '}
             <Time date="2022-07-20T10:00:00Z" />
           </Timeline.Body>
@@ -319,7 +306,7 @@ export const EventState = () => (
             <Octicon icon={IssueReopenedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'reopened this '}
             <Time date="2022-07-26T11:46:07Z" />
           </Timeline.Body>
@@ -336,7 +323,7 @@ export const EventState = () => (
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'transferred this issue from '}
             <Link href="#" inline>
               octo-org/legacy-repo
@@ -355,7 +342,7 @@ export const EventState = () => (
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'pinned this issue '}
             <Time date="2022-07-24T16:40:00Z" />
           </Timeline.Body>
@@ -371,7 +358,7 @@ export const EventState = () => (
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'unpinned this issue '}
             <Time date="2022-07-23T11:05:00Z" />
           </Timeline.Body>
@@ -388,7 +375,7 @@ export const EventState = () => (
             <Octicon icon={CommentDiscussionIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'converted this issue into a discussion '}
             <BoldLink href="#">#123</BoldLink> <Time date="2022-07-22T14:20:00Z" />
           </Timeline.Body>
@@ -404,7 +391,7 @@ export const EventState = () => (
             <Octicon icon={IssueDraftIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'converted this from a draft issue '}
             <Time date="2022-07-21T08:30:00Z" />
           </Timeline.Body>
@@ -433,7 +420,7 @@ export const EventReferences = () => (
             <Octicon icon={CrossReferenceIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'linked a pull request that will close this issue '}
             <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
             <BoldLink href="#">Add retry logic to the uploader</BoldLink>
@@ -456,7 +443,7 @@ export const EventReferences = () => (
             <Octicon icon={GitPullRequestIcon} className={classes.BadgeIconOpen} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'removed a link to a pull request '}
             <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
             <BoldLink href="#">Add retry logic to the uploader</BoldLink>
@@ -475,7 +462,7 @@ export const EventReferences = () => (
             <Octicon icon={GitCommitIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'added a commit that references this issue '}
             <Time date="2022-07-24T16:40:00Z" />
             {/* Simplified ReferencedEventInner card (github-ui composes message +
@@ -506,7 +493,7 @@ export const EventReferences = () => (
             <Octicon icon={GitCommitIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'added 3 commits that reference this issue '}
             <Time date="2022-07-23T11:05:00Z" />
             <div className={classes.CommitRefBox}>
@@ -562,7 +549,7 @@ export const EventDuplicates = () => (
             <Octicon icon={DuplicateIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'marked this as a duplicate of '}
             <Link href="#" className={classes.IssueLink}>
               <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
@@ -586,7 +573,7 @@ export const EventDuplicates = () => (
             <Octicon icon={DuplicateIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'marked '}
             <Link href="#" className={classes.IssueLink}>
               <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
@@ -608,7 +595,7 @@ export const EventDuplicates = () => (
             <Octicon icon={DuplicateIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'unmarked this as a duplicate of '}
             <Link href="#" className={classes.IssueLink}>
               <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
@@ -629,7 +616,7 @@ export const EventDuplicates = () => (
             <Octicon icon={DuplicateIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'unmarked '}
             <Link href="#" className={classes.IssueLink}>
               <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
@@ -662,7 +649,7 @@ export const EventModeration = () => (
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'blocked '}
             <BoldLink href="#">six7</BoldLink> <Time date="2022-07-26T11:46:07Z" />
           </Timeline.Body>
@@ -678,7 +665,7 @@ export const EventModeration = () => (
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'temporarily blocked '}
             <BoldLink href="#">six7</BoldLink> <Time date="2022-07-25T09:12:00Z" />
           </Timeline.Body>
@@ -694,7 +681,7 @@ export const EventModeration = () => (
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'pinned a '}
             <Link href="#" inline>
               comment
@@ -713,7 +700,7 @@ export const EventModeration = () => (
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'unpinned a '}
             <Link href="#" inline>
               comment
@@ -744,7 +731,7 @@ export const EventIssueTypes = () => (
             <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'added the '}
             <span className={classes.TokenWrapper}>
               <Token
@@ -774,7 +761,7 @@ export const EventIssueTypes = () => (
             <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'removed the '}
             <span className={classes.TokenWrapper}>
               <Token
@@ -804,7 +791,7 @@ export const EventIssueTypes = () => (
             <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'changed the issue type from '}
             <span className={classes.TokenWrapper}>
               <Token
@@ -864,7 +851,7 @@ export const EventIssueHierarchy = () => (
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'added a sub-issue '}
             <Time date="2022-07-26T11:46:07Z" />
             <ul className={classes.RefList}>
@@ -889,7 +876,7 @@ export const EventIssueHierarchy = () => (
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'added sub-issues '}
             <Time date="2022-07-25T09:12:00Z" />
             <ul className={classes.RefList}>
@@ -921,7 +908,7 @@ export const EventIssueHierarchy = () => (
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'removed a sub-issue '}
             <Time date="2022-07-24T16:40:00Z" />
             <ul className={classes.RefList}>
@@ -946,7 +933,7 @@ export const EventIssueHierarchy = () => (
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'removed sub-issues '}
             <Time date="2022-07-23T11:05:00Z" />
             <ul className={classes.RefList}>
@@ -978,7 +965,7 @@ export const EventIssueHierarchy = () => (
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'added a parent issue '}
             <Time date="2022-07-22T14:20:00Z" />
             <ul className={classes.RefList}>
@@ -1003,7 +990,7 @@ export const EventIssueHierarchy = () => (
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'added parent issues '}
             <Time date="2022-07-21T08:30:00Z" />
             <ul className={classes.RefList}>
@@ -1035,7 +1022,7 @@ export const EventIssueHierarchy = () => (
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'removed a parent issue '}
             <Time date="2022-07-20T10:00:00Z" />
             <ul className={classes.RefList}>
@@ -1060,7 +1047,7 @@ export const EventIssueHierarchy = () => (
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'removed parent issues '}
             <Time date="2022-07-19T13:15:00Z" />
             <ul className={classes.RefList}>
@@ -1108,7 +1095,7 @@ export const EventDependencies = () => (
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'marked this as blocked '}
             <Time date="2022-07-26T11:46:07Z" />
             <ul className={classes.RefList}>
@@ -1133,7 +1120,7 @@ export const EventDependencies = () => (
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'marked this as blocked by 2 issues '}
             <Time date="2022-07-25T09:12:00Z" />
             <ul className={classes.RefList}>
@@ -1165,7 +1152,7 @@ export const EventDependencies = () => (
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'unmarked this as blocked '}
             <Time date="2022-07-24T16:40:00Z" />
             <ul className={classes.RefList}>
@@ -1190,7 +1177,7 @@ export const EventDependencies = () => (
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'unmarked this as blocked by 2 issues '}
             <Time date="2022-07-23T11:05:00Z" />
             <ul className={classes.RefList}>
@@ -1222,7 +1209,7 @@ export const EventDependencies = () => (
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'marked this as blocking '}
             <Time date="2022-07-22T14:20:00Z" />
             <ul className={classes.RefList}>
@@ -1247,7 +1234,7 @@ export const EventDependencies = () => (
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'marked this as blocking 2 issues '}
             <Time date="2022-07-21T08:30:00Z" />
             <ul className={classes.RefList}>
@@ -1279,7 +1266,7 @@ export const EventDependencies = () => (
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'unmarked this as blocking '}
             <Time date="2022-07-20T10:00:00Z" />
             <ul className={classes.RefList}>
@@ -1304,7 +1291,7 @@ export const EventDependencies = () => (
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'unmarked this as blocking 2 issues '}
             <Time date="2022-07-19T13:15:00Z" />
             <ul className={classes.RefList}>
@@ -1356,7 +1343,7 @@ export const EventIssueFields = () => (
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'set '}
             <span className={classes.FieldName}>Team</span>
             {' to '}
@@ -1377,7 +1364,7 @@ export const EventIssueFields = () => (
             <Octicon icon={NumberIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'set '}
             <span className={classes.FieldName}>Story Points</span>
             {' to '}
@@ -1398,7 +1385,7 @@ export const EventIssueFields = () => (
             <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'set '}
             <span className={classes.FieldName}>Target Date</span>
             {' to '}
@@ -1419,7 +1406,7 @@ export const EventIssueFields = () => (
             <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'set '}
             <span className={classes.FieldName}>Priority</span>
             {' to '}
@@ -1453,7 +1440,7 @@ export const EventIssueFields = () => (
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'changed '}
             <span className={classes.FieldName}>Team</span>
             {' to '}
@@ -1474,7 +1461,7 @@ export const EventIssueFields = () => (
             <Octicon icon={NumberIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'changed '}
             <span className={classes.FieldName}>Story Points</span>
             {' to '}
@@ -1495,7 +1482,7 @@ export const EventIssueFields = () => (
             <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'changed '}
             <span className={classes.FieldName}>Target Date</span>
             {' to '}
@@ -1516,7 +1503,7 @@ export const EventIssueFields = () => (
             <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'changed '}
             <span className={classes.FieldName}>Priority</span>
             {' to '}
@@ -1547,7 +1534,7 @@ export const EventIssueFields = () => (
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'cleared '}
             <span className={classes.FieldName}>Team</span> <Time date="2022-07-19T13:15:00Z" />
           </Timeline.Body>
@@ -1563,7 +1550,7 @@ export const EventIssueFields = () => (
             <Octicon icon={NumberIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'cleared '}
             <span className={classes.FieldName}>Story Points</span> <Time date="2022-07-18T09:00:00Z" />
           </Timeline.Body>
@@ -1579,7 +1566,7 @@ export const EventIssueFields = () => (
             <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'cleared '}
             <span className={classes.FieldName}>Target Date</span> <Time date="2022-07-17T12:00:00Z" />
           </Timeline.Body>
@@ -1595,7 +1582,7 @@ export const EventIssueFields = () => (
             <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'cleared '}
             <span className={classes.FieldName}>Priority</span> <Time date="2022-07-16T08:30:00Z" />
           </Timeline.Body>
@@ -1611,7 +1598,7 @@ export const EventIssueFields = () => (
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'updated '}
             <span className={classes.FieldName}>Team</span>
             <Link href="#" inline className={classes.FieldValue}>
@@ -1636,7 +1623,7 @@ export const EventIssueFields = () => (
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'removed '}
             <span className={classes.FieldName}>Team</span>
             {' and '}
@@ -1654,7 +1641,7 @@ export const EventIssueFields = () => (
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'updated '}
             <span className={classes.FieldName}>Team</span>
             <Link href="#" inline className={classes.FieldValue}>
@@ -1705,7 +1692,7 @@ export const EventProject = () => (
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'added this to '}
             {/* Issue-version ProjectV2 reference (github-ui `ProjectV2.tsx`). */}
             <Octicon icon={TableIcon} size={16} className={classes.ProjectRefIcon} />
@@ -1726,7 +1713,7 @@ export const EventProject = () => (
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'removed this from '}
             <Octicon icon={TableIcon} size={16} className={classes.ProjectRefIcon} />
             <Link href="#" inline className={classes.ProjectRefLink}>
@@ -1750,7 +1737,7 @@ export const EventProject = () => (
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'moved this to In Progress in '}
             <Octicon icon={TableIcon} size={16} className={classes.ProjectRefIcon} />
             <Link href="#" inline className={classes.ProjectRefLink}>
@@ -1764,7 +1751,7 @@ export const EventProject = () => (
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'moved this from Todo to In Progress in '}
             <Octicon icon={TableIcon} size={16} className={classes.ProjectRefIcon} />
             <Link href="#" inline className={classes.ProjectRefLink}>
@@ -1804,7 +1791,7 @@ export const EventLabels = () => (
             <Octicon icon={TagIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'added '}
             <span className={classes.TokenWrapper}>
               <Token
@@ -1833,7 +1820,7 @@ export const EventLabels = () => (
             <Octicon icon={TagIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'removed '}
             <span className={classes.TokenWrapper}>
               <Token
@@ -1863,7 +1850,7 @@ export const EventLabels = () => (
             <Octicon icon={TagIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'added '}
             <span className={classes.TokenWrapper}>
               <Token
@@ -1923,7 +1910,7 @@ export const EventTitle = () => (
             <Octicon icon={PencilIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'changed the title '}
             <del>Fix the uplaod bug</del> Fix the upload bug <Time date="2022-07-23T11:05:00Z" />
           </Timeline.Body>
@@ -1957,7 +1944,7 @@ export const EventMilestones = () => (
             <Octicon icon={MilestoneIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'added this to the '}
             <Link href="#" inline className={classes.ProjectRefLink}>
               v2.0
@@ -1977,7 +1964,7 @@ export const EventMilestones = () => (
             <Octicon icon={MilestoneIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'removed this from the '}
             <Link href="#" inline className={classes.ProjectRefLink}>
               v2.0
@@ -2016,7 +2003,7 @@ export const EventAssignments = () => (
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'self-assigned this '}
             <Time date="2022-07-26T11:46:07Z" />
           </Timeline.Body>
@@ -2032,7 +2019,7 @@ export const EventAssignments = () => (
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'assigned '}
             <BoldLink href="#">hubot</BoldLink> <Time date="2022-07-25T09:12:00Z" />
           </Timeline.Body>
@@ -2048,7 +2035,7 @@ export const EventAssignments = () => (
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'assigned '}
             <BoldLink href="#">hubot</BoldLink>
             {' and '}
@@ -2066,7 +2053,7 @@ export const EventAssignments = () => (
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'removed their assignment '}
             <Time date="2022-07-23T11:05:00Z" />
           </Timeline.Body>
@@ -2082,7 +2069,7 @@ export const EventAssignments = () => (
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'unassigned '}
             <BoldLink href="#">hubot</BoldLink> <Time date="2022-07-22T14:20:00Z" />
           </Timeline.Body>
@@ -2098,7 +2085,7 @@ export const EventAssignments = () => (
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'unassigned '}
             <BoldLink href="#">hubot</BoldLink>
             {' and '}
@@ -2135,7 +2122,7 @@ export const EventLockUnlock = () => (
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'locked as off topic and limited conversation to collaborators '}
             <Time date="2022-07-26T11:46:07Z" />
           </Timeline.Body>
@@ -2145,7 +2132,7 @@ export const EventLockUnlock = () => (
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'locked as resolved and limited conversation to collaborators '}
             <Time date="2022-07-26T11:47:00Z" />
           </Timeline.Body>
@@ -2155,7 +2142,7 @@ export const EventLockUnlock = () => (
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'locked as spam and limited conversation to collaborators '}
             <Time date="2022-07-26T11:48:00Z" />
           </Timeline.Body>
@@ -2165,7 +2152,7 @@ export const EventLockUnlock = () => (
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'locked as too heated and limited conversation to collaborators '}
             <Time date="2022-07-26T11:49:00Z" />
           </Timeline.Body>
@@ -2181,7 +2168,7 @@ export const EventLockUnlock = () => (
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'locked and limited conversation to collaborators '}
             <Time date="2022-07-25T09:12:00Z" />
           </Timeline.Body>
@@ -2197,7 +2184,7 @@ export const EventLockUnlock = () => (
             <Octicon icon={UnlockIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'unlocked this conversation '}
             <Time date="2022-07-24T16:40:00Z" />
           </Timeline.Body>
@@ -2228,7 +2215,7 @@ export const EventCommentDeleted = () => (
             <Octicon icon={TrashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'deleted a comment from '}
             <Link href="#" inline>
               octocat
@@ -2266,7 +2253,7 @@ export const EventCrossReferences = () => (
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'mentioned this '}
             <Time date="2022-07-26T11:46:07Z" />
             <ul className={classes.RefList}>
@@ -2291,7 +2278,7 @@ export const EventCrossReferences = () => (
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'mentioned this '}
             <Time date="2022-07-25T09:12:00Z" />
             <ul className={classes.RefList}>
@@ -2316,7 +2303,7 @@ export const EventCrossReferences = () => (
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <Actor />
+            <UserActor href="#" muted />
             {'linked a pull request that will close this issue '}
             <Time date="2022-07-24T16:40:00Z" />
             <ul className={classes.RefList}>

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -1,0 +1,1562 @@
+import type {Meta} from '@storybook/react-vite'
+import type React from 'react'
+import type {ComponentProps} from '../utils/types'
+import {FeatureFlags} from '../FeatureFlags'
+import Timeline from './Timeline'
+import {
+  BlockedIcon,
+  CalendarIcon,
+  CheckCircleIcon,
+  CircleSlashIcon,
+  CommentDiscussionIcon,
+  CrossReferenceIcon,
+  DuplicateIcon,
+  GitCommitIcon,
+  GitPullRequestIcon,
+  IssueClosedIcon,
+  IssueDraftIcon,
+  IssueOpenedIcon,
+  IssueReopenedIcon,
+  IssueTrackedByIcon,
+  IssueTracksIcon,
+  LinkExternalIcon,
+  NumberIcon,
+  PinIcon,
+  SingleSelectIcon,
+  TableIcon,
+  TypographyIcon,
+} from '@primer/octicons-react'
+import Avatar from '../Avatar'
+import {Button} from '../Button'
+import Label from '../Label'
+import Link from '../Link'
+import Octicon from '../Octicon'
+import RelativeTime from '../RelativeTime'
+import Token from '../Token'
+import classes from './Timeline.issues.features.stories.module.css'
+
+/**
+ * Issue Timeline event examples (Phase 2 of github/primer#6663).
+ *
+ * These stories recreate GitHub's live issue-timeline events using the Primer
+ * `Timeline` compositional slots, sourced from the `timeline-audit` Figma audit
+ * (`issue-timeline-events-for-figma.md`) and verified against the live React
+ * implementation in `github/github-ui` (`packages/timeline-items`).
+ *
+ * FUTURE FILTERING (taxonomy still open — github/primer#6663): category
+ * `data-*` attributes (e.g. `data-event-category="closed"`) will attach to each
+ * `Timeline.Item` below so stories can be filtered/grouped by event family. We
+ * intentionally do NOT add them yet to avoid baking in a taxonomy.
+ *
+ * SLOT USAGE (Phase 1 slots — establishes the convention for downstream groups):
+ * - `Timeline.Avatar` (gutter slot, #6677): the 40px LEFT-GUTTER avatar. Reserved
+ *   for comment-style events. Badge-row events like Closed do NOT use it — the
+ *   live github-ui `ClosedEvent` renders through `TimelineRow`, which places the
+ *   actor's small (20px) avatar INLINE in the body (`EventActor` inline-avatar
+ *   mode), not in the gutter. We mirror that here: avatar inline in `Timeline.Body`.
+ * - `Timeline.Actions` (right-controls slot, #6678): for buttons / SHAs / status
+ *   pills on the right edge. Closed has no right controls, so it is omitted here.
+ *   Downstream groups that DO have right controls (e.g. Duplicates' "Marked as
+ *   duplicate" has a button) should add it as a sibling of `Timeline.Body`:
+ *
+ *     <Timeline.Item>
+ *       <Timeline.Badge>{...}</Timeline.Badge>
+ *       <Timeline.Body>{...}</Timeline.Body>
+ *       <Timeline.Actions>
+ *         <Button size="small">View details</Button>
+ *       </Timeline.Actions>
+ *     </Timeline.Item>
+ */
+
+const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
+
+// Inline 20px avatar + bold username link, matching github-ui's `EventActor`
+// (packages/timeline-items/components/row/EventActor.tsx) inline-avatar mode.
+const Actor = () => (
+  <>
+    <Avatar src={MONALISA_AVATAR} size={20} alt="" className={classes.InlineAvatar} />
+    <Link href="#" className={classes.LinkWithBoldStyle} muted>
+      monalisa
+    </Link>
+  </>
+)
+
+// Muted underlined relative timestamp, mirroring github-ui's `Ago` deep-link.
+const Time = ({date}: {date: string}) => (
+  <Link href="#" className={classes.Timestamp} muted>
+    <RelativeTime date={new Date(date)} format="relative" />
+  </Link>
+)
+
+export default {
+  title: 'Components/Timeline/Issues Features',
+  component: Timeline,
+  subcomponents: {
+    'Timeline.Item': Timeline.Item,
+    'Timeline.Avatar': Timeline.Avatar,
+    'Timeline.Badge': Timeline.Badge,
+    'Timeline.Body': Timeline.Body,
+    'Timeline.Break': Timeline.Break,
+    'Timeline.Actions': Timeline.Actions,
+  },
+  decorators: [
+    // File-scoped: render every story in the future-state list semantics
+    // (`<ol>`/`<li>`). The `primer_react_timeline_list_semantics` flag is merged
+    // on main; this opts these stories into the DOM the timeline will ship.
+    Story => (
+      <FeatureFlags flags={{primer_react_timeline_list_semantics: true}}>
+        <Story />
+      </FeatureFlags>
+    ),
+  ],
+} as Meta<ComponentProps<typeof Timeline>>
+
+/**
+ * The Closed event group — `IssueTimeline.eventClosed` (audit § 2).
+ *
+ * All seven variants are stacked in a single `<Timeline>` so they can be
+ * scanned like a Figma component set. Badge icon and color are dynamically
+ * derived by `useIssueState({ state: 'CLOSED', stateReason })` in the live code:
+ * completed/PR/commit/project/no-reason -> CheckCircleIcon on `done` (purple);
+ * not-planned/duplicate -> CircleSlashIcon on `neutral` (gray).
+ */
+export const EventClosed = () => (
+  <div
+    className={classes.RealisticTimeline}
+    // Prevent the placeholder `href="#"` links from navigating inside Storybook.
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    <Timeline aria-label="Issue timeline">
+      {/* Closed as completed */}
+      <Timeline.Item>
+        <Timeline.Badge variant="done">
+          <Octicon icon={CheckCircleIcon} aria-label="Closed as completed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Closed as completed</span>
+          <Actor />
+          {'closed this as '}
+          <Link href="#" inline>
+            completed
+          </Link>{' '}
+          <Time date="2022-07-26T11:46:07Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Not planned — neutral (gray) badge. Timeline.Badge has no `neutral`
+          variant, so drive the documented `--timelineBadge-bgColor` hook inline
+          (portable for docs copy-paste; matches production `TimelineRow`). */}
+      <Timeline.Item>
+        <Timeline.Badge
+          style={
+            {
+              '--timelineBadge-bgColor': 'var(--bgColor-neutral-emphasis)',
+              color: 'var(--fgColor-onEmphasis)',
+            } as React.CSSProperties
+          }
+        >
+          <Octicon icon={CircleSlashIcon} aria-label="Closed as not planned" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Closed as not planned</span>
+          <Actor />
+          {'closed this as '}
+          <Link href="#" inline>
+            not planned
+          </Link>{' '}
+          <Time date="2022-07-25T09:12:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Closed via pull request */}
+      <Timeline.Item>
+        <Timeline.Badge variant="done">
+          <Octicon icon={CheckCircleIcon} aria-label="Closed via pull request" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Closed via pull request</span>
+          <Actor />
+          {'closed this as '}
+          <Link href="#" inline>
+            completed
+          </Link>
+          {' in '}
+          <Link href="#" className={classes.LinkWithBoldStyle}>
+            #123
+          </Link>{' '}
+          <Time date="2022-07-24T16:40:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Closed via commit */}
+      <Timeline.Item>
+        <Timeline.Badge variant="done">
+          <Octicon icon={CheckCircleIcon} aria-label="Closed via commit" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Closed via commit</span>
+          <Actor />
+          {'closed this as '}
+          <Link href="#" inline>
+            completed
+          </Link>
+          {' in '}
+          <Link href="#" className={classes.CommitSha}>
+            abc1234
+          </Link>{' '}
+          <Time date="2022-07-23T11:05:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Closed via project (ProjectV2 status change). github-ui composes
+          the closer link as TableIcon + project title; there is no Primer
+          equivalent for github-ui's `ProjectV2` closer link. */}
+      <Timeline.Item>
+        <Timeline.Badge variant="done">
+          <Octicon icon={CheckCircleIcon} aria-label="Closed via project" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Closed via project</span>
+          <Actor />
+          {'closed this as '}
+          <Link href="#" inline>
+            completed
+          </Link>
+          {' by moving to Done in '}
+          <Octicon icon={TableIcon} size={16} className={classes.ProjectIcon} />
+          <Link href="#" className={classes.LinkWithBoldStyle}>
+            Roadmap
+          </Link>{' '}
+          <Time date="2022-07-22T14:20:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Closed as duplicate — neutral (gray) badge (see note above). github-ui
+          renders an `IssueLink` (state icon + title + #number + hovercard);
+          composed here from Primer primitives. */}
+      <Timeline.Item>
+        <Timeline.Badge
+          style={
+            {
+              '--timelineBadge-bgColor': 'var(--bgColor-neutral-emphasis)',
+              color: 'var(--fgColor-onEmphasis)',
+            } as React.CSSProperties
+          }
+        >
+          <Octicon icon={CircleSlashIcon} aria-label="Closed as duplicate" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Closed as duplicate</span>
+          <Actor />
+          {'closed this as a '}
+          <Link href="#" inline>
+            duplicate
+          </Link>
+          {' of '}
+          <Link href="#" className={classes.IssueLink}>
+            <Octicon icon={IssueClosedIcon} size={16} className={classes.IssueLinkIcon} />
+            <span className={classes.IssueLinkTitle}>Fix the flaky avatar test</span>{' '}
+            <span className={classes.IssueLinkNumber}>#42</span>
+          </Link>{' '}
+          <Time date="2022-07-21T08:30:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Closed with no state reason */}
+      <Timeline.Item>
+        <Timeline.Badge variant="done">
+          <Octicon icon={CheckCircleIcon} aria-label="Closed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Closed (no reason)</span>
+          <Actor />
+          {'closed this '}
+          <Time date="2022-07-20T10:00:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+    </Timeline>
+  </div>
+)
+
+/**
+ * The Issue-state event group (audit § 3).
+ *
+ * Six state-change variants. Badge icon/color verified against the live
+ * github-ui components (not the audit's icon column): Reopened maps to
+ * `useIssueState({ state: 'OPEN' })` -> `open` (green) badge; the rest are
+ * structural events with a default (muted) badge.
+ */
+export const EventState = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    <Timeline aria-label="Issue timeline">
+      {/* Reopened — open (green) badge via useIssueState (ReopenedEvent.tsx) */}
+      <Timeline.Item>
+        <Timeline.Badge variant="open">
+          <Octicon icon={IssueReopenedIcon} aria-label="Reopened" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Reopened</span>
+          <Actor />
+          {'reopened this '}
+          <Time date="2022-07-26T11:46:07Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Transferred — github-ui's TransferredEvent renders the source repo as a
+          plain inline Link (the audit shows it bold; live code is canonical). */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={LinkExternalIcon} aria-label="Transferred" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Transferred</span>
+          <Actor />
+          {'transferred this issue from '}
+          <Link href="#" inline>
+            octo-org/legacy-repo
+          </Link>{' '}
+          <Time date="2022-07-25T09:12:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Pinned */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={PinIcon} aria-label="Pinned" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Pinned</span>
+          <Actor />
+          {'pinned this issue '}
+          <Time date="2022-07-24T16:40:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Unpinned */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={PinIcon} aria-label="Unpinned" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Unpinned</span>
+          <Actor />
+          {'unpinned this issue '}
+          <Time date="2022-07-23T11:05:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Converted to discussion — github-ui's ConvertedToDiscussionEvent links
+          the resulting discussion by number. */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={CommentDiscussionIcon} aria-label="Converted to discussion" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Converted to discussion</span>
+          <Actor />
+          {'converted this issue into a discussion '}
+          <Link href="#" className={classes.LinkWithBoldStyle}>
+            #123
+          </Link>{' '}
+          <Time date="2022-07-22T14:20:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Converted from draft */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueDraftIcon} aria-label="Converted from draft" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Converted from draft</span>
+          <Actor />
+          {'converted this from a draft issue '}
+          <Time date="2022-07-21T08:30:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+    </Timeline>
+  </div>
+)
+
+/**
+ * The References event group (audit § 5).
+ *
+ * Cross-reference events. All use a default (muted) badge except where the
+ * badge icon is itself a PR state icon. The inline PR state icon mirrors
+ * github-ui's `sourceIcon('PullRequest', isDraft, isInMergeQueue)`; commit
+ * references compose a simplified `ReferencedEventInner` card.
+ */
+export const EventReferences = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    <Timeline aria-label="Issue timeline">
+      {/* Linked pull request — ConnectedEvent.tsx (CrossReferenceIcon badge,
+          open PR state icon inline before the PR title). */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={CrossReferenceIcon} aria-label="Linked pull request" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Linked pull request</span>
+          <Actor />
+          {'linked a pull request that will close this issue '}
+          <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
+          <Link href="#" className={classes.LinkWithBoldStyle}>
+            Add retry logic to the uploader
+          </Link>
+          <span className={classes.IssueLinkNumber}>#42</span> <Time date="2022-07-26T11:46:07Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Unlinked pull request — DisconnectedEvent.tsx uses the PR state icon AS
+          the badge icon (leadingIcon={PullStateIcon}), so the badge octicon is
+          green (open) on a default badge. Verified the live render path is
+          active (in TIMELINE_ITEMS[__typename], current useIssueState hook,
+          story fixture is an OPEN PR) — the Figma audit's gray cross-reference
+          icon is behind the live code here. */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={GitPullRequestIcon} className={classes.BadgeIconOpen} aria-label="Unlinked pull request" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Unlinked pull request</span>
+          <Actor />
+          {'removed a link to a pull request '}
+          <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrStateIcon} aria-label="Open" />
+          <Link href="#" className={classes.LinkWithBoldStyle}>
+            Add retry logic to the uploader
+          </Link>
+          <span className={classes.IssueLinkNumber}>#42</span> <Time date="2022-07-25T09:12:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Single commit reference — ReferencedEvent.tsx. The timestamp renders
+          inline (showAgoTimestamp={false}) and the commit card is sub-content. */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={GitCommitIcon} aria-label="Commit reference" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Single commit reference</span>
+          <Actor />
+          {'added a commit that references this issue '}
+          <Time date="2022-07-24T16:40:00Z" />
+          {/* Simplified ReferencedEventInner card (github-ui composes message +
+              verification status + abbreviated OID per commit). */}
+          <div className={classes.CommitRefBox}>
+            <div className={classes.CommitRefRow}>
+              <Link href="#" className={classes.CommitRefMessage} muted>
+                Fix flaky avatar upload retry
+              </Link>
+              <span>
+                <Label variant="success">Verified</Label>{' '}
+                <Link href="#" className={classes.CommitRefOid} muted>
+                  abc1234
+                </Link>
+              </span>
+            </div>
+          </div>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Multiple commit references — same event, pluralized copy + N cards. */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={GitCommitIcon} aria-label="Commit references" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Multiple commit references</span>
+          <Actor />
+          {'added 3 commits that reference this issue '}
+          <Time date="2022-07-23T11:05:00Z" />
+          <div className={classes.CommitRefBox}>
+            <div className={classes.CommitRefRow}>
+              <Link href="#" className={classes.CommitRefMessage} muted>
+                Fix flaky avatar upload retry
+              </Link>
+              <Link href="#" className={classes.CommitRefOid} muted>
+                abc1234
+              </Link>
+            </div>
+            <div className={classes.CommitRefRow}>
+              <Link href="#" className={classes.CommitRefMessage} muted>
+                Add regression test for retry path
+              </Link>
+              <Link href="#" className={classes.CommitRefOid} muted>
+                def5678
+              </Link>
+            </div>
+            <div className={classes.CommitRefRow}>
+              <Link href="#" className={classes.CommitRefMessage} muted>
+                Document the retry backoff
+              </Link>
+              <Link href="#" className={classes.CommitRefOid} muted>
+                9a0b1c2
+              </Link>
+            </div>
+          </div>
+        </Timeline.Body>
+      </Timeline.Item>
+    </Timeline>
+  </div>
+)
+
+/**
+ * The Duplicates event group (audit § 6).
+ *
+ * All four variants use a default (muted) `DuplicateIcon` badge. This is the
+ * first group with a right-controls case: github-ui's `MarkedAsDuplicateEvent`
+ * renders an "Undo" button via `TimelineRow.Trailing` when the viewer can undo.
+ * We map that to the `Timeline.Actions` slot (sibling of `Timeline.Body`).
+ */
+export const EventDuplicates = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    <Timeline aria-label="Issue timeline">
+      {/* Marked this as a duplicate of <canonical>. Right-controls "Undo" button
+          (viewerCanUndo) → Timeline.Actions. The canonical issue is open, so its
+          IssueLink uses the open (green) state icon. */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={DuplicateIcon} aria-label="Marked as duplicate" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Marked as duplicate</span>
+          <Actor />
+          {'marked this as a duplicate of '}
+          <Link href="#" className={classes.IssueLink}>
+            <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+            <span className={classes.IssueLinkTitle}>Upload fails on large avatars</span>{' '}
+            <span className={classes.IssueLinkNumber}>#42</span>
+          </Link>{' '}
+          <Time date="2022-07-26T11:46:07Z" />
+        </Timeline.Body>
+        <Timeline.Actions>
+          <Button size="small">Undo</Button>
+        </Timeline.Actions>
+      </Timeline.Item>
+
+      {/* Marked <canonical> as a duplicate of this issue — no right controls. */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={DuplicateIcon} aria-label="Marked as canonical" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Marked as canonical</span>
+          <Actor />
+          {'marked '}
+          <Link href="#" className={classes.IssueLink}>
+            <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+            <span className={classes.IssueLinkTitle}>Retry uploads on transient errors</span>{' '}
+            <span className={classes.IssueLinkNumber}>#43</span>
+          </Link>
+          {' as a duplicate of this issue '}
+          <Time date="2022-07-25T09:12:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Unmarked this as a duplicate of <canonical>. */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={DuplicateIcon} aria-label="Unmarked as duplicate" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Unmarked as duplicate</span>
+          <Actor />
+          {'unmarked this as a duplicate of '}
+          <Link href="#" className={classes.IssueLink}>
+            <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+            <span className={classes.IssueLinkTitle}>Upload fails on large avatars</span>{' '}
+            <span className={classes.IssueLinkNumber}>#42</span>
+          </Link>{' '}
+          <Time date="2022-07-24T16:40:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Unmarked <canonical> as a duplicate of this issue. */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={DuplicateIcon} aria-label="Unmarked as canonical" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Unmarked as canonical</span>
+          <Actor />
+          {'unmarked '}
+          <Link href="#" className={classes.IssueLink}>
+            <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+            <span className={classes.IssueLinkTitle}>Retry uploads on transient errors</span>{' '}
+            <span className={classes.IssueLinkNumber}>#43</span>
+          </Link>
+          {' as a duplicate of this issue '}
+          <Time date="2022-07-23T11:05:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+    </Timeline>
+  </div>
+)
+
+/**
+ * The Moderation event group (audit § 7).
+ *
+ * Blocks use a default `BlockedIcon` badge; comment pin/unpin use `PinIcon`.
+ * github-ui's UserBlockedEvent renders the blocked user as a bold profile link
+ * (no avatar) via `ProfileReference`.
+ */
+export const EventModeration = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    <Timeline aria-label="Issue timeline">
+      {/* User blocked (permanent) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={BlockedIcon} aria-label="User blocked" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>User blocked</span>
+          <Actor />
+          {'blocked '}
+          <Link href="#" className={classes.LinkWithBoldStyle}>
+            six7
+          </Link>{' '}
+          <Time date="2022-07-26T11:46:07Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* User temporarily blocked */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={BlockedIcon} aria-label="User temporarily blocked" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>User temporarily blocked</span>
+          <Actor />
+          {'temporarily blocked '}
+          <Link href="#" className={classes.LinkWithBoldStyle}>
+            six7
+          </Link>{' '}
+          <Time date="2022-07-25T09:12:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Comment pinned — IssueCommentPinnedEvent.tsx links the pinned comment. */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={PinIcon} aria-label="Comment pinned" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Comment pinned</span>
+          <Actor />
+          {'pinned a '}
+          <Link href="#" inline>
+            comment
+          </Link>{' '}
+          <Time date="2022-07-24T16:40:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Comment unpinned */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={PinIcon} aria-label="Comment unpinned" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Comment unpinned</span>
+          <Actor />
+          {'unpinned a '}
+          <Link href="#" inline>
+            comment
+          </Link>{' '}
+          <Time date="2022-07-23T11:05:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+    </Timeline>
+  </div>
+)
+
+/**
+ * The Issue-types event group (audit § 10).
+ *
+ * All three variants use a default `IssueOpenedIcon` badge. github-ui composes
+ * a colored `IssueTypeToken` (Primer `Token` with named-color styling) that
+ * links to the type-filtered issue list; approximated here with Primer
+ * functional color tokens.
+ */
+export const EventIssueTypes = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    <Timeline aria-label="Issue timeline">
+      {/* Type added */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueOpenedIcon} aria-label="Issue type added" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Issue type added</span>
+          <Actor />
+          {'added the '}
+          <span className={classes.TokenWrapper}>
+            <Token
+              as="a"
+              href="#"
+              text="Bug"
+              size="small"
+              style={{
+                backgroundColor: 'var(--bgColor-danger-muted)',
+                color: 'var(--fgColor-danger)',
+                borderColor: 'var(--borderColor-danger-muted)',
+              }}
+            />
+          </span>
+          {' issue type '}
+          <Time date="2022-07-26T11:46:07Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Type removed */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueOpenedIcon} aria-label="Issue type removed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Issue type removed</span>
+          <Actor />
+          {'removed the '}
+          <span className={classes.TokenWrapper}>
+            <Token
+              as="a"
+              href="#"
+              text="Bug"
+              size="small"
+              style={{
+                backgroundColor: 'var(--bgColor-danger-muted)',
+                color: 'var(--fgColor-danger)',
+                borderColor: 'var(--borderColor-danger-muted)',
+              }}
+            />
+          </span>
+          {' issue type '}
+          <Time date="2022-07-25T09:12:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Type changed */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueOpenedIcon} aria-label="Issue type changed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Issue type changed</span>
+          <Actor />
+          {'changed the issue type from '}
+          <span className={classes.TokenWrapper}>
+            <Token
+              as="a"
+              href="#"
+              text="Bug"
+              size="small"
+              style={{
+                backgroundColor: 'var(--bgColor-danger-muted)',
+                color: 'var(--fgColor-danger)',
+                borderColor: 'var(--borderColor-danger-muted)',
+              }}
+            />
+          </span>
+          {' to '}
+          <span className={classes.TokenWrapper}>
+            <Token
+              as="a"
+              href="#"
+              text="Feature"
+              size="small"
+              style={{
+                backgroundColor: 'var(--bgColor-accent-muted)',
+                color: 'var(--fgColor-accent)',
+                borderColor: 'var(--borderColor-accent-muted)',
+              }}
+            />
+          </span>{' '}
+          <Time date="2022-07-24T16:40:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+    </Timeline>
+  </div>
+)
+
+/**
+ * The Issue-hierarchy event group (audit § 8).
+ *
+ * Sub-issue events use `IssueTracksIcon`; parent-issue events use
+ * `IssueTrackedByIcon`. All default (muted) badge. github-ui renders the
+ * linked issues in a bordered list (`TimelineRow.Secondary`) below the copy.
+ *
+ * SINGLE vs MULTIPLE: live code branches on `itemsToRender.length` — the
+ * leading copy switches singular/plural ("added a sub-issue" -> "added
+ * sub-issues") AND the secondary list grows from 1 to N `IssueLink` rows.
+ * (SubIssueAddedEvent.tsx: `LABELS.timeline.subIssueAdded[length === 1 ?
+ * 'single' : 'multiple']` + `itemsToRender.map(...)`.)
+ */
+export const EventIssueHierarchy = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    <Timeline aria-label="Issue timeline">
+      {/* Sub-issue added (single) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueTracksIcon} aria-label="Sub-issue added" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Sub-issue added (single)</span>
+          <Actor />
+          {'added a sub-issue '}
+          <Time date="2022-07-26T11:46:07Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
+                <span className={classes.IssueLinkNumber}>#42</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Sub-issue added (multiple) — plural copy + N reference rows */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueTracksIcon} aria-label="Sub-issues added" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Sub-issues added (multiple)</span>
+          <Actor />
+          {'added sub-issues '}
+          <Time date="2022-07-25T09:12:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
+                <span className={classes.IssueLinkNumber}>#42</span>
+              </Link>
+            </li>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueClosedIcon} size={16} className={classes.IssueLinkIcon} />
+                <span className={classes.IssueLinkTitle}>Document the retry backoff</span>{' '}
+                <span className={classes.IssueLinkNumber}>#43</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Sub-issue removed (single) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueTracksIcon} aria-label="Sub-issue removed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Sub-issue removed (single)</span>
+          <Actor />
+          {'removed a sub-issue '}
+          <Time date="2022-07-24T16:40:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
+                <span className={classes.IssueLinkNumber}>#42</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Sub-issues removed (multiple) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueTracksIcon} aria-label="Sub-issues removed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Sub-issues removed (multiple)</span>
+          <Actor />
+          {'removed sub-issues '}
+          <Time date="2022-07-23T11:05:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Add retry logic to the uploader</span>{' '}
+                <span className={classes.IssueLinkNumber}>#42</span>
+              </Link>
+            </li>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueClosedIcon} size={16} className={classes.IssueLinkIcon} />
+                <span className={classes.IssueLinkTitle}>Document the retry backoff</span>{' '}
+                <span className={classes.IssueLinkNumber}>#43</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Parent issue added (single) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueTrackedByIcon} aria-label="Parent issue added" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Parent issue added (single)</span>
+          <Actor />
+          {'added a parent issue '}
+          <Time date="2022-07-22T14:20:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
+                <span className={classes.IssueLinkNumber}>#7</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Parent issues added (multiple) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueTrackedByIcon} aria-label="Parent issues added" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Parent issues added (multiple)</span>
+          <Actor />
+          {'added parent issues '}
+          <Time date="2022-07-21T08:30:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
+                <span className={classes.IssueLinkNumber}>#7</span>
+              </Link>
+            </li>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Q3 reliability tracker</span>{' '}
+                <span className={classes.IssueLinkNumber}>#8</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Parent issue removed (single) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueTrackedByIcon} aria-label="Parent issue removed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Parent issue removed (single)</span>
+          <Actor />
+          {'removed a parent issue '}
+          <Time date="2022-07-20T10:00:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
+                <span className={classes.IssueLinkNumber}>#7</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Parent issues removed (multiple) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={IssueTrackedByIcon} aria-label="Parent issues removed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Parent issues removed (multiple)</span>
+          <Actor />
+          {'removed parent issues '}
+          <Time date="2022-07-19T13:15:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Epic: reliable avatar uploads</span>{' '}
+                <span className={classes.IssueLinkNumber}>#7</span>
+              </Link>
+            </li>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Q3 reliability tracker</span>{' '}
+                <span className={classes.IssueLinkNumber}>#8</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+    </Timeline>
+  </div>
+)
+
+/**
+ * The Dependencies event group (audit § 9).
+ *
+ * Blocked-by and blocking events both use `BlockedIcon` (default badge). The
+ * dependent issues render in a bordered secondary list, like the hierarchy
+ * group.
+ *
+ * SINGLE vs MULTIPLE: live code branches on `itemsToRender.length`. Singular
+ * copy has no count ("marked this as blocked"); plural copy adds a count
+ * ("marked this as blocked by 2 issues") via `LABELS.timeline.blockedByAdded
+ * .multiple(count)`, and the secondary list grows from 1 to N rows.
+ */
+export const EventDependencies = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    <Timeline aria-label="Issue timeline">
+      {/* Blocked by (single) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={BlockedIcon} aria-label="Marked as blocked" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Blocked by (single)</span>
+          <Actor />
+          {'marked this as blocked '}
+          <Time date="2022-07-26T11:46:07Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
+                <span className={classes.IssueLinkNumber}>#51</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Blocked by (multiple) — count in copy + N rows */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={BlockedIcon} aria-label="Marked as blocked by multiple issues" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Blocked by (multiple)</span>
+          <Actor />
+          {'marked this as blocked by 2 issues '}
+          <Time date="2022-07-25T09:12:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
+                <span className={classes.IssueLinkNumber}>#51</span>
+              </Link>
+            </li>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Add multipart upload support</span>{' '}
+                <span className={classes.IssueLinkNumber}>#52</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Blocked by removed (single) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={BlockedIcon} aria-label="Unmarked as blocked" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Blocked by removed (single)</span>
+          <Actor />
+          {'unmarked this as blocked '}
+          <Time date="2022-07-24T16:40:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
+                <span className={classes.IssueLinkNumber}>#51</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Blocked by removed (multiple) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={BlockedIcon} aria-label="Unmarked as blocked by multiple issues" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Blocked by removed (multiple)</span>
+          <Actor />
+          {'unmarked this as blocked by 2 issues '}
+          <Time date="2022-07-23T11:05:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Upgrade the storage client</span>{' '}
+                <span className={classes.IssueLinkNumber}>#51</span>
+              </Link>
+            </li>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Add multipart upload support</span>{' '}
+                <span className={classes.IssueLinkNumber}>#52</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Blocking (single) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={BlockedIcon} aria-label="Marked as blocking" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Blocking (single)</span>
+          <Actor />
+          {'marked this as blocking '}
+          <Time date="2022-07-22T14:20:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
+                <span className={classes.IssueLinkNumber}>#60</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Blocking (multiple) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={BlockedIcon} aria-label="Marked as blocking multiple issues" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Blocking (multiple)</span>
+          <Actor />
+          {'marked this as blocking 2 issues '}
+          <Time date="2022-07-21T08:30:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
+                <span className={classes.IssueLinkNumber}>#60</span>
+              </Link>
+            </li>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Roll out to mobile clients</span>{' '}
+                <span className={classes.IssueLinkNumber}>#61</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Blocking removed (single) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={BlockedIcon} aria-label="Unmarked as blocking" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Blocking removed (single)</span>
+          <Actor />
+          {'unmarked this as blocking '}
+          <Time date="2022-07-20T10:00:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
+                <span className={classes.IssueLinkNumber}>#60</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Blocking removed (multiple) */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={BlockedIcon} aria-label="Unmarked as blocking multiple issues" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Blocking removed (multiple)</span>
+          <Actor />
+          {'unmarked this as blocking 2 issues '}
+          <Time date="2022-07-19T13:15:00Z" />
+          <ul className={classes.RefList}>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Ship the avatar uploader</span>{' '}
+                <span className={classes.IssueLinkNumber}>#60</span>
+              </Link>
+            </li>
+            <li className={classes.RefListItem}>
+              <Link href="#" className={classes.IssueLink}>
+                <Octicon icon={IssueOpenedIcon} size={16} className={classes.IssueLinkIconOpen} />
+                <span className={classes.IssueLinkTitle}>Roll out to mobile clients</span>{' '}
+                <span className={classes.IssueLinkNumber}>#61</span>
+              </Link>
+            </li>
+          </ul>
+        </Timeline.Body>
+      </Timeline.Item>
+    </Timeline>
+  </div>
+)
+
+/**
+ * The Issue-fields event group (audit § 11).
+ *
+ * Custom issue-field updates. The badge icon is per field TYPE, resolved by
+ * github-ui's `getFieldTypeOcticon`: text -> `TypographyIcon`, number ->
+ * `NumberIcon`, date -> `CalendarIcon`, single-select -> `SingleSelectIcon`.
+ * All default (muted) badge. Copy: set -> "set {field} to {value}", changed ->
+ * "changed {field} to {value}", cleared -> "cleared {field}" (no value).
+ * Single-select values render as a colored token; date as a formatted date.
+ *
+ * The final three variants are ROLLUPS (`RolledupIssueFieldEvent`): multiple
+ * field updates collapse into one row — "updated {…}", "removed {…}", or both
+ * joined by "and also". Rollup rows use the default-type (`TypographyIcon`)
+ * badge. (Audit notes the IssueField rollup window is 1 hour; fixtures model
+ * only the rendered variants, not the timing.)
+ */
+export const EventIssueFields = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    <Timeline aria-label="Issue timeline">
+      {/* Set text field */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={TypographyIcon} aria-label="Text field set" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Set · text</span>
+          <Actor />
+          {'set '}
+          <span className={classes.FieldName}>Team</span>
+          {' to '}
+          <Link href="#" inline className={classes.FieldValue}>
+            Identity
+          </Link>{' '}
+          <Time date="2022-07-26T11:46:07Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Set number field */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={NumberIcon} aria-label="Number field set" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Set · number</span>
+          <Actor />
+          {'set '}
+          <span className={classes.FieldName}>Story Points</span>
+          {' to '}
+          <Link href="#" inline className={classes.FieldValue}>
+            5
+          </Link>{' '}
+          <Time date="2022-07-25T15:30:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Set date field */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={CalendarIcon} aria-label="Date field set" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Set · date</span>
+          <Actor />
+          {'set '}
+          <span className={classes.FieldName}>Target Date</span>
+          {' to '}
+          <Link href="#" inline className={classes.FieldValue}>
+            Aug 1, 2022
+          </Link>{' '}
+          <Time date="2022-07-25T09:12:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Set single-select field — value is a colored token */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={SingleSelectIcon} aria-label="Single select field set" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Set · single select</span>
+          <Actor />
+          {'set '}
+          <span className={classes.FieldName}>Priority</span>
+          {' to '}
+          {/* github-ui renders an `IssueFieldSingleSelectValueToken` (colored
+              Primer Token) for select values; approximated with functional
+              color tokens. */}
+          <span className={classes.TokenWrapper}>
+            <Token
+              as="a"
+              href="#"
+              text="High"
+              size="small"
+              style={{
+                backgroundColor: 'var(--bgColor-danger-muted)',
+                color: 'var(--fgColor-danger)',
+                borderColor: 'var(--borderColor-danger-muted)',
+              }}
+            />
+          </span>{' '}
+          <Time date="2022-07-24T16:40:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Changed text field */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={TypographyIcon} aria-label="Text field changed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Changed · text</span>
+          <Actor />
+          {'changed '}
+          <span className={classes.FieldName}>Team</span>
+          {' to '}
+          <Link href="#" inline className={classes.FieldValue}>
+            Platform
+          </Link>{' '}
+          <Time date="2022-07-23T11:05:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Changed number field */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={NumberIcon} aria-label="Number field changed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Changed · number</span>
+          <Actor />
+          {'changed '}
+          <span className={classes.FieldName}>Story Points</span>
+          {' to '}
+          <Link href="#" inline className={classes.FieldValue}>
+            8
+          </Link>{' '}
+          <Time date="2022-07-22T14:20:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Changed date field */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={CalendarIcon} aria-label="Date field changed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Changed · date</span>
+          <Actor />
+          {'changed '}
+          <span className={classes.FieldName}>Target Date</span>
+          {' to '}
+          <Link href="#" inline className={classes.FieldValue}>
+            Aug 15, 2022
+          </Link>{' '}
+          <Time date="2022-07-21T08:30:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Changed single-select field */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={SingleSelectIcon} aria-label="Single select field changed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Changed · single select</span>
+          <Actor />
+          {'changed '}
+          <span className={classes.FieldName}>Priority</span>
+          {' to '}
+          <span className={classes.TokenWrapper}>
+            <Token
+              as="a"
+              href="#"
+              text="Low"
+              size="small"
+              style={{
+                backgroundColor: 'var(--bgColor-success-muted)',
+                color: 'var(--fgColor-success)',
+                borderColor: 'var(--borderColor-success-muted)',
+              }}
+            />
+          </span>{' '}
+          <Time date="2022-07-20T10:00:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Cleared text field — no value */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={TypographyIcon} aria-label="Text field cleared" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Cleared · text</span>
+          <Actor />
+          {'cleared '}
+          <span className={classes.FieldName}>Team</span> <Time date="2022-07-19T13:15:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Cleared number field */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={NumberIcon} aria-label="Number field cleared" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Cleared · number</span>
+          <Actor />
+          {'cleared '}
+          <span className={classes.FieldName}>Story Points</span> <Time date="2022-07-18T09:00:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Cleared date field */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={CalendarIcon} aria-label="Date field cleared" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Cleared · date</span>
+          <Actor />
+          {'cleared '}
+          <span className={classes.FieldName}>Target Date</span> <Time date="2022-07-17T12:00:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Cleared single-select field */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={SingleSelectIcon} aria-label="Single select field cleared" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Cleared · single select</span>
+          <Actor />
+          {'cleared '}
+          <span className={classes.FieldName}>Priority</span> <Time date="2022-07-16T08:30:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Rollup: updated only — multiple field updates collapsed into one row */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={TypographyIcon} aria-label="Fields updated" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Rollup · updated</span>
+          <Actor />
+          {'updated '}
+          <span className={classes.FieldName}>Team</span>
+          <Link href="#" inline className={classes.FieldValue}>
+            Platform
+          </Link>
+          {' and '}
+          <span className={classes.FieldName}>Story Points</span>
+          <Link href="#" inline className={classes.FieldValue}>
+            8
+          </Link>{' '}
+          <Time date="2022-07-15T10:00:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Rollup: removed only */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={TypographyIcon} aria-label="Fields removed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Rollup · removed</span>
+          <Actor />
+          {'removed '}
+          <span className={classes.FieldName}>Team</span>
+          {' and '}
+          <span className={classes.FieldName}>Priority</span> <Time date="2022-07-14T10:00:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+
+      {/* Rollup: updated and also removed — combined row joined by "and also" */}
+      <Timeline.Item>
+        <Timeline.Badge>
+          <Octicon icon={TypographyIcon} aria-label="Fields updated and removed" />
+        </Timeline.Badge>
+        <Timeline.Body>
+          <span className={classes.VariantLabel}>Rollup · updated and removed</span>
+          <Actor />
+          {'updated '}
+          <span className={classes.FieldName}>Team</span>
+          <Link href="#" inline className={classes.FieldValue}>
+            Platform
+          </Link>
+          {', and also removed '}
+          <span className={classes.FieldName}>Priority</span> <Time date="2022-07-13T10:00:00Z" />
+        </Timeline.Body>
+      </Timeline.Item>
+    </Timeline>
+  </div>
+)

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -1785,3 +1785,120 @@ export const EventIssueFields = () => (
     </section>
   </div>
 )
+
+/**
+ * The Project event group — shared timeline events (ProjectV2), Issue version.
+ *
+ * Sourced from the live React `timeline-items` components, which are the ISSUE
+ * implementation of these "shared" events: `AddedToProjectV2Event.tsx`,
+ * `RemovedFromProjectV2Event.tsx`, `ProjectV2ItemStatusChangedEvent.tsx`, and
+ * the shared `ProjectV2.tsx` sub-component. All three use a `TableIcon` badge.
+ *
+ * Issue-version `{ProjectV2}` reference (live `ProjectV2.tsx`): an inline
+ * default-colored `TableIcon` octicon, then a `<Link inline>` with REGULAR
+ * weight and `color: var(--fgColor-default)` (NOT bold, NOT accent-blue). The
+ * `inline` prop supplies the always-on underline. Status text is PLAIN TEXT
+ * (live `ProjectV2ItemStatusChangedEvent.tsx` renders `status`/`previousStatus`
+ * as bare strings, not bold).
+ *
+ * PR-SURFACE DIVERGENCE (build the PR version from ERB later, NOT from this):
+ * The PR (ERB) path renders these events DIFFERENTLY —
+ *   - Project link: `app/views/issues/events/_memex_project_link.html.erb` uses
+ *     `<a class="Link--primary text-bold">` — i.e. a BOLD project name, NO inline
+ *     `TableIcon`, and hover-only underline.
+ *   - Status: `_project_item_status_changed_event.html.erb` wraps the status in
+ *     `<strong>` (BOLD).
+ * So: Issue = inline icon + regular-weight always-underlined link + plain-text
+ * status; PR = bold link, no icon, bold status. Whoever builds the PR surface
+ * must use the ERB spec above, not this Issue composition.
+ */
+export const EventProject = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Added to project */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Added to project</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TableIcon} aria-label="Added to project" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'added this to '}
+            {/* Issue-version ProjectV2 reference (github-ui `ProjectV2.tsx`). */}
+            <Octicon icon={TableIcon} size={16} className={classes.ProjectRefIcon} />
+            <Link href="#" inline className={classes.ProjectRefLink}>
+              Roadmap
+            </Link>{' '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Removed from project */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Removed from project</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TableIcon} aria-label="Removed from project" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'removed this from '}
+            <Octicon icon={TableIcon} size={16} className={classes.ProjectRefIcon} />
+            <Link href="#" inline className={classes.ProjectRefLink}>
+              Roadmap
+            </Link>{' '}
+            <Time date="2022-07-25T09:12:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Project status changed. Two forms per live
+        `ProjectV2ItemStatusChangedEvent.tsx`: with no previous status,
+        "moved this to {status} in {project}"; with a previous status,
+        "moved this from {previousStatus} to {status} in {project}". Status
+        strings are PLAIN TEXT (not bold). Both forms shown under one caption. */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Project status changed</h3>
+      <Timeline aria-label="Issue timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TableIcon} aria-label="Project status changed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'moved this to In Progress in '}
+            <Octicon icon={TableIcon} size={16} className={classes.ProjectRefIcon} />
+            <Link href="#" inline className={classes.ProjectRefLink}>
+              Roadmap
+            </Link>{' '}
+            <Time date="2022-07-24T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={TableIcon} aria-label="Project status changed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <Actor />
+            {'moved this from Todo to In Progress in '}
+            <Octicon icon={TableIcon} size={16} className={classes.ProjectRefIcon} />
+            <Link href="#" inline className={classes.ProjectRefLink}>
+              Roadmap
+            </Link>{' '}
+            <Time date="2022-07-24T16:42:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)


### PR DESCRIPTION
## Summary

Adds Storybook **Features** stories that recreate GitHub's live **Issue timeline events** using the Primer React `Timeline` component and its compositional slots. This is the **Issues surface** of Phase 2 of the Timeline events effort (github/primer#6663). The Pull Request, Shared, and Dependabot surfaces follow separately (Dependabot is in #8071).

The Issue examples live in `Timeline.issues.features.stories.tsx` (+ a `.module.css`), exported under the title **`Components/Timeline/Events/Issues`** — one story export per event group.

This surface uses the shared `UserActor` helper, which lives in `Timeline/internal/timelineStoryHelpers.tsx`. `UserActor` had been copy-pasted across every event surface; it composes the shared `InlineAvatar` + name primitives and takes props for the small per-surface differences (avatar size, link vs plain text, muted vs default color, and an `icon` for system actors like scanning's "GitHub"). **The shared helper now lives in its own PR (#8140)**, so this PR no longer hosts it and doesn't gate the others — once #8140 merges, this PR (and the other surfaces) simply import from it. (A local copy of `UserActor` is present here until #8140 lands, then removed on rebase.)

The file covers **17 event groups / 81 variants total**, split into the Issue-only events and the Issue versions of the shared events (shared events nest per-surface; their PR/Dependabot versions are built separately later).

### Issue-only events (9 groups, 59 variants)

| Group | Story export | Variants |
| --- | --- | --- |
| Closed | `EventClosed` | 7 |
| State | `EventState` | 6 |
| References | `EventReferences` | 4 |
| Duplicates | `EventDuplicates` | 4 |
| Moderation | `EventModeration` | 4 |
| Issue Types | `EventIssueTypes` | 3 |
| Issue Hierarchy | `EventIssueHierarchy` | 8 |
| Dependencies | `EventDependencies` | 8 |
| Issue Fields | `EventIssueFields` | 15 |

### Shared events — Issue versions (8 groups, 22 variants)

| Group | Story export | Variants |
| --- | --- | --- |
| Project | `EventProject` | 3 |
| Labels | `EventLabels` | 3 |
| Title | `EventTitle` | 1 |
| Milestones | `EventMilestones` | 2 |
| Assignments | `EventAssignments` | 6 |
| Lock / Unlock | `EventLockUnlock` | 3 |
| Comment deleted | `EventCommentDeleted` | 1 |
| Cross-references | `EventCrossReferences` | 3 |

Shared events are a shared *concept*, not shared code: the `github-ui` React `timeline-items` components are the **Issue** implementation, while the PR timeline renders the same events through a separate ERB path. Each shared group is built here from the React Issue components, and where the PR (ERB) render diverges (e.g. the Project link styling, the Assignments actor component) that divergence is documented in an inline comment so the future PR/Dependabot surface inherits the spec.

## Source of truth

Each event was recreated from the **live `github-ui` React implementation** (`packages/timeline-items`) as the canonical source, cross-checked against the Figma timeline audit and verified visually against the Figma components. Where the audit and live code disagreed — for example the Closed-event badge icons (`CheckCircle`/`CircleSlash`, not the audit's `IssueClosed`/`Skip`), the Unlinked-PR badge icon, the renamed-title copy (live has no "from"/"to" words), and the Unlocked badge icon (`UnlockIcon`, not `LockIcon`) — **live code won**. In each case we confirmed the live render path is actually reached (present in the timeline item map, not feature-flagged-off or superseded by a newer component) before trusting it.

## Slots used (Phase 1 slots)

- **Inline actor avatar** in `Timeline.Body` — a 20px avatar + bold link, matching how the live `github-ui` events render the actor. These badge-row events deliberately do **not** use the `Timeline.Avatar` gutter slot (github/primer#6677); that 40px gutter slot is reserved for comment-style events, which aren't part of this Issue-only set.
- **`Timeline.Actions`** (right-controls slot, github/primer#6678) for the Duplicates **"Undo"** button — the only right-aligned control in the Issue event set. Everything else (inline commit SHAs, PR-state icons, `#numbers`) is part of the sentence body text in the live render, so it correctly stays **inline in `Timeline.Body`**, not in `Timeline.Actions`.

## Scope & conventions

- Every story is wrapped in a file-scoped `FeatureFlags` decorator enabling `primer_react_timeline_list_semantics` (the future-state `<ol>`/`<li>` DOM, so the stories won't need re-authoring when that flag becomes the default; refs primer/react#7910).
- **Storybook-only by design.** These are intentionally **not** wired into components-json / the primer.style docs page (not added to `Timeline.docs.json` or `build.ts`) — individual timeline events are not consumer-facing components, and the primer.style Timeline page reflects the base `Timeline` component's own stories. Any docs-site representation is a Phase 3 consideration.
- The future event-category `data-*` filtering taxonomy (github/primer#6663) is intentionally **deferred**; a single documented hook location in the file header marks where it'll attach per `Timeline.Item`.

### Changelog

#### New

- `Timeline.issues.features.stories.tsx` and `Timeline.issues.features.stories.module.css` — Storybook Features stories recreating the Issue timeline events (17 groups, 81 variants).
- Uses the shared `UserActor` helper from #8140 (a local copy is present until #8140 merges, then removed on rebase).

#### Changed

- None.

#### Removed

- None.

### Rollout strategy

- [x] None; if selected, include a brief description as to why

Stories-only change — no consumer-facing package code is added or modified, so no changeset is needed (the `skip changeset` label is applied).

### Testing & Reviewing

- prettier, eslint, and stylelint all clean; type-check passes with 0 new errors (the pre-existing `@primer/doc-gen` baseline error in `script/components-json/build.ts` is unchanged).
- The 9 Issue-only groups were visually diffed against the Figma source; where Figma or the audit disagreed with live code, the **live render won**. The 8 shared groups were sourced directly from the live `github-ui` React Issue components.
- Browse the stories under **Components/Timeline/Events/Issues** in Storybook to review each group.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui


