### PR TITLE
Timeline: add Secret Scanning metadata timeline events

### DIFF
--- a/packages/react/src/Timeline/Timeline.secret-scanning.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.secret-scanning.features.stories.tsx
@@ -6,6 +6,8 @@ import {
   AlertIcon,
   CheckCircleIcon,
   CommentIcon,
+  FileAddedIcon,
+  FileRemovedIcon,
   MarkGithubIcon,
   PersonIcon,
   ShieldCheckIcon,
@@ -38,10 +40,11 @@ import {EventSubRow, MutedTime, RealisticTimeline, UserActor, VariantSection} fr
  * badge colors map directly. The actor is rendered by
  * `components/shared/UserComponent.tsx` (16px circle avatar + bold login); the
  * system actor is `MarkGithubIcon` + bold "GitHub". (No ERB secret-scanning
- * timeline exists — the migration to React is complete.) The exact event list
- * built below is the full set of cases the live `switch` actually renders; the
- * defined-but-never-dispatched `REVOCATION` event type (no `case`) renders
- * nothing and is intentionally NOT built.
+ * timeline exists — the migration to React is complete.) The event list built
+ * below tracks the cases the live `switch` actually renders (including the
+ * `MetadataCreated` / `MetadataRemoved` events added upstream after the original
+ * audit); the defined-but-never-dispatched `REVOCATION` event type (no `case`)
+ * renders nothing and is intentionally NOT built.
  *
  * SCOPE: These are Storybook-only examples by design. They are intentionally
  * NOT wired into components-json / the primer.style docs page (do NOT add this
@@ -515,6 +518,56 @@ export const EventReport = () => (
           <Timeline.Body>
             <UserActor size={16} />
             {'reported this secret '}
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </VariantSection>
+  </RealisticTimeline>
+)
+
+/**
+ * The Metadata event group — added upstream AFTER the original audit.
+ *
+ * Source: `case TimelineEventType.MetadataCreated` / `…MetadataRemoved` in
+ * `AlertTimeline.tsx`. Both cases pass `isGitHubActor`, so the actor is ALWAYS
+ * the GitHub system actor (`MarkGithubIcon` + bold "GitHub"). Both use the
+ * default (gray) badge (no `variant`); icon + copy differ:
+ * - Created -> `FileAddedIcon`, "found extended metadata about this secret"
+ * - Removed -> `FileRemovedIcon`, "removed extended metadata after it expired"
+ *
+ * These two events did not exist when the original Phase 2 audit was taken; they
+ * were added to the live `switch` later, so they are built here to keep the
+ * story set in sync with `AlertTimeline.tsx`.
+ */
+export const EventMetadata = () => (
+  <RealisticTimeline>
+    {/* Metadata created — GitHub system actor, FileAddedIcon, default (gray) badge */}
+    <VariantSection label="Extended metadata found">
+      <Timeline aria-label="Secret scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={FileAddedIcon} />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="GitHub" icon={MarkGithubIcon} />
+            {'found extended metadata about this secret '}
+            <MutedTime date={new Date('2022-07-26T11:46:07Z')} />
+          </Timeline.Body>
+        </Timeline.Item>
+      </Timeline>
+    </VariantSection>
+
+    {/* Metadata removed — GitHub system actor, FileRemovedIcon, default (gray) badge */}
+    <VariantSection label="Extended metadata removed">
+      <Timeline aria-label="Secret scanning alert timeline">
+        <Timeline.Item>
+          <Timeline.Badge>
+            <Octicon icon={FileRemovedIcon} />
+          </Timeline.Badge>
+          <Timeline.Body>
+            <UserActor login="GitHub" icon={MarkGithubIcon} />
+            {'removed extended metadata after it expired '}
             <MutedTime date={new Date('2022-07-26T11:46:07Z')} />
           </Timeline.Body>
         </Timeline.Item>


### PR DESCRIPTION
This adds the two Secret Scanning alert timeline events that landed upstream after the original Phase 2 audit (github/primer#6663): `MetadataCreated` and `MetadataRemoved`. Both were missing from our merged Secret Scanning story file because they did not yet exist in the live `switch` when the audit was taken.

The change adds one new exported Storybook story, `EventMetadata`, to `Timeline.secret-scanning.features.stories.tsx`. It contains two `VariantSection`s that recreate the live events using the shared story helpers already in the file:

- **Extended metadata found** (`MetadataCreated`): `FileAddedIcon` on the default (gray) badge, GitHub system actor, copy "found extended metadata about this secret".
- **Extended metadata removed** (`MetadataRemoved`): `FileRemovedIcon` on the default (gray) badge, GitHub system actor, copy "removed extended metadata after it expired".

Both events pass `isGitHubActor` in the live code, so the actor renders as the GitHub system actor (`MarkGithubIcon` + bold "GitHub", no avatar), matching the existing `EventCreated` story. The file header comment is updated so it no longer claims the built set is the full set of live cases.

### Source of truth

`github/github-ui`, package `packages/secret-scanning-alerts/`. The dispatch lives in `components/show/AlertTimeline.tsx` (`switch (event.type)`), verified against `origin/main`:

- `case TimelineEventType.MetadataCreated` renders `<FileAddedIcon />` + "found extended metadata about this secret" with `isGitHubActor`.
- `case TimelineEventType.MetadataRemoved` renders `<FileRemovedIcon />` + "removed extended metadata after it expired" with `isGitHubActor`.

The enum in `types/alert-types.ts` defines `MetadataCreated: 'METADATA_CREATED'` and `MetadataRemoved: 'METADATA_REMOVED'`.

### Changelog

#### New

- `EventMetadata` Storybook story under `Components/Timeline/Events/Secret Scanning`, covering the `MetadataCreated` and `MetadataRemoved` events.

#### Changed

- Updated the Secret Scanning story file header comment so it stays accurate now that the metadata events are included.

#### Removed

- N/A

### Rollout strategy

- [x] None; this is a Storybook-only change. It adds example stories and does not touch any published component code, so it has no consumer-facing impact.

### Testing & Reviewing

This is Storybook-only by design. It is intentionally NOT wired into `Timeline.docs.json` or `build.ts`, and it deliberately omits `data-*` filtering attributes (deferred to Phase 3).

- prettier, eslint, and type-check pass with zero new errors. Stylelint is not applicable (this file has no CSS module).
- Rendered the new `EventMetadata` story headlessly in Chromium. Both rows render with the GitHub system actor (`MarkGithubIcon` + bold "GitHub", no avatar) and the correct file icons (`octicon-file-added` / `octicon-file-removed`), with zero component or React console errors.

To review: open Storybook and navigate to `Components/Timeline/Events/Secret Scanning` -> `EventMetadata`.
