### PR TITLE
UnderlineNav: fix forced reflow from reading offsetTop in useSyncExternalStore snapshot

### DIFF
--- a/.changeset/underline-nav-forced-reflow.md
+++ b/.changeset/underline-nav-forced-reflow.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+UnderlineNav: Fix forced reflow / layout thrashing by measuring item overflow (`offsetTop`) inside the `IntersectionObserver` callback (which runs after layout) and caching the result, instead of reading it in the `useSyncExternalStore` snapshot — which React calls during render and commit while layout is dirty, forcing a synchronous reflow for every item on every render.

--- a/packages/react/src/UnderlineNav/UnderlineNavItem.tsx
+++ b/packages/react/src/UnderlineNav/UnderlineNavItem.tsx
@@ -20,24 +20,39 @@ export const UnderlineNavItem = forwardRef((allProps, forwardedRef) => {
 
   const ref = useRef<HTMLLIElement>(null)
 
+  // Cached overflow state. `offsetTop` is read inside the IntersectionObserver
+  // callback below (which runs *after* the browser has computed layout), so it
+  // never forces a synchronous reflow. `getSnapshot` then just returns this
+  // cached boolean. Reading `offsetTop` directly in `getSnapshot` — as this used
+  // to — forces layout every time React calls it (during render, commit, and on
+  // every store change, for every item), causing significant layout thrashing on
+  // pages with many nav items.
+  const isOverflowingRef = useRef(false)
+
   const {loadingCounters} = useContext(UnderlineNavContext)
 
   const isOverflowing = useSyncExternalStore(
-    useCallback(
-      onChange => {
-        const observer = new IntersectionObserver(() => onChange(), {
+    useCallback(onChange => {
+      // The IntersectionObserver is a trigger to re-check whether the item has
+      // wrapped to the next row (which increases its `offsetTop`) and is clipped
+      // out of the single-row nav. Its callback runs after layout, so measuring
+      // here is reflow-free. Only notify React when the overflow state changes.
+      const observer = new IntersectionObserver(
+        () => {
+          const isOverflowingNow = ref.current ? ref.current.offsetTop > 0 : false
+          if (isOverflowingNow !== isOverflowingRef.current) {
+            isOverflowingRef.current = isOverflowingNow
+            onChange()
+          }
+        },
+        {
           threshold: 1,
-        })
-        if (ref.current) observer.observe(ref.current)
-        return () => observer.disconnect()
-      },
-      [ref],
-    ),
-    // Note: the IntersectionObserver is just being used as a trigger to re-check
-    // `offsetTop > 0`; this is fast and simpler than checking visibility from
-    // the observed entry. When an item wraps, it will move to the next row which
-    // increases its `offsetTop`
-    () => (ref.current ? ref.current.offsetTop > 0 : false),
+        },
+      )
+      if (ref.current) observer.observe(ref.current)
+      return () => observer.disconnect()
+    }, []),
+    () => isOverflowingRef.current,
     () => false,
   )
 


### PR DESCRIPTION
Fixes a forced synchronous reflow (layout thrashing) in `UnderlineNav`, caused by reading `offsetTop` inside the `useSyncExternalStore` snapshot of `UnderlineNavItem`.

React calls `getSnapshot` during render, during commit, and on every store change — while layout is dirty — so reading `offsetTop` there forces a synchronous layout **for every nav item on every render**. Profiling GitHub pages with a nav (repo/PR tabs) showed this as the single largest main-thread block after LCP: ~300 ms on PR pages and up to ~1,062 ms on the repo page (the top entry in Chrome's "Forced reflow" insight, attributed to `UnderlineNavItem`).

### What changed

Keep the same `IntersectionObserver` trigger, but measure `offsetTop` **inside the observer callback** — which runs after the browser has computed layout, so the read is reflow-free — cache the result in a ref, and return the cached boolean from `getSnapshot`. React is also notified only when the overflow state actually changes.

### Changelog

#### Changed

- `UnderlineNav`: measure item overflow (`offsetTop`) inside the `IntersectionObserver` callback and cache it, instead of reading it in the `useSyncExternalStore` snapshot. Eliminates the forced reflow / layout thrashing that occurred during render.

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- Existing `UnderlineNav.test.tsx` passes (19/19); overflow detection semantics (`offsetTop > 0`) are unchanged, so existing coverage applies.
- To verify the perf win: record a performance trace of a page containing an `UnderlineNav` (repo or PR tabs) and confirm the "Forced reflow" insight no longer attributes time to `UnderlineNavItem`.
- **Behavior note for reviewers:** overflow state now initializes to `false` and is corrected on the observer's first (async) callback, rather than synchronously during the first client render. This matches the SSR → hydration flow (all items render server-side; overflow/menu resolve on the client) and CSS already clips wrapped items, so there is no visual flash — only the `aria-hidden` / overflow-menu state settles one frame later.

### Merge checklist

- [ ] Added/updated tests <!-- existing tests cover the unchanged overflow behavior; the change is a perf-only refactor -->
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
