### PR TITLE
Timeline: add Code Scanning event stories (Phase 2)

### DIFF
--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.module.css
@@ -1,0 +1,111 @@
+.RealisticTimeline {
+  /* GitHub renders the timeline at most 1012px wide in product surfaces. */
+  max-width: 1012px;
+}
+
+/* Story-only scaffolding: each variant is wrapped in its own <section> with a
+   small caption heading ABOVE the event, so the event row itself (badge + body)
+   renders exactly as it would in product — the caption never sits inside
+   Timeline.Body. Variants stay scannable like a Figma component set. Not part of
+   the faithful event. */
+.Variant {
+  margin-bottom: var(--base-size-24);
+}
+
+.VariantLabel {
+  margin: 0 0 var(--base-size-4);
+  font-size: var(--text-body-size-small);
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Bold body text, mirroring the live `item.with_body(font_weight: :bold)` used
+   by every system (no-actor) Code Scanning event. */
+.BoldBody {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+}
+
+/* Bold branch ref — live `formatted_ref_name` renders
+   `Primer::Beta::Text.new(font_weight: :bold, classes: "branch-name")` (dotcom
+   defines no `.branch-name` rule, so it is plain bold text, NOT the monospace
+   `BranchName` pill). */
+.RefName {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+}
+
+/* Muted relative timestamp. The shared `timeline_item_component` renders a plain
+   `time_ago_in_words_js` — muted text only, no link wrapper (matching the
+   Dependabot / Secret Scanning timelines, unlike the Issues `Ago` deep-link). */
+.Timestamp {
+  color: var(--fgColor-muted);
+  margin-left: var(--base-size-4);
+}
+
+/* "in configuration {category}" inline pill — live `show_analysis_origin?` rows
+   render `Primer::Beta::Truncate.new(bg: :subtle, font_family: :mono,
+   font_size: 6, border_radius: 1)`: a SUBTLE gray monospace rounded pill.
+   Rendered only when the alert has more than one analysis category. */
+.ConfigPill {
+  display: inline-block;
+  margin-left: var(--base-size-4);
+  padding: 0 var(--base-size-4);
+  font-family: var(--fontStack-monospace);
+  font-size: var(--text-body-size-small);
+  color: var(--fgColor-default);
+  background-color: var(--bgColor-muted);
+  border-radius: var(--borderRadius-small);
+  vertical-align: middle;
+}
+
+/* Supplementary sub-row below a detection event. Live ERB renders a condensed
+   `Primer::Beta::TimelineItem(condensed: true, font_size: 6, classes:
+   "tmp-pl-5")` — a small, indented row beneath the main item. We mirror the
+   established Dependabot / Secret Scanning precedent and compose it as a small
+   muted block inside `Timeline.Body` (not a badge-less Timeline.Item). */
+.SubRow {
+  margin-top: var(--base-size-8);
+  padding-left: var(--base-size-4);
+  font-size: var(--text-body-size-small);
+  color: var(--fgColor-muted);
+}
+
+/* Bold segment inside the path sub-row — live ERB bolds
+   `{file_name}:{start_line} on branch` via
+   `Primer::Beta::Text(color: :default, font_weight: :bold)`. */
+.SubRowStrong {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+}
+
+/* Workflow-run sub-row icon (the green check / pending dot before the run
+   link). Live ERB renders a check-suite conclusion octicon. */
+.SubRowIconSuccess {
+  margin-right: var(--base-size-4);
+  color: var(--fgColor-success);
+  vertical-align: middle;
+}
+
+/* Bold workflow-run link — live ERB `Primer::Beta::Link(scheme: :primary,
+   font_weight: :bold)`. The a11y `link-in-text-block` rule requires in-text
+   links to be visually distinct without relying on color, so the bold weight is
+   the non-color differentiator (matching the Issues / Dependabot precedent). */
+.WorkflowLink {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+}
+
+.WorkflowLink:hover {
+  color: var(--fgColor-accent);
+}
+
+/* Monospace commit-SHA link — live ERB `Primer::Beta::Link(scheme: :secondary,
+   font_family: :mono)` truncated to 8 chars. */
+.CommitSha {
+  margin-left: var(--base-size-4);
+  font-family: var(--fontStack-monospace);
+  color: var(--fgColor-muted);
+}

--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.module.css
@@ -109,3 +109,38 @@
   font-family: var(--fontStack-monospace);
   color: var(--fgColor-muted);
 }
+
+/* Inline user-actor avatar — live `profile_link` wraps a `Primer::Beta::Avatar`
+   (CIRCLE) before the bold login. */
+.InlineAvatar {
+  vertical-align: middle;
+  margin-right: var(--base-size-4);
+}
+
+/* Bold actor / reference link — live `profile_link(scheme: :primary,
+   font_weight: :bold, class: "Link--primary text-bold")`: semibold, default
+   foreground, accent on hover. The bold weight is also the non-color
+   differentiator that satisfies the axe `link-in-text-block` rule. */
+.LinkWithBoldStyle {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+  margin-right: var(--base-size-4);
+}
+
+.LinkWithBoldStyle:hover {
+  color: var(--fgColor-accent);
+}
+
+/* Bold closure / resolution reason — live ERB wraps the reason in
+   `Primer::Beta::Text(font_weight: :bold, classes: "branch-name")`. */
+.Reason {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+}
+
+/* Leading `note` octicon in a NoteSubRow. */
+.SubRowIcon {
+  margin-right: var(--base-size-4);
+  color: var(--fgColor-muted);
+  vertical-align: middle;
+}

--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.module.css
@@ -1,26 +1,3 @@
-.RealisticTimeline {
-  /* GitHub renders the timeline at most 1012px wide in product surfaces. */
-  max-width: 1012px;
-}
-
-/* Story-only scaffolding: each variant is wrapped in its own <section> with a
-   small caption heading ABOVE the event, so the event row itself (badge + body)
-   renders exactly as it would in product — the caption never sits inside
-   Timeline.Body. Variants stay scannable like a Figma component set. Not part of
-   the faithful event. */
-.Variant {
-  margin-bottom: var(--base-size-24);
-}
-
-.VariantLabel {
-  margin: 0 0 var(--base-size-4);
-  font-size: var(--text-body-size-small);
-  font-weight: var(--base-text-weight-semibold);
-  color: var(--fgColor-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
 /* Bold body text, mirroring the live `item.with_body(font_weight: :bold)` used
    by every system (no-actor) Code Scanning event. */
 .BoldBody {
@@ -35,14 +12,6 @@
 .RefName {
   font-weight: var(--base-text-weight-semibold);
   color: var(--fgColor-default);
-}
-
-/* Muted relative timestamp. The shared `timeline_item_component` renders a plain
-   `time_ago_in_words_js` — muted text only, no link wrapper (matching the
-   Dependabot / Secret Scanning timelines, unlike the Issues `Ago` deep-link). */
-.Timestamp {
-  color: var(--fgColor-muted);
-  margin-left: var(--base-size-4);
 }
 
 /* "in configuration {category}" inline pill — live `show_analysis_origin?` rows
@@ -110,26 +79,9 @@
   color: var(--fgColor-muted);
 }
 
-/* Inline user-actor avatar — live `profile_link` wraps a `Primer::Beta::Avatar`
-   (CIRCLE) before the bold login. */
-.InlineAvatar {
-  vertical-align: middle;
-  margin-right: var(--base-size-4);
-}
-
-/* Bold actor / reference link — live `profile_link(scheme: :primary,
-   font_weight: :bold, class: "Link--primary text-bold")`: semibold, default
-   foreground, accent on hover. The bold weight is also the non-color
-   differentiator that satisfies the axe `link-in-text-block` rule. */
-.LinkWithBoldStyle {
-  font-weight: var(--base-text-weight-semibold);
-  color: var(--fgColor-default);
-  margin-right: var(--base-size-4);
-}
-
-.LinkWithBoldStyle:hover {
-  color: var(--fgColor-accent);
-}
+/* Inline user-actor avatar and the bold actor / reference link moved to the
+   shared internal helpers (`InlineAvatar` → github/primer#6827, `BoldLink` →
+   github/primer#6826) in `./internal/timelineStoryHelpers`. */
 
 /* Bold closure / resolution reason — live ERB wraps the reason in
    `Primer::Beta::Text(font_weight: :bold, classes: "branch-name")`. */

--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.module.css
@@ -90,9 +90,5 @@
   color: var(--fgColor-default);
 }
 
-/* Leading `note` octicon in a NoteSubRow. */
-.SubRowIcon {
-  margin-right: var(--base-size-4);
-  color: var(--fgColor-muted);
-  vertical-align: middle;
-}
+/* The note sub-row's `note` octicon styling moved to the shared `EventSubRow`
+   helper (`.EventSubRowIcon`) in `./internal/timelineStoryHelpers`. */

--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
@@ -198,6 +198,37 @@ const NoteSubRow = ({children}: {children: React.ReactNode}) => (
   </SubRow>
 )
 
+/**
+ * Shared story wrapper. Provides the realistic max-width frame and two
+ * environment behaviours every group needs:
+ *
+ * - `data-a11y-link-underlines="true"`: in production GitHub sets this on an
+ *   ancestor from the (default-ON) "Show link underlines" preference, which is
+ *   what activates Primer's underline on `Link inline` content links. Storybook
+ *   never sets it, so we add it here to reproduce the production default. Primer
+ *   only underlines links carrying `data-inline` (i.e. `Link inline`); this
+ *   surface's links are all className-styled — the actor-name profile link is
+ *   bold (`muted`, no `inline`) and the workflow / commit-SHA links are
+ *   bold / monospace — so none are underlined by this attribute (their bold /
+ *   mono weight is the non-color differentiator). The attribute keeps the
+ *   wrapper aligned with production so any future `Link inline` underlines
+ *   correctly without a WCAG 1.4.1 color-only gap.
+ * - `onClick` guard: stops the placeholder `href="#"` links from navigating
+ *   inside Storybook. Guarded with `instanceof Element` so non-element event
+ *   targets can't throw.
+ */
+const Examples = ({children}: {children: React.ReactNode}) => (
+  <div
+    className={classes.RealisticTimeline}
+    data-a11y-link-underlines="true"
+    onClick={e => {
+      if (e.target instanceof Element && e.target.closest('a')) e.preventDefault()
+    }}
+  >
+    {children}
+  </div>
+)
+
 export default {
   title: 'Components/Timeline/Events/Code Scanning',
   component: Timeline,
@@ -240,13 +271,7 @@ export default {
  *    {ref}"; demonstrates the optional "in configuration {category}" pill.
  */
 export const EventDetected = () => (
-  <div
-    className={classes.RealisticTimeline}
-    // Prevent the placeholder `href="#"` links from navigating inside Storybook.
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* First detected — ALERT_CREATED. Bare shield badge, bold body, a path
         sub-row, and a right-aligned tool-version Label (Timeline.Actions). */}
     <section className={classes.Variant}>
@@ -254,7 +279,7 @@ export const EventDetected = () => (
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={ShieldIcon} aria-label="Detected" />
+            <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <span className={classes.BoldBody}>First detected in commit</span>
@@ -289,7 +314,7 @@ export const EventDetected = () => (
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={GitBranchIcon} aria-label="Appeared in branch" />
+            <Octicon icon={GitBranchIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <span className={classes.BoldBody}>Appeared in branch</span> <Ref name="main" />
@@ -320,7 +345,7 @@ export const EventDetected = () => (
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={ShieldIcon} aria-label="Reappeared" />
+            <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <span className={classes.BoldBody}>Reappeared in branch</span> <Ref name="main" />
@@ -330,7 +355,7 @@ export const EventDetected = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -351,14 +376,14 @@ export const EventDetected = () => (
  * Upload".
  */
 export const EventFixed = () => (
-  <div className={classes.RealisticTimeline}>
+  <Examples>
     {/* Fixed — selected ref → SOLID purple shield-check */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Fixed in branch (current ref)</h3>
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Fixed" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <span className={classes.BoldBody}>Fixed in branch</span> <Ref name="main" />
@@ -374,7 +399,7 @@ export const EventFixed = () => (
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CheckIcon} aria-label="Fixed" />
+            <Octicon icon={CheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <span className={classes.BoldBody}>Fixed in branch</span> <Ref name="feature-x" />
@@ -390,7 +415,7 @@ export const EventFixed = () => (
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Closed" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <span className={classes.BoldBody}>Closed as</span> <MonoPill>java</MonoPill>{' '}
@@ -407,7 +432,7 @@ export const EventFixed = () => (
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CheckIcon} aria-label="Closed" />
+            <Octicon icon={CheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <span className={classes.BoldBody}>Closed as</span> <MonoPill>java</MonoPill>{' '}
@@ -417,7 +442,7 @@ export const EventFixed = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -433,19 +458,14 @@ export const EventFixed = () => (
  * shared row appends a `note` sub-row (`show_resolution_note?`).
  */
 export const EventClosedByUser = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Closed as false positive — with a resolution-note sub-row */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Closed as false positive</h3>
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="danger">
-            <Octicon icon={ShieldXIcon} aria-label="Closed" />
+            <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -463,7 +483,7 @@ export const EventClosedByUser = () => (
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="danger">
-            <Octicon icon={ShieldXIcon} aria-label="Closed" />
+            <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -480,7 +500,7 @@ export const EventClosedByUser = () => (
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="danger">
-            <Octicon icon={ShieldXIcon} aria-label="Closed" />
+            <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -498,7 +518,7 @@ export const EventClosedByUser = () => (
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="danger">
-            <Octicon icon={ShieldXIcon} aria-label="Closed" />
+            <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -508,7 +528,7 @@ export const EventClosedByUser = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -520,18 +540,13 @@ export const EventClosedByUser = () => (
  * variant.
  */
 export const EventReopened = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Reopened</h3>
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
-            <Octicon icon={DotFillIcon} aria-label="Reopened" />
+            <Octicon icon={DotFillIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -541,7 +556,7 @@ export const EventReopened = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -561,18 +576,13 @@ export const EventReopened = () => (
  * "Review request"). It is mapped here to the `Timeline.Actions` right slot.
  */
 export const EventDismissalRequested = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Requested to dismiss</h3>
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CommentIcon} aria-label="Dismissal requested" />
+            <Octicon icon={CommentIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -588,7 +598,7 @@ export const EventDismissalRequested = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -606,19 +616,14 @@ export const EventDismissalRequested = () => (
  * `delegated_dismissal_enabled?` is true for the repo.
  */
 export const EventDismissalReviewed = () => (
-  <div
-    className={classes.RealisticTimeline}
-    onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
-    }}
-  >
+  <Examples>
     {/* Approved — check icon + reviewer-comment sub-row */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Approved dismissal</h3>
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CheckIcon} aria-label="Approved" />
+            <Octicon icon={CheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -636,7 +641,7 @@ export const EventDismissalReviewed = () => (
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={XIcon} aria-label="Denied" />
+            <Octicon icon={XIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor />
@@ -646,5 +651,5 @@ export const EventDismissalReviewed = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )

--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
@@ -14,12 +14,18 @@ import {
   ShieldXIcon,
   XIcon,
 } from '@primer/octicons-react'
-import Avatar from '../Avatar'
 import {Button} from '../Button'
 import Label from '../Label'
 import Link from '../Link'
 import Octicon from '../Octicon'
-import RelativeTime from '../RelativeTime'
+import {
+  BoldLink,
+  Examples,
+  InlineAvatar,
+  MutedTime,
+  RealisticTimeline,
+  VariantSection,
+} from './internal/timelineStoryHelpers'
 import classes from './Timeline.code-scanning.features.stories.module.css'
 
 /**
@@ -142,19 +148,22 @@ const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
  */
 const UserActor = ({login = 'monalisa', src = MONALISA_AVATAR}: {login?: string; src?: string}) => (
   <>
-    <Avatar src={src} size={20} alt="" className={classes.InlineAvatar} />
-    <Link href="#" className={classes.LinkWithBoldStyle} muted>
+    <InlineAvatar src={src} />
+    <BoldLink href="#" muted>
       {login}
-    </Link>
+    </BoldLink>
   </>
 )
 
-// Muted relative timestamp. The shared `timeline_item_component` renders a plain
-// `time_ago_in_words_js` (no link wrapper) — muted text only.
+// Muted relative timestamp — the shared `MutedTime` helper (github/primer#6828).
+// The live shared `timeline_item_component` renders a plain `time_ago_in_words_js`
+// (no link wrapper) — muted text only. A leading space preserves the gap the old
+// local `.Timestamp` class provided via `margin-left`.
 const Time = ({date}: {date: string}) => (
-  <span className={classes.Timestamp}>
-    <RelativeTime date={new Date(date)} format="relative" />
-  </span>
+  <>
+    {' '}
+    <MutedTime date={new Date(date)} />
+  </>
 )
 
 /**
@@ -196,37 +205,6 @@ const NoteSubRow = ({children}: {children: React.ReactNode}) => (
     <Octicon icon={NoteIcon} size={16} className={classes.SubRowIcon} />
     {children}
   </SubRow>
-)
-
-/**
- * Shared story wrapper. Provides the realistic max-width frame and two
- * environment behaviours every group needs:
- *
- * - `data-a11y-link-underlines="true"`: in production GitHub sets this on an
- *   ancestor from the (default-ON) "Show link underlines" preference, which is
- *   what activates Primer's underline on `Link inline` content links. Storybook
- *   never sets it, so we add it here to reproduce the production default. Primer
- *   only underlines links carrying `data-inline` (i.e. `Link inline`); this
- *   surface's links are all className-styled — the actor-name profile link is
- *   bold (`muted`, no `inline`) and the workflow / commit-SHA links are
- *   bold / monospace — so none are underlined by this attribute (their bold /
- *   mono weight is the non-color differentiator). The attribute keeps the
- *   wrapper aligned with production so any future `Link inline` underlines
- *   correctly without a WCAG 1.4.1 color-only gap.
- * - `onClick` guard: stops the placeholder `href="#"` links from navigating
- *   inside Storybook. Guarded with `instanceof Element` so non-element event
- *   targets can't throw.
- */
-const Examples = ({children}: {children: React.ReactNode}) => (
-  <div
-    className={classes.RealisticTimeline}
-    data-a11y-link-underlines="true"
-    onClick={e => {
-      if (e.target instanceof Element && e.target.closest('a')) e.preventDefault()
-    }}
-  >
-    {children}
-  </div>
 )
 
 export default {
@@ -274,8 +252,7 @@ export const EventDetected = () => (
   <Examples>
     {/* First detected — ALERT_CREATED. Bare shield badge, bold body, a path
         sub-row, and a right-aligned tool-version Label (Timeline.Actions). */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>First detected in commit</h3>
+    <VariantSection label="First detected in commit">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -304,13 +281,12 @@ export const EventDetected = () => (
           </Timeline.Actions>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Appeared in branch — ALERT_APPEARED_IN_BRANCH. Bare git-branch badge,
         bold "Appeared in branch {ref}", and a workflow-run sub-row (no commit
         card — `show_timeline_commit?` is false for this event). */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Appeared in branch</h3>
+    <VariantSection label="Appeared in branch">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -335,13 +311,12 @@ export const EventDetected = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Reappeared in branch — ALERT_REAPPEARED. Bare shield badge, bold
         "Reappeared in branch {ref}", and the optional "in configuration
         {category}" pill (rendered when the alert has more than one category). */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Reappeared in branch</h3>
+    <VariantSection label="Reappeared in branch">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -354,7 +329,7 @@ export const EventDetected = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -376,10 +351,9 @@ export const EventDetected = () => (
  * Upload".
  */
 export const EventFixed = () => (
-  <Examples>
+  <RealisticTimeline>
     {/* Fixed — selected ref → SOLID purple shield-check */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Fixed in branch (current ref)</h3>
+    <VariantSection label="Fixed in branch (current ref)">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -391,11 +365,10 @@ export const EventFixed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Fixed — non-selected ref → bare default check */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Fixed in branch (other ref)</h3>
+    <VariantSection label="Fixed in branch (other ref)">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -407,11 +380,10 @@ export const EventFixed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Config deleted — selected ref → SOLID purple shield-check */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Configuration deleted (current ref)</h3>
+    <VariantSection label="Configuration deleted (current ref)">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -424,11 +396,10 @@ export const EventFixed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Config deleted — non-selected ref → bare default check */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Configuration deleted (other ref)</h3>
+    <VariantSection label="Configuration deleted (other ref)">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -441,8 +412,8 @@ export const EventFixed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
-  </Examples>
+    </VariantSection>
+  </RealisticTimeline>
 )
 
 /**
@@ -460,8 +431,7 @@ export const EventFixed = () => (
 export const EventClosedByUser = () => (
   <Examples>
     {/* Closed as false positive — with a resolution-note sub-row */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as false positive</h3>
+    <VariantSection label="Closed as false positive">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="danger">
@@ -475,11 +445,10 @@ export const EventClosedByUser = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed as used in tests */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as used in tests</h3>
+    <VariantSection label="Closed as used in tests">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="danger">
@@ -492,11 +461,10 @@ export const EventClosedByUser = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed as won't fix */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as won&apos;t fix</h3>
+    <VariantSection label="Closed as won't fix">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="danger">
@@ -509,12 +477,11 @@ export const EventClosedByUser = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed with no resolution — ERB omits the " as {reason}" clause when
         `resolution == :NO_RESOLUTION`. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed (no resolution)</h3>
+    <VariantSection label="Closed (no resolution)">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="danger">
@@ -527,7 +494,7 @@ export const EventClosedByUser = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -541,8 +508,7 @@ export const EventClosedByUser = () => (
  */
 export const EventReopened = () => (
   <Examples>
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Reopened</h3>
+    <VariantSection label="Reopened">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
@@ -555,7 +521,7 @@ export const EventReopened = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -577,8 +543,7 @@ export const EventReopened = () => (
  */
 export const EventDismissalRequested = () => (
   <Examples>
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Requested to dismiss</h3>
+    <VariantSection label="Requested to dismiss">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -597,7 +562,7 @@ export const EventDismissalRequested = () => (
           </Timeline.Actions>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -618,8 +583,7 @@ export const EventDismissalRequested = () => (
 export const EventDismissalReviewed = () => (
   <Examples>
     {/* Approved — check icon + reviewer-comment sub-row */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Approved dismissal</h3>
+    <VariantSection label="Approved dismissal">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -633,11 +597,10 @@ export const EventDismissalReviewed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Denied — x icon */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Denied dismissal</h3>
+    <VariantSection label="Denied dismissal">
       <Timeline aria-label="Code scanning alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -650,6 +613,6 @@ export const EventDismissalReviewed = () => (
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )

--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
@@ -53,11 +53,10 @@ import classes from './Timeline.code-scanning.features.stories.module.css'
  * base `Timeline` component's own stories, and any docs-site representation is a
  * Phase 3 consideration via base-component story changes, out of scope here.
  *
- * THIS FILE IS A PROOF-OF-PATTERN: it ships only the **Detected** event group
- * (alert created / appeared / reappeared) plus the file scaffold + helpers. The
- * remaining groups (Fixed / Config-deleted, Closed by user, Reopened, Dismissal
- * requested, Dismissal reviewed) are deliberately deferred to a follow-up so the
- * conventions below can be reviewed first.
+ * This file ships all six Code Scanning event groups: **Detected** (alert
+ * created / appeared / reappeared), **Fixed / Config-deleted**, **Closed by
+ * user**, **Reopened**, **Dismissal requested**, and **Dismissal reviewed**.
+ * Each renders as its own story export.
  *
  * AUTHORITATIVE EVENT LIST (live `timeline_component.html.erb` dispatch), for
  * planning the remaining groups:
@@ -103,18 +102,21 @@ import classes from './Timeline.code-scanning.features.stories.module.css'
  * which render a CIRCLE 20px avatar + bold `display_login` profile link. The
  * Detected group below is system-only, so no actor and no in-text link appears.
  *
- * ACCESSIBILITY NOTE: the Detected group renders no in-text `<Link>` in the main
- * body (system events are bold text only). The only links are in the workflow
- * sub-row, where the bold weight is the non-color differentiator required by the
- * axe `link-in-text-block` rule. Any in-text link added when the USER-actor
- * groups are built must likewise use `inline`/bold styling.
+ * ACCESSIBILITY NOTE: the SYSTEM events (Detected, Fixed, Config-deleted) render
+ * no in-text `<Link>` in the main body (bold text only); their only links are in
+ * the workflow sub-row. The USER events (Closed by user, Reopened, both Dismissal
+ * events) DO render an in-text profile `<Link>` via `UserActor` — it carries the
+ * bold weight as its non-color differentiator, which is what the axe
+ * `link-in-text-block` rule (WCAG 1.4.1) requires in high-contrast themes. Any
+ * further in-text link added here must likewise use bold or `inline` styling.
  *
  * RIGHT CONTROLS (`Timeline.Actions`): the shared row renders a right-aligned
  * tool-version `Primer::Beta::Label(scheme: :secondary)` whenever the event
- * carries a `tool_version` (the title reads "Tool version X" or "Tool upgraded
- * to X"). It is `margin-left: auto` inside the body in the ERB; we map it to the
- * `Timeline.Actions` right-controls slot. The "First detected" variant below
- * demonstrates it.
+ * carries a `tool_version` (the live title is
+ * `"Label: #{tool_version_prefix} #{tool_version}"`, e.g. "Label: Tool version
+ * 2.15.0" or "Label: Tool upgraded to X"). It is `margin-left: auto` inside the
+ * body in the ERB; we map it to the `Timeline.Actions` right-controls slot. The
+ * "First detected" variant below demonstrates it.
  */
 
 /**
@@ -267,7 +269,10 @@ export const EventDetected = () => (
           </Timeline.Body>
           <Timeline.Actions>
             {/* Tool-version Label — `Primer::Beta::Label(scheme: :secondary)`,
-                right-aligned, title "Tool version 2.15.0". */}
+                right-aligned. The live ERB sets the title to
+                `"Label: #{tool_version_prefix} #{tool_version}"`, so the faithful
+                title is "Label: Tool version 2.15.0" (the "Label:" prefix is part
+                of dotcom's tooltip text, kept verbatim). */}
             <Label variant="secondary" title="Label: Tool version 2.15.0">
               2.15.0
             </Label>

--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
@@ -1,0 +1,277 @@
+import type {Meta} from '@storybook/react-vite'
+import type React from 'react'
+import type {ComponentProps} from '../utils/types'
+import {FeatureFlags} from '../FeatureFlags'
+import Timeline from './Timeline'
+import {GitBranchIcon, ShieldIcon} from '@primer/octicons-react'
+import Label from '../Label'
+import Link from '../Link'
+import Octicon from '../Octicon'
+import RelativeTime from '../RelativeTime'
+import classes from './Timeline.code-scanning.features.stories.module.css'
+
+/**
+ * Code Scanning alert Timeline event examples (Phase 2 of github/primer#6663).
+ *
+ * These stories recreate GitHub's live code-scanning-alert-timeline events using
+ * the Primer `Timeline` compositional slots. They mirror the established Issues
+ * (`Timeline.issues.features.stories.tsx`), Dependabot
+ * (`Timeline.dependabot.features.stories.tsx`), and Secret Scanning
+ * (`Timeline.secret-scanning.features.stories.tsx`) stories, and are sourced
+ * from the `timeline-audit` inventory
+ * (`code-scanning-timeline-events-for-figma.md`), verified against the live ERB.
+ *
+ * SOURCE OF TRUTH — Code Scanning is NOT (yet) migrated to React. The alert
+ * timeline is entirely SERVER-RENDERED ERB (ViewComponent), exactly like the
+ * Dependabot surface. The events are dispatched by
+ * `CodeScanning::TimelineComponent` (`app/components/code_scanning/
+ * timeline_component.html.erb`), whose `case timeline_event.type` is the
+ * authoritative event list. Every row is rendered through the shared
+ * `CodeScanning::TimelineItemComponent` (`timeline_item_component.html.erb`),
+ * which wraps a `Primer::Beta::TimelineItem` + badge + body and appends optional
+ * supplementary sub-rows (commit card, path, workflow-run, resolution/reviewer
+ * comment). There is no React equivalent in `github/github-ui`. So each event
+ * below is translated faithfully from the live ERB into Primer React, with the
+ * ERB source noted inline.
+ *
+ * SCOPE: These are Storybook-only examples by design. They are intentionally
+ * NOT wired into components-json / the primer.style docs page (do NOT add this
+ * file to `Timeline.docs.json` or `build.ts`). Individual timeline events are
+ * not consumer-facing components — the primer.style Timeline page reflects the
+ * base `Timeline` component's own stories, and any docs-site representation is a
+ * Phase 3 consideration via base-component story changes, out of scope here.
+ *
+ * THIS FILE IS A PROOF-OF-PATTERN: it ships only the **Detected** event group
+ * (alert created / appeared / reappeared) plus the file scaffold + helpers. The
+ * remaining groups (Fixed / Config-deleted, Closed by user, Reopened, Dismissal
+ * requested, Dismissal reviewed) are deliberately deferred to a follow-up so the
+ * conventions below can be reviewed first.
+ *
+ * AUTHORITATIVE EVENT LIST (live `timeline_component.html.erb` dispatch), for
+ * planning the remaining groups:
+ *  - ALERT_CREATED — shield (default), bold "First detected in commit", no actor
+ *  - ALERT_APPEARED_IN_BRANCH — git-branch (default), bold "Appeared in branch
+ *    {ref}", no actor
+ *  - ALERT_REAPPEARED — shield (default), bold "Reappeared in branch {ref}", no
+ *    actor
+ *  - ALERT_CLOSED_BECAME_FIXED — shield-check on `done` (SOLID purple) when the
+ *    event ref is the selected ref, else `check` (default); bold "Fixed in
+ *    branch {ref}", no actor
+ *  - ALERT_CLOSED_BECAME_OUTDATED — same conditional shield-check/check badge;
+ *    bold "Closed as {category} configuration was deleted in branch {ref}", no
+ *    actor
+ *  - ALERT_CLOSED_BY_USER — shield-x on `danger` (SOLID red); USER actor;
+ *    "closed this as {reason}"
+ *  - ALERT_REOPENED_BY_USER — dot-fill on `success` (SOLID green); USER actor;
+ *    "reopened this"
+ *  - ALERT_DISMISSAL_REQUESTED — comment (default); USER actor; "requested to
+ *    dismiss this as {reason}"; carries the Review-request button
+ *  - ALERT_DISMISSAL_REVIEWED — check/x (default); USER actor; "approved /
+ *    denied dismissal"
+ *
+ * FEATURE-GATED PATHS: the audit flagged the two delegated-dismissal events
+ * (DISMISSAL_REQUESTED / DISMISSAL_REVIEWED) as only rendering when
+ * `delegated_dismissal_enabled?`; the Review-request button itself is further
+ * gated on `timeline_event.show_dismissal_actions`. These are dormant on most
+ * repos — worth confirming the live gating before building those groups.
+ *
+ * BADGE MODEL (live `timeline_item_component.html.erb` →
+ * `item.with_badge(bg: @background, color: @color, icon: @icon)`, defaulting to
+ * `background: :subtle, color: :default`): only the events that explicitly pass
+ * a `background:` (`done_emphasis` / `danger_emphasis` / `success_emphasis`)
+ * render a SOLID-color badge → `Timeline.Badge variant=`. Every other event —
+ * including the entire Detected group below — passes only an `icon:`, so it
+ * renders as a BARE `<Timeline.Badge>` (default gray circle, NO solid fill). We
+ * render those as a bare badge to match exactly — the `--timelineBadge-bgColor`
+ * hook is intentionally NOT used.
+ *
+ * ACTOR TREATMENT: Code Scanning splits cleanly into SYSTEM events (the whole
+ * Detected group, Fixed, Config-deleted) which render NO actor — just the bold
+ * body text — and USER events (Closed by user, Reopened, both Dismissal events)
+ * which render a CIRCLE 20px avatar + bold `display_login` profile link. The
+ * Detected group below is system-only, so no actor and no in-text link appears.
+ *
+ * ACCESSIBILITY NOTE: the Detected group renders no in-text `<Link>` in the main
+ * body (system events are bold text only). The only links are in the workflow
+ * sub-row, where the bold weight is the non-color differentiator required by the
+ * axe `link-in-text-block` rule. Any in-text link added when the USER-actor
+ * groups are built must likewise use `inline`/bold styling.
+ *
+ * RIGHT CONTROLS (`Timeline.Actions`): the shared row renders a right-aligned
+ * tool-version `Primer::Beta::Label(scheme: :secondary)` whenever the event
+ * carries a `tool_version` (the title reads "Tool version X" or "Tool upgraded
+ * to X"). It is `margin-left: auto` inside the body in the ERB; we map it to the
+ * `Timeline.Actions` right-controls slot. The "First detected" variant below
+ * demonstrates it.
+ */
+
+/**
+ * Bold branch ref — live `formatted_ref_name` renders
+ * `Primer::Beta::Text.new(font_weight: :bold, classes: "branch-name")`. Dotcom
+ * defines no `.branch-name` rule, so it is plain bold text (NOT the monospace
+ * `BranchName` pill).
+ */
+const Ref = ({name}: {name: string}) => <span className={classes.RefName}>{name}</span>
+
+// Muted relative timestamp. The shared `timeline_item_component` renders a plain
+// `time_ago_in_words_js` (no link wrapper) — muted text only.
+const Time = ({date}: {date: string}) => (
+  <span className={classes.Timestamp}>
+    <RelativeTime date={new Date(date)} format="relative" />
+  </span>
+)
+
+/**
+ * "in configuration {category}" inline pill — live `show_analysis_origin?` rows
+ * render `Primer::Beta::Truncate.new(bg: :subtle, font_family: :mono,
+ * font_size: 6, border_radius: 1)`: a subtle gray monospace rounded pill. Only
+ * shown when the alert has more than one analysis category
+ * (`has_more_than_one_category?`).
+ */
+const ConfigPill = ({category}: {category: string}) => (
+  <>
+    {' in configuration'}
+    <span className={classes.ConfigPill}>{category}</span>
+  </>
+)
+
+/**
+ * Optional supplementary sub-row below a detection event. Live ERB renders these
+ * as a condensed `Primer::Beta::TimelineItem(condensed: true, font_size: 6,
+ * classes: "tmp-pl-5")`. We mirror the established Dependabot / Secret Scanning
+ * precedent and compose the sub-row as a small muted block inside
+ * `Timeline.Body` rather than a badge-less Timeline.Item.
+ */
+const SubRow = ({children}: {children: React.ReactNode}) => <div className={classes.SubRow}>{children}</div>
+
+export default {
+  title: 'Components/Timeline/Events/Code Scanning',
+  component: Timeline,
+  subcomponents: {
+    'Timeline.Item': Timeline.Item,
+    'Timeline.Avatar': Timeline.Avatar,
+    'Timeline.Badge': Timeline.Badge,
+    'Timeline.Body': Timeline.Body,
+    'Timeline.Break': Timeline.Break,
+    'Timeline.Actions': Timeline.Actions,
+  },
+  decorators: [
+    // File-scoped: render every story in the future-state list semantics
+    // (`<ol>`/`<li>`). The `primer_react_timeline_list_semantics` flag is merged
+    // on main; this opts these stories into the DOM the timeline will ship.
+    Story => (
+      <FeatureFlags flags={{primer_react_timeline_list_semantics: true}}>
+        <Story />
+      </FeatureFlags>
+    ),
+  ],
+} as Meta<ComponentProps<typeof Timeline>>
+
+/**
+ * The Detected event group — `CodeScanTimeline.eventDetected` (audit § 1).
+ *
+ * Source: the `ALERT_CREATED`, `ALERT_APPEARED_IN_BRANCH`, and `ALERT_REAPPEARED`
+ * cases in `timeline_component.html.erb`. All three are SYSTEM events with NO
+ * actor — the body is bold text only (`item.with_body(font_weight: :bold)`) —
+ * and all three pass only an `icon:` to `with_badge`, so they render as a BARE
+ * `<Timeline.Badge>` (default gray circle, no solid fill).
+ *
+ * Three variants, differing by icon, copy, and supplementary sub-row:
+ *  - First detected (CREATED): `shield` icon, "First detected in commit"; the
+ *    shared row adds a path sub-row and (when present) a tool-version Label.
+ *  - Appeared in branch (APPEARED_IN_BRANCH): `git-branch` icon, "Appeared in
+ *    branch {ref}"; adds a workflow-run sub-row (this is the only detection
+ *    event with `show_timeline_commit?` false — no commit card).
+ *  - Reappeared in branch (REAPPEARED): `shield` icon, "Reappeared in branch
+ *    {ref}"; demonstrates the optional "in configuration {category}" pill.
+ */
+export const EventDetected = () => (
+  <div
+    className={classes.RealisticTimeline}
+    // Prevent the placeholder `href="#"` links from navigating inside Storybook.
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* First detected — ALERT_CREATED. Bare shield badge, bold body, a path
+        sub-row, and a right-aligned tool-version Label (Timeline.Actions). */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>First detected in commit</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={ShieldIcon} aria-label="Detected" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <span className={classes.BoldBody}>First detected in commit</span>
+            <Time date="2024-01-08T11:46:07Z" />
+            {/* Path sub-row — live `show_path?` (CREATED / REAPPEARED): the dir
+                prefix (plain) + bold `{file_name}:{start_line} on branch` + bold
+                ref. */}
+            <SubRow>
+              {'src/components/'}
+              <span className={classes.SubRowStrong}>Button.tsx:42 on branch</span> <Ref name="main" />
+            </SubRow>
+          </Timeline.Body>
+          <Timeline.Actions>
+            {/* Tool-version Label — `Primer::Beta::Label(scheme: :secondary)`,
+                right-aligned, title "Tool version 2.15.0". */}
+            <Label variant="secondary" title="Label: Tool version 2.15.0">
+              2.15.0
+            </Label>
+          </Timeline.Actions>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Appeared in branch — ALERT_APPEARED_IN_BRANCH. Bare git-branch badge,
+        bold "Appeared in branch {ref}", and a workflow-run sub-row (no commit
+        card — `show_timeline_commit?` is false for this event). */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Appeared in branch</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={GitBranchIcon} aria-label="Appeared in branch" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <span className={classes.BoldBody}>Appeared in branch</span> <Ref name="main" />
+            <Time date="2024-01-09T09:30:00Z" />
+            {/* Workflow-run sub-row — live `show_path?` is false here, so the
+                ERB renders the workflow branch: a conclusion octicon + bold run
+                link + a mono commit-SHA link. */}
+            <SubRow>
+              <Octicon icon={ShieldIcon} className={classes.SubRowIconSuccess} aria-label="Workflow succeeded" />
+              <Link href="#" className={classes.WorkflowLink}>
+                CodeQL #128:
+              </Link>{' '}
+              Commit
+              <Link href="#" className={classes.CommitSha}>
+                adfc29a
+              </Link>
+            </SubRow>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Reappeared in branch — ALERT_REAPPEARED. Bare shield badge, bold
+        "Reappeared in branch {ref}", and the optional "in configuration
+        {category}" pill (rendered when the alert has more than one category). */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Reappeared in branch</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={ShieldIcon} aria-label="Reappeared" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <span className={classes.BoldBody}>Reappeared in branch</span> <Ref name="main" />
+            <ConfigPill category="rust" />
+            <Time date="2024-01-10T14:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)

--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
@@ -3,7 +3,19 @@ import type React from 'react'
 import type {ComponentProps} from '../utils/types'
 import {FeatureFlags} from '../FeatureFlags'
 import Timeline from './Timeline'
-import {GitBranchIcon, ShieldIcon} from '@primer/octicons-react'
+import {
+  CheckIcon,
+  CommentIcon,
+  DotFillIcon,
+  GitBranchIcon,
+  NoteIcon,
+  ShieldCheckIcon,
+  ShieldIcon,
+  ShieldXIcon,
+  XIcon,
+} from '@primer/octicons-react'
+import Avatar from '../Avatar'
+import {Button} from '../Button'
 import Label from '../Label'
 import Link from '../Link'
 import Octicon from '../Octicon'
@@ -113,6 +125,28 @@ import classes from './Timeline.code-scanning.features.stories.module.css'
  */
 const Ref = ({name}: {name: string}) => <span className={classes.RefName}>{name}</span>
 
+const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
+
+/**
+ * User actor — live `profile_link(user, scheme: :primary, font_weight: :bold,
+ * class: "Link--primary text-bold")` wrapping `Primer::Beta::Avatar` +
+ * `display_login`: a CIRCLE avatar + bold login profile link. Used by every
+ * USER event (Closed by user, Reopened, both Dismissal events).
+ *
+ * a11y: this IS a real link, so to satisfy the axe `link-in-text-block` rule the
+ * bold weight is the non-color differentiator (matching the live `text-bold` and
+ * the Dependabot / Issues precedent — bold in-text links pass; only non-bold
+ * ones need `inline`).
+ */
+const UserActor = ({login = 'monalisa', src = MONALISA_AVATAR}: {login?: string; src?: string}) => (
+  <>
+    <Avatar src={src} size={20} alt="" className={classes.InlineAvatar} />
+    <Link href="#" className={classes.LinkWithBoldStyle} muted>
+      {login}
+    </Link>
+  </>
+)
+
 // Muted relative timestamp. The shared `timeline_item_component` renders a plain
 // `time_ago_in_words_js` (no link wrapper) — muted text only.
 const Time = ({date}: {date: string}) => (
@@ -122,16 +156,21 @@ const Time = ({date}: {date: string}) => (
 )
 
 /**
+ * Subtle gray monospace pill — live `Primer::Beta::Truncate.new(bg: :subtle,
+ * font_family: :mono, font_size: 6, border_radius: 1)`. Used both inline mid-copy
+ * (the Config-deleted `{category}`) and after "in configuration" (`ConfigPill`).
+ */
+const MonoPill = ({children}: {children: React.ReactNode}) => <span className={classes.ConfigPill}>{children}</span>
+
+/**
  * "in configuration {category}" inline pill — live `show_analysis_origin?` rows
- * render `Primer::Beta::Truncate.new(bg: :subtle, font_family: :mono,
- * font_size: 6, border_radius: 1)`: a subtle gray monospace rounded pill. Only
- * shown when the alert has more than one analysis category
- * (`has_more_than_one_category?`).
+ * render the `MonoPill` after the literal " in configuration". Only shown when
+ * the alert has more than one analysis category (`has_more_than_one_category?`).
  */
 const ConfigPill = ({category}: {category: string}) => (
   <>
     {' in configuration'}
-    <span className={classes.ConfigPill}>{category}</span>
+    <MonoPill>{category}</MonoPill>
   </>
 )
 
@@ -143,6 +182,19 @@ const ConfigPill = ({category}: {category: string}) => (
  * `Timeline.Body` rather than a badge-less Timeline.Item.
  */
 const SubRow = ({children}: {children: React.ReactNode}) => <div className={classes.SubRow}>{children}</div>
+
+/**
+ * Note sub-row — live `show_resolution_note?` / `show_reviewer_comment?` render a
+ * condensed row with a `note` octicon + the comment text below the event. Used
+ * by Closed-by-user / Dismissal-requested (`resolution_note`) and
+ * Dismissal-reviewed (`reviewer_comment`).
+ */
+const NoteSubRow = ({children}: {children: React.ReactNode}) => (
+  <SubRow>
+    <Octicon icon={NoteIcon} size={16} className={classes.SubRowIcon} />
+    {children}
+  </SubRow>
+)
 
 export default {
   title: 'Components/Timeline/Events/Code Scanning',
@@ -269,6 +321,322 @@ export const EventDetected = () => (
             <span className={classes.BoldBody}>Reappeared in branch</span> <Ref name="main" />
             <ConfigPill category="rust" />
             <Time date="2024-01-10T14:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Fixed / Config-deleted event group — `CodeScanTimeline.eventFixed`
+ * (audit § 2).
+ *
+ * Source: the `ALERT_CLOSED_BECAME_FIXED` and `ALERT_CLOSED_BECAME_OUTDATED`
+ * cases. Both are SYSTEM events (no actor — bold body text only) and both share
+ * the SAME conditional badge: when the event's ref is the currently selected ref
+ * (`timeline_event.ref_name_bytes == @selected_ref`) the badge is
+ * `shield-check` on `done_emphasis` (SOLID purple → `Timeline.Badge
+ * variant="done"`); otherwise it is a plain `check` icon on the default badge
+ * (BARE gray). Both variants are shown below for each event to demonstrate the
+ * conditional.
+ *
+ * Config-deleted renders the analysis category as an inline subtle mono pill
+ * (`MonoPill`); when the category is empty the live ERB substitutes "API
+ * Upload".
+ */
+export const EventFixed = () => (
+  <div className={classes.RealisticTimeline}>
+    {/* Fixed — selected ref → SOLID purple shield-check */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Fixed in branch (current ref)</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Fixed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <span className={classes.BoldBody}>Fixed in branch</span> <Ref name="main" />
+            <Time date="2024-01-12T10:15:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Fixed — non-selected ref → bare default check */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Fixed in branch (other ref)</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CheckIcon} aria-label="Fixed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <span className={classes.BoldBody}>Fixed in branch</span> <Ref name="feature-x" />
+            <Time date="2024-01-12T10:15:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Config deleted — selected ref → SOLID purple shield-check */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Configuration deleted (current ref)</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Closed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <span className={classes.BoldBody}>Closed as</span> <MonoPill>java</MonoPill>{' '}
+            <span className={classes.BoldBody}>configuration was deleted in branch</span> <Ref name="main" />
+            <Time date="2024-01-13T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Config deleted — non-selected ref → bare default check */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Configuration deleted (other ref)</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CheckIcon} aria-label="Closed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <span className={classes.BoldBody}>Closed as</span> <MonoPill>java</MonoPill>{' '}
+            <span className={classes.BoldBody}>configuration was deleted in branch</span> <Ref name="feature-x" />
+            <Time date="2024-01-13T16:40:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Closed-by-user event group — `CodeScanTimeline.eventClosedByUser`
+ * (audit § 3).
+ *
+ * Source: the `ALERT_CLOSED_BY_USER` case. Badge: `shield-x` on
+ * `danger_emphasis` (SOLID red → `Timeline.Badge variant="danger"`). This is a
+ * USER event — a circle avatar + bold login profile link. Copy: "closed this"
+ * plus, when `resolution != :NO_RESOLUTION`, " as {bold reason}". The reason set
+ * (`alert_closure_reasons`, downcased) is exactly three values: "false
+ * positive", "used in tests", "won't fix". When `resolution_note` is present the
+ * shared row appends a `note` sub-row (`show_resolution_note?`).
+ */
+export const EventClosedByUser = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Closed as false positive — with a resolution-note sub-row */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as false positive</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="danger">
+            <Octicon icon={ShieldXIcon} aria-label="Closed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'closed this as '}
+            <span className={classes.Reason}>false positive</span> <Time date="2024-01-14T08:20:00Z" />
+            <NoteSubRow>Verified this pattern only appears in generated fixtures.</NoteSubRow>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Closed as used in tests */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as used in tests</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="danger">
+            <Octicon icon={ShieldXIcon} aria-label="Closed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'closed this as '}
+            <span className={classes.Reason}>used in tests</span> <Time date="2024-01-14T08:20:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Closed as won't fix */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as won&apos;t fix</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="danger">
+            <Octicon icon={ShieldXIcon} aria-label="Closed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'closed this as '}
+            <span className={classes.Reason}>won&apos;t fix</span> <Time date="2024-01-14T08:20:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Closed with no resolution — ERB omits the " as {reason}" clause when
+        `resolution == :NO_RESOLUTION`. */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed (no resolution)</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="danger">
+            <Octicon icon={ShieldXIcon} aria-label="Closed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'closed this '}
+            <Time date="2024-01-14T08:20:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Reopened event group — `CodeScanTimeline.eventReopened` (audit § 4).
+ *
+ * Source: the `ALERT_REOPENED_BY_USER` case. Badge: `dot-fill` on
+ * `success_emphasis` (SOLID green → `Timeline.Badge variant="success"`). USER
+ * event — circle avatar + bold login. Copy is a fixed "reopened this". Single
+ * variant.
+ */
+export const EventReopened = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Reopened</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="success">
+            <Octicon icon={DotFillIcon} aria-label="Reopened" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'reopened this '}
+            <Time date="2024-01-15T11:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Dismissal-requested event group — `CodeScanTimeline.eventDismissalRequested`
+ * (audit § 5).
+ *
+ * Source: the `ALERT_DISMISSAL_REQUESTED` case. Badge: `comment` icon on the
+ * default badge (BARE gray — no `background:` passed). USER event — circle
+ * avatar + bold login. Copy: "requested to dismiss this as {reason}" where the
+ * reason is plain (NOT bold) `alert_closure_reason_description` text. A
+ * `requester_comment` renders as a `note` sub-row (`show_resolution_note?`).
+ *
+ * FEATURE-GATED: this whole event only renders when `delegated_dismissal_enabled?`
+ * is true for the repo, and the Review-request button is further gated on
+ * `timeline_event.show_dismissal_actions` (the live button is a
+ * `Primer::Alpha::Dialog` show-button, `scheme: :primary, size: :small`, label
+ * "Review request"). It is mapped here to the `Timeline.Actions` right slot.
+ */
+export const EventDismissalRequested = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Requested to dismiss</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CommentIcon} aria-label="Dismissal requested" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'requested to dismiss this as false positive '}
+            <Time date="2024-01-16T09:00:00Z" />
+            <NoteSubRow>This finding is a test-only helper, safe to dismiss.</NoteSubRow>
+          </Timeline.Body>
+          <Timeline.Actions>
+            <Button size="small" variant="primary">
+              Review request
+            </Button>
+          </Timeline.Actions>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Dismissal-reviewed event group — `CodeScanTimeline.eventDismissalReviewed`
+ * (audit § 6).
+ *
+ * Source: the `ALERT_DISMISSAL_REVIEWED` case. Badge icon comes from
+ * `exemption_evaluation_icon`: `check` when the request was approved, `x` when
+ * denied — both on the default badge (BARE gray). USER event — circle avatar +
+ * bold login. Copy comes from `dismissal_resolution_msg`: "approved dismissal"
+ * or "denied dismissal". A `reviewer_comment` renders as a `note` sub-row
+ * (`show_reviewer_comment?`).
+ *
+ * FEATURE-GATED: like the request event, this only renders when
+ * `delegated_dismissal_enabled?` is true for the repo.
+ */
+export const EventDismissalReviewed = () => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {/* Approved — check icon + reviewer-comment sub-row */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Approved dismissal</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CheckIcon} aria-label="Approved" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'approved dismissal '}
+            <Time date="2024-01-17T13:30:00Z" />
+            <NoteSubRow>Agreed — this rule does not apply to test fixtures.</NoteSubRow>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Denied — x icon */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Denied dismissal</h3>
+      <Timeline aria-label="Code scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={XIcon} aria-label="Denied" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor />
+            {'denied dismissal '}
+            <Time date="2024-01-17T13:30:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>

--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
@@ -19,11 +19,11 @@ import Label from '../Label'
 import Link from '../Link'
 import Octicon from '../Octicon'
 import {
-  BoldLink,
+  EventSubRow,
   Examples,
-  InlineAvatar,
   MutedTime,
   RealisticTimeline,
+  UserActor,
   VariantSection,
 } from './internal/timelineStoryHelpers'
 import classes from './Timeline.code-scanning.features.stories.module.css'
@@ -133,28 +133,6 @@ import classes from './Timeline.code-scanning.features.stories.module.css'
  */
 const Ref = ({name}: {name: string}) => <span className={classes.RefName}>{name}</span>
 
-const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
-
-/**
- * User actor — live `profile_link(user, scheme: :primary, font_weight: :bold,
- * class: "Link--primary text-bold")` wrapping `Primer::Beta::Avatar` +
- * `display_login`: a CIRCLE avatar + bold login profile link. Used by every
- * USER event (Closed by user, Reopened, both Dismissal events).
- *
- * a11y: this IS a real link, so to satisfy the axe `link-in-text-block` rule the
- * bold weight is the non-color differentiator (matching the live `text-bold` and
- * the Dependabot / Issues precedent — bold in-text links pass; only non-bold
- * ones need `inline`).
- */
-const UserActor = ({login = 'monalisa', src = MONALISA_AVATAR}: {login?: string; src?: string}) => (
-  <>
-    <InlineAvatar src={src} />
-    <BoldLink href="#" muted>
-      {login}
-    </BoldLink>
-  </>
-)
-
 // Muted relative timestamp — the shared `MutedTime` helper (github/primer#6828).
 // The live shared `timeline_item_component` renders a plain `time_ago_in_words_js`
 // (no link wrapper) — muted text only. A leading space preserves the gap the old
@@ -193,19 +171,6 @@ const ConfigPill = ({category}: {category: string}) => (
  * `Timeline.Body` rather than a badge-less Timeline.Item.
  */
 const SubRow = ({children}: {children: React.ReactNode}) => <div className={classes.SubRow}>{children}</div>
-
-/**
- * Note sub-row — live `show_resolution_note?` / `show_reviewer_comment?` render a
- * condensed row with a `note` octicon + the comment text below the event. Used
- * by Closed-by-user / Dismissal-requested (`resolution_note`) and
- * Dismissal-reviewed (`reviewer_comment`).
- */
-const NoteSubRow = ({children}: {children: React.ReactNode}) => (
-  <SubRow>
-    <Octicon icon={NoteIcon} size={16} className={classes.SubRowIcon} />
-    {children}
-  </SubRow>
-)
 
 export default {
   title: 'Components/Timeline/Events/Code Scanning',
@@ -438,10 +403,10 @@ export const EventClosedByUser = () => (
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'closed this as '}
             <span className={classes.Reason}>false positive</span> <Time date="2024-01-14T08:20:00Z" />
-            <NoteSubRow>Verified this pattern only appears in generated fixtures.</NoteSubRow>
+            <EventSubRow icon={NoteIcon}>Verified this pattern only appears in generated fixtures.</EventSubRow>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -455,7 +420,7 @@ export const EventClosedByUser = () => (
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'closed this as '}
             <span className={classes.Reason}>used in tests</span> <Time date="2024-01-14T08:20:00Z" />
           </Timeline.Body>
@@ -471,7 +436,7 @@ export const EventClosedByUser = () => (
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'closed this as '}
             <span className={classes.Reason}>won&apos;t fix</span> <Time date="2024-01-14T08:20:00Z" />
           </Timeline.Body>
@@ -488,7 +453,7 @@ export const EventClosedByUser = () => (
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'closed this '}
             <Time date="2024-01-14T08:20:00Z" />
           </Timeline.Body>
@@ -515,7 +480,7 @@ export const EventReopened = () => (
             <Octicon icon={DotFillIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'reopened this '}
             <Time date="2024-01-15T11:05:00Z" />
           </Timeline.Body>
@@ -550,10 +515,10 @@ export const EventDismissalRequested = () => (
             <Octicon icon={CommentIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'requested to dismiss this as false positive '}
             <Time date="2024-01-16T09:00:00Z" />
-            <NoteSubRow>This finding is a test-only helper, safe to dismiss.</NoteSubRow>
+            <EventSubRow icon={NoteIcon}>This finding is a test-only helper, safe to dismiss.</EventSubRow>
           </Timeline.Body>
           <Timeline.Actions>
             <Button size="small" variant="primary">
@@ -590,10 +555,10 @@ export const EventDismissalReviewed = () => (
             <Octicon icon={CheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'approved dismissal '}
             <Time date="2024-01-17T13:30:00Z" />
-            <NoteSubRow>Agreed — this rule does not apply to test fixtures.</NoteSubRow>
+            <EventSubRow icon={NoteIcon}>Agreed — this rule does not apply to test fixtures.</EventSubRow>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -607,7 +572,7 @@ export const EventDismissalReviewed = () => (
             <Octicon icon={XIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'denied dismissal '}
             <Time date="2024-01-17T13:30:00Z" />
           </Timeline.Body>


### PR DESCRIPTION
## Summary

Adds Storybook **Features** stories that recreate GitHub's live **Code Scanning alert timeline** events using the Primer `Timeline` component and its compositional slots. This is the **Code Scanning surface** — a **Security** surface — of Phase 2 of the Timeline events effort (github/primer#6663). The Issues surface (#8070), Issue comment cards (#8072), the Dependabot alert surface (#8071), and the Secret Scanning surface (#8073) already landed; **License Compliance** will follow as a separate Security surface.

Like Dependabot (and unlike Secret Scanning, which is fully React), **Code Scanning is server-rendered ERB** — there is no React timeline anywhere in `github/github-ui`. So these events were **translated faithfully from the live ERB ViewComponents** into Primer React, the same approach used for the Dependabot surface (#8071).

All examples live in a single new file, `Timeline.code-scanning.features.stories.tsx` (+ a `.module.css`), exported under the title **`Components/Timeline/Events/Code Scanning`** — one story export per event group.

### The 6 event groups (15 variants total)

| Group | Variants | Badge(s) | Actor |
|---|---|---|---|
| `EventDetected` | 3 — First detected / Appeared in branch / Reappeared | bare `shield` / bare `git-branch` (default gray) | none (system) |
| `EventFixed` | 4 — Fixed × (current/other ref) + Config-deleted × (current/other ref) | `shield-check` on solid `done` (purple, selected ref) / bare `check` (other ref) | none (system) |
| `EventClosedByUser` | 4 — false positive / used in tests / won't fix / no resolution | `shield-x` on solid `danger` (red) | User |
| `EventReopened` | 1 — Reopened | `dot-fill` on solid `success` (green) | User |
| `EventDismissalRequested` | 1 — Requested to dismiss | bare `comment` (default gray) | User |
| `EventDismissalReviewed` | 2 — Approved / Denied | bare `check` / bare `x` (default gray) | User |

## Source of truth

These stories were recreated from the **live ERB implementation** in `github/github`. The authoritative dispatch is the `case timeline_event.type` in `app/components/code_scanning/timeline_component.html.erb`; per-event copy, badges, and actors were read directly from it, the shared `timeline_item_component.html.erb`, and the helpers (`code_scanning_helper.rb`, `timeline_component.rb`) and translated faithfully into Primer React. There is **no React Code Scanning timeline** — this surface is server-rendered.

We verified the live render path rather than trusting the Figma audit blindly. The notable resolutions:

- **The 3 closure reasons come from live `alert_closure_reasons`** in `code_scanning_helper.rb` — `False positive`, `Used in tests`, `Won't fix` — and `alert_closure_reason_description` **downcases** them, so they render as "false positive" / "used in tests" / "won't fix". Closed-by-user bolds the reason; the `:NO_RESOLUTION` path (just "closed this") is also built.
- **The Fixed / Config-deleted badge is conditional.** When the event's ref is the currently selected ref (`ref_name_bytes == @selected_ref`) the badge is `shield-check` on solid `done` (purple); otherwise it is a plain `check` on the bare default badge. Both branches are shown for each of the two events.
- **System events render with NO actor** — the entire Detected family plus Fixed/Config-deleted use bold body text only (`item.with_body(font_weight: :bold)`), no avatar or link.
- **The two dismissal events are feature-gated** on `delegated_dismissal_enabled?`, and the "Review request" button is *further* gated on `timeline_event.show_dismissal_actions` — both gates are noted inline. The button label "Review request" was confirmed from `dismissal_review_dialog_component.html.erb` (a `Primer::Alpha::Dialog` show-button, `scheme: :primary, size: :small`).

## Slots

- **No-actor system events** (Detected, Fixed, Config-deleted) render as bold body text; **user events** use a `UserActor` helper — a circle avatar + bold login profile link.
- **`Timeline.Actions`** (right-controls slot, added in #7886) carries the right-aligned tool-version `Label` (`scheme: :secondary`, on any row carrying a `tool_version`) and the Dismissal "Review request" button.

## Badge note

Gray/default events render as a **bare `Timeline.Badge`** (no solid fill, no `--timelineBadge-bgColor` hook) — the whole Detected group, Fixed/Config-deleted on a non-selected ref, and both Dismissal events. Only **Fixed-on-selected-ref** (purple/`done`), **Closed-by-user** (red/`danger`), and **Reopened** (green/`success`) are solid `variant=` badges — matching the live `with_badge(bg:)` model, where only events that pass an explicit `background:` get a solid color.

## Scope & conventions

- Storybook-only by design — **not** added to `Timeline.docs.json` or `build.ts`. Individual timeline events are not consumer-facing components.
- File-scoped **future-state list-semantics** decorator (`primer_react_timeline_list_semantics`, refs primer/react#7910) so every story renders in the `<ol>`/`<li>` DOM the timeline will ship.
- Per-variant `<section><h3 caption>` scaffolding above each row so variants stay scannable like a Figma component set, without polluting `Timeline.Body`.
- Deferred `data-*` event-category taxonomy (still open in github/primer#6663) — intentionally not baked in yet.
- **Simplifications**: the commit-card / path / workflow-run sub-rows are composed as small in-body blocks (the Dependabot / Secret Scanning precedent) rather than the full `repos/scanning/commit` ERB partials — noted in-code.

## Accessibility

The `UserActor` profile link is **bold** — the bold weight is the non-color differentiator that satisfies the axe `link-in-text-block` rule (WCAG 1.4.1) in high-contrast themes, matching the live `text-bold` profile link and the Issues / Dependabot precedent.

## Changelog

Stories-only change — no consumer-facing component or API change, so **no changeset** (the `skip changeset` label is applied).

## Rollout

No rollout concerns — adds Storybook examples only; ships no runtime code.

## Testing

- `prettier` — clean
- `eslint` — clean
- `stylelint` — clean
- `tsc` — 0 new type errors (the only repo tsc error is pre-existing in `script/components-json/build.ts`)

## Merge checklist

- [x] Stories render under `Components/Timeline/Events/Code Scanning`
- [x] All 6 event groups translated and verified against the live ERB
- [x] prettier / eslint / stylelint clean, 0 new tsc errors
- [x] `skip changeset` + `component: Timeline` labels applied
- [ ] Review of copy / badge / actor fidelity