### PR TITLE
docs: Remove merge checklist from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,16 +34,4 @@ Closes #
 <!-- Describe any specific details to help reviewers test or review this Pull Request -->
 <!-- To publish a canary release for integration testing, apply the "Canary Release" label to this PR -->
 
-### Merge checklist
-
-- [ ] Added/updated tests
-- [ ] Added/updated documentation
-- [ ] Added/updated previews (Storybook)
-- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
-- [ ] Tested in Chrome
-- [ ] Tested in Firefox
-- [ ] Tested in Safari
-- [ ] Tested in Edge
-- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
-
 <!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->


### PR DESCRIPTION
Updates our PR template so that it no longer includes the merge checklist. Curious what others think 👀 This is a section that I find myself not really using too often so was curious if others felt the same and if we could remove it