### PR TITLE
fix: guard against missing context in useFeatureFlag

### DIFF
--- a/.changeset/guard-missing-feature-flag-context.md
+++ b/.changeset/guard-missing-feature-flag-context.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+FeatureFlags: Guard against missing context in `useFeatureFlag` so it returns `false` instead of throwing when used outside a provider

--- a/packages/react/src/FeatureFlags/useFeatureFlag.ts
+++ b/packages/react/src/FeatureFlags/useFeatureFlag.ts
@@ -6,5 +6,5 @@ import {FeatureFlagContext} from './FeatureFlagContext'
  */
 export function useFeatureFlag(flag: string): boolean {
   const context = useContext(FeatureFlagContext)
-  return context.enabled(flag)
+  return context?.enabled(flag) ?? false
 }

--- a/packages/react/src/FeatureFlags/useFeatureFlag.ts
+++ b/packages/react/src/FeatureFlags/useFeatureFlag.ts
@@ -6,5 +6,6 @@ import {FeatureFlagContext} from './FeatureFlagContext'
  */
 export function useFeatureFlag(flag: string): boolean {
   const context = useContext(FeatureFlagContext)
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return context?.enabled(flag) ?? false
 }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Relates to https://github.com/primer/react/issues/8114

This pull request makes a small improvement to the `useFeatureFlag` hook to make it more robust against missing context. Now, if the `FeatureFlagContext` is not available, the hook will safely return `false` instead of throwing an error.

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->
- Guard against missing context in `useFeatureFlag`


### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To publish a canary release for integration testing, apply the "Canary Release" label to this PR -->

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
