### PR TITLE
Fix UnderlineNav tab list width in Safari

### DIFF
--- a/.changeset/underline-item-list-flex-grow.md
+++ b/.changeset/underline-item-list-flex-grow.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Fix `UnderlineNav` tab list not filling the full width of the underline nav in Safari

--- a/packages/react/src/internal/components/UnderlineTabbedInterface.module.css
+++ b/packages/react/src/internal/components/UnderlineTabbedInterface.module.css
@@ -24,6 +24,7 @@
     max-height: var(--control-xlarge-size);
 
     .UnderlineItemList {
+      flex-grow: 1;
       flex-wrap: wrap;
       overflow: hidden;
     }


### PR DESCRIPTION
<img width="2684" height="1022" alt="image" src="https://github.com/user-attachments/assets/2e771e32-8973-4a1d-9f15-f43532de9911" />

In Safari the `UnderlineNav` tab list wasn't stretching to fill the underline nav. The list is a flex child of the wrapper but didn't grow, so it collapsed to its content width. Adding `flex-grow: 1` to `.UnderlineItemList` makes it fill the wrapper.

I scoped it to the `data-overflow-mode='wrap'` variant so it only applies to `UnderlineNav`. The base rule is shared with `UnderlinePanels`, which measures the list's natural width (via `ResizeObserver` `contentRect.width`) to decide whether tab icons fit. Growing that measured element would throw off the icons-visible calc, so keeping `flex-grow` off the base rule leaves `UnderlinePanels` untouched.

### Changelog

#### New

<!-- List of things added in this PR -->

#### Changed

- `UnderlineNav`'s tab list now uses `flex-grow: 1` (scoped to the wrap variant) so it fills the underline nav width in Safari

#### Removed

<!-- List of things removed in this PR -->

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Scoped to `UnderlineNav` (always `data-overflow-mode='wrap'`), so `UnderlinePanels` is deliberately unaffected. I confirmed `UnderlinePanels` is the only consumer with the icon-visibility measurement, and per primer-query the only product surface using icon tabs is `github/github-ui`'s Org Security Campaigns page, which this no longer touches. Worth a quick VRT pass on `UnderlineNav` to confirm no snapshot shifts.
