### PR TITLE
chore(deps): add cooldown option to dependabot and min-release-age to npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 7
     versioning-strategy: increase
     labels:
       - 'dependencies'
@@ -49,6 +51,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 7
     labels:
       - 'dependencies'
       - 'skip changeset'

--- a/.npmrc
+++ b/.npmrc
@@ -5,3 +5,5 @@ legacy-peer-deps=true
 fetch-retries=5
 fetch-retry-mintimeout=300000
 fetch-retry-maxtimeout=300000
+# https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age
+min-release-age=7


### PR DESCRIPTION
Update our dependabot and npm config to both use 7 days as the "cooldown" period for dependency updates.