### PR TITLE
refactor(Checkbox): set indeterminate via ref callback instead of layout effect

### DIFF
--- a/.changeset/checkbox-indeterminate-ref-callback.md
+++ b/.changeset/checkbox-indeterminate-ref-callback.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Checkbox: Improve rendering performance by setting the indeterminate state with a ref callback instead of a layout effect

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -1,7 +1,13 @@
 import {clsx} from 'clsx'
-import {useProvidedRefOrCreate} from '../hooks'
-import React, {useContext, useEffect, type ChangeEventHandler, type InputHTMLAttributes, type ReactElement} from 'react'
-import useLayoutEffect from '../utils/useIsomorphicLayoutEffect'
+import {useMergedRefs} from '../hooks'
+import React, {
+  useCallback,
+  useContext,
+  useRef,
+  type ChangeEventHandler,
+  type InputHTMLAttributes,
+  type ReactElement,
+} from 'react'
 import type {FormValidationStatus} from '../utils/types/FormValidationStatus'
 import {CheckboxGroupContext} from '../CheckboxGroup/CheckboxGroupContext'
 import classes from './Checkbox.module.css'
@@ -58,7 +64,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
     ref,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): ReactElement<any> => {
-    const checkboxRef = useProvidedRefOrCreate(ref as React.RefObject<HTMLInputElement>)
+    const checkboxRef = useRef<HTMLInputElement>(null)
     const checkboxGroupContext = useContext(CheckboxGroupContext)
     const handleOnChange: ChangeEventHandler<HTMLInputElement> = e => {
       checkboxGroupContext.onChange && checkboxGroupContext.onChange(e)
@@ -69,10 +75,34 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
         checkboxRef.current.setAttribute('aria-checked', 'mixed')
       }
     }
+
+    // Ref callback that runs synchronously during commit (same timing as
+    // `useLayoutEffect`) to imperatively set the DOM `.indeterminate` property,
+    // which has no HTML attribute equivalent, along with the matching
+    // `aria-checked` value. This avoids a layout effect per Checkbox instance.
+    const setIndeterminate = useCallback(
+      (node: HTMLInputElement | null) => {
+        if (node) {
+          node.indeterminate = indeterminate || false
+          if (indeterminate) {
+            node.setAttribute('aria-checked', 'mixed')
+          } else {
+            node.setAttribute('aria-checked', node.checked ? 'true' : 'false')
+          }
+        }
+      },
+      // `checked` is intentionally included: the callback reads `node.checked` (to also
+      // cover uncontrolled inputs), so it must re-run to refresh `aria-checked` when the
+      // controlled `checked` prop changes. eslint can't see this indirect dependency.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [indeterminate, checked],
+    )
+    const mergedRef = useMergedRefs(ref, useMergedRefs(checkboxRef, setIndeterminate))
+
     const inputProps = {
       type: 'checkbox',
       disabled,
-      ref: checkboxRef,
+      ref: mergedRef,
       checked: indeterminate ? false : checked,
       defaultChecked,
       required,
@@ -84,26 +114,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
       ...rest,
     }
 
-    useLayoutEffect(() => {
-      if (checkboxRef.current) {
-        checkboxRef.current.indeterminate = indeterminate || false
-      }
-    }, [indeterminate, checked, checkboxRef])
-
-    useEffect(() => {
-      const {current: checkbox} = checkboxRef
-      if (!checkbox) {
-        return
-      }
-
-      if (indeterminate) {
-        checkbox.setAttribute('aria-checked', 'mixed')
-      } else {
-        checkbox.setAttribute('aria-checked', checkbox.checked ? 'true' : 'false')
-      }
-    })
     return (
-      // @ts-expect-error inputProp needs a non nullable ref
       <input
         {...inputProps}
         data-component={dataComponent ?? 'Checkbox'}


### PR DESCRIPTION
Closes #7764

Replaces the `useLayoutEffect` that imperatively set the DOM `.indeterminate` property (and the `useEffect` that set `aria-checked`) with a single ref callback merged into the forwarded ref via `useMergedRefs`. The callback runs synchronously during commit, so the timing and behavior are preserved while removing two effects per `Checkbox` instance.

This is an internal-only refactor with **no public API change** and is behavior-preserving.

### Changelog

#### New

- Nothing added.

#### Changed

- `Checkbox` now sets the native `.indeterminate` DOM property (and the matching `aria-checked` value) from a ref callback instead of a `useLayoutEffect` + `useEffect`, eliminating two effects per instance.
- Migrated the internal ref from the deprecated `useProvidedRefOrCreate` to an internal `useRef` merged with the forwarded ref via `useMergedRefs`.

#### Removed

- The per-instance `useLayoutEffect` (indeterminate) and `useEffect` (aria-checked) in `Checkbox`.

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Behavior is unchanged. `aria-checked` still resolves to `true` / `false` / `mixed` and `.indeterminate` is applied with the same commit timing as before. Verified locally:

- Checkbox unit tests: 12/12 pass (including the `aria-checked` true/false/mixed assertions).
- Checkbox + CheckboxGroup + `useMergedRefs`: 31/31 pass.
- `tsc --noEmit`: no new errors.
- ESLint on the changed file: clean. Prettier: clean.

### Merge checklist

- [x] Added/updated tests <!-- existing Checkbox tests cover the behavior; no new tests required for this behavior-preserving refactor -->
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility) <!-- ref callbacks run only on the client during commit, matching the prior isomorphic layout effect -->
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui