### PR TITLE
Link: sync docs.json with component API

### DIFF
--- a/packages/react/src/Link/Link.docs.json
+++ b/packages/react/src/Link/Link.docs.json
@@ -35,17 +35,11 @@
       "description": "Set to true for links adjacent to text, underlining them for clear visibility and improved accessibility."
     },
     {
-      "name": "underline",
-      "type": "boolean",
-      "defaultValue": "false",
-      "description": "Use `inline` instead.",
-      "deprecated": true
-    },
-    {
       "name": "hoverColor",
       "type": "string",
       "defaultValue": "",
-      "description": "Color used when hovering over the link."
+      "description": "Use CSS modules to style hover color.",
+      "deprecated": true
     },
     {
       "name": "ref",


### PR DESCRIPTION
`Link.docs.json` still mentions `underline` prop which was [removed from the component](https://github.com/primer/react/pull/7021) in v38. It also does not have a deprecated key for `hoverColor`. Fixed both.

### Rollout strategy

- [x] None; documentation metadata only, no runtime or published API change.
