### PR TITLE
Timeline: CommentCard uses shared MutedTime permalink helper

### DIFF
--- a/packages/react/src/Timeline/internal/CommentCard.module.css
+++ b/packages/react/src/Timeline/internal/CommentCard.module.css
@@ -148,12 +148,6 @@
   color: var(--fgColor-muted);
 }
 
-/* Muted, underlined relative-time permalink. The underline keeps this muted
-   in-text link high-contrast accessible (matches the badge-row `.Timestamp`). */
-.Timestamp {
-  text-decoration: underline;
-}
-
 .CardActions {
   display: flex;
   align-items: center;

--- a/packages/react/src/Timeline/internal/CommentCard.tsx
+++ b/packages/react/src/Timeline/internal/CommentCard.tsx
@@ -5,9 +5,8 @@ import Avatar from '../../Avatar'
 import {IconButton} from '../../Button'
 import Label from '../../Label'
 import Link from '../../Link'
-import RelativeTime from '../../RelativeTime'
 import Timeline from '../Timeline'
-import {InlineAvatar} from './timelineStoryHelpers'
+import {InlineAvatar, MutedTime} from './timelineStoryHelpers'
 import classes from './CommentCard.module.css'
 
 /**
@@ -207,9 +206,7 @@ export const CommentCard = ({
             {hasInlineHeader ? <span className={classes.CommentedVerb}>commented</span> : null}
             <span className={classes.TimestampLine}>
               {/* Muted + underlined keeps this muted permalink high-contrast accessible. */}
-              <Link href="#" className={classes.Timestamp} muted>
-                <RelativeTime date={new Date(timestamp)} format="relative" />
-              </Link>
+              <MutedTime date={new Date(timestamp)} href="#" />
               {viaApp ? (
                 <>
                   {' – with '}


### PR DESCRIPTION
## Summary

Part of Phase 2 of the Timeline events work (github/primer#6663), and a follow-up to #8072 (merged). It adopts the shared permalink-time helper added in #8140.

The `CommentCard` internal helper had the muted, underlined permalink timestamp baked inline. This swaps it for the shared `MutedTime` helper called with `href`, which renders that exact pattern. Storybook-only, nothing ships in the package.

### Changelog

#### New

- None.

#### Changed

- `CommentCard` now renders its permalink timestamp via the shared `MutedTime` helper (`<MutedTime date={…} href="#" />`) instead of an inline `<Link muted><RelativeTime/></Link>`. Pure refactor, zero visual change.

#### Removed

- The now-unused local `.Timestamp` CSS class and the `RelativeTime` import from `CommentCard`.

### Rollout strategy

- [x] None; Storybook-only helper change with no published/runtime impact (stories don't ship).

### Testing & Reviewing

Storybook-only. Verified the `Components/Timeline/Internal` → `Comment cards` story headlessly: all comment timestamps still render as underlined muted permalinks at both ≥768px and <768px (the responsive collapsed comment form), with zero console errors. prettier / eslint / stylelint / tsc report no new errors.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are SSR compatible
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui
