### PR TITLE
Timeline: add Dependabot event stories (Phase 2)

### DIFF
--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
@@ -1,61 +1,9 @@
-.RealisticTimeline {
-  /* GitHub renders the timeline at most 1012px wide in product surfaces. */
-  max-width: 1012px;
-}
-
-/* Story-only scaffolding: each variant is wrapped in its own <section> with a
-   small caption heading ABOVE the event, so the event row itself (badge +
-   inline avatar + body) renders exactly as it would in product — the caption
-   never sits inside Timeline.Body. Variants stay scannable like a Figma
-   component set. Not part of the faithful event. */
-.Variant {
-  margin-bottom: var(--base-size-24);
-}
-
-.VariantLabel {
-  margin: 0 0 var(--base-size-4);
-  font-size: var(--text-body-size-small);
-  font-weight: var(--base-text-weight-semibold);
-  color: var(--fgColor-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-/* Inline 20px-ish actor avatar in the body. The Dependabot actor renders a
-   SQUARE avatar (live ERB `ActorComponent` uses `GitHub::AvatarComponent` with
-   `is_user: false` → square, the bundled `dependabot-icon.png`). */
-.InlineAvatar {
-  vertical-align: middle;
-  margin-right: var(--base-size-4);
-}
-
-/* Bold actor / reference link: live ERB renders these via
-   `Primer::Beta::Link.new(scheme: :primary, font_weight: :bold)` — semibold,
-   default foreground, accent on hover. Used for the bold `dependabot` actor
-   link and the bold `#123` pull-request link. */
-.LinkWithBoldStyle {
-  font-weight: var(--base-text-weight-semibold);
-  color: var(--fgColor-default);
-  margin-right: var(--base-size-4);
-}
-
-.LinkWithBoldStyle:hover {
-  color: var(--fgColor-accent);
-}
-
 /* `(bot)` identifier tag. Live ERB `bot_identifier_tag` renders
    `<span class="Label Label--secondary">bot</span>`; mirrored here with Primer
    `Label variant="secondary"`. This class only adds inline spacing. */
 .BotLabel {
   margin: 0 var(--base-size-4) 0 0;
   vertical-align: middle;
-}
-
-/* Muted relative timestamp. Unlike the Issues timeline (whose `Ago` renders a
-   muted UNDERLINED deep-link), the Dependabot ERB renders a plain
-   `Primer::Beta::RelativeTime` with no link wrapper — muted text only. */
-.Timestamp {
-  color: var(--fgColor-muted);
 }
 
 /* Push-pill: the `(push-pill: SHA)` SUBTLE light-blue rounded pill from

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
@@ -102,3 +102,26 @@
   margin-right: var(--base-size-4);
   color: var(--fgColor-muted);
 }
+
+/* Colored badge icons for the Dismissal Request / Review / Cancelled events.
+   Their live ERB renders `with_badge(color: :X, icon: …)` with NO `bg:` — in
+   Primer `color:` tints the ICON on the DEFAULT badge background (it is NOT a
+   solid-color badge). So these render as a bare `<Timeline.Badge>` (default gray
+   circle) with the icon color set here, mirroring the Dismissed muted icon. */
+.BadgeIconAttention {
+  color: var(--fgColor-attention);
+}
+
+.BadgeIconSuccess {
+  color: var(--fgColor-success);
+}
+
+.BadgeIconDanger {
+  color: var(--fgColor-danger);
+}
+
+/* `:subtle` icon color. Primer has no `--fgColor-subtle` token, so the closest
+   functional equivalent for the Dismissal Cancelled `color: :subtle` is muted. */
+.BadgeIconMuted {
+  color: var(--fgColor-muted);
+}

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
@@ -58,10 +58,15 @@
   color: var(--fgColor-muted);
 }
 
-/* Push-pill: the `(push-pill: SHA)` blue rounded pill from `PushLinkComponent`
-   (`<code>` wrapping `Primer::Beta::Link` with `bg: :accent, px: 2, py: 1,
-   border_radius: 3`). Primer `Link`'s own color rule is `:where(.Link)` (zero
-   specificity), so this CSS-module class fully drives the pill appearance. */
+/* Push-pill: the `(push-pill: SHA)` SUBTLE light-blue rounded pill from
+   `PushLinkComponent` (`<code>` wrapping `Primer::Beta::Link` with
+   `bg: :accent, px: 2, py: 1, border_radius: 3`). In primer/view_components
+   `bg: :accent` resolves to `.color-bg-accent` = the SUBTLE/MUTED light-blue
+   background (`--color-accent-subtle`), NOT the solid emphasis blue — so the
+   text stays accent-blue (the Link's default color), not white. This is the
+   standard GitHub SHA push-pill look. Primer `Link`'s own color rule is
+   `:where(.Link)` (zero specificity), so this CSS-module class fully drives the
+   pill appearance. */
 .PushPill {
   /* The wrapping <code> element — no own box, the inner link is the pill. */
   font-family: var(--fontStack-monospace);
@@ -71,8 +76,8 @@
   display: inline-block;
   font-family: var(--fontStack-monospace);
   font-size: var(--text-body-size-small);
-  color: var(--fgColor-onEmphasis);
-  background-color: var(--bgColor-accent-emphasis);
+  color: var(--fgColor-accent);
+  background-color: var(--bgColor-accent-muted);
   padding: var(--base-size-2) var(--base-size-4);
   border-radius: var(--borderRadius-medium);
   text-decoration: none;
@@ -80,4 +85,59 @@
 
 .PushPillLink:hover {
   text-decoration: none;
+}
+
+/* Plain bold actor (no avatar, no link) for the delegated-closures Dismissal
+   Request / Reviewed events, whose live `*.html.erb` renders the actor as
+   `<strong><span>{login}</span></strong>`. */
+.PlainActor {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+  margin-right: var(--base-size-4);
+}
+
+/* Muted inline copy — e.g. "requested dismissal" / "approved dismissal request"
+   verb phrases that the ERB wraps in `color-fg-muted`. */
+.Muted {
+  color: var(--fgColor-muted);
+}
+
+/* Second line of the Dismissal Requested event: muted "Dismiss as: {resolution}"
+   (`mt-1` in the ERB). */
+.ResolutionLine {
+  margin-top: var(--base-size-4);
+  color: var(--fgColor-muted);
+}
+
+/* Optional dismissal/auto sub-content row. Live ERB renders a
+   `<div class="TimelineItem tmp-pl-5 pt-0 f6 d-block">` (small, indented block
+   below the event) holding a `note` octicon + the comment text. */
+.NoteComment {
+  margin-top: var(--base-size-8);
+  padding-left: var(--base-size-4);
+  font-size: var(--text-body-size-small);
+  color: var(--fgColor-muted);
+}
+
+.NoteIcon {
+  vertical-align: middle;
+  margin-right: var(--base-size-4);
+  color: var(--fgColor-muted);
+}
+
+/* Dismissal Reviewed (Approved / Denied) optional review comment. Live ERB
+   renders a bordered subtle box (`mt-2 p-2 border rounded-2 color-bg-subtle`)
+   with a "Review comment:" label and a `markdown-body` body. */
+.ReviewCommentBox {
+  margin-top: var(--base-size-8);
+  padding: var(--base-size-8);
+  border: var(--borderWidth-thin) solid var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+  background-color: var(--bgColor-muted);
+  font-size: var(--text-body-size-small);
+}
+
+.ReviewCommentLabel {
+  margin-bottom: var(--base-size-4);
+  color: var(--fgColor-muted);
 }

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
@@ -1,0 +1,83 @@
+.RealisticTimeline {
+  /* GitHub renders the timeline at most 1012px wide in product surfaces. */
+  max-width: 1012px;
+}
+
+/* Story-only scaffolding: each variant is wrapped in its own <section> with a
+   small caption heading ABOVE the event, so the event row itself (badge +
+   inline avatar + body) renders exactly as it would in product — the caption
+   never sits inside Timeline.Body. Variants stay scannable like a Figma
+   component set. Not part of the faithful event. */
+.Variant {
+  margin-bottom: var(--base-size-24);
+}
+
+.VariantLabel {
+  margin: 0 0 var(--base-size-4);
+  font-size: var(--text-body-size-small);
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Inline 20px-ish actor avatar in the body. The Dependabot actor renders a
+   SQUARE avatar (live ERB `ActorComponent` uses `GitHub::AvatarComponent` with
+   `is_user: false` → square, the bundled `dependabot-icon.png`). */
+.InlineAvatar {
+  vertical-align: middle;
+  margin-right: var(--base-size-4);
+}
+
+/* Bold actor / reference link: live ERB renders these via
+   `Primer::Beta::Link.new(scheme: :primary, font_weight: :bold)` — semibold,
+   default foreground, accent on hover. Used for the bold `dependabot` actor
+   link and the bold `#123` pull-request link. */
+.LinkWithBoldStyle {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+  margin-right: var(--base-size-4);
+}
+
+.LinkWithBoldStyle:hover {
+  color: var(--fgColor-accent);
+}
+
+/* `(bot)` identifier tag. Live ERB `bot_identifier_tag` renders
+   `<span class="Label Label--secondary">bot</span>`; mirrored here with Primer
+   `Label variant="secondary"`. This class only adds inline spacing. */
+.BotLabel {
+  margin: 0 var(--base-size-4) 0 0;
+  vertical-align: middle;
+}
+
+/* Muted relative timestamp. Unlike the Issues timeline (whose `Ago` renders a
+   muted UNDERLINED deep-link), the Dependabot ERB renders a plain
+   `Primer::Beta::RelativeTime` with no link wrapper — muted text only. */
+.Timestamp {
+  color: var(--fgColor-muted);
+}
+
+/* Push-pill: the `(push-pill: SHA)` blue rounded pill from `PushLinkComponent`
+   (`<code>` wrapping `Primer::Beta::Link` with `bg: :accent, px: 2, py: 1,
+   border_radius: 3`). Primer `Link`'s own color rule is `:where(.Link)` (zero
+   specificity), so this CSS-module class fully drives the pill appearance. */
+.PushPill {
+  /* The wrapping <code> element — no own box, the inner link is the pill. */
+  font-family: var(--fontStack-monospace);
+}
+
+.PushPillLink {
+  display: inline-block;
+  font-family: var(--fontStack-monospace);
+  font-size: var(--text-body-size-small);
+  color: var(--fgColor-onEmphasis);
+  background-color: var(--bgColor-accent-emphasis);
+  padding: var(--base-size-2) var(--base-size-4);
+  border-radius: var(--borderRadius-medium);
+  text-decoration: none;
+}
+
+.PushPillLink:hover {
+  text-decoration: none;
+}

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
@@ -87,28 +87,6 @@
   text-decoration: none;
 }
 
-/* Plain bold actor (no avatar, no link) for the delegated-closures Dismissal
-   Request / Reviewed events, whose live `*.html.erb` renders the actor as
-   `<strong><span>{login}</span></strong>`. */
-.PlainActor {
-  font-weight: var(--base-text-weight-semibold);
-  color: var(--fgColor-default);
-  margin-right: var(--base-size-4);
-}
-
-/* Muted inline copy — e.g. "requested dismissal" / "approved dismissal request"
-   verb phrases that the ERB wraps in `color-fg-muted`. */
-.Muted {
-  color: var(--fgColor-muted);
-}
-
-/* Second line of the Dismissal Requested event: muted "Dismiss as: {resolution}"
-   (`mt-1` in the ERB). */
-.ResolutionLine {
-  margin-top: var(--base-size-4);
-  color: var(--fgColor-muted);
-}
-
 /* Optional dismissal/auto sub-content row. Live ERB renders a
    `<div class="TimelineItem tmp-pl-5 pt-0 f6 d-block">` (small, indented block
    below the event) holding a `note` octicon + the comment text. */
@@ -122,22 +100,5 @@
 .NoteIcon {
   vertical-align: middle;
   margin-right: var(--base-size-4);
-  color: var(--fgColor-muted);
-}
-
-/* Dismissal Reviewed (Approved / Denied) optional review comment. Live ERB
-   renders a bordered subtle box (`mt-2 p-2 border rounded-2 color-bg-subtle`)
-   with a "Review comment:" label and a `markdown-body` body. */
-.ReviewCommentBox {
-  margin-top: var(--base-size-8);
-  padding: var(--base-size-8);
-  border: var(--borderWidth-thin) solid var(--borderColor-default);
-  border-radius: var(--borderRadius-medium);
-  background-color: var(--bgColor-muted);
-  font-size: var(--text-body-size-small);
-}
-
-.ReviewCommentLabel {
-  margin-bottom: var(--base-size-4);
   color: var(--fgColor-muted);
 }

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
@@ -604,15 +604,18 @@ export const EventReopened = () => (
  * `*.html.erb` sidecar is dead code left in the tree. So every variant here
  * renders the actor via `ActorComponent` (a USER → circle avatar + bold link,
  * our `UserActor`), with status-driven badges:
- * - Requested  (`DismissalRequestedComponent`): `comment` icon / `attention`.
- * - Approved   (`DismissalReviewedComponent`, status approved): `check` / `success`.
- * - Denied     (`DismissalReviewedComponent`, status rejected): `x` / `danger`.
- * - Cancelled  (`DismissalCancelledComponent`): `x` / `subtle` (plain default badge).
+ * - Requested  (`DismissalRequestedComponent`): `comment` icon, attention color.
+ * - Approved   (`DismissalReviewedComponent`, status approved): `check`, success.
+ * - Denied     (`DismissalReviewedComponent`, status rejected): `x`, danger.
+ * - Cancelled  (`DismissalCancelledComponent`): `x`, subtle color.
  *
- * `attention`, `success`, and `danger` are named `TimelineBadgeVariants`, so we
- * use `variant="…"` directly (no inline `--timelineBadge-bgColor` hook needed).
- * Optional review/resolution notes render via the shared `NoteComment` sub-row
- * (the ERB's `note`-octicon `TimelineItem tmp-pl-5 …` block).
+ * BADGE MECHANIC: the ERB uses `with_badge(color: :X, icon: Y)` with NO `bg:`.
+ * In Primer that tints the ICON on the DEFAULT badge background — it does NOT
+ * produce a solid-color badge (unlike Opened/Fixed/Reopened, which DO set
+ * `bg: :X_emphasis` and so use solid `variant`s). So these four render as a bare
+ * `<Timeline.Badge>` (default gray circle) with the icon color set via a
+ * `.BadgeIcon*` class — the same structure as the muted Dismissed badge.
+ * Optional review/resolution notes render via the shared `NoteComment` sub-row.
  */
 export const EventDismissalRequest = () => (
   <div
@@ -629,8 +632,8 @@ export const EventDismissalRequest = () => (
       <h3 className={classes.VariantLabel}>Dismissal requested</h3>
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
-          <Timeline.Badge variant="attention">
-            <Octicon icon={CommentIcon} aria-label="Dismissal requested" />
+          <Timeline.Badge>
+            <Octicon icon={CommentIcon} className={classes.BadgeIconAttention} aria-label="Dismissal requested" />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -647,8 +650,8 @@ export const EventDismissalRequest = () => (
       <h3 className={classes.VariantLabel}>Dismissal approved</h3>
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
-          <Timeline.Badge variant="success">
-            <Octicon icon={CheckIcon} aria-label="Dismissal approved" />
+          <Timeline.Badge>
+            <Octicon icon={CheckIcon} className={classes.BadgeIconSuccess} aria-label="Dismissal approved" />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -665,8 +668,8 @@ export const EventDismissalRequest = () => (
       <h3 className={classes.VariantLabel}>Dismissal denied</h3>
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
-          <Timeline.Badge variant="danger">
-            <Octicon icon={XIcon} aria-label="Dismissal denied" />
+          <Timeline.Badge>
+            <Octicon icon={XIcon} className={classes.BadgeIconDanger} aria-label="Dismissal denied" />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -685,7 +688,7 @@ export const EventDismissalRequest = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={XIcon} aria-label="Dismissal cancelled" />
+            <Octicon icon={XIcon} className={classes.BadgeIconMuted} aria-label="Dismissal cancelled" />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
@@ -438,7 +438,9 @@ export const EventDismissed = () => (
             <Time date="2022-08-03T08:00:00Z" />
             <NoteComment>
               {'Rule created and '}
-              <Link href="#">low-severity-dev-deps</Link>
+              <Link href="#" inline>
+                low-severity-dev-deps
+              </Link>
               {' was applied'}
             </NoteComment>
           </Timeline.Body>
@@ -586,7 +588,9 @@ export const EventReopened = () => (
             <Time date="2022-08-06T09:45:00Z" />
             <NoteComment>
               {'Rule disabled: '}
-              <Link href="#">low-severity-dev-deps</Link>
+              <Link href="#" inline>
+                low-severity-dev-deps
+              </Link>
             </NoteComment>
           </Timeline.Body>
         </Timeline.Item>

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
@@ -4,9 +4,9 @@ import type {ComponentProps} from '../utils/types'
 import {FeatureFlags} from '../FeatureFlags'
 import Timeline from './Timeline'
 import {
-  CheckCircleIcon,
+  CheckIcon,
+  CommentIcon,
   NoteIcon,
-  PersonIcon,
   ShieldCheckIcon,
   ShieldIcon,
   ShieldSlashIcon,
@@ -105,13 +105,6 @@ const UserActor = () => (
     </Link>
   </>
 )
-
-/**
- * Plain bold actor — for the delegated-closures Dismissal Request / Reviewed
- * events, whose live `*.html.erb` renders the actor as plain bold text with NO
- * avatar and NO profile link (`<strong>…<span>…</span></strong>`).
- */
-const PlainActor = ({login = 'monalisa'}: {login?: string}) => <strong className={classes.PlainActor}>{login}</strong>
 
 // Muted relative timestamp. The Dependabot ERB renders a plain
 // `Primer::Beta::RelativeTime` (no link wrapper) — muted text only, which is a
@@ -605,20 +598,21 @@ export const EventReopened = () => (
  * The Dismissal Request event group — `DepTimeline.eventDismissalRequest`
  * (audit § 5). Part of the org-level delegated-closures system.
  *
- * The Requested / Approved / Denied variants render the actor as PLAIN BOLD TEXT
- * with NO avatar and NO profile link (live `dismissal_requested_component.html.erb`
- * / `dismissal_reviewed_component.html.erb`), with a small octicon badge.
- * Cancelled (`DismissalCancelledComponent`) instead renders the user via
- * `ActorComponent` (circle avatar).
+ * SOURCE OF TRUTH — inline `erb_template` (NOT the dormant sidecar): each
+ * `dismissal_*_component.rb` does `include ViewComponent::InlineTemplate` and
+ * defines an `erb_template`, which is the ACTIVE render; the sibling
+ * `*.html.erb` sidecar is dead code left in the tree. So every variant here
+ * renders the actor via `ActorComponent` (a USER → circle avatar + bold link,
+ * our `UserActor`), with status-driven badges:
+ * - Requested  (`DismissalRequestedComponent`): `comment` icon / `attention`.
+ * - Approved   (`DismissalReviewedComponent`, status approved): `check` / `success`.
+ * - Denied     (`DismissalReviewedComponent`, status rejected): `x` / `danger`.
+ * - Cancelled  (`DismissalCancelledComponent`): `x` / `subtle` (plain default badge).
  *
- * SOURCE-OF-TRUTH UNCERTAINTY: each of these `.rb` components ALSO defines a
- * newer inline `erb_template` (via `ViewComponent::InlineTemplate`) that renders
- * the actor WITH an avatar and uses different badges (`comment`/attention for
- * Requested; dynamic check/x for Reviewed). A ViewComponent can only have one
- * active template, so one path is dormant. We follow the `.html.erb` sidecar /
- * no-avatar rendering here because it matches the v11 audit (the audit author's
- * proxy for what actually renders); the newer inline template may be an
- * in-flight migration. FLAGGED for confirmation against the live site / Figma.
+ * `attention`, `success`, and `danger` are named `TimelineBadgeVariants`, so we
+ * use `variant="…"` directly (no inline `--timelineBadge-bgColor` hook needed).
+ * Optional review/resolution notes render via the shared `NoteComment` sub-row
+ * (the ERB's `note`-octicon `TimelineItem tmp-pl-5 …` block).
  */
 export const EventDismissalRequest = () => (
   <div
@@ -627,71 +621,65 @@ export const EventDismissalRequest = () => (
       if ((e.target as HTMLElement).closest('a')) e.preventDefault()
     }}
   >
-    {/* Dismissal requested — no avatar, plain bold actor */}
+    {/* Dismissal requested — circle user actor, attention/comment badge.
+        (The live ERB also renders optional float-right Review/Deny actions via
+        `DismissalReviewDialogComponent` when `show_dismissal_actions` — those
+        would live in `Timeline.Actions`; omitted here as interactive controls.) */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Dismissal requested</h3>
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
-          <Timeline.Badge>
-            <Octicon icon={PersonIcon} aria-label="Dismissal requested" />
+          <Timeline.Badge variant="attention">
+            <Octicon icon={CommentIcon} aria-label="Dismissal requested" />
           </Timeline.Badge>
           <Timeline.Body>
-            <PlainActor />
-            <span className={classes.Muted}>requested dismissal</span>
-            <div className={classes.ResolutionLine}>
-              {'Dismiss as: '}
-              <strong>Risk is tolerable</strong>
-              {' • '}
-              <Time date="2022-08-07T13:20:00Z" />
-            </div>
+            <UserActor />
+            {'requested to dismiss this as '}
+            <strong>Tolerable risk</strong> <Time date="2022-08-07T13:20:00Z" />
+            <NoteComment>This dependency is only used in our test tooling, so the risk is acceptable.</NoteComment>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
     </section>
 
-    {/* Dismissal approved — no avatar, optional review comment box */}
+    {/* Dismissal approved — circle user actor, success/check badge */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Dismissal approved</h3>
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
-          <Timeline.Badge>
-            <Octicon icon={CheckCircleIcon} aria-label="Dismissal approved" />
+          <Timeline.Badge variant="success">
+            <Octicon icon={CheckIcon} aria-label="Dismissal approved" />
           </Timeline.Badge>
           <Timeline.Body>
-            <PlainActor />
-            <span className={classes.Muted}>approved dismissal request</span>
-            <div className={classes.ResolutionLine}>
-              <Time date="2022-08-08T10:05:00Z" />
-            </div>
-            <div className={classes.ReviewCommentBox}>
-              <div className={classes.ReviewCommentLabel}>Review comment:</div>
-              <div>Confirmed this dependency is dev-only — approving the dismissal.</div>
-            </div>
+            <UserActor />
+            {'approved dismissal '}
+            <Time date="2022-08-08T10:05:00Z" />
+            <NoteComment>Confirmed this dependency is dev-only — approving the dismissal.</NoteComment>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
     </section>
 
-    {/* Dismissal denied — no avatar */}
+    {/* Dismissal denied — circle user actor, danger/x badge */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Dismissal denied</h3>
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
-          <Timeline.Badge>
-            <Octicon icon={CheckCircleIcon} aria-label="Dismissal denied" />
+          <Timeline.Badge variant="danger">
+            <Octicon icon={XIcon} aria-label="Dismissal denied" />
           </Timeline.Badge>
           <Timeline.Body>
-            <PlainActor />
-            <span className={classes.Muted}>denied dismissal request</span>
-            <div className={classes.ResolutionLine}>
-              <Time date="2022-08-08T15:40:00Z" />
-            </div>
+            <UserActor />
+            {'denied dismissal '}
+            <Time date="2022-08-08T15:40:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
     </section>
 
-    {/* Dismissal cancelled — user actor via ActorComponent (circle avatar) */}
+    {/* Dismissal cancelled — circle user actor, plain default (subtle) x badge.
+        `DismissalCancelledComponent` renders `with_badge(color: :subtle, icon:
+        "x")` (no bg) → a bare default badge, not a danger/emphasis one. */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Dismissal cancelled</h3>
       <Timeline aria-label="Dependabot alert timeline">

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
@@ -143,6 +143,28 @@ const NoteComment = ({children}: {children: React.ReactNode}) => (
   </div>
 )
 
+/**
+ * Shared story wrapper. Constrains width to product surfaces, and sets
+ * `data-a11y-link-underlines="true"` to reproduce GitHub's default-on "Show link
+ * underlines" preference — Primer gates `<Link inline>` underlines on this
+ * ancestor attribute, so inline content links get a non-color distinction
+ * (WCAG 1.4.1). Actor-name links use `className` WITHOUT `inline`, so they stay
+ * avatar + semibold with no underline. The click handler swallows the
+ * placeholder `href="#"` navigation so the stories don't reload Storybook
+ * (`e.target instanceof Element` guards against SVG/Octicon clicks).
+ */
+const Examples = ({children}: {children: React.ReactNode}) => (
+  <div
+    className={classes.RealisticTimeline}
+    data-a11y-link-underlines="true"
+    onClick={e => {
+      if (e.target instanceof Element && e.target.closest('a')) e.preventDefault()
+    }}
+  >
+    {children}
+  </div>
+)
+
 export default {
   title: 'Components/Timeline/Events/Dependabot',
   component: Timeline,
@@ -179,20 +201,14 @@ export default {
  * blue push-pill.
  */
 export const EventOpened = () => (
-  <div
-    className={classes.RealisticTimeline}
-    // Prevent the placeholder `href="#"` links from navigating inside Storybook.
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Opened — no source */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Opened</h3>
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
-            <Octicon icon={ShieldIcon} aria-label="Opened" />
+            <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -209,7 +225,7 @@ export const EventOpened = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
-            <Octicon icon={ShieldIcon} aria-label="Opened from pull request" />
+            <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -229,7 +245,7 @@ export const EventOpened = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
-            <Octicon icon={ShieldIcon} aria-label="Opened from push" />
+            <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -239,7 +255,7 @@ export const EventOpened = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -256,19 +272,14 @@ export const EventOpened = () => (
  * runtime separator — it is a list-position concern, not part of the event.
  */
 export const EventFixed = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Fixed — no source */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Fixed</h3>
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Fixed" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -285,7 +296,7 @@ export const EventFixed = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Fixed via pull request" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -305,7 +316,7 @@ export const EventFixed = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Fixed via push" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -315,7 +326,7 @@ export const EventFixed = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -332,19 +343,14 @@ export const EventFixed = () => (
  * The optional comment renders as a small indented sub-row (note octicon + text).
  */
 export const EventDismissed = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Manual — risk is tolerable (with an optional dismissal note) */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Dismissed as risk is tolerable</h3>
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={ShieldSlashIcon} aria-label="Dismissed as risk is tolerable" />
+            <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -362,7 +368,7 @@ export const EventDismissed = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={ShieldSlashIcon} aria-label="Dismissed as fix started" />
+            <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -379,7 +385,7 @@ export const EventDismissed = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={ShieldSlashIcon} aria-label="Dismissed as no bandwidth to fix this" />
+            <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -396,7 +402,7 @@ export const EventDismissed = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={ShieldSlashIcon} aria-label="Dismissed as vulnerable code is not actually used" />
+            <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -413,7 +419,7 @@ export const EventDismissed = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={ShieldSlashIcon} aria-label="Dismissed as inaccurate" />
+            <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -430,7 +436,7 @@ export const EventDismissed = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={ShieldSlashIcon} aria-label="Auto-dismissed due to an alert rule" />
+            <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -454,7 +460,7 @@ export const EventDismissed = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={ShieldSlashIcon} aria-label="Auto-dismissed due to an alert rule from pull request" />
+            <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -474,7 +480,7 @@ export const EventDismissed = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={ShieldSlashIcon} aria-label="Auto-dismissed due to an alert rule from push" />
+            <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -484,7 +490,7 @@ export const EventDismissed = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -497,19 +503,14 @@ export const EventDismissed = () => (
  * `with_badge(bg: :success_emphasis, color: :on_emphasis, icon: :sync)`.
  */
 export const EventReopened = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Manual reopen — user actor */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Reopened</h3>
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
-            <Octicon icon={SyncIcon} aria-label="Reopened" />
+            <Octicon icon={SyncIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -526,7 +527,7 @@ export const EventReopened = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
-            <Octicon icon={SyncIcon} aria-label="Reintroduced" />
+            <Octicon icon={SyncIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -543,7 +544,7 @@ export const EventReopened = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
-            <Octicon icon={SyncIcon} aria-label="Reintroduced from pull request" />
+            <Octicon icon={SyncIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -563,7 +564,7 @@ export const EventReopened = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
-            <Octicon icon={SyncIcon} aria-label="Reintroduced from push" />
+            <Octicon icon={SyncIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -580,7 +581,7 @@ export const EventReopened = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
-            <Octicon icon={SyncIcon} aria-label="Auto-reopened" />
+            <Octicon icon={SyncIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <DependabotActor />
@@ -596,7 +597,7 @@ export const EventReopened = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -623,12 +624,7 @@ export const EventReopened = () => (
  * Optional review/resolution notes render via the shared `NoteComment` sub-row.
  */
 export const EventDismissalRequest = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Dismissal requested — circle user actor, attention/comment badge. When
         `show_dismissal_actions` is true, the live inline template
         (`dismissal_requested_component.rb`) renders a `<span class="float-right">`
@@ -641,7 +637,7 @@ export const EventDismissalRequest = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CommentIcon} className={classes.BadgeIconAttention} aria-label="Dismissal requested" />
+            <Octicon icon={CommentIcon} className={classes.BadgeIconAttention} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -664,7 +660,7 @@ export const EventDismissalRequest = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CheckIcon} className={classes.BadgeIconSuccess} aria-label="Dismissal approved" />
+            <Octicon icon={CheckIcon} className={classes.BadgeIconSuccess} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -682,7 +678,7 @@ export const EventDismissalRequest = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={XIcon} className={classes.BadgeIconDanger} aria-label="Dismissal denied" />
+            <Octicon icon={XIcon} className={classes.BadgeIconDanger} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -701,7 +697,7 @@ export const EventDismissalRequest = () => (
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={XIcon} className={classes.BadgeIconMuted} aria-label="Dismissal cancelled" />
+            <Octicon icon={XIcon} className={classes.BadgeIconMuted} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -711,5 +707,5 @@ export const EventDismissalRequest = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
@@ -13,13 +13,12 @@ import {
   SyncIcon,
   XIcon,
 } from '@primer/octicons-react'
-import Avatar from '../Avatar'
 import {Button} from '../Button'
 import Label from '../Label'
 import Link from '../Link'
 import Octicon from '../Octicon'
-import RelativeTime from '../RelativeTime'
 import classes from './Timeline.dependabot.features.stories.module.css'
+import {BoldLink, Examples, InlineAvatar, MutedTime, VariantSection} from './internal/timelineStoryHelpers'
 
 /**
  * Dependabot alert Timeline event examples (Phase 2 of github/primer#6663).
@@ -82,10 +81,10 @@ const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
  */
 const DependabotActor = () => (
   <>
-    <Avatar src={DEPENDABOT_AVATAR} size={20} square alt="" className={classes.InlineAvatar} />
-    <Link href="#" className={classes.LinkWithBoldStyle} muted>
+    <InlineAvatar src={DEPENDABOT_AVATAR} square />
+    <BoldLink href="#" muted>
       dependabot
-    </Link>
+    </BoldLink>
     <Label variant="secondary" className={classes.BotLabel}>
       bot
     </Label>
@@ -100,20 +99,11 @@ const DependabotActor = () => (
  */
 const UserActor = () => (
   <>
-    <Avatar src={MONALISA_AVATAR} size={20} alt="" className={classes.InlineAvatar} />
-    <Link href="#" className={classes.LinkWithBoldStyle} muted>
+    <InlineAvatar src={MONALISA_AVATAR} />
+    <BoldLink href="#" muted>
       monalisa
-    </Link>
+    </BoldLink>
   </>
-)
-
-// Muted relative timestamp. The Dependabot ERB renders a plain
-// `Primer::Beta::RelativeTime` (no link wrapper) — muted text only, which is a
-// deliberate difference from the Issues `Ago` deep-link.
-const Time = ({date}: {date: string}) => (
-  <span className={classes.Timestamp}>
-    <RelativeTime date={new Date(date)} format="relative" />
-  </span>
 )
 
 /**
@@ -139,28 +129,6 @@ const PushPill = ({sha}: {sha: string}) => (
 const NoteComment = ({children}: {children: React.ReactNode}) => (
   <div className={classes.NoteComment}>
     <Octicon icon={NoteIcon} size={16} className={classes.NoteIcon} />
-    {children}
-  </div>
-)
-
-/**
- * Shared story wrapper. Constrains width to product surfaces, and sets
- * `data-a11y-link-underlines="true"` to reproduce GitHub's default-on "Show link
- * underlines" preference — Primer gates `<Link inline>` underlines on this
- * ancestor attribute, so inline content links get a non-color distinction
- * (WCAG 1.4.1). Actor-name links use `className` WITHOUT `inline`, so they stay
- * avatar + semibold with no underline. The click handler swallows the
- * placeholder `href="#"` navigation so the stories don't reload Storybook
- * (`e.target instanceof Element` guards against SVG/Octicon clicks).
- */
-const Examples = ({children}: {children: React.ReactNode}) => (
-  <div
-    className={classes.RealisticTimeline}
-    data-a11y-link-underlines="true"
-    onClick={e => {
-      if (e.target instanceof Element && e.target.closest('a')) e.preventDefault()
-    }}
-  >
     {children}
   </div>
 )
@@ -203,8 +171,7 @@ export default {
 export const EventOpened = () => (
   <Examples>
     {/* Opened — no source */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Opened</h3>
+    <VariantSection label="Opened">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
@@ -213,15 +180,14 @@ export const EventOpened = () => (
           <Timeline.Body>
             <DependabotActor />
             {'opened this '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* OpenedFromPR — bold `#123` pull-request link (scheme: primary, bold) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Opened from pull request</h3>
+    <VariantSection label="Opened from pull request">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
@@ -230,18 +196,14 @@ export const EventOpened = () => (
           <Timeline.Body>
             <DependabotActor />
             {'opened this from '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              #123
-            </Link>{' '}
-            <Time date="2022-07-26T11:46:07Z" />
+            <BoldLink href="#">#123</BoldLink> <MutedTime date={new Date('2022-07-26T11:46:07Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* OpenedFromPush — blue push-pill with the 7-char `after` SHA */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Opened from push</h3>
+    <VariantSection label="Opened from push">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
@@ -250,11 +212,11 @@ export const EventOpened = () => (
           <Timeline.Body>
             <DependabotActor />
             {'opened this from '}
-            <PushPill sha="adfc29a" /> <Time date="2022-07-26T11:46:07Z" />
+            <PushPill sha="adfc29a" /> <MutedTime date={new Date('2022-07-26T11:46:07Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -274,8 +236,7 @@ export const EventOpened = () => (
 export const EventFixed = () => (
   <Examples>
     {/* Fixed — no source */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Fixed</h3>
+    <VariantSection label="Fixed">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -284,15 +245,14 @@ export const EventFixed = () => (
           <Timeline.Body>
             <DependabotActor />
             {'closed this as completed '}
-            <Time date="2022-08-01T09:30:00Z" />
+            <MutedTime date={new Date('2022-08-01T09:30:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* FixedViaPR — bold `#123` pull-request link */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Fixed via pull request</h3>
+    <VariantSection label="Fixed via pull request">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -301,18 +261,14 @@ export const EventFixed = () => (
           <Timeline.Body>
             <DependabotActor />
             {'closed this as completed in '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              #123
-            </Link>{' '}
-            <Time date="2022-08-01T09:30:00Z" />
+            <BoldLink href="#">#123</BoldLink> <MutedTime date={new Date('2022-08-01T09:30:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* FixedViaPush — blue push-pill */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Fixed via push</h3>
+    <VariantSection label="Fixed via push">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -321,11 +277,11 @@ export const EventFixed = () => (
           <Timeline.Body>
             <DependabotActor />
             {'closed this as completed in '}
-            <PushPill sha="adfc29a" /> <Time date="2022-08-01T09:30:00Z" />
+            <PushPill sha="adfc29a" /> <MutedTime date={new Date('2022-08-01T09:30:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -345,8 +301,7 @@ export const EventFixed = () => (
 export const EventDismissed = () => (
   <Examples>
     {/* Manual — risk is tolerable (with an optional dismissal note) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Dismissed as risk is tolerable</h3>
+    <VariantSection label="Dismissed as risk is tolerable">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -355,16 +310,15 @@ export const EventDismissed = () => (
           <Timeline.Body>
             <UserActor />
             {'dismissed this as risk is tolerable '}
-            <Time date="2022-08-02T14:10:00Z" />
+            <MutedTime date={new Date('2022-08-02T14:10:00Z')} />
             <NoteComment>This dependency is only used in our test tooling, so the risk is acceptable.</NoteComment>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Manual — fix started */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Dismissed as fix started</h3>
+    <VariantSection label="Dismissed as fix started">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -373,15 +327,14 @@ export const EventDismissed = () => (
           <Timeline.Body>
             <UserActor />
             {'dismissed this as fix started '}
-            <Time date="2022-08-02T14:10:00Z" />
+            <MutedTime date={new Date('2022-08-02T14:10:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Manual — no bandwidth to fix this */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Dismissed as no bandwidth</h3>
+    <VariantSection label="Dismissed as no bandwidth">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -390,15 +343,14 @@ export const EventDismissed = () => (
           <Timeline.Body>
             <UserActor />
             {'dismissed this as no bandwidth to fix this '}
-            <Time date="2022-08-02T14:10:00Z" />
+            <MutedTime date={new Date('2022-08-02T14:10:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Manual — vulnerable code is not actually used */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Dismissed as not used</h3>
+    <VariantSection label="Dismissed as not used">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -407,15 +359,14 @@ export const EventDismissed = () => (
           <Timeline.Body>
             <UserActor />
             {'dismissed this as vulnerable code is not actually used '}
-            <Time date="2022-08-02T14:10:00Z" />
+            <MutedTime date={new Date('2022-08-02T14:10:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Manual — inaccurate */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Dismissed as inaccurate</h3>
+    <VariantSection label="Dismissed as inaccurate">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -424,15 +375,14 @@ export const EventDismissed = () => (
           <Timeline.Body>
             <UserActor />
             {'dismissed this as inaccurate '}
-            <Time date="2022-08-02T14:10:00Z" />
+            <MutedTime date={new Date('2022-08-02T14:10:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Auto — rule-based, no source (with optional rule comment) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Auto-dismissed by alert rule</h3>
+    <VariantSection label="Auto-dismissed by alert rule">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -441,7 +391,7 @@ export const EventDismissed = () => (
           <Timeline.Body>
             <DependabotActor />
             {'dismissed this due to an alert rule '}
-            <Time date="2022-08-03T08:00:00Z" />
+            <MutedTime date={new Date('2022-08-03T08:00:00Z')} />
             <NoteComment>
               {'Rule created and '}
               <Link href="#" inline>
@@ -452,11 +402,10 @@ export const EventDismissed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Auto — from a pull request */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Auto-dismissed from pull request</h3>
+    <VariantSection label="Auto-dismissed from pull request">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -465,18 +414,14 @@ export const EventDismissed = () => (
           <Timeline.Body>
             <DependabotActor />
             {'dismissed this due to an alert rule from '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              #123
-            </Link>{' '}
-            <Time date="2022-08-03T08:00:00Z" />
+            <BoldLink href="#">#123</BoldLink> <MutedTime date={new Date('2022-08-03T08:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Auto — from a push */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Auto-dismissed from push</h3>
+    <VariantSection label="Auto-dismissed from push">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -485,11 +430,11 @@ export const EventDismissed = () => (
           <Timeline.Body>
             <DependabotActor />
             {'dismissed this due to an alert rule from '}
-            <PushPill sha="adfc29a" /> <Time date="2022-08-03T08:00:00Z" />
+            <PushPill sha="adfc29a" /> <MutedTime date={new Date('2022-08-03T08:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -505,8 +450,7 @@ export const EventDismissed = () => (
 export const EventReopened = () => (
   <Examples>
     {/* Manual reopen — user actor */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Reopened</h3>
+    <VariantSection label="Reopened">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
@@ -515,15 +459,14 @@ export const EventReopened = () => (
           <Timeline.Body>
             <UserActor />
             {'reopened this '}
-            <Time date="2022-08-04T10:15:00Z" />
+            <MutedTime date={new Date('2022-08-04T10:15:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Reintroduced — no source */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Reintroduced</h3>
+    <VariantSection label="Reintroduced">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
@@ -532,15 +475,14 @@ export const EventReopened = () => (
           <Timeline.Body>
             <DependabotActor />
             {'reopened this '}
-            <Time date="2022-08-05T11:00:00Z" />
+            <MutedTime date={new Date('2022-08-05T11:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Reintroduced — from a pull request */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Reintroduced from pull request</h3>
+    <VariantSection label="Reintroduced from pull request">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
@@ -549,18 +491,14 @@ export const EventReopened = () => (
           <Timeline.Body>
             <DependabotActor />
             {'reopened this from '}
-            <Link href="#" className={classes.LinkWithBoldStyle}>
-              #123
-            </Link>{' '}
-            <Time date="2022-08-05T11:00:00Z" />
+            <BoldLink href="#">#123</BoldLink> <MutedTime date={new Date('2022-08-05T11:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Reintroduced — from a push */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Reintroduced from push</h3>
+    <VariantSection label="Reintroduced from push">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
@@ -569,15 +507,14 @@ export const EventReopened = () => (
           <Timeline.Body>
             <DependabotActor />
             {'reopened this from '}
-            <PushPill sha="adfc29a" /> <Time date="2022-08-05T11:00:00Z" />
+            <PushPill sha="adfc29a" /> <MutedTime date={new Date('2022-08-05T11:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Auto-reopened — rule change (with optional rule comment) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Auto-reopened by rule change</h3>
+    <VariantSection label="Auto-reopened by rule change">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
@@ -586,7 +523,7 @@ export const EventReopened = () => (
           <Timeline.Body>
             <DependabotActor />
             {'reopened this '}
-            <Time date="2022-08-06T09:45:00Z" />
+            <MutedTime date={new Date('2022-08-06T09:45:00Z')} />
             <NoteComment>
               {'Rule disabled: '}
               <Link href="#" inline>
@@ -596,7 +533,7 @@ export const EventReopened = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -632,8 +569,7 @@ export const EventDismissalRequest = () => (
         SINGLE small primary "Review request" button that opens a review dialog
         (the approve/deny choice lives inside the dialog, not on the row). We
         place that right-aligned control in the `Timeline.Actions` slot. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Dismissal requested</h3>
+    <VariantSection label="Dismissal requested">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -642,7 +578,7 @@ export const EventDismissalRequest = () => (
           <Timeline.Body>
             <UserActor />
             {'requested to dismiss this as '}
-            <strong>Tolerable risk</strong> <Time date="2022-08-07T13:20:00Z" />
+            <strong>Tolerable risk</strong> <MutedTime date={new Date('2022-08-07T13:20:00Z')} />
             <NoteComment>This dependency is only used in our test tooling, so the risk is acceptable.</NoteComment>
           </Timeline.Body>
           <Timeline.Actions>
@@ -652,11 +588,10 @@ export const EventDismissalRequest = () => (
           </Timeline.Actions>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Dismissal approved — circle user actor, success/check badge */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Dismissal approved</h3>
+    <VariantSection label="Dismissal approved">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -665,16 +600,15 @@ export const EventDismissalRequest = () => (
           <Timeline.Body>
             <UserActor />
             {'approved dismissal '}
-            <Time date="2022-08-08T10:05:00Z" />
+            <MutedTime date={new Date('2022-08-08T10:05:00Z')} />
             <NoteComment>Confirmed this dependency is dev-only — approving the dismissal.</NoteComment>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Dismissal denied — circle user actor, danger/x badge */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Dismissal denied</h3>
+    <VariantSection label="Dismissal denied">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -683,17 +617,16 @@ export const EventDismissalRequest = () => (
           <Timeline.Body>
             <UserActor />
             {'denied dismissal '}
-            <Time date="2022-08-08T15:40:00Z" />
+            <MutedTime date={new Date('2022-08-08T15:40:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Dismissal cancelled — circle user actor, plain default (subtle) x badge.
         `DismissalCancelledComponent` renders `with_badge(color: :subtle, icon:
         "x")` (no bg) → a bare default badge, not a danger/emphasis one. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Dismissal cancelled</h3>
+    <VariantSection label="Dismissal cancelled">
       <Timeline aria-label="Dependabot alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -702,10 +635,10 @@ export const EventDismissalRequest = () => (
           <Timeline.Body>
             <UserActor />
             {'cancelled their dismissal request '}
-            <Time date="2022-08-09T09:00:00Z" />
+            <MutedTime date={new Date('2022-08-09T09:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
@@ -3,7 +3,16 @@ import type React from 'react'
 import type {ComponentProps} from '../utils/types'
 import {FeatureFlags} from '../FeatureFlags'
 import Timeline from './Timeline'
-import {ShieldIcon} from '@primer/octicons-react'
+import {
+  CheckCircleIcon,
+  NoteIcon,
+  PersonIcon,
+  ShieldCheckIcon,
+  ShieldIcon,
+  ShieldSlashIcon,
+  SyncIcon,
+  XIcon,
+} from '@primer/octicons-react'
 import Avatar from '../Avatar'
 import Label from '../Label'
 import Link from '../Link'
@@ -52,20 +61,23 @@ import classes from './Timeline.dependabot.features.stories.module.css'
  *   pills on the right edge. Opened has no right controls, so it is omitted here.
  *
  * DEPENDABOT-SPECIFIC COMPOSITION (see helpers below): the square bot avatar,
- * the `(bot)` identifier tag, and the blue `(push-pill: SHA)` are composed from
- * Primer primitives (`Avatar square`, `Label variant="secondary"`, and a
- * `<code>`-wrapped styled `Link`) to match the live ERB.
+ * the `(bot)` identifier tag, and the SUBTLE light-blue `(push-pill: SHA)` are
+ * composed from Primer primitives (`Avatar square`, `Label variant="secondary"`,
+ * and a `<code>`-wrapped styled `Link`) to match the live ERB.
  */
 
 // Live ERB uses the bundled `modules/site/dependabot-icon.png`; this is the
 // public dependabot[bot] avatar (square Dependabot logo) for Storybook.
 const DEPENDABOT_AVATAR = 'https://avatars.githubusercontent.com/u/27347476?v=4'
+const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
 
 /**
  * Dependabot actor — `DependabotAlerts::TimelineItems::ActorComponent` in
  * `:dependabot` mode (`actor_component.html.erb`):
  *   square avatar + bold `dependabot` docs link + `(bot)` identifier tag.
  * (`bot_identifier_tag` → `<span class="Label Label--secondary">bot</span>`.)
+ * Used by Dependabot-authored events (Opened / Fixed / Reintroduced /
+ * Auto-dismissed / Auto-reopened).
  */
 const DependabotActor = () => (
   <>
@@ -79,6 +91,28 @@ const DependabotActor = () => (
   </>
 )
 
+/**
+ * User actor — `ActorComponent` regular-user branch (`linked_avatar_for(actor,
+ * 20)` + `profile_link(... "text-bold")`): a CIRCLE 20px avatar + bold profile
+ * link, no `(bot)` tag. Used by user-authored events (manual Dismissed, manual
+ * Reopened, Dismissal Cancelled).
+ */
+const UserActor = () => (
+  <>
+    <Avatar src={MONALISA_AVATAR} size={20} alt="" className={classes.InlineAvatar} />
+    <Link href="#" className={classes.LinkWithBoldStyle} muted>
+      monalisa
+    </Link>
+  </>
+)
+
+/**
+ * Plain bold actor — for the delegated-closures Dismissal Request / Reviewed
+ * events, whose live `*.html.erb` renders the actor as plain bold text with NO
+ * avatar and NO profile link (`<strong>…<span>…</span></strong>`).
+ */
+const PlainActor = ({login = 'monalisa'}: {login?: string}) => <strong className={classes.PlainActor}>{login}</strong>
+
 // Muted relative timestamp. The Dependabot ERB renders a plain
 // `Primer::Beta::RelativeTime` (no link wrapper) — muted text only, which is a
 // deliberate difference from the Issues `Ago` deep-link.
@@ -90,8 +124,9 @@ const Time = ({date}: {date: string}) => (
 
 /**
  * Push-pill — `PushLinkComponent`: a `<code>` wrapping a `Primer::Beta::Link`
- * (`bg: :accent, px: 2, py: 1, border_radius: 3`) → blue rounded pill with the
- * 7-char `after` SHA (single commit) or a `before..after` range (multi-commit).
+ * (`bg: :accent, px: 2, py: 1, border_radius: 3`) → SUBTLE light-blue rounded
+ * pill with accent-blue monospace text (the standard GitHub SHA pill), showing
+ * the 7-char `after` SHA (single commit) or a `before..after` range (multi).
  */
 const PushPill = ({sha}: {sha: string}) => (
   <code className={classes.PushPill}>
@@ -99,6 +134,19 @@ const PushPill = ({sha}: {sha: string}) => (
       {sha}
     </Link>
   </code>
+)
+
+/**
+ * Optional sub-content row rendered below a dismissal/auto event — the live ERB
+ * renders a `<div class="TimelineItem tmp-pl-5 pt-0 f6 d-block">` with a `note`
+ * octicon and the comment text. Rendered here as a small muted block inside the
+ * event body.
+ */
+const NoteComment = ({children}: {children: React.ReactNode}) => (
+  <div className={classes.NoteComment}>
+    <Octicon icon={NoteIcon} size={16} className={classes.NoteIcon} />
+    {children}
+  </div>
 )
 
 export default {
@@ -193,6 +241,468 @@ export const EventOpened = () => (
             <DependabotActor />
             {'opened this from '}
             <PushPill sha="adfc29a" /> <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Fixed event group — `DepTimeline.eventFixed` (audit § 2).
+ *
+ * Source: `FixedComponent` (`fixed_component.html.erb`). Actor is ALWAYS
+ * Dependabot. Badge: `shield-check` on `done` (purple) — the ERB renders
+ * `with_badge(bg: :done_emphasis, color: :on_emphasis, icon: "shield-check")`,
+ * mapping to `Timeline.Badge variant="done"`. Three source variants differ only
+ * by the optional "in …" clause (no source / bold `#123` PR link / push-pill).
+ *
+ * NOTE: the live ERB renders a `TimelineItem-break` separator after this event
+ * (unless it is the last). In these stacked, single-event stories we omit the
+ * runtime separator — it is a list-position concern, not part of the event.
+ */
+export const EventFixed = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Fixed — no source */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Fixed</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Fixed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'closed this as completed '}
+            <Time date="2022-08-01T09:30:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* FixedViaPR — bold `#123` pull-request link */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Fixed via pull request</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Fixed via pull request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'closed this as completed in '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              #123
+            </Link>{' '}
+            <Time date="2022-08-01T09:30:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* FixedViaPush — blue push-pill */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Fixed via push</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Fixed via push" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'closed this as completed in '}
+            <PushPill sha="adfc29a" /> <Time date="2022-08-01T09:30:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Dismissed event group — `DepTimeline.eventDismissed` (audit § 3).
+ *
+ * Consolidates MANUAL user dismissals (`DismissedComponent`, circle user actor)
+ * and rule-based AUTO dismissals (`AutoDismissedComponent`, square Dependabot
+ * actor). Badge: `shield-slash` on the PLAIN DEFAULT badge (subtle gray circle,
+ * muted icon) — the live ERB renders `with_badge(color: :muted, ...)` /
+ * `with_badge(icon: "shield-slash")` with NO `bg:` override, so we use a bare
+ * `Timeline.Badge` (no variant), NOT the neutral-emphasis hook.
+ *
+ * Manual reasons are `RepositoryVulnerabilityAlert::DISMISS_REASONS` downcased.
+ * The optional comment renders as a small indented sub-row (note octicon + text).
+ */
+export const EventDismissed = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Manual — risk is tolerable (with an optional dismissal note) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Dismissed as risk is tolerable</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={ShieldSlashIcon} aria-label="Dismissed as risk is tolerable" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'dismissed this as risk is tolerable '}
+            <Time date="2022-08-02T14:10:00Z" />
+            <NoteComment>This dependency is only used in our test tooling, so the risk is acceptable.</NoteComment>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Manual — fix started */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Dismissed as fix started</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={ShieldSlashIcon} aria-label="Dismissed as fix started" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'dismissed this as fix started '}
+            <Time date="2022-08-02T14:10:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Manual — no bandwidth to fix this */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Dismissed as no bandwidth</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={ShieldSlashIcon} aria-label="Dismissed as no bandwidth to fix this" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'dismissed this as no bandwidth to fix this '}
+            <Time date="2022-08-02T14:10:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Manual — vulnerable code is not actually used */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Dismissed as not used</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={ShieldSlashIcon} aria-label="Dismissed as vulnerable code is not actually used" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'dismissed this as vulnerable code is not actually used '}
+            <Time date="2022-08-02T14:10:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Manual — inaccurate */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Dismissed as inaccurate</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={ShieldSlashIcon} aria-label="Dismissed as inaccurate" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'dismissed this as inaccurate '}
+            <Time date="2022-08-02T14:10:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Auto — rule-based, no source (with optional rule comment) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Auto-dismissed by alert rule</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={ShieldSlashIcon} aria-label="Auto-dismissed due to an alert rule" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'dismissed this due to an alert rule '}
+            <Time date="2022-08-03T08:00:00Z" />
+            <NoteComment>
+              {'Rule created and '}
+              <Link href="#">low-severity-dev-deps</Link>
+              {' was applied'}
+            </NoteComment>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Auto — from a pull request */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Auto-dismissed from pull request</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={ShieldSlashIcon} aria-label="Auto-dismissed due to an alert rule from pull request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'dismissed this due to an alert rule from '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              #123
+            </Link>{' '}
+            <Time date="2022-08-03T08:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Auto — from a push */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Auto-dismissed from push</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={ShieldSlashIcon} aria-label="Auto-dismissed due to an alert rule from push" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'dismissed this due to an alert rule from '}
+            <PushPill sha="adfc29a" /> <Time date="2022-08-03T08:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Reopened event group — `DepTimeline.eventReopened` (audit § 4).
+ *
+ * Consolidates MANUAL reopens (`ReopenedComponent`, circle user actor),
+ * REINTRODUCTIONS (`ReintroducedComponent`, square Dependabot actor, × source)
+ * and rule-based AUTO reopens (`AutoReopenedComponent`, square Dependabot
+ * actor). Badge: `sync` on `success` (green) for all — the ERB renders
+ * `with_badge(bg: :success_emphasis, color: :on_emphasis, icon: :sync)`.
+ */
+export const EventReopened = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Manual reopen — user actor */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Reopened</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="success">
+            <Octicon icon={SyncIcon} aria-label="Reopened" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'reopened this '}
+            <Time date="2022-08-04T10:15:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Reintroduced — no source */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Reintroduced</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="success">
+            <Octicon icon={SyncIcon} aria-label="Reintroduced" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'reopened this '}
+            <Time date="2022-08-05T11:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Reintroduced — from a pull request */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Reintroduced from pull request</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="success">
+            <Octicon icon={SyncIcon} aria-label="Reintroduced from pull request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'reopened this from '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              #123
+            </Link>{' '}
+            <Time date="2022-08-05T11:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Reintroduced — from a push */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Reintroduced from push</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="success">
+            <Octicon icon={SyncIcon} aria-label="Reintroduced from push" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'reopened this from '}
+            <PushPill sha="adfc29a" /> <Time date="2022-08-05T11:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Auto-reopened — rule change (with optional rule comment) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Auto-reopened by rule change</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="success">
+            <Octicon icon={SyncIcon} aria-label="Auto-reopened" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'reopened this '}
+            <Time date="2022-08-06T09:45:00Z" />
+            <NoteComment>
+              {'Rule disabled: '}
+              <Link href="#">low-severity-dev-deps</Link>
+            </NoteComment>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Dismissal Request event group — `DepTimeline.eventDismissalRequest`
+ * (audit § 5). Part of the org-level delegated-closures system.
+ *
+ * The Requested / Approved / Denied variants render the actor as PLAIN BOLD TEXT
+ * with NO avatar and NO profile link (live `dismissal_requested_component.html.erb`
+ * / `dismissal_reviewed_component.html.erb`), with a small octicon badge.
+ * Cancelled (`DismissalCancelledComponent`) instead renders the user via
+ * `ActorComponent` (circle avatar).
+ *
+ * SOURCE-OF-TRUTH UNCERTAINTY: each of these `.rb` components ALSO defines a
+ * newer inline `erb_template` (via `ViewComponent::InlineTemplate`) that renders
+ * the actor WITH an avatar and uses different badges (`comment`/attention for
+ * Requested; dynamic check/x for Reviewed). A ViewComponent can only have one
+ * active template, so one path is dormant. We follow the `.html.erb` sidecar /
+ * no-avatar rendering here because it matches the v11 audit (the audit author's
+ * proxy for what actually renders); the newer inline template may be an
+ * in-flight migration. FLAGGED for confirmation against the live site / Figma.
+ */
+export const EventDismissalRequest = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Dismissal requested — no avatar, plain bold actor */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Dismissal requested</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={PersonIcon} aria-label="Dismissal requested" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <PlainActor />
+            <span className={classes.Muted}>requested dismissal</span>
+            <div className={classes.ResolutionLine}>
+              {'Dismiss as: '}
+              <strong>Risk is tolerable</strong>
+              {' • '}
+              <Time date="2022-08-07T13:20:00Z" />
+            </div>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Dismissal approved — no avatar, optional review comment box */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Dismissal approved</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CheckCircleIcon} aria-label="Dismissal approved" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <PlainActor />
+            <span className={classes.Muted}>approved dismissal request</span>
+            <div className={classes.ResolutionLine}>
+              <Time date="2022-08-08T10:05:00Z" />
+            </div>
+            <div className={classes.ReviewCommentBox}>
+              <div className={classes.ReviewCommentLabel}>Review comment:</div>
+              <div>Confirmed this dependency is dev-only — approving the dismissal.</div>
+            </div>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Dismissal denied — no avatar */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Dismissal denied</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CheckCircleIcon} aria-label="Dismissal denied" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <PlainActor />
+            <span className={classes.Muted}>denied dismissal request</span>
+            <div className={classes.ResolutionLine}>
+              <Time date="2022-08-08T15:40:00Z" />
+            </div>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Dismissal cancelled — user actor via ActorComponent (circle avatar) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Dismissal cancelled</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={XIcon} aria-label="Dismissal cancelled" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'cancelled their dismissal request '}
+            <Time date="2022-08-09T09:00:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
@@ -650,7 +650,9 @@ export const EventDismissalRequest = () => (
             <NoteComment>This dependency is only used in our test tooling, so the risk is acceptable.</NoteComment>
           </Timeline.Body>
           <Timeline.Actions>
-            <Button size="small">Review request</Button>
+            <Button variant="primary" size="small">
+              Review request
+            </Button>
           </Timeline.Actions>
         </Timeline.Item>
       </Timeline>

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
@@ -1,0 +1,201 @@
+import type {Meta} from '@storybook/react-vite'
+import type React from 'react'
+import type {ComponentProps} from '../utils/types'
+import {FeatureFlags} from '../FeatureFlags'
+import Timeline from './Timeline'
+import {ShieldIcon} from '@primer/octicons-react'
+import Avatar from '../Avatar'
+import Label from '../Label'
+import Link from '../Link'
+import Octicon from '../Octicon'
+import RelativeTime from '../RelativeTime'
+import classes from './Timeline.dependabot.features.stories.module.css'
+
+/**
+ * Dependabot alert Timeline event examples (Phase 2 of github/primer#6663).
+ *
+ * These stories recreate GitHub's live Dependabot-alert-timeline events using
+ * the Primer `Timeline` compositional slots. They mirror the established Issues
+ * stories (`Timeline.issues.features.stories.tsx`) and are sourced from the
+ * `timeline-audit` Figma audit (`dependabot-timeline-events-for-figma.md`).
+ *
+ * SOURCE OF TRUTH — Dependabot is NOT (yet) migrated to React. The Dependabot
+ * alert timeline is entirely SERVER-RENDERED ERB (ViewComponent). The events
+ * are rendered by `DependabotAlerts::TimelineComponent`, which dispatches to
+ * per-event components in `app/components/dependabot_alerts/timeline_items/`
+ * (e.g. `OpenedComponent`) in the `github/github` Rails monorepo. There is no
+ * React equivalent in `github/github-ui` — that repo only ships Catalyst
+ * custom-element controllers (`dependabot-alert-*-element.ts`) for table-row /
+ * load-all / dismissal interactions, not the timeline event rows. So each event
+ * below is translated faithfully from the live ERB into Primer React, with the
+ * ERB source file commented inline.
+ *
+ * SCOPE: These are Storybook-only examples by design. They are intentionally
+ * NOT wired into components-json / the primer.style docs page (do NOT add this
+ * file to `Timeline.docs.json` or `build.ts`). Individual timeline events are
+ * not consumer-facing components — the primer.style Timeline page reflects the
+ * base `Timeline` component's own stories, and any docs-site representation is a
+ * Phase 3 consideration via base-component story changes, out of scope here.
+ *
+ * FUTURE FILTERING (taxonomy still open — github/primer#6663): category
+ * `data-*` attributes (e.g. `data-event-category="opened"`) will attach to each
+ * `Timeline.Item` below so stories can be filtered/grouped by event family. We
+ * intentionally do NOT add them yet to avoid baking in a taxonomy.
+ *
+ * SLOT USAGE (Phase 1 slots — same convention as the Issues group):
+ * - `Timeline.Avatar` (gutter slot, #6677): the 40px LEFT-GUTTER avatar.
+ *   Reserved for comment-style events. Badge-row events like Opened do NOT use
+ *   it — the live ERB renders the actor's small SQUARE avatar INLINE in the body
+ *   (`ActorComponent`), not in the gutter. We mirror that: avatar inline in
+ *   `Timeline.Body`.
+ * - `Timeline.Actions` (right-controls slot, #6678): for buttons / SHAs / status
+ *   pills on the right edge. Opened has no right controls, so it is omitted here.
+ *
+ * DEPENDABOT-SPECIFIC COMPOSITION (see helpers below): the square bot avatar,
+ * the `(bot)` identifier tag, and the blue `(push-pill: SHA)` are composed from
+ * Primer primitives (`Avatar square`, `Label variant="secondary"`, and a
+ * `<code>`-wrapped styled `Link`) to match the live ERB.
+ */
+
+// Live ERB uses the bundled `modules/site/dependabot-icon.png`; this is the
+// public dependabot[bot] avatar (square Dependabot logo) for Storybook.
+const DEPENDABOT_AVATAR = 'https://avatars.githubusercontent.com/u/27347476?v=4'
+
+/**
+ * Dependabot actor — `DependabotAlerts::TimelineItems::ActorComponent` in
+ * `:dependabot` mode (`actor_component.html.erb`):
+ *   square avatar + bold `dependabot` docs link + `(bot)` identifier tag.
+ * (`bot_identifier_tag` → `<span class="Label Label--secondary">bot</span>`.)
+ */
+const DependabotActor = () => (
+  <>
+    <Avatar src={DEPENDABOT_AVATAR} size={20} square alt="" className={classes.InlineAvatar} />
+    <Link href="#" className={classes.LinkWithBoldStyle} muted>
+      dependabot
+    </Link>
+    <Label variant="secondary" className={classes.BotLabel}>
+      bot
+    </Label>
+  </>
+)
+
+// Muted relative timestamp. The Dependabot ERB renders a plain
+// `Primer::Beta::RelativeTime` (no link wrapper) — muted text only, which is a
+// deliberate difference from the Issues `Ago` deep-link.
+const Time = ({date}: {date: string}) => (
+  <span className={classes.Timestamp}>
+    <RelativeTime date={new Date(date)} format="relative" />
+  </span>
+)
+
+/**
+ * Push-pill — `PushLinkComponent`: a `<code>` wrapping a `Primer::Beta::Link`
+ * (`bg: :accent, px: 2, py: 1, border_radius: 3`) → blue rounded pill with the
+ * 7-char `after` SHA (single commit) or a `before..after` range (multi-commit).
+ */
+const PushPill = ({sha}: {sha: string}) => (
+  <code className={classes.PushPill}>
+    <Link href="#" className={classes.PushPillLink}>
+      {sha}
+    </Link>
+  </code>
+)
+
+export default {
+  title: 'Components/Timeline/Events/Dependabot',
+  component: Timeline,
+  subcomponents: {
+    'Timeline.Item': Timeline.Item,
+    'Timeline.Avatar': Timeline.Avatar,
+    'Timeline.Badge': Timeline.Badge,
+    'Timeline.Body': Timeline.Body,
+    'Timeline.Break': Timeline.Break,
+    'Timeline.Actions': Timeline.Actions,
+  },
+  decorators: [
+    // File-scoped: render every story in the future-state list semantics
+    // (`<ol>`/`<li>`). The `primer_react_timeline_list_semantics` flag is merged
+    // on main; this opts these stories into the DOM the timeline will ship.
+    Story => (
+      <FeatureFlags flags={{primer_react_timeline_list_semantics: true}}>
+        <Story />
+      </FeatureFlags>
+    ),
+  ],
+} as Meta<ComponentProps<typeof Timeline>>
+
+/**
+ * The Opened event group — `DepTimeline.eventOpened` (audit § 1).
+ *
+ * Source: `OpenedComponent` (`opened_component.html.erb`). The actor is ALWAYS
+ * Dependabot. Badge: `shield` icon on `success` (green) — the ERB renders
+ * `with_badge(bg: :success_emphasis, color: :on_emphasis, icon: :shield)`,
+ * which maps exactly to `Timeline.Badge variant="success"`.
+ *
+ * Three source variants (`Opened` / `OpenedFromPR` / `OpenedFromPush`) differ
+ * only by the optional "from …" clause: no source, a bold `#123` PR link, or a
+ * blue push-pill.
+ */
+export const EventOpened = () => (
+  <div
+    className={classes.RealisticTimeline}
+    // Prevent the placeholder `href="#"` links from navigating inside Storybook.
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Opened — no source */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Opened</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="success">
+            <Octicon icon={ShieldIcon} aria-label="Opened" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'opened this '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* OpenedFromPR — bold `#123` pull-request link (scheme: primary, bold) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Opened from pull request</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="success">
+            <Octicon icon={ShieldIcon} aria-label="Opened from pull request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'opened this from '}
+            <Link href="#" className={classes.LinkWithBoldStyle}>
+              #123
+            </Link>{' '}
+            <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* OpenedFromPush — blue push-pill with the 7-char `after` SHA */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Opened from push</h3>
+      <Timeline aria-label="Dependabot alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="success">
+            <Octicon icon={ShieldIcon} aria-label="Opened from push" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <DependabotActor />
+            {'opened this from '}
+            <PushPill sha="adfc29a" /> <Time date="2022-07-26T11:46:07Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
@@ -14,6 +14,7 @@ import {
   XIcon,
 } from '@primer/octicons-react'
 import Avatar from '../Avatar'
+import {Button} from '../Button'
 import Label from '../Label'
 import Link from '../Link'
 import Octicon from '../Octicon'
@@ -624,10 +625,13 @@ export const EventDismissalRequest = () => (
       if ((e.target as HTMLElement).closest('a')) e.preventDefault()
     }}
   >
-    {/* Dismissal requested — circle user actor, attention/comment badge.
-        (The live ERB also renders optional float-right Review/Deny actions via
-        `DismissalReviewDialogComponent` when `show_dismissal_actions` — those
-        would live in `Timeline.Actions`; omitted here as interactive controls.) */}
+    {/* Dismissal requested — circle user actor, attention/comment badge. When
+        `show_dismissal_actions` is true, the live inline template
+        (`dismissal_requested_component.rb`) renders a `<span class="float-right">`
+        holding `DismissalReviewDialogComponent` — whose visible control is a
+        SINGLE small primary "Review request" button that opens a review dialog
+        (the approve/deny choice lives inside the dialog, not on the row). We
+        place that right-aligned control in the `Timeline.Actions` slot. */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Dismissal requested</h3>
       <Timeline aria-label="Dependabot alert timeline">
@@ -641,6 +645,9 @@ export const EventDismissalRequest = () => (
             <strong>Tolerable risk</strong> <Time date="2022-08-07T13:20:00Z" />
             <NoteComment>This dependency is only used in our test tooling, so the risk is acceptable.</NoteComment>
           </Timeline.Body>
+          <Timeline.Actions>
+            <Button size="small">Review request</Button>
+          </Timeline.Actions>
         </Timeline.Item>
       </Timeline>
     </section>


### PR DESCRIPTION
## Summary

Adds Storybook **Features** stories that recreate GitHub's live **Dependabot alert timeline** events using the Primer `Timeline` component and its compositional slots. This is the **Dependabot surface** of Phase 2 of the Timeline events effort (github/primer#6663). The Issues surface already landed in #8070; the PR and other surfaces will follow separately.

All examples live in a single new file, `Timeline.dependabot.features.stories.tsx` (+ a `.module.css`), exported under the title **`Components/Timeline/Events/Dependabot`** — one story export per event group.

### The 5 event groups (23 variants total)

| Group | Variants | Badge |
|---|---|---|
| `EventOpened` | 3 — Opened / from PR / from push | `shield` on solid `success` |
| `EventFixed` | 3 — Fixed / via PR / via push | `shield-check` on solid `done` |
| `EventDismissed` | 8 — 5 manual reasons (+ optional note) + 3 auto (rule-based, incl. from PR/push) | bare `shield-slash` (muted icon) |
| `EventReopened` | 5 — manual reopen + reintroduced ×source + auto-reopened | `sync` on solid `success` |
| `EventDismissalRequest` | 4 — Requested / Approved / Denied / Cancelled | bare badge + colored icon |

## Source of truth

These stories were recreated from the **live, server-rendered ERB ViewComponents** in `app/components/dependabot_alerts/timeline_items/` in `github/github`. Each component's render markup and the Primer component arguments it passes were read directly and translated faithfully into Primer React; the source file is cited inline next to each event.

**Notably, Dependabot's alert timeline has _no React implementation yet_ — it is 100% ERB.** `github/github-ui` ships only Catalyst custom-element controllers (`dependabot-alert-*-element.ts`) for table-row / load-all / dismissal interactions, not the timeline event rows. So beyond documenting the design system, these stories double as a useful reference for that team's eventual ERB→React migration.

We verified the live render path per component rather than trusting the Figma audit blindly. The most important catch: the **dismissal request/review events use a newer inline `erb_template`** (`include ViewComponent::InlineTemplate`), which is the active render — the older sibling `*.html.erb` sidecars are dormant dead code. The Figma audit reflected the dormant sidecar (no-avatar, `person`/`check-circle` badges); the live inline template renders a circle **user** avatar with status-driven icons. Live won.

We were also careful about the Primer badge mechanic: events whose ERB sets `bg: :*_emphasis` (Opened/Fixed/Reopened) correctly use a solid `Timeline.Badge variant`, while events whose ERB sets only `color: :*` with **no** `bg:` (Dismissed, Dismissal Request/Review/Cancelled) render as a **bare default badge with a colored icon** — not a solid-color badge.

## Slots used (Phase 1 slots)

- **Inline actor avatar** in `Timeline.Body` for badge-row events — a **square** avatar + bold link + `(bot)` `Label` for Dependabot-authored events (`ActorComponent` `:dependabot` mode), and a **circle** 20px user avatar + bold link for user-authored events.
- **`Timeline.Actions`** (right-controls slot, added in #7886) for the **Dismissal Requested** "Review request" button — the live inline template renders a `float-right` `DismissalReviewDialogComponent`, whose visible control is a single small primary button that opens the approve/deny dialog.
- Dependabot-specific bits composed from primitives: the **square bot avatar**, the **`(bot)` tag** (`Label variant="secondary"`, mirroring ERB `bot_identifier_tag`), and the inline **push-pill** SHA (`PushLinkComponent` → a `<code>`-wrapped `Link` styled as the subtle light-blue GitHub SHA pill). Push-pills are part of the sentence body text in the live `PushLinkComponent`, so they correctly stay **inline in `Timeline.Body`**, not in `Timeline.Actions`.

## Scope & conventions

- Every story is wrapped in a file-scoped `FeatureFlags` decorator enabling `primer_react_timeline_list_semantics` (the future-state `<ol>`/`<li>` DOM; refs primer/react#7910).
- **Storybook-only by design.** These are intentionally **not** wired into components-json / the primer.style docs page (not added to `Timeline.docs.json` or `build.ts`) — individual timeline events are not consumer-facing components.
- The future event-category `data-*` filtering taxonomy (github/primer#6663) is intentionally **deferred**; the hook location is documented in the file header.

### Changelog

#### New

- `Timeline.dependabot.features.stories.tsx` and `Timeline.dependabot.features.stories.module.css` — Storybook Features stories recreating the Dependabot alert timeline events (5 groups, 23 variants).

#### Changed

- None.

#### Removed

- None.

### Rollout strategy

- [x] None; if selected, include a brief description as to why

Stories-only change — no consumer-facing package code is added or modified, so no changeset is needed (the `skip changeset` label is applied).

### Testing & Reviewing

- prettier, eslint, and stylelint all clean; type-check passes with 0 new errors (the pre-existing `@primer/doc-gen` baseline error in `script/components-json/build.ts` is unchanged).
- All 5 groups were visually diffed against the live ERB render and the Figma source. Where Figma was behind live (the dismissal events), the **live render won**.
- Browse the stories under **Components/Timeline/Events/Dependabot** in Storybook to review each group.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui
