### PR TITLE
fix(react): enable React Compiler for hooks

### DIFF
--- a/.changeset/react-compiler-hooks.md
+++ b/.changeset/react-compiler-hooks.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Hooks: Enable React Compiler optimization for hook utilities

--- a/.changeset/react-compiler-hooks.md
+++ b/.changeset/react-compiler-hooks.md
@@ -2,4 +2,4 @@
 '@primer/react': patch
 ---
 
-Hooks: Enable React Compiler optimization for hook utilities
+Enable React Compiler optimization for `useAnchoredPosition`, `useFocusTrap`, `useFocusZone`, `useMenuInitialFocus`, `useOnEscapePress`, `useResizeObserver`, and `useSafeTimeout`

--- a/packages/react/script/react-compiler.mjs
+++ b/packages/react/script/react-compiler.mjs
@@ -22,13 +22,6 @@ const unsupportedPatterns = [
   'src/SelectPanel/SelectPanel.test.tsx',
   'src/SelectPanel/SelectPanel.tsx',
   'src/experimental/SelectPanel2/SelectPanel.tsx',
-  'src/hooks/useAnchoredPosition.ts',
-  'src/hooks/useFocusTrap.ts',
-  'src/hooks/useFocusZone.ts',
-  'src/hooks/useMenuInitialFocus.ts',
-  'src/hooks/useOnEscapePress.ts',
-  'src/hooks/useResizeObserver.ts',
-  'src/hooks/useSafeTimeout.ts',
   'src/TooltipV2/Tooltip.tsx',
 ]
 

--- a/packages/react/src/hooks/useAnchoredPosition.ts
+++ b/packages/react/src/hooks/useAnchoredPosition.ts
@@ -3,6 +3,7 @@ import {getAnchoredPosition} from '@primer/behaviors'
 import type {AnchorPosition, PositionSettings} from '@primer/behaviors'
 import {useProvidedRefOrCreate} from './useProvidedRefOrCreate'
 import {useResizeObserver} from './useResizeObserver'
+import {useDependencyListEffect, useDependencyListLayoutEffect} from '../internal/hooks/useDependencyListEffect'
 import useLayoutEffect from '../utils/useIsomorphicLayoutEffect'
 
 /**
@@ -83,37 +84,33 @@ export function useAnchoredPosition(
     return heightUpdated
   }
 
-  const updatePosition = React.useCallback(
-    () => {
-      if (!enabled) return
-      if (floatingElementRef.current instanceof Element && anchorElementRef.current instanceof Element) {
-        const newPosition = getAnchoredPosition(floatingElementRef.current, anchorElementRef.current, settings)
-        setPosition(prev => {
-          if (settings?.pinPosition && topPositionChanged(prev, newPosition)) {
-            const anchorTop = anchorElementRef.current?.getBoundingClientRect().top ?? 0
-            const elementStillFitsOnTop = anchorTop > (floatingElementRef.current?.clientHeight ?? 0)
+  const updatePosition = () => {
+    if (!enabled) return
+    if (floatingElementRef.current instanceof Element && anchorElementRef.current instanceof Element) {
+      const newPosition = getAnchoredPosition(floatingElementRef.current, anchorElementRef.current, settings)
+      setPosition(prev => {
+        if (settings?.pinPosition && topPositionChanged(prev, newPosition)) {
+          const anchorTop = anchorElementRef.current?.getBoundingClientRect().top ?? 0
+          const elementStillFitsOnTop = anchorTop > (floatingElementRef.current?.clientHeight ?? 0)
 
-            if (elementStillFitsOnTop && updateElementHeight()) {
-              return prev
-            }
+          if (elementStillFitsOnTop && updateElementHeight()) {
+            return prev
           }
+        }
 
-          if (prev && prev.anchorSide === newPosition.anchorSide) {
-            // if the position hasn't changed, don't update
-            savedOnPositionChange.current?.(newPosition)
-          }
+        if (prev && prev.anchorSide === newPosition.anchorSide) {
+          // if the position hasn't changed, don't update
+          savedOnPositionChange.current?.(newPosition)
+        }
 
-          return newPosition
-        })
-      } else {
-        setPosition(undefined)
-        savedOnPositionChange.current?.(undefined)
-      }
-      setPrevHeight(floatingElementRef.current?.clientHeight)
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps, react-hooks/use-memo
-    [floatingElementRef, anchorElementRef, enabled, ...dependencies],
-  )
+        return newPosition
+      })
+    } else {
+      setPosition(undefined)
+      savedOnPositionChange.current?.(undefined)
+    }
+    setPrevHeight(floatingElementRef.current?.clientHeight)
+  }
 
   useLayoutEffect(() => {
     savedOnPositionChange.current = settings?.onPositionChange
@@ -125,54 +122,60 @@ export function useAnchoredPosition(
   // After mount (including Suspense reappear), only call updatePosition when
   // both refs are attached — skipping closed overlays avoids unnecessary setState.
   const hasMountedRef = React.useRef(false)
-  useLayoutEffect(() => {
-    if (floatingElementRef.current instanceof Element && anchorElementRef.current instanceof Element) {
-      hasMountedRef.current = true
-      updatePosition()
-    }
-  }, [updatePosition, floatingElementRef, anchorElementRef])
+  useDependencyListLayoutEffect(
+    () => {
+      if (floatingElementRef.current instanceof Element && anchorElementRef.current instanceof Element) {
+        hasMountedRef.current = true
+        updatePosition()
+      }
+    },
+    () => [floatingElementRef.current, anchorElementRef.current, enabled, ...dependencies],
+  )
 
   React.useEffect(() => {
     if (!hasMountedRef.current) {
       hasMountedRef.current = true
       updatePosition()
     }
-  }, [updatePosition])
+  })
 
   useResizeObserver(updatePosition, undefined, [], enabled) // watches for changes in window size
   useResizeObserver(updatePosition, floatingElementRef as React.RefObject<HTMLElement | null>, [], enabled) // watches for changes in floating element size
 
   // Recalculate position when any scrollable ancestor of the anchor scrolls.
   // Uses requestAnimationFrame to avoid layout thrashing during scroll.
-  React.useEffect(() => {
-    if (!enabled) return
-    const anchorEl = anchorElementRef.current
-    if (!anchorEl) return
+  useDependencyListEffect(
+    () => {
+      if (!enabled) return
+      const anchorEl = anchorElementRef.current
+      if (!anchorEl) return
 
-    let rafId: number | null = null
-    const handleScroll = () => {
-      if (rafId !== null) return
-      rafId = requestAnimationFrame(() => {
-        rafId = null
-        updatePosition()
-      })
-    }
+      let rafId: number | null = null
+      const handleScroll = () => {
+        if (rafId !== null) return
+        rafId = requestAnimationFrame(() => {
+          rafId = null
+          updatePosition()
+        })
+      }
 
-    const scrollables = getScrollableAncestors(anchorEl)
-    for (const scrollable of scrollables) {
-      // eslint-disable-next-line github/prefer-observers -- IntersectionObserver cannot detect continuous scroll position changes needed for repositioning
-      scrollable.addEventListener('scroll', handleScroll)
-    }
-
-    return () => {
+      const scrollables = getScrollableAncestors(anchorEl)
       for (const scrollable of scrollables) {
-        scrollable.removeEventListener('scroll', handleScroll)
+        // eslint-disable-next-line github/prefer-observers -- IntersectionObserver cannot detect continuous scroll position changes needed for repositioning
+        scrollable.addEventListener('scroll', handleScroll)
       }
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId)
+
+      return () => {
+        for (const scrollable of scrollables) {
+          scrollable.removeEventListener('scroll', handleScroll)
+        }
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId)
+        }
       }
-    }
-  }, [anchorElementRef, updatePosition, enabled])
+    },
+    () => [anchorElementRef.current, enabled, ...dependencies],
+  )
 
   return {
     floatingElementRef,

--- a/packages/react/src/hooks/useFocusTrap.ts
+++ b/packages/react/src/hooks/useFocusTrap.ts
@@ -2,6 +2,7 @@ import React from 'react'
 import {focusTrap} from '@primer/behaviors'
 import {useProvidedRefOrCreate} from './useProvidedRefOrCreate'
 import {useOnOutsideClick} from './useOnOutsideClick'
+import {useDependencyListEffect} from '../internal/hooks/useDependencyListEffect'
 
 export interface FocusTrapHookSettings {
   /**
@@ -52,39 +53,40 @@ export function useFocusTrap(
   settings?: FocusTrapHookSettings,
   dependencies: React.DependencyList = [],
 ): {containerRef: React.RefObject<HTMLElement | null>; initialFocusRef: React.RefObject<HTMLElement | null>} {
-  const [outsideClicked, setOutsideClicked] = React.useState(false)
   const containerRef = useProvidedRefOrCreate(settings?.containerRef)
   const initialFocusRef = useProvidedRefOrCreate(settings?.initialFocusRef)
   const disabled = settings?.disabled
+  const allowOutsideClick = settings?.allowOutsideClick ?? false
+  const returnFocusRef = settings?.returnFocusRef
+  const restoreFocusOnCleanUp = settings?.restoreFocusOnCleanUp ?? false
   const abortController = React.useRef<AbortController>()
   const previousFocusedElement = React.useRef<Element | null>(null)
-
-  // If we are enabling a focus trap and haven't already stored the previously focused element
-  // go ahead an do that so we can restore later when the trap is disabled.
-  // eslint-disable-next-line react-hooks/refs
-  if (!previousFocusedElement.current && !disabled) {
-    previousFocusedElement.current = document.activeElement
-  }
+  const outsideClickedRef = React.useRef(false)
 
   // This function removes the event listeners that enable the focus trap and restores focus
   // to the previously-focused element (if necessary).
   function disableTrap() {
     abortController.current?.abort()
-    if (settings?.allowOutsideClick && outsideClicked) {
+    abortController.current = undefined
+    if (allowOutsideClick && outsideClickedRef.current) {
       return
     }
-    if (settings?.returnFocusRef && settings.returnFocusRef.current instanceof HTMLElement) {
-      settings.returnFocusRef.current.focus()
-    } else if (settings?.restoreFocusOnCleanUp && previousFocusedElement.current instanceof HTMLElement) {
+    if (returnFocusRef?.current instanceof HTMLElement) {
+      returnFocusRef.current.focus()
+    } else if (restoreFocusOnCleanUp && previousFocusedElement.current instanceof HTMLElement) {
       previousFocusedElement.current.focus()
       previousFocusedElement.current = null
     }
   }
 
-  React.useEffect(
+  useDependencyListEffect(
     () => {
       if (containerRef.current instanceof HTMLElement) {
         if (!disabled) {
+          outsideClickedRef.current = false
+          if (!previousFocusedElement.current) {
+            previousFocusedElement.current = document.activeElement
+          }
           abortController.current = focusTrap(containerRef.current, initialFocusRef.current ?? undefined)
           return () => {
             disableTrap()
@@ -94,17 +96,21 @@ export function useFocusTrap(
         }
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [containerRef, initialFocusRef, disabled, ...dependencies],
+    () => [
+      containerRef,
+      initialFocusRef,
+      disabled,
+      allowOutsideClick,
+      returnFocusRef,
+      restoreFocusOnCleanUp,
+      ...dependencies,
+    ],
   )
   useOnOutsideClick({
     containerRef: containerRef as React.RefObject<HTMLDivElement>,
     onClickOutside: () => {
-      setOutsideClicked(true)
-      if (settings?.allowOutsideClick) {
-        // eslint-disable-next-line react-hooks/immutability
-        if (settings.returnFocusRef) settings.returnFocusRef = undefined
-        settings.restoreFocusOnCleanUp = false
+      if (allowOutsideClick) {
+        outsideClickedRef.current = true
         abortController.current?.abort()
       }
     },

--- a/packages/react/src/hooks/useFocusZone.ts
+++ b/packages/react/src/hooks/useFocusZone.ts
@@ -1,7 +1,8 @@
-import React, {useEffect} from 'react'
+import React from 'react'
 import {focusZone} from '@primer/behaviors'
 import type {FocusZoneSettings} from '@primer/behaviors'
 import {useProvidedRefOrCreate} from './useProvidedRefOrCreate'
+import {useDependencyListEffect} from '../internal/hooks/useDependencyListEffect'
 export {FocusKeys} from '@primer/behaviors'
 export type {Direction} from '@primer/behaviors'
 
@@ -47,11 +48,10 @@ export function useFocusZone(
   const disabled = settings.disabled
   const abortController = React.useRef<AbortController>()
 
-  useEffect(
+  useDependencyListEffect(
     () => {
       if (
         containerRef.current instanceof HTMLElement &&
-        // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
         (!useActiveDescendant || activeDescendantControlRef.current instanceof HTMLElement)
       ) {
         if (!disabled) {
@@ -68,8 +68,7 @@ export function useFocusZone(
         }
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [disabled, ...dependencies],
+    () => [containerRef, activeDescendantControlRef, disabled, useActiveDescendant, ...dependencies],
   )
 
   return {containerRef, activeDescendantControlRef}

--- a/packages/react/src/hooks/useMenuInitialFocus.ts
+++ b/packages/react/src/hooks/useMenuInitialFocus.ts
@@ -1,5 +1,6 @@
 import React from 'react'
 import {iterateFocusableElements} from '@primer/behaviors/utils'
+import {useDependencyListEffect} from '../internal/hooks/useDependencyListEffect'
 
 export const useMenuInitialFocus = (
   open: boolean,
@@ -44,9 +45,8 @@ export const useMenuInitialFocus = (
    * ArrowDown | Space | Enter: first element
    * ArrowUp: last element
    */
-  React.useEffect(
-    function moveFocusOnOpen() {
-      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
+  useDependencyListEffect(
+    () => {
       if (!open || !containerRef?.current) return // wait till the menu is open
 
       const iterable = iterateFocusableElements(containerRef.current)
@@ -57,22 +57,24 @@ export const useMenuInitialFocus = (
       } else if (openingGesture && ['ArrowDown', 'Space', 'Enter'].includes(openingGesture)) {
         const firstElement = iterable.next().value
         /** We push imperative focus to the next tick to prevent React's batching */
-        setTimeout(() => firstElement?.focus())
+        const timeoutId = window.setTimeout(() => firstElement?.focus())
+        return () => window.clearTimeout(timeoutId)
       } else if ('ArrowUp' === openingGesture) {
         const elements = [...iterable]
         const lastElement = elements[elements.length - 1]
-        setTimeout(() => lastElement.focus())
+        const timeoutId = window.setTimeout(() => lastElement.focus())
+        return () => window.clearTimeout(timeoutId)
       } else {
         /** if the menu was not opened with the anchor, we default to the first element
          *  for example: with keyboard shortcut (see stories/fixtures)
          */
         const firstElement = iterable.next().value
-        setTimeout(() => firstElement?.focus())
+        const timeoutId = window.setTimeout(() => firstElement?.focus())
+        return () => window.clearTimeout(timeoutId)
       }
     },
-    // we don't want containerRef in dependencies
-    // because re-renders to containerRef while it's open should not fire initialMenuFocus
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [open, openingGesture, anchorRef],
+    // We intentionally do not include containerRef because re-renders to
+    // containerRef while open should not fire initialMenuFocus.
+    () => [open, openingGesture, anchorRef],
   )
 }

--- a/packages/react/src/hooks/useOnEscapePress.ts
+++ b/packages/react/src/hooks/useOnEscapePress.ts
@@ -1,4 +1,5 @@
-import {useEffect, useCallback, useMemo} from 'react'
+import {useEffect, useCallback, useMemo, useRef} from 'react'
+import {useDependencyListEffect} from '../internal/hooks/useDependencyListEffect'
 
 /**
  * Calls all handlers in reverse order
@@ -6,7 +7,7 @@ import {useEffect, useCallback, useMemo} from 'react'
  */
 function handleEscape(event: KeyboardEvent) {
   if (!event.defaultPrevented) {
-    for (const handler of Object.values(registry).reverse()) {
+    for (const handler of Array.from(registry.values()).reverse()) {
       handler(event)
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (event.defaultPrevented) break
@@ -16,18 +17,15 @@ function handleEscape(event: KeyboardEvent) {
 
 type KeyboardEventCallback = (event: KeyboardEvent) => void
 
-const registry: {[id: number]: KeyboardEventCallback} = {}
+const registry = new Map<symbol, KeyboardEventCallback>()
 
-function register(id: number, handler: KeyboardEventCallback): void {
-  registry[id] = handler
+function register(id: symbol, handler: KeyboardEventCallback): void {
+  registry.set(id, handler)
 }
 
-function deregister(id: number) {
-  delete registry[id]
+function deregister(id: symbol) {
+  registry.delete(id)
 }
-
-// For auto-incrementing unique identifiers for registered handlers.
-let handlerId = 0
 
 /**
  * Sets up a `keydown` listener on `window.document`. If
@@ -54,26 +52,29 @@ export const useOnEscapePress = (
   onEscape: (e: KeyboardEvent) => void,
   callbackDependencies: React.DependencyList = [onEscape],
 ): void => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps, react-hooks/use-memo
-  const escapeCallback = useCallback(onEscape, callbackDependencies)
+  const savedOnEscape = useRef(onEscape)
 
-  const handler = useCallback<KeyboardEventCallback>(
-    event => {
-      if (event.key === 'Escape') escapeCallback(event)
+  useDependencyListEffect(
+    () => {
+      savedOnEscape.current = onEscape
     },
-    [escapeCallback],
+    () => callbackDependencies,
   )
 
-  const id = useMemo(() => handlerId++, [])
+  const handler = useCallback<KeyboardEventCallback>(event => {
+    if (event.key === 'Escape') savedOnEscape.current(event)
+  }, [])
+
+  const id = useMemo(() => Symbol('useOnEscapePress'), [])
   useEffect(() => {
-    if (Object.keys(registry).length === 0) {
+    if (registry.size === 0) {
       document.addEventListener('keydown', handleEscape)
     }
     register(id, handler)
 
     return () => {
       deregister(id)
-      if (Object.keys(registry).length === 0) {
+      if (registry.size === 0) {
         document.removeEventListener('keydown', handleEscape)
       }
     }

--- a/packages/react/src/hooks/useResizeObserver.ts
+++ b/packages/react/src/hooks/useResizeObserver.ts
@@ -1,5 +1,6 @@
 import type {RefObject} from 'react'
-import {useRef, useState} from 'react'
+import {useRef} from 'react'
+import {useDependencyListLayoutEffect} from '../internal/hooks/useDependencyListEffect'
 import useLayoutEffect from '../utils/useIsomorphicLayoutEffect'
 
 // https://gist.github.com/strothj/708afcf4f01dd04de8f49c92e88093c3
@@ -15,53 +16,55 @@ export function useResizeObserver<T extends HTMLElement>(
   depsArray: unknown[] = [],
   enabled: boolean = true,
 ) {
-  const [targetClientRect, setTargetClientRect] = useState<DOMRect | null>(null)
+  const targetClientRectRef = useRef<DOMRect | null>(null)
   const savedCallback = useRef(callback)
 
   useLayoutEffect(() => {
     savedCallback.current = callback
   })
 
-  useLayoutEffect(() => {
-    if (!enabled) {
-      return
-    }
-    const targetEl = target && 'current' in target ? target.current : document.documentElement
-    if (!targetEl) {
-      return
-    }
-
-    if (typeof ResizeObserver === 'function') {
-      const observer = new ResizeObserver(entries => {
-        savedCallback.current(entries)
-      })
-
-      observer.observe(targetEl)
-
-      return () => {
-        observer.disconnect()
+  useDependencyListLayoutEffect(
+    () => {
+      if (!enabled) {
+        return
       }
-    } else {
-      const saveTargetDimensions = () => {
-        const currTargetRect = targetEl.getBoundingClientRect()
+      const targetEl = target && 'current' in target ? target.current : document.documentElement
+      if (!targetEl) {
+        return
+      }
 
-        if (currTargetRect.width !== targetClientRect?.width || currTargetRect.height !== targetClientRect.height) {
-          savedCallback.current([
-            {
-              contentRect: currTargetRect,
-            },
-          ])
+      if (typeof ResizeObserver === 'function') {
+        const observer = new ResizeObserver(entries => {
+          savedCallback.current(entries)
+        })
+
+        observer.observe(targetEl)
+
+        return () => {
+          observer.disconnect()
         }
-        setTargetClientRect(currTargetRect)
-      }
-      // eslint-disable-next-line github/prefer-observers
-      window.addEventListener('resize', saveTargetDimensions)
+      } else {
+        const saveTargetDimensions = () => {
+          const currTargetRect = targetEl.getBoundingClientRect()
+          const targetClientRect = targetClientRectRef.current
 
-      return () => {
-        window.removeEventListener('resize', saveTargetDimensions)
-      }
-    }
+          if (currTargetRect.width !== targetClientRect?.width || currTargetRect.height !== targetClientRect.height) {
+            savedCallback.current([
+              {
+                contentRect: currTargetRect,
+              },
+            ])
+          }
+          targetClientRectRef.current = currTargetRect
+        }
+        // eslint-disable-next-line github/prefer-observers
+        window.addEventListener('resize', saveTargetDimensions)
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [target?.current, enabled, ...depsArray])
+        return () => {
+          window.removeEventListener('resize', saveTargetDimensions)
+        }
+      }
+    },
+    () => [target && 'current' in target ? target.current : document.documentElement, enabled, ...depsArray],
+  )
 }

--- a/packages/react/src/hooks/useSafeTimeout.ts
+++ b/packages/react/src/hooks/useSafeTimeout.ts
@@ -26,11 +26,13 @@ export default function useSafeTimeout(): {safeSetTimeout: SetTimeout; safeClear
   }, [])
 
   useEffect(() => {
+    const currentTimers = timers.current
+
     return () => {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      for (const id of timers.current) {
+      for (const id of currentTimers) {
         clearTimeout(id)
       }
+      currentTimers.clear()
     }
   }, [])
 

--- a/packages/react/src/internal/hooks/useDependencyListEffect.ts
+++ b/packages/react/src/internal/hooks/useDependencyListEffect.ts
@@ -1,0 +1,82 @@
+import type React from 'react'
+import {useEffect, useRef} from 'react'
+import useLayoutEffect from '../../utils/useIsomorphicLayoutEffect'
+
+function areDependencyListsEqual(
+  previousDependencies: React.DependencyList,
+  nextDependencies: React.DependencyList,
+): boolean {
+  if (previousDependencies.length !== nextDependencies.length) {
+    return false
+  }
+
+  for (let i = 0; i < previousDependencies.length; i++) {
+    if (!Object.is(previousDependencies[i], nextDependencies[i])) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function runCleanup(cleanup: void | (() => void)): void {
+  if (typeof cleanup === 'function') {
+    cleanup()
+  }
+}
+
+export function useDependencyListEffect(
+  effect: React.EffectCallback,
+  getDependencies: () => React.DependencyList,
+): void {
+  const cleanupRef = useRef<void | (() => void)>()
+  const dependenciesRef = useRef<React.DependencyList | null>(null)
+
+  useEffect(() => {
+    const dependencies = getDependencies()
+
+    if (dependenciesRef.current !== null && areDependencyListsEqual(dependenciesRef.current, dependencies)) {
+      return
+    }
+
+    runCleanup(cleanupRef.current)
+    dependenciesRef.current = dependencies
+    cleanupRef.current = effect()
+  })
+
+  useEffect(() => {
+    return () => {
+      runCleanup(cleanupRef.current)
+      cleanupRef.current = undefined
+      dependenciesRef.current = null
+    }
+  }, [])
+}
+
+export function useDependencyListLayoutEffect(
+  effect: React.EffectCallback,
+  getDependencies: () => React.DependencyList,
+): void {
+  const cleanupRef = useRef<void | (() => void)>()
+  const dependenciesRef = useRef<React.DependencyList | null>(null)
+
+  useLayoutEffect(() => {
+    const dependencies = getDependencies()
+
+    if (dependenciesRef.current !== null && areDependencyListsEqual(dependenciesRef.current, dependencies)) {
+      return
+    }
+
+    runCleanup(cleanupRef.current)
+    dependenciesRef.current = dependencies
+    cleanupRef.current = effect()
+  })
+
+  useLayoutEffect(() => {
+    return () => {
+      runCleanup(cleanupRef.current)
+      cleanupRef.current = undefined
+      dependenciesRef.current = null
+    }
+  }, [])
+}


### PR DESCRIPTION
Follow up to the React Compiler migration work. This PR enables React Compiler for the remaining hook utilities under `packages/react/src/hooks`.

### Changelog

#### New

- Add an internal dependency-list effect helper used by hook utilities that expose dependency-list APIs.

#### Changed

- Update hook utilities to avoid React hook-rule suppressions while preserving the existing public hook APIs.
- Remove hook files from the React Compiler unsupported list.

#### Removed

- Remove React Compiler exclusions for `useAnchoredPosition`, `useFocusTrap`, `useFocusZone`, `useMenuInitialFocus`, `useOnEscapePress`, `useResizeObserver`, and `useSafeTimeout`.

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

This keeps the published API the same and updates our internal compiler compatibility for hooks.

### Testing & Reviewing

Would love a review on the dependency tracking changes in the hook utilities, especially `useFocusTrap` and `useAnchoredPosition`, since those preserve existing dependency-list behavior while avoiding React Compiler skips.

Verified with:

- `npm run build`
- `npm test -- --run`
- `npm run type-check`
- `npm run lint`
- `npm run lint:css`
- `npm run format:diff`
- `packages/react/node_modules/.bin/tsx script/react-compiler-migration-status.mts`
- Direct React Compiler transform check for the enabled hook files

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Storybook)
- [x] Changes are [SSR compatible](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#ssr-compatibility)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui ([Learn more about how to run integration tests](https://github.com/github/primer-engineering/blob/main/how-we-work/testing-primer-react-pr-at-dotcom.md))
