### PR TITLE
docs(Button): document built-in loading announcement

### DIFF
--- a/packages/react/src/Button/Button.docs.json
+++ b/packages/react/src/Button/Button.docs.json
@@ -135,12 +135,13 @@
     {
       "name": "loading",
       "type": "boolean",
-      "description": "When true, the button is in a loading state."
+      "description": "When true, the button is in a loading state. A spinner replaces the button's content and the button automatically announces its loading state to screen readers through a built-in, visually hidden live region. Do not add your own separate `aria-live` loading message for the button, as that would cause a duplicate announcement."
     },
     {
       "name": "loadingAnnouncement",
       "type": "string",
-      "description": "The content to announce to screen readers when loading. This requires `loading` prop to be true"
+      "defaultValue": "'Loading'",
+      "description": "The text announced to screen readers through the built-in, visually hidden live region when the button enters its loading state. Requires the `loading` prop to be true."
     },
     {
       "name": "ref",

--- a/packages/react/src/Button/Button.docs.json
+++ b/packages/react/src/Button/Button.docs.json
@@ -74,6 +74,12 @@
       "id": "components-button-features--loading-trigger"
     },
     {
+      "id": "components-button-examples--loading-status-announcement-successful"
+    },
+    {
+      "id": "components-button-examples--loading-status-announcement-error"
+    },
+    {
       "id": "components-button-features--label-wrap"
     },
     {

--- a/packages/react/src/Button/Button.examples.stories.tsx
+++ b/packages/react/src/Button/Button.examples.stories.tsx
@@ -43,6 +43,14 @@ export const LoadingStatusAnnouncementSuccessful = () => {
     </>
   )
 }
+LoadingStatusAnnouncementSuccessful.parameters = {
+  docs: {
+    description: {
+      story:
+        'While `loading` is set, the button announces its loading state for you through its built-in live region, so you should not add a separate loading announcement. Announcing the *result* of the action is still your responsibility — here, a polite `AriaStatus` live region announces "Export completed" once the action resolves successfully.',
+    },
+  },
+}
 
 export const LoadingStatusAnnouncementError = () => {
   const [loading, setLoading] = React.useState(false)
@@ -80,4 +88,12 @@ export const LoadingStatusAnnouncementError = () => {
       </Button>
     </>
   )
+}
+LoadingStatusAnnouncementError.parameters = {
+  docs: {
+    description: {
+      story:
+        'The button handles the loading announcement for you, so you only need to announce the outcome. Here, an assertive `AriaAlert` surfaces an error `Banner` when the action fails.',
+    },
+  },
 }

--- a/packages/react/src/Button/Button.features.stories.tsx
+++ b/packages/react/src/Button/Button.features.stories.tsx
@@ -154,12 +154,28 @@ export const Medium = () => <Button size="medium">Default</Button>
 export const Large = () => <Button size="large">Default</Button>
 
 export const Loading = () => <Button loading>Default</Button>
+Loading.parameters = {
+  docs: {
+    description: {
+      story:
+        'When `loading` is set, the button automatically renders a visually hidden live region that announces "Loading" to screen readers. Because this announcement is built in, do not add your own separate `aria-live` loading message for the button — doing so would cause a duplicate announcement.',
+    },
+  },
+}
 
 export const LoadingCustomAnnouncement = () => (
   <Button loading loadingAnnouncement="This is a custom loading announcement">
     Default
   </Button>
 )
+LoadingCustomAnnouncement.parameters = {
+  docs: {
+    description: {
+      story:
+        'Use the `loadingAnnouncement` prop to customize the text announced to screen readers when the button enters its loading state. This replaces the default "Loading" announcement.',
+    },
+  },
+}
 
 export const LoadingWithLeadingVisual = () => (
   <Button loading leadingVisual={DownloadIcon}>

--- a/packages/react/src/Button/IconButton.docs.json
+++ b/packages/react/src/Button/IconButton.docs.json
@@ -82,6 +82,17 @@
       "description": "Changes the size of the icon button component"
     },
     {
+      "name": "loading",
+      "type": "boolean",
+      "description": "When true, the button is in a loading state. A spinner replaces the icon and the button automatically announces its loading state to screen readers through a built-in, visually hidden live region. Do not add your own separate `aria-live` loading message for the button, as that would cause a duplicate announcement."
+    },
+    {
+      "name": "loadingAnnouncement",
+      "type": "string",
+      "defaultValue": "'Loading'",
+      "description": "The text announced to screen readers through the built-in, visually hidden live region when the button enters its loading state. Requires the `loading` prop to be true."
+    },
+    {
       "name": "inactive",
       "type": "boolean",
       "description": "Whether the button looks visually disabled, but can still accept all the same interactions as an enabled button."

--- a/packages/react/src/Button/IconButton.features.stories.tsx
+++ b/packages/react/src/Button/IconButton.features.stories.tsx
@@ -64,6 +64,14 @@ export const AsAMenuAnchor = () => (
 )
 
 export const Loading = () => <IconButton loading icon={HeartIcon} variant="primary" aria-label="Primary" />
+Loading.parameters = {
+  docs: {
+    description: {
+      story:
+        'When `loading` is set, the button automatically renders a visually hidden live region that announces "Loading" to screen readers. Customize this text with the `loadingAnnouncement` prop. Because the announcement is built in, do not add your own separate `aria-live` loading message for the button — doing so would cause a duplicate announcement.',
+    },
+  },
+}
 
 export const LoadingTrigger = () => {
   const [isLoading, setIsLoading] = useState(false)

--- a/packages/react/src/Button/types.ts
+++ b/packages/react/src/Button/types.ts
@@ -31,11 +31,16 @@ export type ButtonBaseProps = {
    */
   block?: boolean
   /**
-   * Specify whether the button is in a loading state
+   * Specify whether the button is in a loading state. While loading, a spinner replaces the
+   * button's content and the button automatically announces its loading state to screen readers
+   * through a visually hidden live region. Do not add a separate `aria-live` loading message for
+   * the button, as that would cause a duplicate announcement.
    */
   loading?: boolean
   /**
-   * The content to announce to screen readers when loading
+   * The text announced to screen readers through the built-in visually hidden live region when the
+   * button enters its loading state. Requires `loading` to be true.
+   * @default 'Loading'
    */
   loadingAnnouncement?: string
   /*


### PR DESCRIPTION
Closes #7881

Documents the `Button` (and `IconButton`) built-in loading announcement behavior. When the `loading` prop is set, the component already renders a visually hidden, polite live-region announcement (default `"Loading"`), customizable via the `loadingAnnouncement` prop. The previous docs omitted this and instead told consumers to build their own `aria-live` loading message, which causes a duplicate announcement.

This is a **docs-only** change (prop doc metadata, JSDoc comments, and Storybook story descriptions). No component source or runtime behavior is affected.

> [!NOTE]
> This supersedes the earlier closed attempt in #7882. That PR's review feedback was that it updated the prop documentation but *"completely missed the React examples section in the main component docs."* This PR addresses that by adding narrative to the loading example stories via the standard `parameters.docs.description.story` pattern (rather than rendering prose inside the story components), and by surfacing the existing `LoadingStatusAnnouncement*` result-announcement examples in the docs.

### Changelog

#### New

- Added the missing `loading` and `loadingAnnouncement` prop entries to `IconButton.docs.json`.
- Surfaced the existing `LoadingStatusAnnouncementSuccessful` / `LoadingStatusAnnouncementError` examples in `Button.docs.json`, with descriptions explaining how announcing the *result* complements the built-in loading announcement.

#### Changed

- Expanded the `loading` / `loadingAnnouncement` JSDoc in `Button/types.ts` and their descriptions in `Button.docs.json` to explain the built-in announcement and warn against adding a separate `aria-live` message.
- Added narrative story descriptions for the Button/IconButton loading stories.

#### Removed

- N/A

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

Docs-only change — no changes to the published component source or runtime behavior, so no release is required. The `skip changeset` label is applied.

### Testing & Reviewing

Review the updated prop descriptions in `Button.docs.json` / `IconButton.docs.json`, the JSDoc in `types.ts`, and the story descriptions in `Button.features.stories.tsx`, `IconButton.features.stories.tsx`, and `Button.examples.stories.tsx`. Confirmed against `ButtonBase.tsx`: `loadingAnnouncement` defaults to `'Loading'` and renders a `VisuallyHidden` `AriaStatus` (polite) live region when `loading` is set.

> [!NOTE]
> The narrative accessibility guidance on primer.style/product (which previously recommended a manual `aria-live` message) lives in the separate `github/primer-docs` repo and is updated in a companion PR.

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [ ] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui