### PR TITLE
Timeline: Dependabot stories use shared internal helpers (UserActor, EventSubRow)

### DIFF
--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.module.css
@@ -35,22 +35,6 @@
   text-decoration: none;
 }
 
-/* Optional dismissal/auto sub-content row. Live ERB renders a
-   `<div class="TimelineItem tmp-pl-5 pt-0 f6 d-block">` (small, indented block
-   below the event) holding a `note` octicon + the comment text. */
-.NoteComment {
-  margin-top: var(--base-size-8);
-  padding-left: var(--base-size-4);
-  font-size: var(--text-body-size-small);
-  color: var(--fgColor-muted);
-}
-
-.NoteIcon {
-  vertical-align: middle;
-  margin-right: var(--base-size-4);
-  color: var(--fgColor-muted);
-}
-
 /* Colored badge icons for the Dismissal Request / Review / Cancelled events.
    Their live ERB renders `with_badge(color: :X, icon: …)` with NO `bg:` — in
    Primer `color:` tints the ICON on the DEFAULT badge background (it is NOT a

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
@@ -1,5 +1,4 @@
 import type {Meta} from '@storybook/react-vite'
-import type React from 'react'
 import type {ComponentProps} from '../utils/types'
 import {FeatureFlags} from '../FeatureFlags'
 import Timeline from './Timeline'
@@ -18,7 +17,15 @@ import Label from '../Label'
 import Link from '../Link'
 import Octicon from '../Octicon'
 import classes from './Timeline.dependabot.features.stories.module.css'
-import {BoldLink, Examples, InlineAvatar, MutedTime, VariantSection} from './internal/timelineStoryHelpers'
+import {
+  BoldLink,
+  EventSubRow,
+  Examples,
+  InlineAvatar,
+  MutedTime,
+  UserActor,
+  VariantSection,
+} from './internal/timelineStoryHelpers'
 
 /**
  * Dependabot alert Timeline event examples (Phase 2 of github/primer#6663).
@@ -69,7 +76,6 @@ import {BoldLink, Examples, InlineAvatar, MutedTime, VariantSection} from './int
 // Live ERB uses the bundled `modules/site/dependabot-icon.png`; this is the
 // public dependabot[bot] avatar (square Dependabot logo) for Storybook.
 const DEPENDABOT_AVATAR = 'https://avatars.githubusercontent.com/u/27347476?v=4'
-const MONALISA_AVATAR = 'https://avatars.githubusercontent.com/u/583231?v=4'
 
 /**
  * Dependabot actor — `DependabotAlerts::TimelineItems::ActorComponent` in
@@ -92,21 +98,6 @@ const DependabotActor = () => (
 )
 
 /**
- * User actor — `ActorComponent` regular-user branch (`linked_avatar_for(actor,
- * 20)` + `profile_link(... "text-bold")`): a CIRCLE 20px avatar + bold profile
- * link, no `(bot)` tag. Used by user-authored events (manual Dismissed, manual
- * Reopened, Dismissal Cancelled).
- */
-const UserActor = () => (
-  <>
-    <InlineAvatar src={MONALISA_AVATAR} />
-    <BoldLink href="#" muted>
-      monalisa
-    </BoldLink>
-  </>
-)
-
-/**
  * Push-pill — `PushLinkComponent`: a `<code>` wrapping a `Primer::Beta::Link`
  * (`bg: :accent, px: 2, py: 1, border_radius: 3`) → SUBTLE light-blue rounded
  * pill with accent-blue monospace text (the standard GitHub SHA pill), showing
@@ -118,19 +109,6 @@ const PushPill = ({sha}: {sha: string}) => (
       {sha}
     </Link>
   </code>
-)
-
-/**
- * Optional sub-content row rendered below a dismissal/auto event — the live ERB
- * renders a `<div class="TimelineItem tmp-pl-5 pt-0 f6 d-block">` with a `note`
- * octicon and the comment text. Rendered here as a small muted block inside the
- * event body.
- */
-const NoteComment = ({children}: {children: React.ReactNode}) => (
-  <div className={classes.NoteComment}>
-    <Octicon icon={NoteIcon} size={16} className={classes.NoteIcon} />
-    {children}
-  </div>
 )
 
 export default {
@@ -296,7 +274,7 @@ export const EventFixed = () => (
  * `Timeline.Badge` (no variant), NOT the neutral-emphasis hook.
  *
  * Manual reasons are `RepositoryVulnerabilityAlert::DISMISS_REASONS` downcased.
- * The optional comment renders as a small indented sub-row (note octicon + text).
+ * The optional comment renders as a small sub-row (note octicon + text).
  */
 export const EventDismissed = () => (
   <Examples>
@@ -308,10 +286,12 @@ export const EventDismissed = () => (
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'dismissed this as risk is tolerable '}
             <MutedTime date={new Date('2022-08-02T14:10:00Z')} />
-            <NoteComment>This dependency is only used in our test tooling, so the risk is acceptable.</NoteComment>
+            <EventSubRow icon={NoteIcon}>
+              This dependency is only used in our test tooling, so the risk is acceptable.
+            </EventSubRow>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -325,7 +305,7 @@ export const EventDismissed = () => (
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'dismissed this as fix started '}
             <MutedTime date={new Date('2022-08-02T14:10:00Z')} />
           </Timeline.Body>
@@ -341,7 +321,7 @@ export const EventDismissed = () => (
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'dismissed this as no bandwidth to fix this '}
             <MutedTime date={new Date('2022-08-02T14:10:00Z')} />
           </Timeline.Body>
@@ -357,7 +337,7 @@ export const EventDismissed = () => (
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'dismissed this as vulnerable code is not actually used '}
             <MutedTime date={new Date('2022-08-02T14:10:00Z')} />
           </Timeline.Body>
@@ -373,7 +353,7 @@ export const EventDismissed = () => (
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'dismissed this as inaccurate '}
             <MutedTime date={new Date('2022-08-02T14:10:00Z')} />
           </Timeline.Body>
@@ -392,13 +372,13 @@ export const EventDismissed = () => (
             <DependabotActor />
             {'dismissed this due to an alert rule '}
             <MutedTime date={new Date('2022-08-03T08:00:00Z')} />
-            <NoteComment>
+            <EventSubRow icon={NoteIcon}>
               {'Rule created and '}
               <Link href="#" inline>
                 low-severity-dev-deps
               </Link>
               {' was applied'}
-            </NoteComment>
+            </EventSubRow>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -457,7 +437,7 @@ export const EventReopened = () => (
             <Octicon icon={SyncIcon} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'reopened this '}
             <MutedTime date={new Date('2022-08-04T10:15:00Z')} />
           </Timeline.Body>
@@ -524,12 +504,12 @@ export const EventReopened = () => (
             <DependabotActor />
             {'reopened this '}
             <MutedTime date={new Date('2022-08-06T09:45:00Z')} />
-            <NoteComment>
+            <EventSubRow icon={NoteIcon}>
               {'Rule disabled: '}
               <Link href="#" inline>
                 low-severity-dev-deps
               </Link>
-            </NoteComment>
+            </EventSubRow>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -558,7 +538,7 @@ export const EventReopened = () => (
  * `bg: :X_emphasis` and so use solid `variant`s). So these four render as a bare
  * `<Timeline.Badge>` (default gray circle) with the icon color set via a
  * `.BadgeIcon*` class — the same structure as the muted Dismissed badge.
- * Optional review/resolution notes render via the shared `NoteComment` sub-row.
+ * Optional review/resolution notes render via the shared `EventSubRow` sub-row.
  */
 export const EventDismissalRequest = () => (
   <Examples>
@@ -576,10 +556,12 @@ export const EventDismissalRequest = () => (
             <Octicon icon={CommentIcon} className={classes.BadgeIconAttention} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'requested to dismiss this as '}
             <strong>Tolerable risk</strong> <MutedTime date={new Date('2022-08-07T13:20:00Z')} />
-            <NoteComment>This dependency is only used in our test tooling, so the risk is acceptable.</NoteComment>
+            <EventSubRow icon={NoteIcon}>
+              This dependency is only used in our test tooling, so the risk is acceptable.
+            </EventSubRow>
           </Timeline.Body>
           <Timeline.Actions>
             <Button variant="primary" size="small">
@@ -598,10 +580,10 @@ export const EventDismissalRequest = () => (
             <Octicon icon={CheckIcon} className={classes.BadgeIconSuccess} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'approved dismissal '}
             <MutedTime date={new Date('2022-08-08T10:05:00Z')} />
-            <NoteComment>Confirmed this dependency is dev-only — approving the dismissal.</NoteComment>
+            <EventSubRow icon={NoteIcon}>Confirmed this dependency is dev-only — approving the dismissal.</EventSubRow>
           </Timeline.Body>
         </Timeline.Item>
       </Timeline>
@@ -615,7 +597,7 @@ export const EventDismissalRequest = () => (
             <Octicon icon={XIcon} className={classes.BadgeIconDanger} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'denied dismissal '}
             <MutedTime date={new Date('2022-08-08T15:40:00Z')} />
           </Timeline.Body>
@@ -633,7 +615,7 @@ export const EventDismissalRequest = () => (
             <Octicon icon={XIcon} className={classes.BadgeIconMuted} />
           </Timeline.Badge>
           <Timeline.Body>
-            <UserActor />
+            <UserActor href="#" muted />
             {'cancelled their dismissal request '}
             <MutedTime date={new Date('2022-08-09T09:00:00Z')} />
           </Timeline.Body>


### PR DESCRIPTION
## Summary

Part of Phase 2 of the Timeline events work (github/primer#6663), and a follow-up to #8071 (merged). It adopts the shared internal story helpers added in #8140 so the Dependabot event stories stop duplicating scaffolding. Storybook-only, no consumer-facing change.

Swaps the Dependabot story's local helpers for the shared ones in `./internal/timelineStoryHelpers`:

- Local `UserActor` (avatar + bold muted link) → shared `<UserActor href="#" muted />`.
- Local `NoteComment` (a `NoteIcon` sub-row) → shared `<EventSubRow icon={NoteIcon}>…</EventSubRow>`.

Kept local on purpose:

- `DependabotActor` — the square-avatar + linked bot + `bot` label shape is Dependabot-specific, so it stays a thin local helper built from the shared primitives.
- `PushPill` — the SHA pill needs its own live-parity check, so it's left exactly as-is for now.

### Changelog

#### New

- None.

#### Changed

- Dependabot Timeline event stories now use the shared `UserActor` and `EventSubRow` helpers instead of local duplicates. `UserActor` is pixel-identical. The note sub-rows have an intentional minor spacing normalization — the shared `EventSubRow` is the new canonical layout (`margin-top: base-size-4`, no left indent) vs. the old local `.NoteComment` (`margin-top: base-size-8` + `padding-left: base-size-4`), a small consistency shift on the 3 note rows, matching how #8074 (Code) flagged the same delta.

#### Removed

- The unused local `UserActor`/`NoteComment` helpers, their `.NoteComment`/`.NoteIcon` CSS, and the unused `MONALISA_AVATAR` constant.

### Rollout strategy

- [x] None; Storybook-only refactor with no runtime/API impact (stories don't ship).

### Testing & Reviewing

Pure refactor, zero consumer-facing change.

- Headless render: all 5 Dependabot stories render in real Chromium; axe-core reports 0 violations.
- Real axe AAT (`Axe.test.ts` against a served `storybook-static`, scoped to Dependabot): 45/45 passed (5 stories × 9 themes), unchanged.
- prettier / eslint / stylelint clean; no new type errors. Grep-swept for dangling refs — none.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Storybook)
- [x] Changes are SSR compatible
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] (GitHub staff only) Integration tests pass at github/github-ui