### PR TITLE
Use `base-size-32` instead of hardcoded `32px` for item height

### DIFF
--- a/.changeset/heavy-brooms-wash.md
+++ b/.changeset/heavy-brooms-wash.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Fix `UnderlineNav` items all being considered overflowing on Safari with text size overrides

--- a/packages/react/src/internal/components/OverflowObserverProvider.tsx
+++ b/packages/react/src/internal/components/OverflowObserverProvider.tsx
@@ -49,7 +49,7 @@ export function OverflowObserverProvider({
           for (const cb of callbacks) cb(isOverflowing)
         }
       },
-      {root, threshold: [0, 1]},
+      {root, threshold: [0, 0.95]},
     )
     observerRootRef.current = root
     return observerRef.current
@@ -112,12 +112,12 @@ export function OverflowObserverProvider({
 }
 
 /**
- * Treat any target that is not fully visible within the observer root as overflowing. Wrapped items should be fully
- * clipped (`isIntersecting: false`, `intersectionRatio: 0`), but partial ratios also count as overflowing to guard
- * against sub-pixel boundary cases.
+ * Treat any target that is not fully visible within the observer root as overflowing. Unwrapped items should be fully
+ * visible, but in some scenarios the layout isn't perfectly accurate (ie, in Safari with extra-large text size) so we
+ * allow for up to 5% to be clipped before hiding the item.
  */
 function getIsOverflowing(entry: Pick<IntersectionObserverEntry, 'intersectionRatio' | 'isIntersecting'>) {
-  return !entry.isIntersecting || entry.intersectionRatio < 1
+  return !entry.isIntersecting || entry.intersectionRatio < 0.95
 }
 
 function supportsIntersectionObserver() {

--- a/packages/react/src/internal/components/UnderlineTabbedInterface.module.css
+++ b/packages/react/src/internal/components/UnderlineTabbedInterface.module.css
@@ -68,7 +68,7 @@
   border-radius: var(--borderRadius-medium);
   max-width: 100%;
   margin-bottom: var(--base-size-8);
-  height: 32px;
+  height: var(--base-size-32);
 
   /* button resets */
   appearance: none;


### PR DESCRIPTION
The underline nav item height is hardcoded at 32px. This means that when the font size changes (ie, "Make text smaller" in Safari), the item height doesn't respect the new font size. But the container does, because it has `max-height: var(--control-xlarge-size)` which is font-size dynamic. This causes the container to clip all the items by having a smaller height than they can fit in, which treats them all as overflowing.

The fix is simple, we can just use `--base-size-32` instead. 

**However**, this still doesn't work perfectly. On sufficiently large font sizes (+3 zoom levels), the pixel-perfect accuracy of the sizes just isn't calculated quite right, and so the items still overflow even though they seem fully visible. I think this is a safari issue and there's not much we can do about it except to make the overflow logic slightly more forgiving, allowing up to 5% of an item to be clipped before hiding it. 

### Changelog

#### Changed

- Fixes `UnderlineNav` items all being considered overflowing on Safari with font size overrides

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To publish a canary release for integration testing, apply the "Canary Release" label to this PR -->

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
