### PR TITLE
Add trigger ARIA state for detached AnchoredOverlay/SelectPanel anchors

### DIFF
--- a/.changeset/anchored-overlay-detached-anchor-aria.md
+++ b/.changeset/anchored-overlay-detached-anchor-aria.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+AnchoredOverlay and SelectPanel: add trigger ARIA state for detached anchors

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.docs.json
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.docs.json
@@ -170,6 +170,13 @@
       "defaultValue": "true"
     },
     {
+      "name": "anchorHasPopup",
+      "type": "'true' | 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid'",
+      "required": false,
+      "description": "Indicates the type of popup opened by the anchor. Defaults to `'true'`, which is equivalent to `'menu'` in ARIA.",
+      "defaultValue": "'true'"
+    },
+    {
       "name": "closeButtonProps",
       "type": "Partial<ButtonProps>",
       "required": false,

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
@@ -3,6 +3,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {act, fireEvent, render} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {AnchoredOverlay} from '../AnchoredOverlay'
+import type {AnchorHasPopup} from '../AnchoredOverlay'
 import {Button} from '../Button'
 import BaseStyles from '../BaseStyles'
 import type {AnchorPosition} from '@primer/behaviors'
@@ -252,8 +253,8 @@ describe('AnchoredOverlay anchor ARIA', () => {
     consumerHasPopup,
   }: {
     initiallyOpen?: boolean
-    anchorHasPopup?: 'true' | 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid'
-    consumerHasPopup?: 'true' | 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid'
+    anchorHasPopup?: AnchorHasPopup
+    consumerHasPopup?: AnchorHasPopup
   }) {
     const [open, setOpen] = useState(initiallyOpen)
     const anchorRef = useRef<HTMLButtonElement>(null)

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
@@ -349,16 +349,30 @@ describe('AnchoredOverlay anchor ARIA', () => {
     expect(anchor).not.toHaveAttribute('aria-expanded', 'true')
   })
 
-  it('does not write ARIA to a non-interactive (e.g. <div>) detached anchor', async () => {
-    function DivAnchorComponent() {
+  it('does not write ARIA to a non-interactive detached anchor (<div> or plain <input>)', async () => {
+    function NonInteractiveAnchorComponent({tag}: {tag: 'div' | 'input'}) {
       const [open, setOpen] = useState(false)
-      const anchorRef = useRef<HTMLDivElement>(null)
+      const anchorRef = useRef<HTMLElement>(null)
 
       return (
         <BaseStyles>
-          <div ref={anchorRef} data-testid="div-anchor" onClick={() => setOpen(isOpen => !isOpen)}>
-            Detached div anchor
-          </div>
+          {tag === 'div' ? (
+            <div
+              ref={anchorRef as React.RefObject<HTMLDivElement>}
+              data-testid="anchor"
+              onClick={() => setOpen(isOpen => !isOpen)}
+            >
+              Detached div anchor
+            </div>
+          ) : (
+            <input
+              ref={anchorRef as React.RefObject<HTMLInputElement>}
+              data-testid="anchor"
+              onClick={() => setOpen(isOpen => !isOpen)}
+              readOnly
+              value="Detached input anchor"
+            />
+          )}
           <AnchoredOverlay
             open={open}
             onOpen={() => setOpen(true)}
@@ -372,12 +386,52 @@ describe('AnchoredOverlay anchor ARIA', () => {
       )
     }
 
-    const {baseElement} = render(<DivAnchorComponent />)
+    for (const tag of ['div', 'input'] as const) {
+      const {baseElement, unmount} = render(<NonInteractiveAnchorComponent tag={tag} />)
+      await act(async () => {})
+
+      const anchor = baseElement.querySelector('[data-testid="anchor"]')
+      expect(anchor).not.toHaveAttribute('aria-haspopup')
+      expect(anchor).not.toHaveAttribute('aria-expanded')
+      unmount()
+    }
+  })
+
+  it('writes ARIA to a detached anchor with a popup-supporting role (e.g. role="combobox")', async () => {
+    function ComboboxAnchorComponent() {
+      const [open, setOpen] = useState(false)
+      const anchorRef = useRef<HTMLInputElement>(null)
+
+      return (
+        <BaseStyles>
+          <input
+            ref={anchorRef}
+            data-testid="anchor"
+            role="combobox"
+            aria-controls="overlay"
+            readOnly
+            value="Combobox anchor"
+            onClick={() => setOpen(isOpen => !isOpen)}
+          />
+          <AnchoredOverlay
+            open={open}
+            onOpen={() => setOpen(true)}
+            onClose={() => setOpen(false)}
+            renderAnchor={null}
+            anchorRef={anchorRef}
+          >
+            <button type="button">Focusable Child</button>
+          </AnchoredOverlay>
+        </BaseStyles>
+      )
+    }
+
+    const {baseElement} = render(<ComboboxAnchorComponent />)
     await act(async () => {})
 
-    const anchor = baseElement.querySelector('[data-testid="div-anchor"]')
-    expect(anchor).not.toHaveAttribute('aria-haspopup')
-    expect(anchor).not.toHaveAttribute('aria-expanded')
+    const anchor = baseElement.querySelector('[data-testid="anchor"]')
+    expect(anchor).toHaveAttribute('aria-haspopup', 'true')
+    expect(anchor).toHaveAttribute('aria-expanded', 'false')
   })
 })
 

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
@@ -348,6 +348,37 @@ describe('AnchoredOverlay anchor ARIA', () => {
     await userEvent.click(anchor)
     expect(anchor).not.toHaveAttribute('aria-expanded', 'true')
   })
+
+  it('does not write ARIA to a non-interactive (e.g. <div>) detached anchor', async () => {
+    function DivAnchorComponent() {
+      const [open, setOpen] = useState(false)
+      const anchorRef = useRef<HTMLDivElement>(null)
+
+      return (
+        <BaseStyles>
+          <div ref={anchorRef} data-testid="div-anchor" onClick={() => setOpen(isOpen => !isOpen)}>
+            Detached div anchor
+          </div>
+          <AnchoredOverlay
+            open={open}
+            onOpen={() => setOpen(true)}
+            onClose={() => setOpen(false)}
+            renderAnchor={null}
+            anchorRef={anchorRef}
+          >
+            <button type="button">Focusable Child</button>
+          </AnchoredOverlay>
+        </BaseStyles>
+      )
+    }
+
+    const {baseElement} = render(<DivAnchorComponent />)
+    await act(async () => {})
+
+    const anchor = baseElement.querySelector('[data-testid="div-anchor"]')
+    expect(anchor).not.toHaveAttribute('aria-haspopup')
+    expect(anchor).not.toHaveAttribute('aria-expanded')
+  })
 })
 
 describe('AnchoredOverlay scroll/resize cascade', () => {

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.test.tsx
@@ -245,6 +245,110 @@ describe.each([true, false])(
   },
 )
 
+describe('AnchoredOverlay anchor ARIA', () => {
+  function DetachedOverlayTestComponent({
+    initiallyOpen = false,
+    anchorHasPopup = 'true',
+    consumerHasPopup,
+  }: {
+    initiallyOpen?: boolean
+    anchorHasPopup?: 'true' | 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid'
+    consumerHasPopup?: 'true' | 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid'
+  }) {
+    const [open, setOpen] = useState(initiallyOpen)
+    const anchorRef = useRef<HTMLButtonElement>(null)
+
+    return (
+      <BaseStyles>
+        <button
+          type="button"
+          ref={anchorRef}
+          data-testid="detached-anchor"
+          onClick={() => setOpen(isOpen => !isOpen)}
+          {...(consumerHasPopup ? {'aria-haspopup': consumerHasPopup} : {})}
+        >
+          Detached anchor
+        </button>
+        <AnchoredOverlay
+          open={open}
+          onOpen={() => setOpen(true)}
+          onClose={() => setOpen(false)}
+          renderAnchor={null}
+          anchorRef={anchorRef}
+          anchorHasPopup={anchorHasPopup}
+        >
+          <button type="button">Focusable Child</button>
+        </AnchoredOverlay>
+      </BaseStyles>
+    )
+  }
+
+  it('sets aria-haspopup and aria-expanded on a detached anchor when closed', async () => {
+    const {baseElement} = render(<DetachedOverlayTestComponent />)
+    await act(async () => {})
+
+    const anchor = baseElement.querySelector('[data-testid="detached-anchor"]')
+    expect(anchor).toHaveAttribute('aria-haspopup', 'true')
+    expect(anchor).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('reflects aria-expanded on a detached anchor when opened and closed', async () => {
+    const {baseElement} = render(<DetachedOverlayTestComponent />)
+    await act(async () => {})
+
+    const anchor = baseElement.querySelector('[data-testid="detached-anchor"]') as HTMLElement
+    expect(anchor).toHaveAttribute('aria-expanded', 'false')
+
+    await userEvent.click(anchor)
+    expect(anchor).toHaveAttribute('aria-expanded', 'true')
+
+    await userEvent.click(anchor)
+    expect(anchor).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('does not overwrite aria-haspopup supplied by a detached anchor consumer', async () => {
+    const {baseElement} = render(<DetachedOverlayTestComponent consumerHasPopup="listbox" />)
+    await act(async () => {})
+
+    const anchor = baseElement.querySelector('[data-testid="detached-anchor"]')
+    expect(anchor).toHaveAttribute('aria-haspopup', 'listbox')
+    expect(anchor).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('reflects anchorHasPopup on the rendered anchor path', () => {
+    const {baseElement} = render(
+      <BaseStyles>
+        <AnchoredOverlay
+          open={false}
+          onOpen={() => {}}
+          onClose={() => {}}
+          anchorHasPopup="dialog"
+          renderAnchor={props => (
+            <button type="button" {...props}>
+              Anchor Button
+            </button>
+          )}
+        >
+          <button type="button">Focusable Child</button>
+        </AnchoredOverlay>
+      </BaseStyles>,
+    )
+
+    expect(baseElement.querySelector('button')).toHaveAttribute('aria-haspopup', 'dialog')
+  })
+
+  it('does not leave aria-expanded="true" on a detached anchor after close', async () => {
+    const {baseElement} = render(<DetachedOverlayTestComponent initiallyOpen={true} />)
+    await act(async () => {})
+
+    const anchor = baseElement.querySelector('[data-testid="detached-anchor"]') as HTMLElement
+    expect(anchor).toHaveAttribute('aria-expanded', 'true')
+
+    await userEvent.click(anchor)
+    expect(anchor).not.toHaveAttribute('aria-expanded', 'true')
+  })
+})
+
 describe('AnchoredOverlay scroll/resize cascade', () => {
   it('does not re-render after close when window scrolls (closed-overlay listeners detached)', async () => {
     // Before the `enabled: open` fix, useAnchoredPosition kept its scroll

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -18,7 +18,8 @@ import {useFeatureFlag} from '../FeatureFlags'
 import {widthMap} from '../Overlay/constants'
 import {reactMajorVersion} from '../utils/environment'
 
-type AnchorHasPopup = 'true' | 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid'
+type AnchorHasPopup = Exclude<React.AriaAttributes['aria-haspopup'], boolean | 'false' | undefined>
+export type {AnchorHasPopup}
 
 interface AnchoredOverlayPropsWithAnchor {
   /**
@@ -324,28 +325,37 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
   useEffect(() => {
     // Read the node from the ref (available once committed) rather than the
     // anchorElement state, which lags a render behind for a detached anchor and
-    // would leave the collapsed trigger without ARIA until first opened.
+    // would leave the collapsed trigger without aria-haspopup until first opened.
+    // aria-haspopup is stable for the component's lifetime, so this effect is
+    // kept separate from `open` to avoid rewriting the attribute on every toggle.
+    const node = anchorRef.current ?? anchorElement
+    if (renderAnchor !== null || !node) return
+    if (node.hasAttribute('aria-haspopup')) return // don't clobber a consumer value
+
+    node.setAttribute('aria-haspopup', anchorHasPopup)
+
+    return () => {
+      if (node.getAttribute('aria-haspopup') === anchorHasPopup) {
+        node.removeAttribute('aria-haspopup')
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [renderAnchor, anchorElement, anchorHasPopup])
+
+  useEffect(() => {
     const node = anchorRef.current ?? anchorElement
     if (renderAnchor !== null || !node) return
 
-    const addedHasPopup = !node.hasAttribute('aria-haspopup')
     const expandedValue = String(open)
-
-    if (addedHasPopup) {
-      node.setAttribute('aria-haspopup', anchorHasPopup)
-    }
     node.setAttribute('aria-expanded', expandedValue)
 
     return () => {
-      if (addedHasPopup && node.getAttribute('aria-haspopup') === anchorHasPopup) {
-        node.removeAttribute('aria-haspopup')
-      }
       if (node.getAttribute('aria-expanded') === expandedValue) {
         node.removeAttribute('aria-expanded')
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [renderAnchor, anchorElement, anchorHasPopup, open])
+  }, [renderAnchor, anchorElement, open])
 
   useEffect(() => {
     if (!cssAnchorPositioning || !anchorElement) return

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -21,6 +21,48 @@ import {reactMajorVersion} from '../utils/environment'
 type AnchorHasPopup = Exclude<React.AriaAttributes['aria-haspopup'], boolean | 'false' | undefined>
 export type {AnchorHasPopup}
 
+// `aria-haspopup` and `aria-expanded` are only valid on elements whose role
+// supports them. In detached-anchor mode the consumer owns the anchor element,
+// so guard the imperative ARIA writes: if the ref points at a non-interactive
+// element (e.g. a wrapper `<div>`), writing these attributes produces invalid
+// ARIA (axe `aria-allowed-attr`). In that case the consumer should point the
+// ref at the real trigger, and we skip rather than emit a violation.
+const rolesSupportingPopupAria = new Set([
+  'application',
+  'button',
+  'checkbox',
+  'columnheader',
+  'combobox',
+  'gridcell',
+  'link',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'row',
+  'rowheader',
+  'switch',
+  'tab',
+  'treeitem',
+])
+
+function anchorSupportsPopupAria(node: HTMLElement): boolean {
+  const explicitRole = node.getAttribute('role')
+  if (explicitRole) return rolesSupportingPopupAria.has(explicitRole)
+  switch (node.tagName) {
+    case 'BUTTON':
+    case 'SUMMARY':
+    case 'SELECT':
+    case 'TEXTAREA':
+      return true
+    case 'A':
+      return node.hasAttribute('href')
+    case 'INPUT':
+      return (node as HTMLInputElement).type !== 'hidden'
+    default:
+      return false
+  }
+}
+
 interface AnchoredOverlayPropsWithAnchor {
   /**
    * A custom function component used to render the anchor element.
@@ -330,6 +372,7 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
     // kept separate from `open` to avoid rewriting the attribute on every toggle.
     const node = anchorRef.current ?? anchorElement
     if (renderAnchor !== null || !node) return
+    if (!anchorSupportsPopupAria(node)) return // avoid invalid ARIA on non-interactive anchors
     if (node.hasAttribute('aria-haspopup')) return // don't clobber a consumer value
 
     node.setAttribute('aria-haspopup', anchorHasPopup)
@@ -344,6 +387,7 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
   useEffect(() => {
     const node = anchorRef.current ?? anchorElement
     if (renderAnchor !== null || !node) return
+    if (!anchorSupportsPopupAria(node)) return // avoid invalid ARIA on non-interactive anchors
 
     const expandedValue = String(open)
     node.setAttribute('aria-expanded', expandedValue)

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -339,8 +339,7 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
         node.removeAttribute('aria-haspopup')
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [renderAnchor, anchorElement, anchorHasPopup])
+  }, [renderAnchor, anchorRef, anchorElement, anchorHasPopup])
 
   useEffect(() => {
     const node = anchorRef.current ?? anchorElement
@@ -354,8 +353,7 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
         node.removeAttribute('aria-expanded')
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [renderAnchor, anchorElement, open])
+  }, [renderAnchor, anchorRef, anchorElement, open])
 
   useEffect(() => {
     if (!cssAnchorPositioning || !anchorElement) return

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -21,26 +21,23 @@ import {reactMajorVersion} from '../utils/environment'
 type AnchorHasPopup = Exclude<React.AriaAttributes['aria-haspopup'], boolean | 'false' | undefined>
 export type {AnchorHasPopup}
 
-// `aria-haspopup` and `aria-expanded` are only valid on elements whose role
-// supports them. In detached-anchor mode the consumer owns the anchor element,
-// so guard the imperative ARIA writes: if the ref points at a non-interactive
-// element (e.g. a wrapper `<div>`), writing these attributes produces invalid
-// ARIA (axe `aria-allowed-attr`). In that case the consumer should point the
-// ref at the real trigger, and we skip rather than emit a violation.
+// `aria-haspopup` and `aria-expanded` describe a button-like trigger that opens
+// a popup, and are only valid on elements whose role supports both. In
+// detached-anchor mode the consumer owns the anchor element, so guard the
+// imperative ARIA writes: if the ref points at an element that can't legally
+// carry them (e.g. a wrapper `<div>` or a plain `<input>`/textbox), writing them
+// produces invalid ARIA (axe `aria-allowed-attr`). In that case the consumer
+// should point the ref at the real trigger (or give it an appropriate role), and
+// we skip rather than emit a violation.
 const rolesSupportingPopupAria = new Set([
   'application',
   'button',
-  'checkbox',
-  'columnheader',
   'combobox',
   'gridcell',
   'link',
   'menuitem',
   'menuitemcheckbox',
   'menuitemradio',
-  'row',
-  'rowheader',
-  'switch',
   'tab',
   'treeitem',
 ])
@@ -51,13 +48,9 @@ function anchorSupportsPopupAria(node: HTMLElement): boolean {
   switch (node.tagName) {
     case 'BUTTON':
     case 'SUMMARY':
-    case 'SELECT':
-    case 'TEXTAREA':
       return true
     case 'A':
       return node.hasAttribute('href')
-    case 'INPUT':
-      return (node as HTMLInputElement).type !== 'hidden'
     default:
       return false
   }

--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -18,6 +18,8 @@ import {useFeatureFlag} from '../FeatureFlags'
 import {widthMap} from '../Overlay/constants'
 import {reactMajorVersion} from '../utils/environment'
 
+type AnchorHasPopup = 'true' | 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid'
+
 interface AnchoredOverlayPropsWithAnchor {
   /**
    * A custom function component used to render the anchor element.
@@ -117,6 +119,10 @@ interface AnchoredOverlayBaseProps extends Pick<OverlayProps, 'height' | 'width'
    */
   displayCloseButton?: boolean
   /**
+   * Indicates the type of popup opened by the anchor. Defaults to `'true'`, which is equivalent to `'menu'` in ARIA.
+   */
+  anchorHasPopup?: AnchorHasPopup
+  /**
    * Props to be spread on the close button in the overlay.
    */
   closeButtonProps?: Partial<IconButtonProps>
@@ -178,6 +184,7 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
   preventOverflow = true,
   onPositionChange,
   displayCloseButton = true,
+  anchorHasPopup = 'true',
   closeButtonProps = defaultCloseButtonProps,
   renderAs = 'portal',
   cssAnchorPositioningSettings,
@@ -315,6 +322,32 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
   }, [cssAnchorPositioning, anchorElement, anchorName])
 
   useEffect(() => {
+    // Read the node from the ref (available once committed) rather than the
+    // anchorElement state, which lags a render behind for a detached anchor and
+    // would leave the collapsed trigger without ARIA until first opened.
+    const node = anchorRef.current ?? anchorElement
+    if (renderAnchor !== null || !node) return
+
+    const addedHasPopup = !node.hasAttribute('aria-haspopup')
+    const expandedValue = String(open)
+
+    if (addedHasPopup) {
+      node.setAttribute('aria-haspopup', anchorHasPopup)
+    }
+    node.setAttribute('aria-expanded', expandedValue)
+
+    return () => {
+      if (addedHasPopup && node.getAttribute('aria-haspopup') === anchorHasPopup) {
+        node.removeAttribute('aria-haspopup')
+      }
+      if (node.getAttribute('aria-expanded') === expandedValue) {
+        node.removeAttribute('aria-expanded')
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [renderAnchor, anchorElement, anchorHasPopup, open])
+
+  useEffect(() => {
     if (!cssAnchorPositioning || !anchorElement) return
 
     const currentOverlay = overlayRef.current
@@ -408,7 +441,7 @@ export const AnchoredOverlay: React.FC<React.PropsWithChildren<AnchoredOverlayPr
         renderAnchor({
           ref: anchorRef,
           id: anchorId,
-          'aria-haspopup': 'true',
+          'aria-haspopup': anchorHasPopup,
           'aria-expanded': open,
           tabIndex: 0,
           onClick: onAnchorClick,

--- a/packages/react/src/AnchoredOverlay/index.ts
+++ b/packages/react/src/AnchoredOverlay/index.ts
@@ -1,2 +1,2 @@
 export {AnchoredOverlay} from './AnchoredOverlay'
-export type {AnchoredOverlayProps} from './AnchoredOverlay'
+export type {AnchoredOverlayProps, AnchorHasPopup} from './AnchoredOverlay'

--- a/packages/react/src/SelectPanel/SelectPanel.test.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.test.tsx
@@ -110,7 +110,44 @@ for (const usingRemoveActiveDescendant of [false, true]) {
       const trigger = screen.getByRole('button', {
         name: 'Select items',
       })
-      expect(trigger).toHaveAttribute('aria-haspopup', 'true')
+      expect(trigger).toHaveAttribute('aria-haspopup', 'dialog')
+      expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('sets aria-haspopup="dialog" on a detached anchor', async () => {
+      function DetachedSelectPanel() {
+        const [selected, setSelected] = React.useState<SelectPanelProps['items']>([])
+        const [filter, setFilter] = React.useState('')
+        const [open, setOpen] = React.useState(false)
+        const anchorRef = React.useRef<HTMLButtonElement>(null)
+
+        return (
+          <>
+            <button type="button" ref={anchorRef} onClick={() => setOpen(isOpen => !isOpen)}>
+              Detached select anchor
+            </button>
+            <SelectPanel
+              title="test title"
+              items={items}
+              selected={selected}
+              onSelectedChange={setSelected}
+              filterValue={filter}
+              onFilterChange={setFilter}
+              open={open}
+              onOpenChange={setOpen}
+              renderAnchor={null}
+              anchorRef={anchorRef}
+            />
+          </>
+        )
+      }
+
+      render(<DetachedSelectPanel />)
+
+      const trigger = screen.getByRole('button', {name: 'Detached select anchor'})
+      await waitFor(() => {
+        expect(trigger).toHaveAttribute('aria-haspopup', 'dialog')
+      })
       expect(trigger).toHaveAttribute('aria-expanded', 'false')
     })
 

--- a/packages/react/src/SelectPanel/SelectPanel.test.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.test.tsx
@@ -110,11 +110,11 @@ for (const usingRemoveActiveDescendant of [false, true]) {
       const trigger = screen.getByRole('button', {
         name: 'Select items',
       })
-      expect(trigger).toHaveAttribute('aria-haspopup', 'dialog')
+      expect(trigger).toHaveAttribute('aria-haspopup', 'true')
       expect(trigger).toHaveAttribute('aria-expanded', 'false')
     })
 
-    it('sets aria-haspopup="dialog" on a detached anchor', async () => {
+    it('sets aria-haspopup="true" on a detached anchor', async () => {
       function DetachedSelectPanel() {
         const [selected, setSelected] = React.useState<SelectPanelProps['items']>([])
         const [filter, setFilter] = React.useState('')
@@ -146,7 +146,7 @@ for (const usingRemoveActiveDescendant of [false, true]) {
 
       const trigger = screen.getByRole('button', {name: 'Detached select anchor'})
       await waitFor(() => {
-        expect(trigger).toHaveAttribute('aria-haspopup', 'dialog')
+        expect(trigger).toHaveAttribute('aria-haspopup', 'true')
       })
       expect(trigger).toHaveAttribute('aria-expanded', 'false')
     })

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -893,6 +893,7 @@ function Panel({
         open={open}
         onOpen={onOpen}
         onClose={onClose}
+        anchorHasPopup="dialog"
         overlayProps={mergedOverlayProps}
         focusTrapSettings={focusTrapSettings}
         focusZoneSettings={focusZoneSettings}

--- a/packages/react/src/SelectPanel/SelectPanel.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.tsx
@@ -893,7 +893,6 @@ function Panel({
         open={open}
         onOpen={onOpen}
         onClose={onClose}
-        anchorHasPopup="dialog"
         overlayProps={mergedOverlayProps}
         focusTrapSettings={focusTrapSettings}
         focusZoneSettings={focusZoneSettings}


### PR DESCRIPTION
## Summary

In **detached-anchor mode** (`renderAnchor={null}`, where the consumer owns and renders the trigger element), `AnchoredOverlay` never applied the `aria-haspopup`/`aria-expanded` attributes it normally sets in the `renderAnchor` path. Screen reader users had no indication that the trigger opens a popup, nor whether it's currently expanded.

Fixes the accessibility gap described in github/primer#6776.

## What changed

- **`AnchoredOverlay`** — imperatively reflects `aria-haspopup` and `aria-expanded` onto the detached anchor node, mirroring the existing `anchor-name` effect that already writes to that consumer-owned element. The effect:
  - reads `anchorRef.current` (attached by commit time) so the **collapsed** trigger is labelled on mount — not just after the overlay is first opened;
  - **guards against clobbering** a consumer-supplied `aria-haspopup`;
  - reflects `aria-expanded` from `open`, and **cleans up** on close/unmount.
- **New `anchorHasPopup` prop** — `'true' | 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid'`, default `'true'` (non-breaking; `'true'` is spec-equivalent to `'menu'`). Applied in **both** the `renderAnchor` and detached paths so the popup role can be described accurately.
- **`SelectPanel`** passes `anchorHasPopup="dialog"` to match its `role="dialog"` popup (previously it hardcoded the spec-equivalent-of-menu default, which mis-described the dialog).

## Before / after

| | Detached trigger (collapsed) | Detached trigger (open) |
|---|---|---|
| **Before** | _no `aria-haspopup`, no `aria-expanded`_ | _no ARIA state_ |
| **After** | `aria-haspopup="…"` `aria-expanded="false"` | `aria-expanded="true"` |
| **SelectPanel** | `aria-haspopup="dialog"` | `aria-expanded="true"` |


## Testing

Added coverage on `AnchoredOverlay` (collapsed state, open/close toggle, consumer-override, `renderAnchor` path, cleanup) and `SelectPanel` (`aria-haspopup="dialog"` on both default and detached anchors)

