### PR TITLE
Pin UnderlineNav wrap-mode vertical box model

### DIFF
--- a/.changeset/underline-wrapper-force-no-border.md
+++ b/.changeset/underline-wrapper-force-no-border.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Pin the underline tabbed interface wrapper's vertical box model in wrap mode so external border and padding overrides can no longer offset its height and incorrectly trigger the overflow "more" menu

--- a/packages/react/src/internal/components/UnderlineTabbedInterface.module.css
+++ b/packages/react/src/internal/components/UnderlineTabbedInterface.module.css
@@ -25,7 +25,7 @@
 
     /* Pin the vertical box model so external border/padding overrides can't change the height budget and incorrectly trigger the overflow "more" menu */
     box-sizing: border-box;
-    border: 0 !important;
+    border-block: 0 !important;
     padding-block: var(--base-size-8) 0 !important;
 
     .UnderlineItemList {

--- a/packages/react/src/internal/components/UnderlineTabbedInterface.module.css
+++ b/packages/react/src/internal/components/UnderlineTabbedInterface.module.css
@@ -23,6 +23,11 @@
     overflow: hidden;
     max-height: var(--control-xlarge-size);
 
+    /* Pin the vertical box model so external border/padding overrides can't change the height budget and incorrectly trigger the overflow "more" menu */
+    box-sizing: border-box;
+    border: 0 !important;
+    padding-block: var(--base-size-8) 0 !important;
+
     .UnderlineItemList {
       flex-grow: 1;
       flex-wrap: wrap;


### PR DESCRIPTION
Someone added a border to `UnderlineWrapper` downstream and it started incorrectly showing the overflow "more" menu. The wrap-mode overflow detection uses an `IntersectionObserver` rooted on the wrapper with a fixed `max-height`, so any external `border`/`padding` that changes the wrapper's height eats into the row budget and pushes first-row items partially out of the clip rect, which reads as an overflow.

This pins the vertical box model in wrap mode (`box-sizing`, `border: 0`, and `padding-block`) so consumer overrides can't offset the height budget. It only touches the vertical axis — `padding-inline` and the `flush` variant's horizontal spacing are untouched.

### Changelog

#### New

#### Changed

- Pin the vertical box model on the underline tabbed interface wrapper in wrap
  mode so external `border`/`padding` overrides can no longer trigger the
  overflow "more" menu

#### Removed

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Verify `UnderlineNav` overflow still behaves correctly, and that applying a
border or vertical padding to the wrapper no longer forces the "more" menu on.
