### PR TITLE
CounterLabel, StateLabel: sync docs.json with deprecated props

### DIFF
--- a/packages/react/src/CounterLabel/CounterLabel.docs.json
+++ b/packages/react/src/CounterLabel/CounterLabel.docs.json
@@ -17,10 +17,17 @@
   "importPath": "@primer/react",
   "props": [
     {
+      "name": "variant",
+      "type": "'primary' | 'secondary'",
+      "defaultValue": "",
+      "description": "Pass in 'primary' for a darker background and inverse text, or 'secondary' for a lighter background and primary text. Omitting the variant prop renders the default counter scheme"
+    },
+    {
       "name": "scheme",
       "type": "'primary' | 'secondary'",
       "defaultValue": "",
-      "description": "Pass in 'primary' for a darker background and inverse text, or 'secondary' for a lighter background and primary text. Omitting the scheme prop renders the default counter scheme"
+      "description": "Use `variant` instead.",
+      "deprecated": true
     },
     {
       "name": "className",

--- a/packages/react/src/StateLabel/StateLabel.docs.json
+++ b/packages/react/src/StateLabel/StateLabel.docs.json
@@ -65,9 +65,16 @@
   "importPath": "@primer/react",
   "props": [
     {
+      "name": "size",
+      "type": "'small' | 'medium'",
+      "defaultValue": "'medium'"
+    },
+    {
       "name": "variant",
       "type": "'small' | 'normal'",
-      "defaultValue": "'normal'"
+      "defaultValue": "'normal'",
+      "description": "Use `size` instead.",
+      "deprecated": true
     },
     {
       "name": "status",


### PR DESCRIPTION
docs.json for `CounterLabel` and `StateLabel` did not reflect deprecations that already exist in the source.

Marked `CounterLabel.scheme` and `StateLabel.variant` as deprecated for the docs.

### Rollout strategy

- [x] None; documentation metadata only

