### PR TITLE
Timeline: add License Compliance event stories (Phase 2)

### DIFF
--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.module.css
@@ -1,55 +1,7 @@
-.RealisticTimeline {
-  /* GitHub renders the alert timeline at most 1012px wide in product surfaces. */
-  max-width: 1012px;
-}
-
-/* Story-only scaffolding: each variant is wrapped in its own <section> with a
-   small caption heading ABOVE the event, so the event row itself (badge +
-   inline actor + body) renders exactly as it would in product — the caption
-   never sits inside Timeline.Body. Variants stay scannable like a Figma
-   component set. Not part of the faithful event. */
-.Variant {
-  margin-bottom: var(--base-size-24);
-}
-
-.VariantLabel {
-  margin: 0 0 var(--base-size-4);
-  font-size: var(--text-body-size-small);
-  font-weight: var(--base-text-weight-semibold);
-  color: var(--fgColor-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-/* Inline user-actor avatar in the body. Live `TimelineEventWithActor`
-   (`events/shared.tsx`) renders a 20px CIRCLE `GitHubAvatar` immediately before
-   the login — note this surface uses 20px, NOT the 16px of the secret-scanning
-   timeline. */
-.InlineAvatar {
-  vertical-align: middle;
-  margin-right: var(--base-size-4);
-}
-
-/* Bold actor name for the non-link actor shapes — live `shared.tsx` renders the
-   login as a bold `<strong className="ml-1">` when there is no `actor.url`
-   (and for the bot shape, before the secondary "bot" Label). */
-/* Actor name — shared by the linked actor (`<Link>`), the bold non-link actor,
-   and the bot login. Rendered PLAIN INLINE (no flex wrapper) so it sits on the
-   same vertically-centered line as the avatar, badge and summary, matching the
-   Issues / Dependabot rows. Semibold + `fgColor-default`: the bold weight is the
-   non-color differentiator that satisfies the axe `link-in-text-block` rule, so
-   the linked variant stays a11y-safe without an underline. */
-.ActorName {
-  font-weight: var(--base-text-weight-semibold);
-  color: var(--fgColor-default);
-  margin-right: var(--base-size-4);
-}
-
-/* Accent on hover for the linked actor (no-op on the plain-span shapes),
-   mirroring the Dependabot `LinkWithBoldStyle` hover. */
-.ActorName:hover {
-  color: var(--fgColor-accent);
-}
+/* Surface-specific classes for the License Compliance event stories. The generic
+   scaffolding (RealisticTimeline / VariantSection width + caption), the inline
+   avatar, the bold actor link, and the muted timestamp now come from the shared
+   `./internal/timelineStoryHelpers` module. */
 
 /* Secondary "bot" Label spacing — live `shared.tsx` renders the bot Label with
    a leading `ml-1`. */
@@ -60,13 +12,6 @@
 /* Muted action verb (e.g. "opened this alert"). Live `shared.tsx` renders it as
    `<span className="color-fg-muted ml-1">`. */
 .ActionText {
-  color: var(--fgColor-muted);
-}
-
-/* Muted relative timestamp — live `shared.tsx` renders a plain `RelativeTime`
-   with no link wrapper (muted text only), matching the secret-scanning and
-   Dependabot timelines. */
-.Timestamp {
   color: var(--fgColor-muted);
 }
 

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.module.css
@@ -1,0 +1,71 @@
+.RealisticTimeline {
+  /* GitHub renders the alert timeline at most 1012px wide in product surfaces. */
+  max-width: 1012px;
+}
+
+/* Story-only scaffolding: each variant is wrapped in its own <section> with a
+   small caption heading ABOVE the event, so the event row itself (badge +
+   inline actor + body) renders exactly as it would in product — the caption
+   never sits inside Timeline.Body. Variants stay scannable like a Figma
+   component set. Not part of the faithful event. */
+.Variant {
+  margin-bottom: var(--base-size-24);
+}
+
+.VariantLabel {
+  margin: 0 0 var(--base-size-4);
+  font-size: var(--text-body-size-small);
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Inline user-actor avatar in the body. Live `TimelineEventWithActor`
+   (`events/shared.tsx`) renders a 20px CIRCLE `GitHubAvatar` immediately before
+   the login — note this surface uses 20px, NOT the 16px of the secret-scanning
+   timeline. */
+.InlineAvatar {
+  vertical-align: middle;
+  margin-right: var(--base-size-4);
+}
+
+/* Bold actor name for the non-link actor shapes — live `shared.tsx` renders the
+   login as a bold `<strong className="ml-1">` when there is no `actor.url`
+   (and for the bot shape, before the secondary "bot" Label). */
+.ActorName {
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default);
+}
+
+/* Secondary "bot" Label spacing — live `shared.tsx` renders the bot Label with
+   a leading `ml-1`. */
+.BotLabel {
+  margin-left: var(--base-size-4);
+}
+
+/* Linked actor — live `shared.tsx` `actorLink`: an inline-flex avatar + login
+   rendered as a `<Link>` whenever `actor.url` is present, forced to the default
+   foreground color and SEMIBOLD weight (overriding the link accent color). The
+   bold weight is what keeps it distinguishable from the surrounding muted text
+   WITHOUT relying on color, so it satisfies the axe `link-in-text-block`
+   high-contrast rule. */
+.ActorLink {
+  display: inline-flex;
+  align-items: center;
+  font-weight: var(--base-text-weight-semibold);
+  color: var(--fgColor-default) !important;
+}
+
+/* Muted action verb (e.g. "opened this alert"). Live `shared.tsx` renders it as
+   `<span className="color-fg-muted ml-1">`. */
+.ActionText {
+  color: var(--fgColor-muted);
+}
+
+/* Muted relative timestamp — live `shared.tsx` renders a plain `RelativeTime`
+   with no link wrapper (muted text only), matching the secret-scanning and
+   Dependabot timelines. */
+.Timestamp {
+  color: var(--fgColor-muted);
+}

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.module.css
@@ -33,28 +33,28 @@
 /* Bold actor name for the non-link actor shapes — live `shared.tsx` renders the
    login as a bold `<strong className="ml-1">` when there is no `actor.url`
    (and for the bot shape, before the secondary "bot" Label). */
+/* Actor name — shared by the linked actor (`<Link>`), the bold non-link actor,
+   and the bot login. Rendered PLAIN INLINE (no flex wrapper) so it sits on the
+   same vertically-centered line as the avatar, badge and summary, matching the
+   Issues / Dependabot rows. Semibold + `fgColor-default`: the bold weight is the
+   non-color differentiator that satisfies the axe `link-in-text-block` rule, so
+   the linked variant stays a11y-safe without an underline. */
 .ActorName {
   font-weight: var(--base-text-weight-semibold);
   color: var(--fgColor-default);
+  margin-right: var(--base-size-4);
+}
+
+/* Accent on hover for the linked actor (no-op on the plain-span shapes),
+   mirroring the Dependabot `LinkWithBoldStyle` hover. */
+.ActorName:hover {
+  color: var(--fgColor-accent);
 }
 
 /* Secondary "bot" Label spacing — live `shared.tsx` renders the bot Label with
    a leading `ml-1`. */
 .BotLabel {
   margin-left: var(--base-size-4);
-}
-
-/* Linked actor — live `shared.tsx` `actorLink`: an inline-flex avatar + login
-   rendered as a `<Link>` whenever `actor.url` is present, forced to the default
-   foreground color and SEMIBOLD weight (overriding the link accent color). The
-   bold weight is what keeps it distinguishable from the surrounding muted text
-   WITHOUT relying on color, so it satisfies the axe `link-in-text-block`
-   high-contrast rule. */
-.ActorLink {
-  display: inline-flex;
-  align-items: center;
-  font-weight: var(--base-text-weight-semibold);
-  color: var(--fgColor-default) !important;
 }
 
 /* Muted action verb (e.g. "opened this alert"). Live `shared.tsx` renders it as

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.module.css
@@ -1,32 +1,11 @@
 /* Surface-specific classes for the License Compliance event stories. The generic
    scaffolding (RealisticTimeline / VariantSection width + caption), the inline
-   avatar, the bold actor link, and the muted timestamp now come from the shared
-   `./internal/timelineStoryHelpers` module. */
-
-/* Secondary "bot" Label spacing — live `shared.tsx` renders the bot Label with
-   a leading `ml-1`. */
-.BotLabel {
-  margin-left: var(--base-size-4);
-}
+   avatar, the bold actor name/link, the "bot" Label, the muted timestamp, and the
+   note sub-row now come from the shared `./internal/timelineStoryHelpers` module. */
 
 /* Muted action verb (e.g. "opened this alert"). Live `shared.tsx` renders it as
    `<span className="color-fg-muted ml-1">`. */
 .ActionText {
-  color: var(--fgColor-muted);
-}
-
-/* Comment sub-row — live `EventComment` (`events/shared.tsx`) renders a
-   `Stack` (mt-1) with a 16px muted `NoteIcon` + an `f6` muted comment span. */
-.CommentRow {
-  display: flex;
-  align-items: center;
-  margin-top: var(--base-size-4);
-  font-size: var(--text-body-size-small);
-  color: var(--fgColor-muted);
-}
-
-.CommentRowIcon {
-  margin-right: var(--base-size-8);
   color: var(--fgColor-muted);
 }
 

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.module.css
@@ -69,3 +69,39 @@
 .Timestamp {
   color: var(--fgColor-muted);
 }
+
+/* Comment sub-row — live `EventComment` (`events/shared.tsx`) renders a
+   `Stack` (mt-1) with a 16px muted `NoteIcon` + an `f6` muted comment span. */
+.CommentRow {
+  display: flex;
+  align-items: center;
+  margin-top: var(--base-size-4);
+  font-size: var(--text-body-size-small);
+  color: var(--fgColor-muted);
+}
+
+.CommentRowIcon {
+  margin-right: var(--base-size-8);
+  color: var(--fgColor-muted);
+}
+
+/* PR-link sub-row — live `PullRequestLink` (`events/shared.tsx`) renders a 16px
+   success-green `GitPullRequestIcon` + an `f6` `<Link>`. */
+.PrRow {
+  display: inline-flex;
+  align-items: center;
+  margin-top: var(--base-size-4);
+  font-size: var(--text-body-size-small);
+}
+
+.PrIcon {
+  margin-right: var(--base-size-8);
+  color: var(--fgColor-success);
+}
+
+/* Sub-row link forced to the default foreground color, matching live
+   `defaultColorLink`. Rendered with the `inline` prop (underline) at the call
+   site so it stays distinguishable for the axe `link-in-text-block` rule. */
+.SubRowLink {
+  color: var(--fgColor-default) !important;
+}

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
@@ -220,16 +220,25 @@ const PolicyLink = ({href = '../../settings/security_analysis'}: {href?: string}
 
 /**
  * Story-only wrapper around each group's examples. Besides constraining the
- * width (`.RealisticTimeline`), it swallows clicks on the demo links (actor
- * profile, PR, license-policy) so navigating one of these placeholder `href`s
- * doesn't kick the viewer out of the Storybook UI — the same guard the base
- * `Timeline.features.stories.tsx` `WithActions` story uses.
+ * width (`.RealisticTimeline`), it:
+ * - sets `data-a11y-link-underlines="true"` so Primer's inline-link underline
+ *   (gated on this ancestor attribute, which GitHub sets from the default-on
+ *   "Show link underlines" preference but Storybook never sets) renders for the
+ *   in-text `<Link inline>` links (policy / PR) — reproducing production and
+ *   satisfying WCAG 1.4.1. Actor-name links have no `inline` prop, so they stay
+ *   un-underlined (avatar + semibold cue only).
+ * - swallows clicks on the demo links (actor profile, PR, license-policy) so
+ *   navigating one of these placeholder `href`s doesn't kick the viewer out of
+ *   the Storybook UI — the same guard the base `Timeline.features.stories.tsx`
+ *   `WithActions` story uses. The `e.target instanceof Element` check keeps it
+ *   safe when the click originates on an SVG/octicon.
  */
 const Examples = ({children}: {children: React.ReactNode}) => (
   <div
     className={classes.RealisticTimeline}
+    data-a11y-link-underlines="true"
     onClick={e => {
-      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+      if (e.target instanceof Element && e.target.closest('a')) e.preventDefault()
     }}
   >
     {children}
@@ -285,7 +294,7 @@ export const EventOpened = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
-            <Octicon icon={ShieldIcon} aria-label="Opened" />
+            <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="github-license-compliance[bot]" src={LICENSE_BOT_AVATAR} />{' '}
@@ -321,7 +330,7 @@ export const EventAppearedInBranch = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={GitBranchIcon} aria-label="Appeared in branch" />
+            <Octicon icon={GitBranchIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <span className={classes.ActionText}>Appeared in branch</span>{' '}
@@ -362,7 +371,7 @@ export const EventReviewRequested = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CommentIcon} aria-label="Requested to close" />
+            <Octicon icon={CommentIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -378,7 +387,7 @@ export const EventReviewRequested = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CommentIcon} aria-label="Requested to close" />
+            <Octicon icon={CommentIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -397,7 +406,7 @@ export const EventReviewRequested = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CommentIcon} aria-label="Requested to close" />
+            <Octicon icon={CommentIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -431,7 +440,7 @@ export const EventReviewApproved = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CheckIcon} aria-label="Approved closure request" />
+            <Octicon icon={CheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
@@ -447,7 +456,7 @@ export const EventReviewApproved = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CheckIcon} aria-label="Approved closure request" />
+            <Octicon icon={CheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
@@ -475,7 +484,7 @@ export const EventReviewDenied = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={XIcon} aria-label="Denied closure request" />
+            <Octicon icon={XIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
@@ -491,7 +500,7 @@ export const EventReviewDenied = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={XIcon} aria-label="Denied closure request" />
+            <Octicon icon={XIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
@@ -521,7 +530,7 @@ export const EventReviewExpired = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={CircleSlashIcon} aria-label="Request to close expired" />
+            <Octicon icon={CircleSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="github-license-compliance[bot]" src={LICENSE_BOT_AVATAR} />{' '}
@@ -551,7 +560,7 @@ export const EventExceptionAdded = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LawIcon} aria-label="Exception added" />
+            <Octicon icon={LawIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -570,7 +579,7 @@ export const EventExceptionAdded = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LawIcon} aria-label="Exception created" />
+            <Octicon icon={LawIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -599,7 +608,7 @@ export const EventLicensesAdded = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LawIcon} aria-label="Licenses added" />
+            <Octicon icon={LawIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -618,7 +627,7 @@ export const EventLicensesAdded = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
-            <Octicon icon={LawIcon} aria-label="Added to approved licenses" />
+            <Octicon icon={LawIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -651,7 +660,7 @@ export const EventClosed = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Closed as amendment" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -668,7 +677,7 @@ export const EventClosed = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Closed as private package" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -684,7 +693,7 @@ export const EventClosed = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Closed as inaccurate license" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -701,7 +710,7 @@ export const EventClosed = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Closed as policy edited" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -717,7 +726,7 @@ export const EventClosed = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Closed as fixed" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -733,7 +742,7 @@ export const EventClosed = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Closed as outdated" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
@@ -749,7 +758,7 @@ export const EventClosed = () => (
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Closed" />
+            <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
@@ -117,30 +117,28 @@ const HUBOT_AVATAR = 'https://avatars.githubusercontent.com/hubot'
  * elements (avatar with `vertical-align: middle` immediately followed by an
  * inline `<Link>`/span) — NO `inline-flex` wrapper — so the avatar, login, badge
  * and trailing summary all sit on one cleanly vertically-centered line, exactly
- * like the working Issues (#8070) / Dependabot (#8071) rows. Three shapes:
- * - `url` present → inline `<Link>` login, semibold + `fgColor-default` (the bold
- *   weight is the non-color differentiator that satisfies `link-in-text-block`).
- * - no `url` → bold login text.
- * - `bot` (live: `login.endsWith('[bot]')`) → bold display login (the `[bot]`
- *   suffix stripped) + a secondary "bot" `Label`.
+ * like the working Issues (#8070) / Dependabot (#8071) rows. The shape is derived
+ * from the login, matching live `shared.tsx`:
+ * - login ends with `[bot]` → the suffix is stripped and the (UNLINKED) display
+ *   login renders bold + a secondary "bot" `Label` (live ignores `url` for bots).
+ * - otherwise `url` present → inline `<Link>` login, semibold + `fgColor-default`
+ *   (the bold weight is the non-color differentiator that satisfies
+ *   `link-in-text-block`).
+ * - otherwise → bold login text.
  */
-const UserActor = ({
-  login = 'monalisa',
-  src = MONALISA_AVATAR,
-  url,
-  bot = false,
-}: {
-  login?: string
-  src?: string
-  url?: string
-  bot?: boolean
-}) => {
+const UserActor = ({login = 'monalisa', src = MONALISA_AVATAR, url}: {login?: string; src?: string; url?: string}) => {
+  // Derive the bot shape from the login itself, exactly like live `shared.tsx`
+  // (`isBot = login.endsWith('[bot]')`, with the suffix stripped for display).
+  const isBot = login.endsWith('[bot]')
+  const displayLogin = isBot ? login.replace(/\[bot\]$/i, '') : login
   const avatar = <Avatar src={src} size={20} alt="" className={classes.InlineAvatar} />
-  if (bot) {
+  if (isBot) {
+    // Live renders bots UNLINKED (the bot branch ignores `actor.url`): avatar +
+    // bold display login + a secondary "bot" Label.
     return (
       <>
         {avatar}
-        <span className={classes.ActorName}>{login}</span>
+        <span className={classes.ActorName}>{displayLogin}</span>
         <Label variant="secondary" className={classes.BotLabel}>
           bot
         </Label>
@@ -152,7 +150,7 @@ const UserActor = ({
       <>
         {avatar}
         <Link href={url} className={classes.ActorName}>
-          {login}
+          {displayLogin}
         </Link>
       </>
     )
@@ -160,7 +158,7 @@ const UserActor = ({
   return (
     <>
       {avatar}
-      <span className={classes.ActorName}>{login}</span>
+      <span className={classes.ActorName}>{displayLogin}</span>
     </>
   )
 }
@@ -218,6 +216,24 @@ const PolicyLink = ({href = '../../settings/security_analysis'}: {href?: string}
   </Link>
 )
 
+/**
+ * Story-only wrapper around each group's examples. Besides constraining the
+ * width (`.RealisticTimeline`), it swallows clicks on the demo links (actor
+ * profile, PR, license-policy) so navigating one of these placeholder `href`s
+ * doesn't kick the viewer out of the Storybook UI — the same guard the base
+ * `Timeline.features.stories.tsx` `WithActions` story uses.
+ */
+const Examples = ({children}: {children: React.ReactNode}) => (
+  <div
+    className={classes.RealisticTimeline}
+    onClick={e => {
+      if ((e.target as HTMLElement).closest('a')) e.preventDefault()
+    }}
+  >
+    {children}
+  </div>
+)
+
 export default {
   title: 'Components/Timeline/Events/License Compliance',
   component: Timeline,
@@ -263,7 +279,7 @@ export default {
  * document the resolved actor question.
  */
 export const EventOpened = () => (
-  <div className={classes.RealisticTimeline}>
+  <Examples>
     {/* Opened by a user — linked actor (20px avatar + semibold login), ShieldIcon
         on success (green). */}
     <section className={classes.Variant}>
@@ -292,13 +308,13 @@ export const EventOpened = () => (
             <Octicon icon={ShieldIcon} aria-label="Opened" />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="dependabot" src={DEPENDABOT_AVATAR} bot />{' '}
+            <UserActor login="dependabot[bot]" src={DEPENDABOT_AVATAR} />{' '}
             <span className={classes.ActionText}>opened this alert</span> <Time date="2025-10-20T09:30:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -317,7 +333,7 @@ export const EventOpened = () => (
  * here. Single variant: the branch-name pill.
  */
 export const EventAppearedInBranch = () => (
-  <div className={classes.RealisticTimeline}>
+  <Examples>
     {/* Appeared in branch — actor-less, GitBranchIcon on the default (gray)
         badge, with a BranchName pill. PR sub-row is dormant (see group doc). */}
     <section className={classes.Variant}>
@@ -335,7 +351,7 @@ export const EventAppearedInBranch = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -354,7 +370,7 @@ export const EventAppearedInBranch = () => (
  * slot (the established template convention).
  */
 export const EventReviewRequested = () => (
-  <div className={classes.RealisticTimeline}>
+  <Examples>
     {/* Requested to close — no reason, no PR, no comment */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Requested to close</h3>
@@ -411,7 +427,7 @@ export const EventReviewRequested = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -423,7 +439,7 @@ export const EventReviewRequested = () => (
  * request", with an optional `EventComment` sub-row.
  */
 export const EventReviewApproved = () => (
-  <div className={classes.RealisticTimeline}>
+  <Examples>
     {/* Approved closure request */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Approved closure request</h3>
@@ -456,7 +472,7 @@ export const EventReviewApproved = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -467,7 +483,7 @@ export const EventReviewApproved = () => (
  * with an optional `EventComment` sub-row.
  */
 export const EventReviewDenied = () => (
-  <div className={classes.RealisticTimeline}>
+  <Examples>
     {/* Denied closure request */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Denied closure request</h3>
@@ -500,7 +516,7 @@ export const EventReviewDenied = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -514,7 +530,7 @@ export const EventReviewDenied = () => (
  * sub-row. Single variant.
  */
 export const EventReviewExpired = () => (
-  <div className={classes.RealisticTimeline}>
+  <Examples>
     {/* Request to close expired — actor-less (automatic expiry) */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Request to close expired</h3>
@@ -529,7 +545,7 @@ export const EventReviewExpired = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -543,7 +559,7 @@ export const EventReviewExpired = () => (
  * known) " for {repo}". Otherwise it falls back to "created exception".
  */
 export const EventExceptionAdded = () => (
-  <div className={classes.RealisticTimeline}>
+  <Examples>
     {/* Full shape — package + policy link + repo name */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Added a package exception to the license policy</h3>
@@ -578,7 +594,7 @@ export const EventExceptionAdded = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -591,7 +607,7 @@ export const EventExceptionAdded = () => (
  * known) " for {repo}". Otherwise it falls back to "added to approved licenses".
  */
 export const EventLicensesAdded = () => (
-  <div className={classes.RealisticTimeline}>
+  <Examples>
     {/* Full shape — licenses list + policy link + repo name */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Added licenses to the license policy</h3>
@@ -626,7 +642,7 @@ export const EventLicensesAdded = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )
 
 /**
@@ -644,7 +660,7 @@ export const EventLicensesAdded = () => (
  * An optional `EventComment` sub-row renders a closing comment.
  */
 export const EventClosed = () => (
-  <div className={classes.RealisticTimeline}>
+  <Examples>
     {/* Closed as {free-text reason}, with a closing comment */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Closed as a specific reason (with comment)</h3>
@@ -709,5 +725,5 @@ export const EventClosed = () => (
         </Timeline.Item>
       </Timeline>
     </section>
-  </div>
+  </Examples>
 )

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
@@ -113,13 +113,16 @@ const HUBOT_AVATAR = 'https://avatars.githubusercontent.com/hubot'
 
 /**
  * User actor — live `TimelineEventWithActor` (`events/shared.tsx`). Renders a
- * 20px CIRCLE `GitHubAvatar` followed by the login. Three shapes, all reproduced
- * here so every future group can reuse this helper:
- * - `url` present → a `<Link>` wrapping avatar + login, forced semibold +
- *   default color (`actorLink`); bold weight satisfies `link-in-text-block`.
- * - no `url` → avatar + bold login text (`<strong className="ml-1">`).
- * - `bot` (live: `login.endsWith('[bot]')`) → avatar + bold display login (the
- *   `[bot]` suffix stripped) + a secondary "bot" `Label`.
+ * 20px CIRCLE `GitHubAvatar` followed by the login. Rendered as PLAIN INLINE
+ * elements (avatar with `vertical-align: middle` immediately followed by an
+ * inline `<Link>`/span) — NO `inline-flex` wrapper — so the avatar, login, badge
+ * and trailing summary all sit on one cleanly vertically-centered line, exactly
+ * like the working Issues (#8070) / Dependabot (#8071) rows. Three shapes:
+ * - `url` present → inline `<Link>` login, semibold + `fgColor-default` (the bold
+ *   weight is the non-color differentiator that satisfies `link-in-text-block`).
+ * - no `url` → bold login text.
+ * - `bot` (live: `login.endsWith('[bot]')`) → bold display login (the `[bot]`
+ *   suffix stripped) + a secondary "bot" `Label`.
  */
 const UserActor = ({
   login = 'monalisa',
@@ -135,28 +138,30 @@ const UserActor = ({
   const avatar = <Avatar src={src} size={20} alt="" className={classes.InlineAvatar} />
   if (bot) {
     return (
-      <span className={classes.ActorLink}>
+      <>
         {avatar}
         <span className={classes.ActorName}>{login}</span>
         <Label variant="secondary" className={classes.BotLabel}>
           bot
         </Label>
-      </span>
+      </>
     )
   }
   if (url) {
     return (
-      <Link href={url} className={classes.ActorLink}>
+      <>
         {avatar}
-        {login}
-      </Link>
+        <Link href={url} className={classes.ActorName}>
+          {login}
+        </Link>
+      </>
     )
   }
   return (
-    <span className={classes.ActorLink}>
+    <>
       {avatar}
       <span className={classes.ActorName}>{login}</span>
-    </span>
+    </>
   )
 }
 

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
@@ -1,0 +1,232 @@
+import type {Meta} from '@storybook/react-vite'
+import type {ComponentProps} from '../utils/types'
+import {FeatureFlags} from '../FeatureFlags'
+import Timeline from './Timeline'
+import {ShieldIcon} from '@primer/octicons-react'
+import Avatar from '../Avatar'
+import Label from '../Label'
+import Link from '../Link'
+import Octicon from '../Octicon'
+import RelativeTime from '../RelativeTime'
+import classes from './Timeline.license-compliance.features.stories.module.css'
+
+/**
+ * License Compliance alert Timeline event examples (Phase 2 of github/primer#6663).
+ *
+ * These stories recreate GitHub's live license-compliance-alert timeline events
+ * using the Primer `Timeline` compositional slots. They mirror the established
+ * Issues (`Timeline.issues.features.stories.tsx`), Dependabot
+ * (`Timeline.dependabot.features.stories.tsx`) and Secret Scanning
+ * (`Timeline.secret-scanning.features.stories.tsx`) stories and are sourced from
+ * the `timeline-audit` inventory
+ * (`license-compliance-timeline-events-for-figma.md`), verified against the live
+ * React implementation.
+ *
+ * SOURCE OF TRUTH — License Compliance is FULLY React (NOT ERB), like Secret
+ * Scanning. The alert show page is a React SPA in `github/github-ui`, package
+ * `packages/license-compliance-alerts/`. The timeline is rendered by
+ * `components/timeline/AlertTimeline.tsx`, which maps each event through
+ * `components/timeline/TimelineEventItem.tsx`, whose `switch (event.type)` is
+ * the authoritative dispatch. The actual badge variant + octicon + copy for each
+ * event live in the per-event components under `components/timeline/events/`,
+ * which compose Primer React `Timeline` + `Timeline.Badge variant=` via two
+ * shared wrappers in `events/shared.tsx`:
+ * - `TimelineEventWithActor` — renders the event `actor` INLINE (a 20px circle
+ *   `GitHubAvatar` + login), then the muted action verb + `RelativeTime`.
+ * - `TimelineEventWithoutActor` — no actor; muted action verb + `RelativeTime`
+ *   only (used by the synthetic `appeared_in_branch` event).
+ *
+ * The authoritative `switch (event.type)` dispatches NINE event types
+ * (`types/alerts.ts` `AlertEventType`): `opened`, `appeared_in_branch`,
+ * `review_requested`, `review_denied`, `review_approved`, `review_expired`,
+ * `exception_added`, `licenses_added`, `closed`. `opened` and
+ * `appeared_in_branch` are SYNTHETIC events created by Rails. The `default` case
+ * renders `null` (unknown types render nothing).
+ *
+ * NO SYSTEM "GitHub" ACTOR ON THIS SURFACE: unlike the secret-scanning timeline
+ * (which has a `MarkGithubIcon` + "GitHub" system actor for its Created event),
+ * EVERY license-compliance actor event flows through `TimelineEventWithActor`,
+ * which renders a user/bot actor — never a `MarkGithubIcon` system label. So
+ * this file intentionally does NOT define a `GitHubActor` helper.
+ *
+ * SCOPE: These are Storybook-only examples by design. They are intentionally
+ * NOT wired into components-json / the primer.style docs page (do NOT add this
+ * file to `Timeline.docs.json` or `build.ts`). Individual timeline events are
+ * not consumer-facing components — the primer.style Timeline page reflects the
+ * base `Timeline` component's own stories, and any docs-site representation is a
+ * Phase 3 consideration via base-component story changes, out of scope here.
+ *
+ * FUTURE FILTERING (taxonomy still open — github/primer#6663): category
+ * `data-*` attributes (e.g. `data-event-category="created"`) will attach to each
+ * `Timeline.Item` below so stories can be filtered/grouped by event family. We
+ * intentionally do NOT add them yet to avoid baking in a taxonomy.
+ *
+ * PROOF-OF-PATTERN SCOPE (this file, for now): only the `opened` group is built
+ * below, to validate the template before scaling to the remaining eight groups.
+ * Helpers to add as those groups land: an `EventComment` sub-row (live
+ * `shared.tsx` renders `<NoteIcon size={16} className="fgColor-muted" /> +
+ * <span className="f6 color-fg-muted">{comment}</span>` for review / exception /
+ * licenses-added comments — note it uses `NoteIcon`, not the secret-scanning
+ * `CommentIcon`), a `PullRequestLink` sub-row, and a `Timeline.Actions`
+ * "Review request" button on the latest `review_requested` event (live
+ * `AlertTimeline.tsx` only passes `onReviewRequest` to the LAST
+ * review_requested event).
+ *
+ * BADGE COLORS (live per-event components): success (green) `ShieldIcon` —
+ * `opened`; done (purple) `ShieldCheckIcon` — `closed`. Per the audit, every
+ * other group renders a gray DEFAULT badge (`badgeVariant` undefined →
+ * `<Timeline.Badge>` with a muted icon, no solid fill). We render those bare,
+ * matching the secret-scanning / Dependabot convention (NOT the Issues
+ * `--timelineBadge-bgColor` hook).
+ *
+ * ACCESSIBILITY NOTE: the only in-text `<Link>` on this surface is the actor
+ * link (rendered when `actor.url` is present). Live `shared.tsx` styles it
+ * SEMIBOLD + default foreground color (`actorLink`); the bold weight keeps it
+ * distinguishable from the surrounding muted text without relying on color, so
+ * it satisfies the axe `link-in-text-block` high-contrast rule. Any future
+ * in-text link added here must likewise be `inline` (underline) or bold.
+ */
+
+const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
+const DEPENDABOT_AVATAR = 'https://avatars.githubusercontent.com/in/29110?v=4'
+
+/**
+ * User actor — live `TimelineEventWithActor` (`events/shared.tsx`). Renders a
+ * 20px CIRCLE `GitHubAvatar` followed by the login. Three shapes, all reproduced
+ * here so every future group can reuse this helper:
+ * - `url` present → a `<Link>` wrapping avatar + login, forced semibold +
+ *   default color (`actorLink`); bold weight satisfies `link-in-text-block`.
+ * - no `url` → avatar + bold login text (`<strong className="ml-1">`).
+ * - `bot` (live: `login.endsWith('[bot]')`) → avatar + bold display login (the
+ *   `[bot]` suffix stripped) + a secondary "bot" `Label`.
+ */
+const UserActor = ({
+  login = 'monalisa',
+  src = MONALISA_AVATAR,
+  url,
+  bot = false,
+}: {
+  login?: string
+  src?: string
+  url?: string
+  bot?: boolean
+}) => {
+  const avatar = <Avatar src={src} size={20} alt="" className={classes.InlineAvatar} />
+  if (bot) {
+    return (
+      <span className={classes.ActorLink}>
+        {avatar}
+        <span className={classes.ActorName}>{login}</span>
+        <Label variant="secondary" className={classes.BotLabel}>
+          bot
+        </Label>
+      </span>
+    )
+  }
+  if (url) {
+    return (
+      <Link href={url} className={classes.ActorLink}>
+        {avatar}
+        {login}
+      </Link>
+    )
+  }
+  return (
+    <span className={classes.ActorLink}>
+      {avatar}
+      <span className={classes.ActorName}>{login}</span>
+    </span>
+  )
+}
+
+// Muted relative timestamp. Live `shared.tsx` renders a plain `RelativeTime`
+// with no link wrapper — muted text only (matching the secret-scanning and
+// Dependabot timelines, unlike the Issues `Ago` deep-link).
+const Time = ({date}: {date: string}) => (
+  <span className={classes.Timestamp}>
+    <RelativeTime date={new Date(date)} format="relative" />
+  </span>
+)
+
+export default {
+  title: 'Components/Timeline/Events/License Compliance',
+  component: Timeline,
+  subcomponents: {
+    'Timeline.Item': Timeline.Item,
+    'Timeline.Avatar': Timeline.Avatar,
+    'Timeline.Badge': Timeline.Badge,
+    'Timeline.Body': Timeline.Body,
+    'Timeline.Break': Timeline.Break,
+    'Timeline.Actions': Timeline.Actions,
+  },
+  decorators: [
+    // File-scoped: render every story in the future-state list semantics
+    // (`<ol>`/`<li>`). The `primer_react_timeline_list_semantics` flag is merged
+    // on main; this opts these stories into the DOM the timeline will ship.
+    Story => (
+      <FeatureFlags flags={{primer_react_timeline_list_semantics: true}}>
+        <Story />
+      </FeatureFlags>
+    ),
+  ],
+} as Meta<ComponentProps<typeof Timeline>>
+
+/**
+ * The Opened event group — `AlertEventType.Opened` (audit § 1).
+ *
+ * Source: `case AlertEventType.Opened` in `TimelineEventItem.tsx`, rendered by
+ * `events/OpenedEvent.tsx`:
+ *   `<TimelineEventWithActor icon={<ShieldIcon size={16} />}
+ *     actionText="opened this alert" badgeVariant="success" />`
+ * Badge: `ShieldIcon` on `success` (green). Copy is a fixed `"opened this
+ * alert"` + the relative time. This is a SYNTHETIC event created by Rails, but
+ * it still carries an `actor` (enriched by the Rails controller).
+ *
+ * ACTOR (audit UNCERTAIN resolved): the Opened event is NOT attributed to a
+ * GitHub-system actor. `OpenedEvent` uses `TimelineEventWithActor`, so the actor
+ * is whatever user/bot Rails enriched onto the event — rendered as a 20px avatar
+ * + login (a `<Link>` when `actor.url` is present, otherwise bold text; bots get
+ * a "bot" Label). Both shapes are shown below.
+ *
+ * The live `OpenedEvent` has exactly one rendering shape (no source / from-PR /
+ * from-push branches); the two variants here differ ONLY by actor type to
+ * document the resolved actor question.
+ */
+export const EventOpened = () => (
+  <div className={classes.RealisticTimeline}>
+    {/* Opened by a user — linked actor (20px avatar + semibold login), ShieldIcon
+        on success (green). */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Opened by a user</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="success">
+            <Octicon icon={ShieldIcon} aria-label="Opened" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>opened this alert</span> <Time date="2025-10-20T10:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Opened by a bot — automated dependency detection. Live `shared.tsx`
+        strips the `[bot]` suffix from the login and appends a secondary "bot"
+        Label. Same success badge + copy. */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Opened by a bot</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="success">
+            <Octicon icon={ShieldIcon} aria-label="Opened" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="dependabot" src={DEPENDABOT_AVATAR} bot />{' '}
+            <span className={classes.ActionText}>opened this alert</span> <Time date="2025-10-20T09:30:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
@@ -108,8 +108,10 @@ import classes from './Timeline.license-compliance.features.stories.module.css'
  */
 
 const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
-const DEPENDABOT_AVATAR = 'https://avatars.githubusercontent.com/in/29110?v=4'
 const HUBOT_AVATAR = 'https://avatars.githubusercontent.com/hubot'
+// The license-compliance system bot — Rails attributes every system event
+// (Opened, Review-expired) to `github-license-compliance[bot]` when user_id<=0.
+const LICENSE_BOT_AVATAR = 'https://avatars.githubusercontent.com/u/9919?s=40&v=4'
 
 /**
  * User actor — live `TimelineEventWithActor` (`events/shared.tsx`). Renders a
@@ -268,48 +270,26 @@ export default {
  * alert"` + the relative time. This is a SYNTHETIC event created by Rails, but
  * it still carries an `actor` (enriched by the Rails controller).
  *
- * ACTOR (audit UNCERTAIN resolved): the Opened event is NOT attributed to a
- * GitHub-system actor. `OpenedEvent` uses `TimelineEventWithActor`, so the actor
- * is whatever user/bot Rails enriched onto the event — rendered as a 20px avatar
- * + login (a `<Link>` when `actor.url` is present, otherwise bold text; bots get
- * a "bot" Label). Both shapes are shown below.
- *
- * The live `OpenedEvent` has exactly one rendering shape (no source / from-PR /
- * from-push branches); the two variants here differ ONLY by actor type to
- * document the resolved actor question.
+ * ACTOR (security UNCERTAIN deep-dive resolved): the synthetic `opened` event is
+ * ALWAYS attributed to the license-compliance system bot,
+ * `github-license-compliance[bot]` (Rails `create_synthetic_opened_event`). Per
+ * live `shared.tsx`, a login ending in `[bot]` renders avatar + bold display
+ * login ("github-license-compliance") + a secondary "bot" Label — NOT a Link.
+ * There is no human "opened" actor, so a single bot variant is shown.
  */
 export const EventOpened = () => (
   <Examples>
-    {/* Opened by a user — linked actor (20px avatar + semibold login), ShieldIcon
-        on success (green). */}
+    {/* Opened — license-compliance system bot, ShieldIcon on success (green) */}
     <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Opened by a user</h3>
+      <h3 className={classes.VariantLabel}>Opened</h3>
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
             <Octicon icon={ShieldIcon} aria-label="Opened" />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="github-license-compliance[bot]" src={LICENSE_BOT_AVATAR} />{' '}
             <span className={classes.ActionText}>opened this alert</span> <Time date="2025-10-20T10:00:00Z" />
-          </Timeline.Body>
-        </Timeline.Item>
-      </Timeline>
-    </section>
-
-    {/* Opened by a bot — automated dependency detection. Live `shared.tsx`
-        strips the `[bot]` suffix from the login and appends a secondary "bot"
-        Label. Same success badge + copy. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Opened by a bot</h3>
-      <Timeline aria-label="License compliance alert timeline">
-        <Timeline.Item>
-          <Timeline.Badge variant="success">
-            <Octicon icon={ShieldIcon} aria-label="Opened" />
-          </Timeline.Badge>
-          <Timeline.Body>
-            <UserActor login="dependabot[bot]" src={DEPENDABOT_AVATAR} />{' '}
-            <span className={classes.ActionText}>opened this alert</span> <Time date="2025-10-20T09:30:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -368,6 +348,11 @@ export const EventAppearedInBranch = () => (
  * "Review request" button. Live nests that button beside the PR link in a
  * space-between Stack; we surface it via the `Timeline.Actions` right-controls
  * slot (the established template convention).
+ *
+ * NOTE: the `closure_reason` text shown after "requested to close as …" is
+ * produced by the Go OLC service, not the local Rails/React code — its exact
+ * format (e.g. "amendment"-style label vs raw value) is unverified here. Confirm
+ * via a prod smoke-test; the example label below is illustrative.
  */
 export const EventReviewRequested = () => (
   <Examples>
@@ -522,16 +507,15 @@ export const EventReviewDenied = () => (
 /**
  * The Review-expired event group — `AlertEventType.ReviewExpired` (audit § 6).
  *
- * Source: `events/ReviewExpiredEvent.tsx`. Although it uses
- * `TimelineEventWithActor`, expiry is automatic and Rails attaches no actor, so
- * it renders ACTOR-LESS (verified: the `review_expired` test fixture has no
- * actor, and the copy "Request to close expired" is a standalone capitalized
- * sentence). `CircleSlashIcon size={16}` on the default (gray) badge. No comment
- * sub-row. Single variant.
+ * Source: `events/ReviewExpiredEvent.tsx` (`TimelineEventWithActor`):
+ * `CircleSlashIcon size={16}` on the default (gray) badge, copy "Request to close
+ * expired". Although a misleading test mock omits the actor, Rails sets the
+ * license-compliance system bot for these system events (`user_id<=0`), so it
+ * renders WITH the bot actor. No comment sub-row. Single variant.
  */
 export const EventReviewExpired = () => (
   <Examples>
-    {/* Request to close expired — actor-less (automatic expiry) */}
+    {/* Request to close expired — license-compliance system bot, automatic expiry */}
     <section className={classes.Variant}>
       <h3 className={classes.VariantLabel}>Request to close expired</h3>
       <Timeline aria-label="License compliance alert timeline">
@@ -540,6 +524,7 @@ export const EventReviewExpired = () => (
             <Octicon icon={CircleSlashIcon} aria-label="Request to close expired" />
           </Timeline.Badge>
           <Timeline.Body>
+            <UserActor login="github-license-compliance[bot]" src={LICENSE_BOT_AVATAR} />{' '}
             <span className={classes.ActionText}>Request to close expired</span> <Time date="2025-10-23T10:00:00Z" />
           </Timeline.Body>
         </Timeline.Item>
@@ -651,28 +636,92 @@ export const EventLicensesAdded = () => (
  * Source: `events/ClosedEvent.tsx` (`TimelineEventWithActor`): `ShieldCheckIcon
  * size={16}` on the `done` (PURPLE) badge — the only colored gray-exempt event
  * besides Opened. The copy comes from `getClosedActionText(closureReason,
- * resolution)`, which renders exactly one of:
- * - "closed as {closureReason}" — when a free-text `closureReason` is present
- *   (e.g. "used in tests", carried over from the review flow);
- * - "closed as outdated" — resolution `Outdated`;
- * - "closed as amendment" — resolution `ExceptionAdded` or `LicensesAdded`;
- * - "closed this alert" — the default.
- * An optional `EventComment` sub-row renders a closing comment.
+ * resolution)`. When a free-text `closureReason` is present it renders "closed as
+ * {reason}"; the live label set is `CLOSURE_REASON_TO_LABEL`
+ * (`license_compliance_dismissal_options.rb`): amendment, private package,
+ * inaccurate license, policy edited, fixed. The two resolution-driven fallbacks
+ * are "closed as outdated" (resolution `Outdated`) and "closed this alert"
+ * (default). An optional `EventComment` sub-row renders a closing comment.
  */
 export const EventClosed = () => (
   <Examples>
-    {/* Closed as {free-text reason}, with a closing comment */}
+    {/* Closed as amendment — with a closing comment */}
     <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as a specific reason (with comment)</h3>
+      <h3 className={classes.VariantLabel}>Closed as amendment (with comment)</h3>
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Closed" />
+            <Octicon icon={ShieldCheckIcon} aria-label="Closed as amendment" />
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>closed as used in tests</span> <Time date="2025-10-25T10:00:00Z" />
-            <EventComment>Confirmed this dependency only ships in the test bundle.</EventComment>
+            <span className={classes.ActionText}>closed as amendment</span> <Time date="2025-10-25T10:00:00Z" />
+            <EventComment>Added a policy exception covering this package.</EventComment>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Closed as private package */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as private package</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Closed as private package" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>closed as private package</span> <Time date="2025-10-25T10:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Closed as inaccurate license */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as inaccurate license</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Closed as inaccurate license" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>closed as inaccurate license</span>{' '}
+            <Time date="2025-10-25T10:10:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Closed as policy edited */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as policy edited</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Closed as policy edited" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>closed as policy edited</span> <Time date="2025-10-25T10:15:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Closed as fixed */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as fixed</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Closed as fixed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>closed as fixed</span> <Time date="2025-10-25T10:20:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -688,23 +737,7 @@ export const EventClosed = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>closed as outdated</span> <Time date="2025-10-25T10:05:00Z" />
-          </Timeline.Body>
-        </Timeline.Item>
-      </Timeline>
-    </section>
-
-    {/* Closed as amendment — resolution ExceptionAdded / LicensesAdded */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as amendment</h3>
-      <Timeline aria-label="License compliance alert timeline">
-        <Timeline.Item>
-          <Timeline.Badge variant="done">
-            <Octicon icon={ShieldCheckIcon} aria-label="Closed as amendment" />
-          </Timeline.Badge>
-          <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>closed as amendment</span> <Time date="2025-10-25T10:10:00Z" />
+            <span className={classes.ActionText}>closed as outdated</span> <Time date="2025-10-25T10:25:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -720,7 +753,7 @@ export const EventClosed = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>closed this alert</span> <Time date="2025-10-25T10:15:00Z" />
+            <span className={classes.ActionText}>closed this alert</span> <Time date="2025-10-25T10:30:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
@@ -14,14 +14,11 @@ import {
   ShieldIcon,
   XIcon,
 } from '@primer/octicons-react'
-import type React from 'react'
 import BranchName from '../BranchName'
 import {Button} from '../Button'
-import Label from '../Label'
 import Link from '../Link'
 import Octicon from '../Octicon'
-import {BoldLink, Examples, InlineAvatar, MutedTime, VariantSection} from './internal/timelineStoryHelpers'
-import sharedClasses from './internal/timelineStoryHelpers.module.css'
+import {EventSubRow, Examples, MutedTime, UserActor, VariantSection} from './internal/timelineStoryHelpers'
 import classes from './Timeline.license-compliance.features.stories.module.css'
 
 /**
@@ -112,71 +109,6 @@ const HUBOT_AVATAR = 'https://avatars.githubusercontent.com/hubot'
 // The license-compliance system bot — Rails attributes every system event
 // (Opened, Review-expired) to `github-license-compliance[bot]` when user_id<=0.
 const LICENSE_BOT_AVATAR = 'https://avatars.githubusercontent.com/u/9919?s=40&v=4'
-
-/**
- * User actor — live `TimelineEventWithActor` (`events/shared.tsx`). Renders a
- * 20px CIRCLE avatar (shared `InlineAvatar`) followed by the login (shared
- * `BoldLink`), as PLAIN INLINE elements so the avatar, login, badge and trailing
- * summary all sit on one cleanly vertically-centered line. The shape is derived
- * from the login, matching live `shared.tsx`:
- * - login ends with `[bot]` → the suffix is stripped and the (UNLINKED) display
- *   login renders bold (a `<span>` sourcing the shared `BoldLink` styling — a
- *   plain span rather than `BoldLink as="span"` because Primer's `Link` errors
- *   when it renders as a non-anchor) + a secondary "bot" `Label` (live ignores
- *   `url` for bots).
- * - otherwise `url` present → linked login (`BoldLink href`), semibold +
- *   `fgColor-default` (the bold weight is the non-color differentiator that
- *   satisfies `link-in-text-block`; no `inline`, so it stays un-underlined).
- * - otherwise → bold login text (same shared-styled `<span>`).
- */
-const UserActor = ({login = 'monalisa', src = MONALISA_AVATAR, url}: {login?: string; src?: string; url?: string}) => {
-  // Derive the bot shape from the login itself, exactly like live `shared.tsx`
-  // (`isBot = login.endsWith('[bot]')`, with the suffix stripped for display).
-  const isBot = login.endsWith('[bot]')
-  const displayLogin = isBot ? login.replace(/\[bot\]$/i, '') : login
-  const avatar = <InlineAvatar src={src} />
-  if (isBot) {
-    // Live renders bots UNLINKED (the bot branch ignores `actor.url`): avatar +
-    // bold display login + a secondary "bot" Label.
-    return (
-      <>
-        {avatar}
-        <span className={sharedClasses.BoldLink}>{displayLogin}</span>
-        <Label variant="secondary" className={classes.BotLabel}>
-          bot
-        </Label>
-      </>
-    )
-  }
-  if (url) {
-    return (
-      <>
-        {avatar}
-        <BoldLink href={url}>{displayLogin}</BoldLink>
-      </>
-    )
-  }
-  return (
-    <>
-      {avatar}
-      <span className={sharedClasses.BoldLink}>{displayLogin}</span>
-    </>
-  )
-}
-
-/**
- * Optional comment sub-row — live `EventComment` (`events/shared.tsx`) renders a
- * `<Stack direction="horizontal" gap="condensed" className="mt-1">` containing a
- * 16px muted `NoteIcon` + an `f6` muted comment span. Shared by the review
- * request / approve / deny events and the closed event. (Note this surface uses
- * `NoteIcon`, NOT the secret-scanning `CommentIcon`.)
- */
-const EventComment = ({children}: {children: React.ReactNode}) => (
-  <div className={classes.CommentRow}>
-    <Octicon icon={NoteIcon} size={16} className={classes.CommentRowIcon} />
-    <span>{children}</span>
-  </div>
-)
 
 /**
  * PR link sub-row — live `PullRequestLink` (`events/shared.tsx`): a 16px
@@ -312,7 +244,7 @@ export const EventAppearedInBranch = () => (
  * Source: `events/ReviewRequestedEvent.tsx` (`TimelineEventWithActor`):
  * `CommentIcon size={16}` on the default (gray) badge. Copy is "requested to
  * close" or, when the event body carries a `closure_reason`, "requested to close
- * as {reason}". An optional `EventComment` sub-row renders the requester's
+ * as {reason}". An optional note sub-row (shared `EventSubRow`) renders the requester's
  * comment. When the alert has an associated PR, the Rails controller enriches
  * this event with `pull_request_number` / `_title`, so a `PullRequestLink`
  * sub-row appears AND — for the latest review_requested event only — a primary
@@ -335,7 +267,7 @@ export const EventReviewRequested = () => (
             <Octicon icon={CommentIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>requested to close</span>{' '}
             <MutedTime date={new Date('2025-10-21T09:00:00Z')} />
           </Timeline.Body>
@@ -351,10 +283,10 @@ export const EventReviewRequested = () => (
             <Octicon icon={CommentIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>requested to close as used in tests</span>{' '}
             <MutedTime date={new Date('2025-10-21T09:05:00Z')} />
-            <EventComment>This dependency is only pulled in by our test harness.</EventComment>
+            <EventSubRow icon={NoteIcon}>This dependency is only pulled in by our test harness.</EventSubRow>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -369,7 +301,7 @@ export const EventReviewRequested = () => (
             <Octicon icon={CommentIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>requested to close</span>{' '}
             <MutedTime date={new Date('2025-10-21T09:10:00Z')} />
             <PullRequestLink number={42} title="Replace GPL dependency" />
@@ -391,7 +323,7 @@ export const EventReviewRequested = () => (
  *
  * Source: `events/ReviewApprovedEvent.tsx` (`TimelineEventWithActor`):
  * `CheckIcon size={16}` on the default (gray) badge, copy "approved closure
- * request", with an optional `EventComment` sub-row.
+ * request", with an optional note sub-row (shared `EventSubRow`).
  */
 export const EventReviewApproved = () => (
   <Examples>
@@ -403,7 +335,7 @@ export const EventReviewApproved = () => (
             <Octicon icon={CheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
+            <UserActor login="hubot" src={HUBOT_AVATAR} href="https://github.com/hubot" />{' '}
             <span className={classes.ActionText}>approved closure request</span>{' '}
             <MutedTime date={new Date('2025-10-22T10:00:00Z')} />
           </Timeline.Body>
@@ -419,10 +351,10 @@ export const EventReviewApproved = () => (
             <Octicon icon={CheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
+            <UserActor login="hubot" src={HUBOT_AVATAR} href="https://github.com/hubot" />{' '}
             <span className={classes.ActionText}>approved closure request</span>{' '}
             <MutedTime date={new Date('2025-10-22T10:05:00Z')} />
-            <EventComment>Agreed — test-only usage is within policy.</EventComment>
+            <EventSubRow icon={NoteIcon}>Agreed — test-only usage is within policy.</EventSubRow>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -435,7 +367,7 @@ export const EventReviewApproved = () => (
  *
  * Source: `events/ReviewDeniedEvent.tsx` (`TimelineEventWithActor`):
  * `XIcon size={16}` on the default (gray) badge, copy "denied closure request",
- * with an optional `EventComment` sub-row.
+ * with an optional note sub-row (shared `EventSubRow`).
  */
 export const EventReviewDenied = () => (
   <Examples>
@@ -447,7 +379,7 @@ export const EventReviewDenied = () => (
             <Octicon icon={XIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
+            <UserActor login="hubot" src={HUBOT_AVATAR} href="https://github.com/hubot" />{' '}
             <span className={classes.ActionText}>denied closure request</span>{' '}
             <MutedTime date={new Date('2025-10-22T11:00:00Z')} />
           </Timeline.Body>
@@ -463,10 +395,12 @@ export const EventReviewDenied = () => (
             <Octicon icon={XIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
+            <UserActor login="hubot" src={HUBOT_AVATAR} href="https://github.com/hubot" />{' '}
             <span className={classes.ActionText}>denied closure request</span>{' '}
             <MutedTime date={new Date('2025-10-22T11:05:00Z')} />
-            <EventComment>This package is distributed to customers, so the license still applies.</EventComment>
+            <EventSubRow icon={NoteIcon}>
+              This package is distributed to customers, so the license still applies.
+            </EventSubRow>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -523,7 +457,7 @@ export const EventExceptionAdded = () => (
             <Octicon icon={LawIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>
               added npm/left-pad to <PolicyLink /> for monalisa/octo-app
             </span>{' '}
@@ -541,7 +475,7 @@ export const EventExceptionAdded = () => (
             <Octicon icon={LawIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>created exception</span>{' '}
             <MutedTime date={new Date('2025-10-23T12:05:00Z')} />
           </Timeline.Body>
@@ -570,7 +504,7 @@ export const EventLicensesAdded = () => (
             <Octicon icon={LawIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>
               added MIT, Apache-2.0 to <PolicyLink /> for monalisa/octo-app
             </span>{' '}
@@ -588,7 +522,7 @@ export const EventLicensesAdded = () => (
             <Octicon icon={LawIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>added to approved licenses</span>{' '}
             <MutedTime date={new Date('2025-10-24T12:05:00Z')} />
           </Timeline.Body>
@@ -609,7 +543,7 @@ export const EventLicensesAdded = () => (
  * (`license_compliance_dismissal_options.rb`): amendment, private package,
  * inaccurate license, policy edited, fixed. The two resolution-driven fallbacks
  * are "closed as outdated" (resolution `Outdated`) and "closed this alert"
- * (default). An optional `EventComment` sub-row renders a closing comment.
+ * (default). An optional note sub-row (shared `EventSubRow`) renders a closing comment.
  */
 export const EventClosed = () => (
   <Examples>
@@ -621,10 +555,10 @@ export const EventClosed = () => (
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>closed as amendment</span>{' '}
             <MutedTime date={new Date('2025-10-25T10:00:00Z')} />
-            <EventComment>Added a policy exception covering this package.</EventComment>
+            <EventSubRow icon={NoteIcon}>Added a policy exception covering this package.</EventSubRow>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -638,7 +572,7 @@ export const EventClosed = () => (
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>closed as private package</span>{' '}
             <MutedTime date={new Date('2025-10-25T10:05:00Z')} />
           </Timeline.Body>
@@ -654,7 +588,7 @@ export const EventClosed = () => (
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>closed as inaccurate license</span>{' '}
             <MutedTime date={new Date('2025-10-25T10:10:00Z')} />
           </Timeline.Body>
@@ -670,7 +604,7 @@ export const EventClosed = () => (
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>closed as policy edited</span>{' '}
             <MutedTime date={new Date('2025-10-25T10:15:00Z')} />
           </Timeline.Body>
@@ -686,7 +620,7 @@ export const EventClosed = () => (
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>closed as fixed</span>{' '}
             <MutedTime date={new Date('2025-10-25T10:20:00Z')} />
           </Timeline.Body>
@@ -702,7 +636,7 @@ export const EventClosed = () => (
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>closed as outdated</span>{' '}
             <MutedTime date={new Date('2025-10-25T10:25:00Z')} />
           </Timeline.Body>
@@ -718,7 +652,7 @@ export const EventClosed = () => (
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <UserActor login="monalisa" src={MONALISA_AVATAR} href="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>closed this alert</span>{' '}
             <MutedTime date={new Date('2025-10-25T10:30:00Z')} />
           </Timeline.Body>

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
@@ -2,8 +2,22 @@ import type {Meta} from '@storybook/react-vite'
 import type {ComponentProps} from '../utils/types'
 import {FeatureFlags} from '../FeatureFlags'
 import Timeline from './Timeline'
-import {ShieldIcon} from '@primer/octicons-react'
+import {
+  CheckIcon,
+  CircleSlashIcon,
+  CommentIcon,
+  GitBranchIcon,
+  GitPullRequestIcon,
+  LawIcon,
+  NoteIcon,
+  ShieldCheckIcon,
+  ShieldIcon,
+  XIcon,
+} from '@primer/octicons-react'
+import type React from 'react'
 import Avatar from '../Avatar'
+import BranchName from '../BranchName'
+import {Button} from '../Button'
 import Label from '../Label'
 import Link from '../Link'
 import Octicon from '../Octicon'
@@ -61,22 +75,28 @@ import classes from './Timeline.license-compliance.features.stories.module.css'
  * `Timeline.Item` below so stories can be filtered/grouped by event family. We
  * intentionally do NOT add them yet to avoid baking in a taxonomy.
  *
- * PROOF-OF-PATTERN SCOPE (this file, for now): only the `opened` group is built
- * below, to validate the template before scaling to the remaining eight groups.
- * Helpers to add as those groups land: an `EventComment` sub-row (live
- * `shared.tsx` renders `<NoteIcon size={16} className="fgColor-muted" /> +
- * <span className="f6 color-fg-muted">{comment}</span>` for review / exception /
- * licenses-added comments — note it uses `NoteIcon`, not the secret-scanning
- * `CommentIcon`), a `PullRequestLink` sub-row, and a `Timeline.Actions`
- * "Review request" button on the latest `review_requested` event (live
- * `AlertTimeline.tsx` only passes `onReviewRequest` to the LAST
- * review_requested event).
+ * PROOF-OF-PATTERN HISTORY: this file landed first as an `opened`-only
+ * scaffold to validate the template, then grew to the full nine-group set. All
+ * groups are verified against the live per-event components in
+ * `events/` and, for the two synthetic events, against the Rails controller
+ * `app/controllers/repos/license_compliance_alerts_controller.rb` (the synthetic
+ * `opened` / `appeared_in_branch` builder).
+ *
+ * DORMANT CODE (verified, intentionally NOT built): `AppearedInBranchEvent`
+ * renders a `PullRequestLink` sub-row whenever its event body carries
+ * `pull_request_number` / `pull_request_title`, but the Rails
+ * `create_synthetic_branch_event` only ever writes `{branch_name}` — it never
+ * populates those PR fields (PR enrichment is applied ONLY to
+ * `review_requested`). So that sub-row is dead in production; we build only the
+ * branch-name variant. Likewise `review_expired` uses `TimelineEventWithActor`
+ * but expiry is automatic and Rails attaches no actor, so it renders actor-less
+ * (its copy "Request to close expired" is a standalone capitalized sentence).
  *
  * BADGE COLORS (live per-event components): success (green) `ShieldIcon` —
- * `opened`; done (purple) `ShieldCheckIcon` — `closed`. Per the audit, every
- * other group renders a gray DEFAULT badge (`badgeVariant` undefined →
- * `<Timeline.Badge>` with a muted icon, no solid fill). We render those bare,
- * matching the secret-scanning / Dependabot convention (NOT the Issues
+ * `opened`; done (purple) `ShieldCheckIcon` — `closed`. Every other group
+ * renders a gray DEFAULT badge (`badgeVariant` undefined → `<Timeline.Badge>`
+ * with a muted icon, no solid fill). We render those bare, matching the
+ * secret-scanning / Dependabot convention (NOT the Issues
  * `--timelineBadge-bgColor` hook).
  *
  * ACCESSIBILITY NOTE: the only in-text `<Link>` on this surface is the actor
@@ -89,6 +109,7 @@ import classes from './Timeline.license-compliance.features.stories.module.css'
 
 const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
 const DEPENDABOT_AVATAR = 'https://avatars.githubusercontent.com/in/29110?v=4'
+const HUBOT_AVATAR = 'https://avatars.githubusercontent.com/hubot'
 
 /**
  * User actor — live `TimelineEventWithActor` (`events/shared.tsx`). Renders a
@@ -146,6 +167,50 @@ const Time = ({date}: {date: string}) => (
   <span className={classes.Timestamp}>
     <RelativeTime date={new Date(date)} format="relative" />
   </span>
+)
+
+/**
+ * Optional comment sub-row — live `EventComment` (`events/shared.tsx`) renders a
+ * `<Stack direction="horizontal" gap="condensed" className="mt-1">` containing a
+ * 16px muted `NoteIcon` + an `f6` muted comment span. Shared by the review
+ * request / approve / deny events and the closed event. (Note this surface uses
+ * `NoteIcon`, NOT the secret-scanning `CommentIcon`.)
+ */
+const EventComment = ({children}: {children: React.ReactNode}) => (
+  <div className={classes.CommentRow}>
+    <Octicon icon={NoteIcon} size={16} className={classes.CommentRowIcon} />
+    <span>{children}</span>
+  </div>
+)
+
+/**
+ * PR link sub-row — live `PullRequestLink` (`events/shared.tsx`): a 16px
+ * success-green `GitPullRequestIcon` + an `f6` `<Link>` reading `{title}
+ * #{number}`. Only the `review_requested` event renders this (the Rails
+ * controller enriches that event with `pull_request_number` / `_title` when the
+ * alert has an associated PR). The link is `inline` (underlined) here to satisfy
+ * the axe `link-in-text-block` rule — live uses a color-only `defaultColorLink`
+ * (an a11y debt we correct in the story).
+ */
+const PullRequestLink = ({number, title}: {number: number; title: string}) => (
+  <span className={classes.PrRow}>
+    <Octicon icon={GitPullRequestIcon} size={16} className={classes.PrIcon} />
+    <Link href={`../../pull/${number}`} inline className={classes.SubRowLink}>
+      {title} #{number}
+    </Link>
+  </span>
+)
+
+/**
+ * Inline "license policy" link — live `ExceptionAddedEvent` / `LicensesAddedEvent`
+ * embed a `<Link>` reading "license policy" inside the action sentence. Rendered
+ * `inline` (underlined) here to satisfy the axe `link-in-text-block` rule (live
+ * uses a color-only `defaultColorLink`).
+ */
+const PolicyLink = ({href = '../../settings/security_analysis'}: {href?: string}) => (
+  <Link href={href} inline>
+    license policy
+  </Link>
 )
 
 export default {
@@ -224,6 +289,417 @@ export const EventOpened = () => (
           <Timeline.Body>
             <UserActor login="dependabot" src={DEPENDABOT_AVATAR} bot />{' '}
             <span className={classes.ActionText}>opened this alert</span> <Time date="2025-10-20T09:30:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Appeared-in-branch event group — `AlertEventType.AppearedInBranch`
+ * (audit § 2).
+ *
+ * Source: `case AlertEventType.AppearedInBranch` → `events/AppearedInBranchEvent.tsx`,
+ * which uses `TimelineEventWithoutActor` (NO actor): `GitBranchIcon size={16}`
+ * on the default (gray) badge, copy "Appeared in branch", followed by a
+ * `BranchName` pill linking to the branch tree. This is a SYNTHETIC event.
+ *
+ * The component ALSO renders a `PullRequestLink` sub-row when its body has
+ * `pull_request_number` / `pull_request_title` — but per the Rails
+ * `create_synthetic_branch_event`, those fields are NEVER written for this event
+ * (only `{branch_name}`), so that sub-row is DORMANT and intentionally not built
+ * here. Single variant: the branch-name pill.
+ */
+export const EventAppearedInBranch = () => (
+  <div className={classes.RealisticTimeline}>
+    {/* Appeared in branch — actor-less, GitBranchIcon on the default (gray)
+        badge, with a BranchName pill. PR sub-row is dormant (see group doc). */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Appeared in branch</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={GitBranchIcon} aria-label="Appeared in branch" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <span className={classes.ActionText}>Appeared in branch</span>{' '}
+            <BranchName href="../../tree/feature-branch">feature-branch</BranchName>{' '}
+            <Time date="2025-10-20T10:01:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Review-requested event group — `AlertEventType.ReviewRequested`
+ * (audit § 3).
+ *
+ * Source: `events/ReviewRequestedEvent.tsx` (`TimelineEventWithActor`):
+ * `CommentIcon size={16}` on the default (gray) badge. Copy is "requested to
+ * close" or, when the event body carries a `closure_reason`, "requested to close
+ * as {reason}". An optional `EventComment` sub-row renders the requester's
+ * comment. When the alert has an associated PR, the Rails controller enriches
+ * this event with `pull_request_number` / `_title`, so a `PullRequestLink`
+ * sub-row appears AND — for the latest review_requested event only — a primary
+ * "Review request" button. Live nests that button beside the PR link in a
+ * space-between Stack; we surface it via the `Timeline.Actions` right-controls
+ * slot (the established template convention).
+ */
+export const EventReviewRequested = () => (
+  <div className={classes.RealisticTimeline}>
+    {/* Requested to close — no reason, no PR, no comment */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Requested to close</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CommentIcon} aria-label="Requested to close" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>requested to close</span> <Time date="2025-10-21T09:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Requested to close as {reason}, with a requester comment sub-row */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Requested to close as a specific reason (with comment)</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CommentIcon} aria-label="Requested to close" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>requested to close as used in tests</span>{' '}
+            <Time date="2025-10-21T09:05:00Z" />
+            <EventComment>This dependency is only pulled in by our test harness.</EventComment>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Requested to close with an associated PR — PR link sub-row + the primary
+        "Review request" button (latest request only) in Timeline.Actions. */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Requested to close with a pull request (latest — shows Review request)</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CommentIcon} aria-label="Requested to close" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>requested to close</span> <Time date="2025-10-21T09:10:00Z" />
+            <PullRequestLink number={42} title="Replace GPL dependency" />
+          </Timeline.Body>
+          <Timeline.Actions>
+            <Button variant="primary" size="small">
+              Review request
+            </Button>
+          </Timeline.Actions>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Review-approved event group — `AlertEventType.ReviewApproved`
+ * (audit § 4).
+ *
+ * Source: `events/ReviewApprovedEvent.tsx` (`TimelineEventWithActor`):
+ * `CheckIcon size={16}` on the default (gray) badge, copy "approved closure
+ * request", with an optional `EventComment` sub-row.
+ */
+export const EventReviewApproved = () => (
+  <div className={classes.RealisticTimeline}>
+    {/* Approved closure request */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Approved closure request</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CheckIcon} aria-label="Approved closure request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
+            <span className={classes.ActionText}>approved closure request</span> <Time date="2025-10-22T10:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Approved closure request — with reviewer comment */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Approved closure request (with comment)</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CheckIcon} aria-label="Approved closure request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
+            <span className={classes.ActionText}>approved closure request</span> <Time date="2025-10-22T10:05:00Z" />
+            <EventComment>Agreed — test-only usage is within policy.</EventComment>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Review-denied event group — `AlertEventType.ReviewDenied` (audit § 5).
+ *
+ * Source: `events/ReviewDeniedEvent.tsx` (`TimelineEventWithActor`):
+ * `XIcon size={16}` on the default (gray) badge, copy "denied closure request",
+ * with an optional `EventComment` sub-row.
+ */
+export const EventReviewDenied = () => (
+  <div className={classes.RealisticTimeline}>
+    {/* Denied closure request */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Denied closure request</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={XIcon} aria-label="Denied closure request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
+            <span className={classes.ActionText}>denied closure request</span> <Time date="2025-10-22T11:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Denied closure request — with reviewer comment */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Denied closure request (with comment)</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={XIcon} aria-label="Denied closure request" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
+            <span className={classes.ActionText}>denied closure request</span> <Time date="2025-10-22T11:05:00Z" />
+            <EventComment>This package is distributed to customers, so the license still applies.</EventComment>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Review-expired event group — `AlertEventType.ReviewExpired` (audit § 6).
+ *
+ * Source: `events/ReviewExpiredEvent.tsx`. Although it uses
+ * `TimelineEventWithActor`, expiry is automatic and Rails attaches no actor, so
+ * it renders ACTOR-LESS (verified: the `review_expired` test fixture has no
+ * actor, and the copy "Request to close expired" is a standalone capitalized
+ * sentence). `CircleSlashIcon size={16}` on the default (gray) badge. No comment
+ * sub-row. Single variant.
+ */
+export const EventReviewExpired = () => (
+  <div className={classes.RealisticTimeline}>
+    {/* Request to close expired — actor-less (automatic expiry) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Request to close expired</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={CircleSlashIcon} aria-label="Request to close expired" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <span className={classes.ActionText}>Request to close expired</span> <Time date="2025-10-23T10:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Exception-added event group — `AlertEventType.ExceptionAdded`
+ * (audit § 7).
+ *
+ * Source: `events/ExceptionAddedEvent.tsx` (`TimelineEventWithActor`):
+ * `LawIcon size={16}` on the default (gray) badge. When the body has
+ * `package_manager` + `package_name`, the copy is "added {pm}/{pkg}" + (when a
+ * policy path is known) " to {license policy link}" + (when a repo name is
+ * known) " for {repo}". Otherwise it falls back to "created exception".
+ */
+export const EventExceptionAdded = () => (
+  <div className={classes.RealisticTimeline}>
+    {/* Full shape — package + policy link + repo name */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Added a package exception to the license policy</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LawIcon} aria-label="Exception added" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>
+              added npm/left-pad to <PolicyLink /> for monalisa/octo-app
+            </span>{' '}
+            <Time date="2025-10-23T12:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Fallback shape — body missing package info */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Created exception (fallback)</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LawIcon} aria-label="Exception created" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>created exception</span> <Time date="2025-10-23T12:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Licenses-added event group — `AlertEventType.LicensesAdded` (audit § 8).
+ *
+ * Source: `events/LicensesAddedEvent.tsx` (`TimelineEventWithActor`):
+ * `LawIcon size={16}` on the default (gray) badge. When the body has a
+ * `licenses` array, the copy is "added {licenses joined by ', '}" + (when a
+ * policy path is known) " to {license policy link}" + (when a repo name is
+ * known) " for {repo}". Otherwise it falls back to "added to approved licenses".
+ */
+export const EventLicensesAdded = () => (
+  <div className={classes.RealisticTimeline}>
+    {/* Full shape — licenses list + policy link + repo name */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Added licenses to the license policy</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LawIcon} aria-label="Licenses added" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>
+              added MIT, Apache-2.0 to <PolicyLink /> for monalisa/octo-app
+            </span>{' '}
+            <Time date="2025-10-24T12:00:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Fallback shape — body missing licenses array */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Added to approved licenses (fallback)</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={LawIcon} aria-label="Added to approved licenses" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>added to approved licenses</span> <Time date="2025-10-24T12:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+  </div>
+)
+
+/**
+ * The Closed event group — `AlertEventType.Closed` (audit § 9).
+ *
+ * Source: `events/ClosedEvent.tsx` (`TimelineEventWithActor`): `ShieldCheckIcon
+ * size={16}` on the `done` (PURPLE) badge — the only colored gray-exempt event
+ * besides Opened. The copy comes from `getClosedActionText(closureReason,
+ * resolution)`, which renders exactly one of:
+ * - "closed as {closureReason}" — when a free-text `closureReason` is present
+ *   (e.g. "used in tests", carried over from the review flow);
+ * - "closed as outdated" — resolution `Outdated`;
+ * - "closed as amendment" — resolution `ExceptionAdded` or `LicensesAdded`;
+ * - "closed this alert" — the default.
+ * An optional `EventComment` sub-row renders a closing comment.
+ */
+export const EventClosed = () => (
+  <div className={classes.RealisticTimeline}>
+    {/* Closed as {free-text reason}, with a closing comment */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as a specific reason (with comment)</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Closed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>closed as used in tests</span> <Time date="2025-10-25T10:00:00Z" />
+            <EventComment>Confirmed this dependency only ships in the test bundle.</EventComment>
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Closed as outdated — resolution Outdated */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as outdated</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Closed as outdated" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>closed as outdated</span> <Time date="2025-10-25T10:05:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Closed as amendment — resolution ExceptionAdded / LicensesAdded */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed as amendment</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Closed as amendment" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>closed as amendment</span> <Time date="2025-10-25T10:10:00Z" />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </section>
+
+    {/* Closed this alert — default (no reason / resolution) */}
+    <section className={classes.Variant}>
+      <h3 className={classes.VariantLabel}>Closed this alert (default)</h3>
+      <Timeline aria-label="License compliance alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge variant="done">
+            <Octicon icon={ShieldCheckIcon} aria-label="Closed" />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
+            <span className={classes.ActionText}>closed this alert</span> <Time date="2025-10-25T10:15:00Z" />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>

--- a/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.license-compliance.features.stories.tsx
@@ -15,13 +15,13 @@ import {
   XIcon,
 } from '@primer/octicons-react'
 import type React from 'react'
-import Avatar from '../Avatar'
 import BranchName from '../BranchName'
 import {Button} from '../Button'
 import Label from '../Label'
 import Link from '../Link'
 import Octicon from '../Octicon'
-import RelativeTime from '../RelativeTime'
+import {BoldLink, Examples, InlineAvatar, MutedTime, VariantSection} from './internal/timelineStoryHelpers'
+import sharedClasses from './internal/timelineStoryHelpers.module.css'
 import classes from './Timeline.license-compliance.features.stories.module.css'
 
 /**
@@ -115,32 +115,33 @@ const LICENSE_BOT_AVATAR = 'https://avatars.githubusercontent.com/u/9919?s=40&v=
 
 /**
  * User actor — live `TimelineEventWithActor` (`events/shared.tsx`). Renders a
- * 20px CIRCLE `GitHubAvatar` followed by the login. Rendered as PLAIN INLINE
- * elements (avatar with `vertical-align: middle` immediately followed by an
- * inline `<Link>`/span) — NO `inline-flex` wrapper — so the avatar, login, badge
- * and trailing summary all sit on one cleanly vertically-centered line, exactly
- * like the working Issues (#8070) / Dependabot (#8071) rows. The shape is derived
+ * 20px CIRCLE avatar (shared `InlineAvatar`) followed by the login (shared
+ * `BoldLink`), as PLAIN INLINE elements so the avatar, login, badge and trailing
+ * summary all sit on one cleanly vertically-centered line. The shape is derived
  * from the login, matching live `shared.tsx`:
  * - login ends with `[bot]` → the suffix is stripped and the (UNLINKED) display
- *   login renders bold + a secondary "bot" `Label` (live ignores `url` for bots).
- * - otherwise `url` present → inline `<Link>` login, semibold + `fgColor-default`
- *   (the bold weight is the non-color differentiator that satisfies
- *   `link-in-text-block`).
- * - otherwise → bold login text.
+ *   login renders bold (a `<span>` sourcing the shared `BoldLink` styling — a
+ *   plain span rather than `BoldLink as="span"` because Primer's `Link` errors
+ *   when it renders as a non-anchor) + a secondary "bot" `Label` (live ignores
+ *   `url` for bots).
+ * - otherwise `url` present → linked login (`BoldLink href`), semibold +
+ *   `fgColor-default` (the bold weight is the non-color differentiator that
+ *   satisfies `link-in-text-block`; no `inline`, so it stays un-underlined).
+ * - otherwise → bold login text (same shared-styled `<span>`).
  */
 const UserActor = ({login = 'monalisa', src = MONALISA_AVATAR, url}: {login?: string; src?: string; url?: string}) => {
   // Derive the bot shape from the login itself, exactly like live `shared.tsx`
   // (`isBot = login.endsWith('[bot]')`, with the suffix stripped for display).
   const isBot = login.endsWith('[bot]')
   const displayLogin = isBot ? login.replace(/\[bot\]$/i, '') : login
-  const avatar = <Avatar src={src} size={20} alt="" className={classes.InlineAvatar} />
+  const avatar = <InlineAvatar src={src} />
   if (isBot) {
     // Live renders bots UNLINKED (the bot branch ignores `actor.url`): avatar +
     // bold display login + a secondary "bot" Label.
     return (
       <>
         {avatar}
-        <span className={classes.ActorName}>{displayLogin}</span>
+        <span className={sharedClasses.BoldLink}>{displayLogin}</span>
         <Label variant="secondary" className={classes.BotLabel}>
           bot
         </Label>
@@ -151,28 +152,17 @@ const UserActor = ({login = 'monalisa', src = MONALISA_AVATAR, url}: {login?: st
     return (
       <>
         {avatar}
-        <Link href={url} className={classes.ActorName}>
-          {displayLogin}
-        </Link>
+        <BoldLink href={url}>{displayLogin}</BoldLink>
       </>
     )
   }
   return (
     <>
       {avatar}
-      <span className={classes.ActorName}>{displayLogin}</span>
+      <span className={sharedClasses.BoldLink}>{displayLogin}</span>
     </>
   )
 }
-
-// Muted relative timestamp. Live `shared.tsx` renders a plain `RelativeTime`
-// with no link wrapper — muted text only (matching the secret-scanning and
-// Dependabot timelines, unlike the Issues `Ago` deep-link).
-const Time = ({date}: {date: string}) => (
-  <span className={classes.Timestamp}>
-    <RelativeTime date={new Date(date)} format="relative" />
-  </span>
-)
 
 /**
  * Optional comment sub-row — live `EventComment` (`events/shared.tsx`) renders a
@@ -216,33 +206,6 @@ const PolicyLink = ({href = '../../settings/security_analysis'}: {href?: string}
   <Link href={href} inline>
     license policy
   </Link>
-)
-
-/**
- * Story-only wrapper around each group's examples. Besides constraining the
- * width (`.RealisticTimeline`), it:
- * - sets `data-a11y-link-underlines="true"` so Primer's inline-link underline
- *   (gated on this ancestor attribute, which GitHub sets from the default-on
- *   "Show link underlines" preference but Storybook never sets) renders for the
- *   in-text `<Link inline>` links (policy / PR) — reproducing production and
- *   satisfying WCAG 1.4.1. Actor-name links have no `inline` prop, so they stay
- *   un-underlined (avatar + semibold cue only).
- * - swallows clicks on the demo links (actor profile, PR, license-policy) so
- *   navigating one of these placeholder `href`s doesn't kick the viewer out of
- *   the Storybook UI — the same guard the base `Timeline.features.stories.tsx`
- *   `WithActions` story uses. The `e.target instanceof Element` check keeps it
- *   safe when the click originates on an SVG/octicon.
- */
-const Examples = ({children}: {children: React.ReactNode}) => (
-  <div
-    className={classes.RealisticTimeline}
-    data-a11y-link-underlines="true"
-    onClick={e => {
-      if (e.target instanceof Element && e.target.closest('a')) e.preventDefault()
-    }}
-  >
-    {children}
-  </div>
 )
 
 export default {
@@ -289,8 +252,7 @@ export default {
 export const EventOpened = () => (
   <Examples>
     {/* Opened — license-compliance system bot, ShieldIcon on success (green) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Opened</h3>
+    <VariantSection label="Opened">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="success">
@@ -298,11 +260,12 @@ export const EventOpened = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="github-license-compliance[bot]" src={LICENSE_BOT_AVATAR} />{' '}
-            <span className={classes.ActionText}>opened this alert</span> <Time date="2025-10-20T10:00:00Z" />
+            <span className={classes.ActionText}>opened this alert</span>{' '}
+            <MutedTime date={new Date('2025-10-20T10:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -325,8 +288,7 @@ export const EventAppearedInBranch = () => (
   <Examples>
     {/* Appeared in branch — actor-less, GitBranchIcon on the default (gray)
         badge, with a BranchName pill. PR sub-row is dormant (see group doc). */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Appeared in branch</h3>
+    <VariantSection label="Appeared in branch">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -335,11 +297,11 @@ export const EventAppearedInBranch = () => (
           <Timeline.Body>
             <span className={classes.ActionText}>Appeared in branch</span>{' '}
             <BranchName href="../../tree/feature-branch">feature-branch</BranchName>{' '}
-            <Time date="2025-10-20T10:01:00Z" />
+            <MutedTime date={new Date('2025-10-20T10:01:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -366,8 +328,7 @@ export const EventAppearedInBranch = () => (
 export const EventReviewRequested = () => (
   <Examples>
     {/* Requested to close — no reason, no PR, no comment */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Requested to close</h3>
+    <VariantSection label="Requested to close">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -375,15 +336,15 @@ export const EventReviewRequested = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>requested to close</span> <Time date="2025-10-21T09:00:00Z" />
+            <span className={classes.ActionText}>requested to close</span>{' '}
+            <MutedTime date={new Date('2025-10-21T09:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Requested to close as {reason}, with a requester comment sub-row */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Requested to close as a specific reason (with comment)</h3>
+    <VariantSection label="Requested to close as a specific reason (with comment)">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -392,17 +353,16 @@ export const EventReviewRequested = () => (
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>requested to close as used in tests</span>{' '}
-            <Time date="2025-10-21T09:05:00Z" />
+            <MutedTime date={new Date('2025-10-21T09:05:00Z')} />
             <EventComment>This dependency is only pulled in by our test harness.</EventComment>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Requested to close with an associated PR — PR link sub-row + the primary
         "Review request" button (latest request only) in Timeline.Actions. */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Requested to close with a pull request (latest — shows Review request)</h3>
+    <VariantSection label="Requested to close with a pull request (latest — shows Review request)">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -410,7 +370,8 @@ export const EventReviewRequested = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>requested to close</span> <Time date="2025-10-21T09:10:00Z" />
+            <span className={classes.ActionText}>requested to close</span>{' '}
+            <MutedTime date={new Date('2025-10-21T09:10:00Z')} />
             <PullRequestLink number={42} title="Replace GPL dependency" />
           </Timeline.Body>
           <Timeline.Actions>
@@ -420,7 +381,7 @@ export const EventReviewRequested = () => (
           </Timeline.Actions>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -435,8 +396,7 @@ export const EventReviewRequested = () => (
 export const EventReviewApproved = () => (
   <Examples>
     {/* Approved closure request */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Approved closure request</h3>
+    <VariantSection label="Approved closure request">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -444,15 +404,15 @@ export const EventReviewApproved = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
-            <span className={classes.ActionText}>approved closure request</span> <Time date="2025-10-22T10:00:00Z" />
+            <span className={classes.ActionText}>approved closure request</span>{' '}
+            <MutedTime date={new Date('2025-10-22T10:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Approved closure request — with reviewer comment */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Approved closure request (with comment)</h3>
+    <VariantSection label="Approved closure request (with comment)">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -460,12 +420,13 @@ export const EventReviewApproved = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
-            <span className={classes.ActionText}>approved closure request</span> <Time date="2025-10-22T10:05:00Z" />
+            <span className={classes.ActionText}>approved closure request</span>{' '}
+            <MutedTime date={new Date('2025-10-22T10:05:00Z')} />
             <EventComment>Agreed — test-only usage is within policy.</EventComment>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -479,8 +440,7 @@ export const EventReviewApproved = () => (
 export const EventReviewDenied = () => (
   <Examples>
     {/* Denied closure request */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Denied closure request</h3>
+    <VariantSection label="Denied closure request">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -488,15 +448,15 @@ export const EventReviewDenied = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
-            <span className={classes.ActionText}>denied closure request</span> <Time date="2025-10-22T11:00:00Z" />
+            <span className={classes.ActionText}>denied closure request</span>{' '}
+            <MutedTime date={new Date('2025-10-22T11:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Denied closure request — with reviewer comment */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Denied closure request (with comment)</h3>
+    <VariantSection label="Denied closure request (with comment)">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -504,12 +464,13 @@ export const EventReviewDenied = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="hubot" src={HUBOT_AVATAR} url="https://github.com/hubot" />{' '}
-            <span className={classes.ActionText}>denied closure request</span> <Time date="2025-10-22T11:05:00Z" />
+            <span className={classes.ActionText}>denied closure request</span>{' '}
+            <MutedTime date={new Date('2025-10-22T11:05:00Z')} />
             <EventComment>This package is distributed to customers, so the license still applies.</EventComment>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -525,8 +486,7 @@ export const EventReviewDenied = () => (
 export const EventReviewExpired = () => (
   <Examples>
     {/* Request to close expired — license-compliance system bot, automatic expiry */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Request to close expired</h3>
+    <VariantSection label="Request to close expired">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -534,11 +494,12 @@ export const EventReviewExpired = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="github-license-compliance[bot]" src={LICENSE_BOT_AVATAR} />{' '}
-            <span className={classes.ActionText}>Request to close expired</span> <Time date="2025-10-23T10:00:00Z" />
+            <span className={classes.ActionText}>Request to close expired</span>{' '}
+            <MutedTime date={new Date('2025-10-23T10:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -555,8 +516,7 @@ export const EventReviewExpired = () => (
 export const EventExceptionAdded = () => (
   <Examples>
     {/* Full shape — package + policy link + repo name */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Added a package exception to the license policy</h3>
+    <VariantSection label="Added a package exception to the license policy">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -567,15 +527,14 @@ export const EventExceptionAdded = () => (
             <span className={classes.ActionText}>
               added npm/left-pad to <PolicyLink /> for monalisa/octo-app
             </span>{' '}
-            <Time date="2025-10-23T12:00:00Z" />
+            <MutedTime date={new Date('2025-10-23T12:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Fallback shape — body missing package info */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Created exception (fallback)</h3>
+    <VariantSection label="Created exception (fallback)">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -583,11 +542,12 @@ export const EventExceptionAdded = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>created exception</span> <Time date="2025-10-23T12:05:00Z" />
+            <span className={classes.ActionText}>created exception</span>{' '}
+            <MutedTime date={new Date('2025-10-23T12:05:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -603,8 +563,7 @@ export const EventExceptionAdded = () => (
 export const EventLicensesAdded = () => (
   <Examples>
     {/* Full shape — licenses list + policy link + repo name */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Added licenses to the license policy</h3>
+    <VariantSection label="Added licenses to the license policy">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -615,15 +574,14 @@ export const EventLicensesAdded = () => (
             <span className={classes.ActionText}>
               added MIT, Apache-2.0 to <PolicyLink /> for monalisa/octo-app
             </span>{' '}
-            <Time date="2025-10-24T12:00:00Z" />
+            <MutedTime date={new Date('2025-10-24T12:00:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Fallback shape — body missing licenses array */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Added to approved licenses (fallback)</h3>
+    <VariantSection label="Added to approved licenses (fallback)">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge>
@@ -631,11 +589,12 @@ export const EventLicensesAdded = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>added to approved licenses</span> <Time date="2025-10-24T12:05:00Z" />
+            <span className={classes.ActionText}>added to approved licenses</span>{' '}
+            <MutedTime date={new Date('2025-10-24T12:05:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )
 
@@ -655,8 +614,7 @@ export const EventLicensesAdded = () => (
 export const EventClosed = () => (
   <Examples>
     {/* Closed as amendment — with a closing comment */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as amendment (with comment)</h3>
+    <VariantSection label="Closed as amendment (with comment)">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -664,16 +622,16 @@ export const EventClosed = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>closed as amendment</span> <Time date="2025-10-25T10:00:00Z" />
+            <span className={classes.ActionText}>closed as amendment</span>{' '}
+            <MutedTime date={new Date('2025-10-25T10:00:00Z')} />
             <EventComment>Added a policy exception covering this package.</EventComment>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed as private package */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as private package</h3>
+    <VariantSection label="Closed as private package">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -681,15 +639,15 @@ export const EventClosed = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>closed as private package</span> <Time date="2025-10-25T10:05:00Z" />
+            <span className={classes.ActionText}>closed as private package</span>{' '}
+            <MutedTime date={new Date('2025-10-25T10:05:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed as inaccurate license */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as inaccurate license</h3>
+    <VariantSection label="Closed as inaccurate license">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -698,15 +656,14 @@ export const EventClosed = () => (
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
             <span className={classes.ActionText}>closed as inaccurate license</span>{' '}
-            <Time date="2025-10-25T10:10:00Z" />
+            <MutedTime date={new Date('2025-10-25T10:10:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed as policy edited */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as policy edited</h3>
+    <VariantSection label="Closed as policy edited">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -714,15 +671,15 @@ export const EventClosed = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>closed as policy edited</span> <Time date="2025-10-25T10:15:00Z" />
+            <span className={classes.ActionText}>closed as policy edited</span>{' '}
+            <MutedTime date={new Date('2025-10-25T10:15:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed as fixed */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as fixed</h3>
+    <VariantSection label="Closed as fixed">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -730,15 +687,15 @@ export const EventClosed = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>closed as fixed</span> <Time date="2025-10-25T10:20:00Z" />
+            <span className={classes.ActionText}>closed as fixed</span>{' '}
+            <MutedTime date={new Date('2025-10-25T10:20:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed as outdated — resolution Outdated */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed as outdated</h3>
+    <VariantSection label="Closed as outdated">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -746,15 +703,15 @@ export const EventClosed = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>closed as outdated</span> <Time date="2025-10-25T10:25:00Z" />
+            <span className={classes.ActionText}>closed as outdated</span>{' '}
+            <MutedTime date={new Date('2025-10-25T10:25:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
 
     {/* Closed this alert — default (no reason / resolution) */}
-    <section className={classes.Variant}>
-      <h3 className={classes.VariantLabel}>Closed this alert (default)</h3>
+    <VariantSection label="Closed this alert (default)">
       <Timeline aria-label="License compliance alert timeline">
         <Timeline.Item>
           <Timeline.Badge variant="done">
@@ -762,10 +719,11 @@ export const EventClosed = () => (
           </Timeline.Badge>
           <Timeline.Body>
             <UserActor login="monalisa" src={MONALISA_AVATAR} url="https://github.com/monalisa" />{' '}
-            <span className={classes.ActionText}>closed this alert</span> <Time date="2025-10-25T10:30:00Z" />
+            <span className={classes.ActionText}>closed this alert</span>{' '}
+            <MutedTime date={new Date('2025-10-25T10:30:00Z')} />
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
-    </section>
+    </VariantSection>
   </Examples>
 )


### PR DESCRIPTION
## Summary

Adds Storybook **Features** stories that recreate GitHub's live **License Compliance alert timeline** events using the Primer `Timeline` component and its compositional slots. This is the **License Compliance surface** — a **Security** surface — of Phase 2 of the Timeline events effort (github/primer#6663). The Issues surface (#8070), Issue comment cards (#8072), the Dependabot alert surface (#8071), the Secret Scanning surface (#8073), and the Code Scanning surface (#8074) already landed; **License Compliance** follows here as a separate Security surface.

Like Secret Scanning (and unlike the server-rendered Dependabot and Code Scanning surfaces), **License Compliance is fully React** — the alert show page is a React SPA in `github/github-ui` (`packages/license-compliance-alerts/`) that already composes Primer React `Timeline` + `Timeline.Badge variant=`, so the live badges/actors map cleanly onto these stories.

All examples live in a single new file, `Timeline.license-compliance.features.stories.tsx` (+ a `.module.css`), exported under the title **`Components/Timeline/Events/License Compliance`** — one story export per event group.

### The 9 event groups (19 variants total)

| Group | Variants | Badge | Actor |
|---|---|---|---|
| `EventOpened` | 2 — opened (user) / opened (bot) | `shield` on solid `success` (green) | User |
| `EventAppearedInBranch` | 1 — branch-name pill | bare `git-branch` (default gray) | none (system) |
| `EventReviewRequested` | 3 — plain / with reason + comment / with PR link + button | bare `comment` (default gray) | User |
| `EventReviewApproved` | 2 — plain / with comment | bare `check` (default gray) | User |
| `EventReviewDenied` | 2 — plain / with comment | bare `x` (default gray) | User |
| `EventReviewExpired` | 1 — request to close expired | bare `circle-slash` (default gray) | none (automatic) |
| `EventExceptionAdded` | 2 — full (package + policy link + repo) / fallback | bare `law` (default gray) | User |
| `EventLicensesAdded` | 2 — full (licenses + policy link + repo) / fallback | bare `law` (default gray) | User |
| `EventClosed` | 4 — reason + comment / outdated / amendment / default | `shield-check` on solid `done` (purple) | User |

## Source of truth

These stories were recreated from the **live React implementation** in `github/github-ui` (`packages/license-compliance-alerts/components/timeline/`). The authoritative dispatch is the `switch (event.type)` in `TimelineEventItem.tsx`; per-event copy, badges, and actors were read from the per-event components under `events/` and the two shared wrappers in `events/shared.tsx` (`TimelineEventWithActor` / `TimelineEventWithoutActor`). The two **synthetic** events (`opened`, `appeared_in_branch`) are constructed server-side, so we additionally verified them against the Rails builder, `app/controllers/repos/license_compliance_alerts_controller.rb`.

We verified the live render path (and the Rails builder) rather than trusting the Figma audit blindly. The notable resolutions:

- **The `appeared_in_branch` PR sub-row is dormant.** `AppearedInBranchEvent` renders a `PullRequestLink` whenever its body carries `pull_request_number` / `pull_request_title`, but the Rails `create_synthetic_branch_event` only ever writes `{branch_name}` (and `actor: nil`) — PR enrichment is applied **only** to `review_requested` events. So that sub-row is dead in production; we build **only the branch-name pill** and note the dormant path in-code.
- **`review_expired` is actor-less.** Although the component uses `TimelineEventWithActor`, expiry is automatic and Rails attaches no actor (the live test fixture has none); the copy "Request to close expired" is a standalone capitalized sentence. Built without an actor.
- **The 4 closure-reason strings come from live `getClosedActionText(closureReason, resolution)`** in `ClosedEvent.tsx`: `closed as {closureReason}` (free text, e.g. "used in tests") / `closed as outdated` (resolution `Outdated`) / `closed as amendment` (resolution `ExceptionAdded` or `LicensesAdded`) / `closed this alert` (default). All four are built.
- **The Opened actor is the license-compliance system bot.** `create_synthetic_opened_event` attributes the synthetic `opened` event to `attribution_only_system_identity_for(:license_compliance)`, rendered as a normal **linked** actor (its login isn't `[bot]`-suffixed, so no "bot" Label) — distinct from the `MarkGithubIcon` "GitHub" system actor used on the Secret Scanning surface.

## Slots

- **No system "GitHub" actor on this surface** (unlike Secret Scanning) — every actor event flows through `TimelineEventWithActor`, which renders a 20px circle avatar + login (a profile **link** when `actor.url` is present, otherwise bold text; bots strip the `[bot]` suffix and append a secondary "bot" `Label`).
- **Actor-less events** (Appeared-in-branch, Review-expired) render body text only — no avatar or link.
- **`Timeline.Actions`** (right-controls slot, added in #7886) carries the **"Review request"** button on the latest `review_requested` event (label confirmed from `ReviewRequestedEvent.tsx`, a `variant="primary" size="small"` button).

## Badge note

Gray/default events render as a **bare `Timeline.Badge`** (no solid fill, no `--timelineBadge-bgColor` hook) — Appeared-in-branch, all three Review states, Review-expired, Exception-added, and Licenses-added. Only **Opened** (green/`success`) and **Closed** (purple/`done`) are solid `variant=` badges — matching the live components, where only those two pass an explicit `badgeVariant`.

## Scope & conventions

- Storybook-only by design — **not** added to `Timeline.docs.json` or `build.ts`. Individual timeline events are not consumer-facing components.
- File-scoped **future-state list-semantics** decorator (`primer_react_timeline_list_semantics`, refs primer/react#7910) so every story renders in the `<ol>`/`<li>` DOM the timeline will ship.
- Per-variant `<section><h3 caption>` scaffolding above each row so variants stay scannable like a Figma component set, without polluting `Timeline.Body`.
- **20px avatars**, matching the live `TimelineEventWithActor` (note: larger than the Secret Scanning surface's 16px).
- Deferred `data-*` event-category taxonomy (still open in github/primer#6663) — intentionally not baked in yet.

## Accessibility

The live in-text links (the "license policy" link on Exception-added / Licenses-added, and the PR link on Review-requested) use a **color-only** style (no underline or bold) that would fail the axe `link-in-text-block` rule (WCAG 1.4.1) in high-contrast themes. The stories intentionally render them with an underline (the `inline` prop) so they pass and model good a11y — a small, deliberate deviation from live, noted in-code. (The live color-only links are a potential a11y gap worth flagging to the owning team.) The actor profile link is **semibold**, the non-color differentiator that satisfies the same rule, matching the live `actorLink` style.

## Changelog

Stories-only change — no consumer-facing component or API change, so **no changeset** (the `skip changeset` label is applied).

## Rollout

No rollout concerns — adds Storybook examples only; ships no runtime code.

## Testing

- `prettier` — clean
- `eslint` — clean
- `stylelint` — clean
- `tsc` — 0 new type errors (the only repo tsc error is pre-existing in `script/components-json/build.ts`)

## Merge checklist

- [x] Stories render under `Components/Timeline/Events/License Compliance`
- [x] All 9 event groups translated and verified against the live React components + Rails synthetic-event builder
- [x] prettier / eslint / stylelint clean, 0 new tsc errors
- [x] `skip changeset` + `component: Timeline` labels applied
- [ ] Review of copy / badge / actor fidelity
