### PR TITLE
Avatar: add min-width to prevent collapse in min-content containers

### DIFF
--- a/.changeset/avatar-min-width.md
+++ b/.changeset/avatar-min-width.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Avatar: Prevent the image from collapsing when rendered inside a `min-content` sized container, such as the Button `leadingVisual` slot

--- a/packages/react/src/Avatar/Avatar.module.css
+++ b/packages/react/src/Avatar/Avatar.module.css
@@ -1,6 +1,7 @@
 :where(.Avatar) {
   display: inline-block;
   width: var(--avatarSize-regular);
+  min-width: var(--avatarSize-regular);
   height: var(--avatarSize-regular);
   overflow: hidden; /* Ensure page layout in Firefox should images fail to load */
   /* stylelint-disable-next-line primer/typography */
@@ -18,16 +19,19 @@
   &:where([data-responsive]) {
     @media screen and (--viewportRange-narrow) {
       width: var(--avatarSize-narrow);
+      min-width: var(--avatarSize-narrow);
       height: var(--avatarSize-narrow);
     }
 
     @media screen and (--viewportRange-regular) {
       width: var(--avatarSize-regular);
+      min-width: var(--avatarSize-regular);
       height: var(--avatarSize-regular);
     }
 
     @media screen and (--viewportRange-wide) {
       width: var(--avatarSize-wide);
+      min-width: var(--avatarSize-wide);
       height: var(--avatarSize-wide);
     }
   }

--- a/packages/react/src/Button/Button.dev.stories.tsx
+++ b/packages/react/src/Button/Button.dev.stories.tsx
@@ -1,6 +1,7 @@
 import {SearchIcon, TriangleDownIcon, EyeIcon, HeartFillIcon} from '@primer/octicons-react'
 import {Button, IconButton} from '.'
 import {Stack} from '../Stack'
+import Avatar from '../Avatar'
 
 export default {
   title: 'Components/Button/Dev',
@@ -82,6 +83,27 @@ export const DisabledButtonVariants = () => {
         <IconButton icon={HeartFillIcon} variant="primary" aria-label="Primary" disabled />
         <IconButton icon={HeartFillIcon} variant="danger" aria-label="Danger" disabled />
       </Stack>
+    </Stack>
+  )
+}
+
+export const LeadingVisualAvatar = () => {
+  const avatarSrc = 'https://avatars.githubusercontent.com/u/7143434?v=4'
+  return (
+    <Stack direction="horizontal" align="center">
+      <Button leadingVisual={<Avatar src={avatarSrc} alt="mona" />}>Default</Button>
+      <Button variant="primary" leadingVisual={<Avatar src={avatarSrc} alt="mona" />}>
+        Primary
+      </Button>
+      <Button variant="invisible" leadingVisual={<Avatar src={avatarSrc} alt="mona" />}>
+        Invisible
+      </Button>
+      <Button size="small" leadingVisual={<Avatar size={16} src={avatarSrc} alt="mona" />}>
+        Small
+      </Button>
+      <Button size="large" leadingVisual={<Avatar size={24} src={avatarSrc} alt="mona" />}>
+        Large
+      </Button>
     </Stack>
   )
 }


### PR DESCRIPTION
Closes #7974

Passing an `Avatar` into the Button `leadingVisual` slot rendered the image at the wrong width (collapsed to `0`). The cause is a collision between the global `img { max-width: 100% }` rule and Avatar's less-specific `width: var(--avatarSize-regular)`. Because Button sizes the `leadingVisual` grid area with `min-content`, `max-width` can resolve to `0` and the image collapses.

This adds a matching `min-width` alongside every `width` declaration in `Avatar.module.css` (base regular + responsive narrow/regular/wide; the `[data-square]` variant inherits the base). `min-width` only sets a floor, so rendered size in normal usage is unchanged — the avatar simply can no longer be shrunk below its intended size by an ancestor's `min-content` sizing or a global `img` max-width rule.

### Changelog

#### New

- Added a `LeadingVisualAvatar` Button dev story (Button + Avatar `leadingVisual` across variants/sizes) as a visual-regression anchor.

#### Changed

- `Avatar` now sets `min-width` matching its `width` for all size variants, preventing the image from collapsing inside `min-content` containers such as the Button `leadingVisual` slot.

#### Removed

- N/A

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Open the **Components/Button/Dev → Leading Visual Avatar** story in Storybook and confirm the avatar renders at its intended size (20px default, 16px small, 24px large) rather than collapsing.

Verified locally: avatars measure 20/16/24px in-browser. A counterfactual (forcing `min-width: 0` + `max-width: 100%` in the `min-content` track) collapses the avatar to `0px`, confirming `min-width` is what resolves the bug. Existing Avatar unit tests (6/6) and the Storybook smoke test (313/313, including the new story) pass; `tsc --noEmit`, stylelint, and eslint are clean.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))