### PR TITLE
feat: add React Compiler support for Autocomplete

### DIFF
--- a/.changeset/react-compiler-autocomplete.md
+++ b/.changeset/react-compiler-autocomplete.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Autocomplete: Improve rendering performance with React Compiler support

--- a/.changeset/react-compiler-no-error-files.md
+++ b/.changeset/react-compiler-no-error-files.md
@@ -2,4 +2,4 @@
 '@primer/react': minor
 ---
 
-React Compiler: Enable compiler output for additional components
+React Compiler: Enable compiler output for Banner, ConfirmationDialog, PageLayout, Pagination, UnderlineNav, `useMergedRefs`, and `useScrollFlash`

--- a/.changeset/react-compiler-no-error-files.md
+++ b/.changeset/react-compiler-no-error-files.md
@@ -2,4 +2,4 @@
 '@primer/react': minor
 ---
 
-React Compiler: Enable compiler output for Banner, ConfirmationDialog, PageLayout, Pagination, UnderlineNav, `useMergedRefs`, and `useScrollFlash`
+React Compiler: Enable compiler output for Autocomplete, Banner, ConfirmationDialog, PageLayout, Pagination, UnderlineNav, `useMergedRefs`, and `useScrollFlash`

--- a/.changeset/react-compiler-no-error-files.md
+++ b/.changeset/react-compiler-no-error-files.md
@@ -1,5 +1,0 @@
----
-'@primer/react': minor
----
-
-React Compiler: Enable compiler output for Autocomplete, Banner, ConfirmationDialog, PageLayout, Pagination, UnderlineNav, `useMergedRefs`, and `useScrollFlash`

--- a/.changeset/react-compiler-no-error-files.md
+++ b/.changeset/react-compiler-no-error-files.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+React Compiler: Enable compiler output for additional components

--- a/packages/react/script/react-compiler.mjs
+++ b/packages/react/script/react-compiler.mjs
@@ -12,17 +12,14 @@ const files = glob
     return path.join(PACKAGE_DIR, match)
   })
 const unsupportedPatterns = [
-  'src/ActionMenu/**/*.tsx',
-  'src/Autocomplete/**/*.tsx',
-  'src/Banner/**/*.tsx',
-  'src/Button/**/*.tsx',
-  'src/ConfirmationDialog/**/*.tsx',
-  'src/Dialog/**/*.tsx',
-  'src/PageLayout/**/*.tsx',
-  'src/Pagination/**/*.tsx',
-  'src/SelectPanel/**/*.tsx',
-  'src/UnderlineNav/**/*.tsx',
-  'src/experimental/SelectPanel2/**/*.tsx',
+  'src/ActionMenu/ActionMenu.tsx',
+  'src/Autocomplete/Autocomplete.test.tsx',
+  'src/Autocomplete/AutocompleteInput.tsx',
+  'src/Button/ButtonBase.tsx',
+  'src/Dialog/Dialog.tsx',
+  'src/SelectPanel/SelectPanel.examples.stories.tsx',
+  'src/SelectPanel/SelectPanel.tsx',
+  'src/experimental/SelectPanel2/SelectPanel.tsx',
   'src/hooks/useAnchoredPosition.ts',
   'src/hooks/useFocusTrap.ts',
   'src/hooks/useFocusZone.ts',
@@ -30,9 +27,7 @@ const unsupportedPatterns = [
   'src/hooks/useOnEscapePress.ts',
   'src/hooks/useResizeObserver.ts',
   'src/hooks/useSafeTimeout.ts',
-  'src/hooks/useScrollFlash.ts',
-  'src/hooks/useMergedRefs.ts',
-  'src/TooltipV2/**/*.tsx',
+  'src/TooltipV2/Tooltip.tsx',
 ]
 
 const unsupported = new Set(

--- a/packages/react/script/react-compiler.mjs
+++ b/packages/react/script/react-compiler.mjs
@@ -13,8 +13,6 @@ const files = glob
   })
 const unsupportedPatterns = [
   'src/ActionMenu/ActionMenu.tsx',
-  'src/Autocomplete/Autocomplete.test.tsx',
-  'src/Autocomplete/AutocompleteInput.tsx',
   'src/Button/ButtonBase.tsx',
   'src/Dialog/Dialog.tsx',
   'src/SelectPanel/SelectPanel.examples.stories.tsx',

--- a/packages/react/src/ActionMenu/ActionMenu.test.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.test.tsx
@@ -82,8 +82,11 @@ function ExampleWithTooltip(): JSX.Element {
   )
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function ExampleWithTooltipV2(actionMenuTrigger: React.ReactElement<any>): JSX.Element {
+interface ExampleWithTooltipV2Props {
+  actionMenuTrigger: React.ReactElement
+}
+
+function ExampleWithTooltipV2({actionMenuTrigger}: ExampleWithTooltipV2Props): JSX.Element {
   return (
     <BaseStyles>
       <ActionMenu>
@@ -99,6 +102,8 @@ function ExampleWithTooltipV2(actionMenuTrigger: React.ReactElement<any>): JSX.E
 }
 
 function ExampleWithReplaceableAnchor(): JSX.Element {
+  'use no memo'
+
   const anchorRef = useRef<HTMLButtonElement>(null)
   const [open, setOpen] = useState(false)
   const [anchorKey, setAnchorKey] = useState(0)
@@ -392,11 +397,13 @@ describe('ActionMenu', () => {
 
   it('should open menu on menu button click and it is wrapped with tooltip v2', async () => {
     const component = HTMLRender(
-      ExampleWithTooltipV2(
-        <TooltipV2 text="Additional context about the menu button" direction="s">
-          <ActionMenu.Button>Toggle Menu</ActionMenu.Button>
-        </TooltipV2>,
-      ),
+      <ExampleWithTooltipV2
+        actionMenuTrigger={
+          <TooltipV2 text="Additional context about the menu button" direction="s">
+            <ActionMenu.Button>Toggle Menu</ActionMenu.Button>
+          </TooltipV2>
+        }
+      />,
     )
     const button = component.getByRole('button')
 
@@ -415,11 +422,13 @@ describe('ActionMenu', () => {
 
   it('should display tooltip v2 when menu button is focused', async () => {
     const component = HTMLRender(
-      ExampleWithTooltipV2(
-        <TooltipV2 text="Additional context about the menu button" direction="s">
-          <ActionMenu.Button>Toggle Menu</ActionMenu.Button>
-        </TooltipV2>,
-      ),
+      <ExampleWithTooltipV2
+        actionMenuTrigger={
+          <TooltipV2 text="Additional context about the menu button" direction="s">
+            <ActionMenu.Button>Toggle Menu</ActionMenu.Button>
+          </TooltipV2>
+        }
+      />,
     )
     const button = component.getByRole('button')
     act(() => {
@@ -431,13 +440,15 @@ describe('ActionMenu', () => {
 
   it('should open menu on menu anchor click and it is wrapped with tooltip v2', async () => {
     const component = HTMLRender(
-      ExampleWithTooltipV2(
-        <ActionMenu.Anchor>
-          <TooltipV2 text="Additional context about the menu button" direction="n">
-            <Button>Toggle Menu</Button>
-          </TooltipV2>
-        </ActionMenu.Anchor>,
-      ),
+      <ExampleWithTooltipV2
+        actionMenuTrigger={
+          <ActionMenu.Anchor>
+            <TooltipV2 text="Additional context about the menu button" direction="n">
+              <Button>Toggle Menu</Button>
+            </TooltipV2>
+          </ActionMenu.Anchor>
+        }
+      />,
     )
     const button = component.getByRole('button')
 
@@ -449,13 +460,15 @@ describe('ActionMenu', () => {
 
   it('should display tooltip v2 and menu anchor is focused', async () => {
     const component = HTMLRender(
-      ExampleWithTooltipV2(
-        <ActionMenu.Anchor>
-          <TooltipV2 text="Additional context about the menu button" direction="n">
-            <Button>Toggle Menu</Button>
-          </TooltipV2>
-        </ActionMenu.Anchor>,
-      ),
+      <ExampleWithTooltipV2
+        actionMenuTrigger={
+          <ActionMenu.Anchor>
+            <TooltipV2 text="Additional context about the menu button" direction="n">
+              <Button>Toggle Menu</Button>
+            </TooltipV2>
+          </ActionMenu.Anchor>
+        }
+      />,
     )
     const button = component.getByRole('button')
     act(() => {
@@ -808,8 +821,10 @@ describe('ActionMenu', () => {
 
       // The new anchor should have the same anchor-name re-applied, and the
       // overlay should still reference it via position-anchor.
-      expect(newAnchor.style.getPropertyValue('anchor-name')).toBe(initialAnchorName)
-      expect(overlay.style.getPropertyValue('position-anchor')).toBe(initialPositionAnchor)
+      await waitFor(() => {
+        expect(newAnchor.style.getPropertyValue('anchor-name')).toBe(initialAnchorName)
+        expect(overlay.style.getPropertyValue('position-anchor')).toBe(initialPositionAnchor)
+      })
     })
   })
 

--- a/packages/react/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/react/src/Autocomplete/Autocomplete.test.tsx
@@ -31,7 +31,7 @@ const LabelledAutocomplete = <T extends AutocompleteMenuItem>({
   inputProps?: AutocompleteInputProps
   menuProps: AutocompleteMenuInternalProps<T>
 }) => {
-  const {['aria-labelledby']: ariaLabelledBy, ...menuPropsRest} = menuProps
+  const ariaLabelledBy = menuProps['aria-labelledby']
   const {id = 'autocompleteInput', ...inputPropsRest} = inputProps
   return (
     <BaseStyles>
@@ -41,7 +41,7 @@ const LabelledAutocomplete = <T extends AutocompleteMenuItem>({
       <Autocomplete id="autocompleteId">
         <Autocomplete.Input id={id} {...inputPropsRest} />
         <Autocomplete.Overlay>
-          <Autocomplete.Menu aria-labelledby={ariaLabelledBy} {...menuPropsRest} />
+          <Autocomplete.Menu {...menuProps} />
         </Autocomplete.Overlay>
       </Autocomplete>
     </BaseStyles>

--- a/packages/react/src/Autocomplete/AutocompleteInput.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteInput.tsx
@@ -1,5 +1,5 @@
 import type {ChangeEventHandler, FocusEventHandler, KeyboardEventHandler} from 'react'
-import React, {useCallback, useContext, useEffect, useState} from 'react'
+import React, {useCallback, useContext, useEffect, useRef} from 'react'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 import {AutocompleteContext, AutocompleteInputContext} from './AutocompleteContext'
 import TextInput from '../TextInput'
@@ -44,7 +44,7 @@ const AutocompleteInput = React.forwardRef(
     const {activeDescendantRef, id, inputRef, setInputValue, setShowMenu, showMenu} = autocompleteContext
     const {autocompleteSuggestion = '', inputValue = '', isMenuDirectlyActivated} = inputContext
     const mergedRef = useMergedRefs(forwardedRef, inputRef)
-    const [highlightRemainingText, setHighlightRemainingText] = useState<boolean>(true)
+    const highlightRemainingTextRef = useRef(true)
     const {safeSetTimeout} = useSafeTimeout()
 
     const handleInputFocus: FocusEventHandler<HTMLInputElement> = event => {
@@ -91,7 +91,7 @@ const AutocompleteInput = React.forwardRef(
         onKeyDown && onKeyDown(event)
 
         if (event.key === 'Backspace') {
-          setHighlightRemainingText(false)
+          highlightRemainingTextRef.current = false
         }
 
         if (event.key === 'Escape' && inputRef.current?.value) {
@@ -102,7 +102,7 @@ const AutocompleteInput = React.forwardRef(
           setShowMenu(true)
         }
       },
-      [inputRef, setInputValue, setHighlightRemainingText, onKeyDown, showMenu, setShowMenu],
+      [inputRef, setInputValue, onKeyDown, showMenu, setShowMenu],
     )
 
     const handleInputKeyUp: KeyboardEventHandler<HTMLInputElement> = useCallback(
@@ -110,10 +110,10 @@ const AutocompleteInput = React.forwardRef(
         onKeyUp && onKeyUp(event)
 
         if (event.key === 'Backspace') {
-          setHighlightRemainingText(true)
+          highlightRemainingTextRef.current = true
         }
       },
-      [setHighlightRemainingText, onKeyUp],
+      [onKeyUp],
     )
 
     const onInputKeyPress: KeyboardEventHandler<HTMLInputElement> = useCallback(
@@ -151,8 +151,7 @@ const AutocompleteInput = React.forwardRef(
 
       if (
         isInputFocused &&
-        // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
-        highlightRemainingText &&
+        highlightRemainingTextRef.current &&
         autocompleteSuggestion &&
         (inputValue || isMenuDirectlyActivated)
       ) {
@@ -162,9 +161,6 @@ const AutocompleteInput = React.forwardRef(
           inputRef.current.setSelectionRange(inputValue.length, autocompleteSuggestion.length)
         }
       }
-
-      // calling this useEffect when `highlightRemainingText` changes breaks backspace functionality
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [autocompleteSuggestion, inputValue, inputRef, isMenuDirectlyActivated])
 
     useEffect(() => {

--- a/packages/react/src/SelectPanel/SelectPanel.test.tsx
+++ b/packages/react/src/SelectPanel/SelectPanel.test.tsx
@@ -603,12 +603,11 @@ for (const usingRemoveActiveDescendant of [false, true]) {
       const [selected, setSelected] = React.useState<SelectPanelProps['items']>([])
       const [filter, setFilter] = React.useState('')
       const [open, setOpen] = React.useState(false)
+      const [items, setItems] = React.useState<SelectPanelProps['items']>([])
 
       const onSelectedChange = (selected: SelectPanelProps['items']) => {
         setSelected(selected)
       }
-
-      const items: SelectPanelProps['items'] = []
 
       return (
         <SelectPanel
@@ -622,6 +621,7 @@ for (const usingRemoveActiveDescendant of [false, true]) {
           filterValue={filter}
           onFilterChange={value => {
             setFilter(value)
+            setItems(currentItems => [...currentItems])
           }}
           open={open}
           onOpenChange={isOpen => {
@@ -940,8 +940,9 @@ for (const usingRemoveActiveDescendant of [false, true]) {
 
         renderWithProp(<NoItemAvailableSelectPanel />, usingRemoveActiveDescendant)
 
-        await waitFor(async () => {
-          await user.click(screen.getByText('Select items'))
+        await user.click(screen.getByText('Select items'))
+
+        await waitFor(() => {
           expect(screen.getByText('No items available')).toBeInTheDocument()
         })
       })

--- a/packages/react/src/TooltipV2/__tests__/Tooltip.test.tsx
+++ b/packages/react/src/TooltipV2/__tests__/Tooltip.test.tsx
@@ -29,8 +29,11 @@ const TooltipComponentWithExistingDescription = (props: Omit<TooltipProps, 'text
   </>
 )
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function ExampleWithActionMenu(actionMenuTrigger: React.ReactElement<any>): JSX.Element {
+interface ExampleWithActionMenuProps {
+  actionMenuTrigger: React.ReactElement
+}
+
+function ExampleWithActionMenu({actionMenuTrigger}: ExampleWithActionMenuProps): JSX.Element {
   return (
     <BaseStyles>
       <ActionMenu>
@@ -82,11 +85,13 @@ describe('Tooltip', () => {
 
   it('should spread the accessibility attributes correctly on the trigger (ActionMenu.Button) when tooltip is used in an action menu', () => {
     const {getByRole, getByText} = HTMLRender(
-      ExampleWithActionMenu(
-        <Tooltip text="Additional context about the menu button">
-          <ActionMenu.Button>Toggle Menu</ActionMenu.Button>
-        </Tooltip>,
-      ),
+      <ExampleWithActionMenu
+        actionMenuTrigger={
+          <Tooltip text="Additional context about the menu button">
+            <ActionMenu.Button>Toggle Menu</ActionMenu.Button>
+          </Tooltip>
+        }
+      />,
     )
     const menuButton = getByRole('button')
     const tooltip = getByText('Additional context about the menu button')
@@ -96,13 +101,15 @@ describe('Tooltip', () => {
 
   it('should spread the accessibility attributes correctly on the trigger (Button) when tooltip is used in an action menu', () => {
     const {getByRole, getByText} = HTMLRender(
-      ExampleWithActionMenu(
-        <ActionMenu.Anchor>
-          <Tooltip text="Additional context about the menu button">
-            <Button>Toggle Menu</Button>
-          </Tooltip>
-        </ActionMenu.Anchor>,
-      ),
+      <ExampleWithActionMenu
+        actionMenuTrigger={
+          <ActionMenu.Anchor>
+            <Tooltip text="Additional context about the menu button">
+              <Button>Toggle Menu</Button>
+            </Tooltip>
+          </ActionMenu.Anchor>
+        }
+      />,
     )
     const menuButton = getByRole('button')
     const tooltip = getByText('Additional context about the menu button')


### PR DESCRIPTION
Closes N/A

Follow up to #8105.

This PR updates Autocomplete so it can be removed from the React Compiler unsupported list. The main runtime change is in `AutocompleteInput`, where the callback dependency handling now avoids the hook suppression that caused React Compiler to skip the file.

As a result, Autocomplete can be compiled as part of the React Compiler migration while keeping the public API and behavior unchanged.

### Changelog

#### New

N/A

#### Changed

- Update Autocomplete to support React Compiler
- Update test fixtures so the full test suite can run with the compiler enabled for this batch

#### Removed

N/A

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

Selected `minor` since this enables React Compiler output for Autocomplete as part of the migration.

### Testing & Reviewing

- `npm run format:diff`
- `npm run lint`
- `npm run lint:css`
- `npm test -- --run`
- `npm run type-check`
- `npm run build`

Would love a review on the `AutocompleteInput` dependency handling to confirm this stays equivalent to the previous callback behavior.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
