### PR TITLE
ci: annotate React Compiler lint failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Check className test coverage
         run: npm run test:classname-coverage
       - name: Check react compiler coverage
-        run: npx turbo run lint:react-compiler
+        run: npx turbo run lint:react-compiler --log-prefix=none
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,20 @@ jobs:
         run: npx turbo run lint:npm
       - name: Check className test coverage
         run: npm run test:classname-coverage
+      - name: Get changed files
+        id: diff
+        if: github.base_ref != ''
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          {
+            echo 'files<<EOF'
+            git diff --name-only "origin/${{ github.base_ref }}" HEAD
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Check react compiler coverage
         run: npx turbo run lint:react-compiler --log-prefix=none
+        env:
+          CHANGED_FILES: ${{ steps.diff.outputs.files }}
 
   test:
     runs-on: ubuntu-latest

--- a/packages/react/script/lint-react-compiler.ts
+++ b/packages/react/script/lint-react-compiler.ts
@@ -12,19 +12,26 @@ type CompilerFailure = Extract<CheckResult, {ok: false}> & {
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const packageDirectory = path.resolve(dirname, '..')
 const repositoryDirectory = path.resolve(packageDirectory, '../..')
-const migratedFiles = files.filter(isSupported)
-const failures = migratedFiles.map(checkCompilerFile).filter((result): result is CompilerFailure => !result.ok)
+const allResults = files.map(checkCompilerFile)
+const migratedFailures = allResults.filter(
+  (result): result is CompilerFailure => !result.ok && isSupported(result.filepath),
+)
+const nonMigratedFailures = allResults.filter(
+  (result): result is CompilerFailure => !result.ok && !isSupported(result.filepath),
+)
 
-if (failures.length > 0) {
+if (migratedFailures.length > 0) {
   // eslint-disable-next-line no-console
-  console.error(`React Compiler failed for ${failures.length} migrated file${failures.length === 1 ? '' : 's'}:\n`)
+  console.error(
+    `React Compiler failed for ${migratedFailures.length} migrated file${migratedFailures.length === 1 ? '' : 's'}:\n`,
+  )
 
-  for (const failure of failures) {
+  for (const failure of migratedFailures) {
     const relativePath = path.relative(packageDirectory, failure.filepath)
 
     for (const error of failure.errors) {
       if (process.env.GITHUB_ACTIONS === 'true') {
-        writeGitHubError(path.relative(repositoryDirectory, failure.filepath), error)
+        writeGitHubAnnotation('error', path.relative(repositoryDirectory, failure.filepath), error)
       }
 
       const line = getLocationLine(error.location)
@@ -37,15 +44,50 @@ if (failures.length > 0) {
 
   process.exitCode = 1
 } else {
+  const migratedCount = files.filter(isSupported).length
   // eslint-disable-next-line no-console
-  console.log(`React Compiler passed for ${migratedFiles.length} migrated files.`)
+  console.log(`React Compiler passed for ${migratedCount} migrated files.`)
+}
+
+if (nonMigratedFailures.length > 0) {
+  // eslint-disable-next-line no-console
+  console.log(
+    `\nReact Compiler found issues in ${nonMigratedFailures.length} not-yet-migrated file${nonMigratedFailures.length === 1 ? '' : 's'}:\n`,
+  )
+
+  for (const failure of nonMigratedFailures) {
+    const relativePath = path.relative(packageDirectory, failure.filepath)
+
+    for (const error of failure.errors) {
+      if (process.env.GITHUB_ACTIONS === 'true') {
+        writeGitHubAnnotation(
+          'notice',
+          path.relative(repositoryDirectory, failure.filepath),
+          error,
+          getMigrationSuggestion(relativePath),
+        )
+      }
+
+      const line = getLocationLine(error.location)
+      const location = line === undefined ? relativePath : `${relativePath}:${line}`
+
+      // eslint-disable-next-line no-console
+      console.log(`- ${location} ${formatReason(error.reason)}`)
+      // eslint-disable-next-line no-console
+      console.log(`  Suggestion: ${getMigrationSuggestion(relativePath)}`)
+    }
+  }
+}
+
+function getMigrationSuggestion(relativePath: string): string {
+  return `To migrate ${relativePath} to React Compiler, remove it from the exclusion list in script/react-compiler.mjs and fix the compiler errors above.`
 }
 
 function formatReason(reason: string): string {
   return reason.replaceAll('\n', ' ')
 }
 
-function writeGitHubError(filepath: string, error: CheckError): void {
+function writeGitHubAnnotation(level: 'error' | 'notice', filepath: string, error: CheckError, message?: string): void {
   const properties = [`file=${escapeWorkflowProperty(filepath)}`, 'title=React Compiler']
   const line = getLocationLine(error.location)
   const column = getLocationColumn(error.location)
@@ -58,8 +100,10 @@ function writeGitHubError(filepath: string, error: CheckError): void {
     properties.push(`col=${column}`)
   }
 
+  const detail = message ? `${error.reason}\n${message}` : error.reason
+
   // eslint-disable-next-line no-console
-  console.log(`::error ${properties.join(',')}::${escapeWorkflowCommand(error.reason)}`)
+  console.log(`::${level} ${properties.join(',')}::${escapeWorkflowCommand(detail)}`)
 }
 
 function escapeWorkflowCommand(value: string): string {
@@ -87,8 +131,17 @@ function getLocationColumn(location: CheckError['location']): number | undefined
 }
 
 function checkCompilerFile(filepath: string): CheckResult & {filepath: string} {
-  return {
-    filepath,
-    ...checkFile(filepath, fs.readFileSync(filepath, 'utf8')),
+  try {
+    return {
+      filepath,
+      ...checkFile(filepath, fs.readFileSync(filepath, 'utf8')),
+    }
+  } catch (error: unknown) {
+    const reason = error instanceof Error ? error.message : String(error)
+    return {
+      filepath,
+      ok: false,
+      errors: [{location: null, reason}],
+    }
   }
 }

--- a/packages/react/script/lint-react-compiler.ts
+++ b/packages/react/script/lint-react-compiler.ts
@@ -12,70 +12,114 @@ type CompilerFailure = Extract<CheckResult, {ok: false}> & {
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const packageDirectory = path.resolve(dirname, '..')
 const repositoryDirectory = path.resolve(packageDirectory, '../..')
-const allResults = files.map(checkCompilerFile)
-const migratedFailures = allResults.filter(
-  (result): result is CompilerFailure => !result.ok && isSupported(result.filepath),
-)
-const nonMigratedFailures = allResults.filter(
-  (result): result is CompilerFailure => !result.ok && !isSupported(result.filepath),
-)
 
-if (migratedFailures.length > 0) {
-  // eslint-disable-next-line no-console
-  console.error(
-    `React Compiler failed for ${migratedFailures.length} migrated file${migratedFailures.length === 1 ? '' : 's'}:\n`,
-  )
+// When CHANGED_FILES is set (CI PR mode), only check the files changed in the PR.
+// Otherwise fall back to checking all migrated files.
+const changedFilesEnv = process.env.CHANGED_FILES
+const changedFilePaths = changedFilesEnv ? changedFilesEnv.split('\n').filter(Boolean) : null
 
-  for (const failure of migratedFailures) {
-    const relativePath = path.relative(packageDirectory, failure.filepath)
+if (changedFilePaths !== null) {
+  const filesSet = new Set(files)
+  const relevantFiles = changedFilePaths
+    .map(changedFile => path.resolve(repositoryDirectory, changedFile))
+    .filter(changedFile => filesSet.has(changedFile))
 
-    for (const error of failure.errors) {
-      if (process.env.GITHUB_ACTIONS === 'true') {
-        writeGitHubAnnotation('error', path.relative(repositoryDirectory, failure.filepath), error)
+  if (relevantFiles.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log('No changed files overlap with @primer/react package. Skipping React Compiler check.')
+  } else {
+    const results = relevantFiles.map(checkCompilerFile)
+    const migratedFailures = results.filter(
+      (result): result is CompilerFailure => !result.ok && isSupported(result.filepath),
+    )
+    const nonMigratedFailures = results.filter(
+      (result): result is CompilerFailure => !result.ok && !isSupported(result.filepath),
+    )
+
+    if (migratedFailures.length > 0) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `React Compiler failed for ${migratedFailures.length} migrated file${migratedFailures.length === 1 ? '' : 's'}:\n`,
+      )
+
+      for (const failure of migratedFailures) {
+        const relativePath = path.relative(packageDirectory, failure.filepath)
+
+        for (const error of failure.errors) {
+          if (process.env.GITHUB_ACTIONS === 'true') {
+            writeGitHubAnnotation('error', path.relative(repositoryDirectory, failure.filepath), error)
+          }
+
+          const line = getLocationLine(error.location)
+          const location = line === undefined ? relativePath : `${relativePath}:${line}`
+
+          // eslint-disable-next-line no-console
+          console.error(`- ${location} ${formatReason(error.reason)}`)
+        }
       }
 
-      const line = getLocationLine(error.location)
-      const location = line === undefined ? relativePath : `${relativePath}:${line}`
+      process.exitCode = 1
+    }
 
+    if (nonMigratedFailures.length > 0) {
       // eslint-disable-next-line no-console
-      console.error(`- ${location} ${formatReason(error.reason)}`)
+      console.log(
+        `\nReact Compiler found issues in ${nonMigratedFailures.length} not-yet-migrated file${nonMigratedFailures.length === 1 ? '' : 's'}:\n`,
+      )
+
+      for (const failure of nonMigratedFailures) {
+        const relativePath = path.relative(packageDirectory, failure.filepath)
+
+        for (const error of failure.errors) {
+          if (process.env.GITHUB_ACTIONS === 'true') {
+            writeGitHubAnnotation(
+              'notice',
+              path.relative(repositoryDirectory, failure.filepath),
+              error,
+              getMigrationSuggestion(relativePath),
+            )
+          }
+
+          const line = getLocationLine(error.location)
+          const location = line === undefined ? relativePath : `${relativePath}:${line}`
+
+          // eslint-disable-next-line no-console
+          console.log(`- ${location} ${formatReason(error.reason)}`)
+          // eslint-disable-next-line no-console
+          console.log(`  Suggestion: ${getMigrationSuggestion(relativePath)}`)
+        }
+      }
     }
   }
-
-  process.exitCode = 1
 } else {
-  const migratedCount = files.filter(isSupported).length
-  // eslint-disable-next-line no-console
-  console.log(`React Compiler passed for ${migratedCount} migrated files.`)
-}
+  // Fallback: check all migrated files for compiler errors
+  const migratedFiles = files.filter(isSupported)
+  const failures = migratedFiles.map(checkCompilerFile).filter((result): result is CompilerFailure => !result.ok)
 
-if (nonMigratedFailures.length > 0) {
-  // eslint-disable-next-line no-console
-  console.log(
-    `\nReact Compiler found issues in ${nonMigratedFailures.length} not-yet-migrated file${nonMigratedFailures.length === 1 ? '' : 's'}:\n`,
-  )
+  if (failures.length > 0) {
+    // eslint-disable-next-line no-console
+    console.error(`React Compiler failed for ${failures.length} migrated file${failures.length === 1 ? '' : 's'}:\n`)
 
-  for (const failure of nonMigratedFailures) {
-    const relativePath = path.relative(packageDirectory, failure.filepath)
+    for (const failure of failures) {
+      const relativePath = path.relative(packageDirectory, failure.filepath)
 
-    for (const error of failure.errors) {
-      if (process.env.GITHUB_ACTIONS === 'true') {
-        writeGitHubAnnotation(
-          'notice',
-          path.relative(repositoryDirectory, failure.filepath),
-          error,
-          getMigrationSuggestion(relativePath),
-        )
+      for (const error of failure.errors) {
+        if (process.env.GITHUB_ACTIONS === 'true') {
+          writeGitHubAnnotation('error', path.relative(repositoryDirectory, failure.filepath), error)
+        }
+
+        const line = getLocationLine(error.location)
+        const location = line === undefined ? relativePath : `${relativePath}:${line}`
+
+        // eslint-disable-next-line no-console
+        console.error(`- ${location} ${formatReason(error.reason)}`)
       }
-
-      const line = getLocationLine(error.location)
-      const location = line === undefined ? relativePath : `${relativePath}:${line}`
-
-      // eslint-disable-next-line no-console
-      console.log(`- ${location} ${formatReason(error.reason)}`)
-      // eslint-disable-next-line no-console
-      console.log(`  Suggestion: ${getMigrationSuggestion(relativePath)}`)
     }
+
+    process.exitCode = 1
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(`React Compiler passed for ${migratedFiles.length} migrated files.`)
   }
 }
 

--- a/packages/react/script/lint-react-compiler.ts
+++ b/packages/react/script/lint-react-compiler.ts
@@ -11,6 +11,7 @@ type CompilerFailure = Extract<CheckResult, {ok: false}> & {
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const packageDirectory = path.resolve(dirname, '..')
+const repositoryDirectory = path.resolve(packageDirectory, '../..')
 const migratedFiles = files.filter(isSupported)
 const failures = migratedFiles.map(checkCompilerFile).filter((result): result is CompilerFailure => !result.ok)
 
@@ -22,6 +23,10 @@ if (failures.length > 0) {
     const relativePath = path.relative(packageDirectory, failure.filepath)
 
     for (const error of failure.errors) {
+      if (process.env.GITHUB_ACTIONS === 'true') {
+        writeGitHubError(path.relative(repositoryDirectory, failure.filepath), error)
+      }
+
       const line = getLocationLine(error.location)
       const location = line === undefined ? relativePath : `${relativePath}:${line}`
 
@@ -40,12 +45,45 @@ function formatReason(reason: string): string {
   return reason.replaceAll('\n', ' ')
 }
 
+function writeGitHubError(filepath: string, error: CheckError): void {
+  const properties = [`file=${escapeWorkflowProperty(filepath)}`, 'title=React Compiler']
+  const line = getLocationLine(error.location)
+  const column = getLocationColumn(error.location)
+
+  if (line !== undefined) {
+    properties.push(`line=${line}`)
+  }
+
+  if (column !== undefined) {
+    properties.push(`col=${column}`)
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`::error ${properties.join(',')}::${escapeWorkflowCommand(error.reason)}`)
+}
+
+function escapeWorkflowCommand(value: string): string {
+  return value.replaceAll('%', '%25').replaceAll('\r', '%0D').replaceAll('\n', '%0A')
+}
+
+function escapeWorkflowProperty(value: string): string {
+  return escapeWorkflowCommand(value).replaceAll(':', '%3A').replaceAll(',', '%2C')
+}
+
 function getLocationLine(location: CheckError['location']): number | undefined {
   if (location === null || typeof location !== 'object' || !('start' in location)) {
     return undefined
   }
 
   return location.start.line
+}
+
+function getLocationColumn(location: CheckError['location']): number | undefined {
+  if (location === null || typeof location !== 'object' || !('start' in location)) {
+    return undefined
+  }
+
+  return location.start.column + 1
 }
 
 function checkCompilerFile(filepath: string): CheckResult & {filepath: string} {

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,8 @@
     },
     "lint:react-compiler": {
       "dependsOn": [],
-      "outputs": []
+      "outputs": [],
+      "env": ["CHANGED_FILES"]
     },
     "type-check": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
This PR updates our React Compiler lint task so failures create file annotations in GitHub Actions.

### Changelog

#### New

- Add GitHub Actions error annotations with the file, line, column, and compiler failure.

#### Changed

- Update the React Compiler CI task to remove Turbo log prefixes so GitHub can recognize workflow commands.

#### Removed

- None.

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; this is a change to our internal CI workflow and has no public-facing impact.

### Testing & Reviewing

Reviewers can verify that:

- A React Compiler failure creates an annotation on the affected source file.
- The existing readable failure summary is still included in the job log.
- The lint task continues to pass without annotations when all migrated files compile.
