### PR TITLE
Announce `SegmentedControl` selected state with `aria-pressed`

### DIFF
--- a/.changeset/segmented-control-aria-pressed.md
+++ b/.changeset/segmented-control-aria-pressed.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Use `aria-pressed` instead of `aria-current` on `SegmentedControl.Button` and `SegmentedControl.IconButton` so JAWS announces the selected state when a segment is activated.

--- a/packages/react/src/SegmentedControl/SegmentedControl.module.css
+++ b/packages/react/src/SegmentedControl/SegmentedControl.module.css
@@ -256,7 +256,7 @@
     width: 0;
   }
 
-  &[aria-disabled='true']:not([aria-current='true']) {
+  &[aria-disabled='true']:not([aria-pressed='true']) {
     cursor: not-allowed;
     color: var(--fgColor-disabled);
     background-color: transparent;
@@ -305,7 +305,7 @@
   justify-content: center;
 }
 
-.Button[aria-current='true'] {
+.Button[aria-pressed='true'] {
   padding: 0;
   font-weight: var(--base-text-weight-semibold);
 
@@ -321,7 +321,7 @@
   }
 }
 
-.Button:not([aria-current='true'], [aria-disabled='true']) {
+.Button:not([aria-pressed='true'], [aria-disabled='true']) {
   &:hover .Content {
     background-color: var(--controlTrack-bgColor-hover);
   }

--- a/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
@@ -85,7 +85,7 @@ describe('SegmentedControl', () => {
 
     const selectedButton = getByText('Raw').closest('button')
 
-    expect(selectedButton?.getAttribute('aria-current')).toBe('true')
+    expect(selectedButton?.getAttribute('aria-pressed')).toBe('true')
   })
 
   it('renders with a selected segment - uncontrolled', () => {
@@ -101,7 +101,7 @@ describe('SegmentedControl', () => {
 
     const selectedButton = getByText('Raw').closest('button')
 
-    expect(selectedButton?.getAttribute('aria-current')).toBe('true')
+    expect(selectedButton?.getAttribute('aria-pressed')).toBe('true')
   })
 
   it('renders the dropdown variant', () => {
@@ -148,7 +148,7 @@ describe('SegmentedControl', () => {
 
     const selectedButton = getByText('Preview').closest('button')
 
-    expect(selectedButton?.getAttribute('aria-current')).toBe('true')
+    expect(selectedButton?.getAttribute('aria-pressed')).toBe('true')
   })
 
   it('renders segments with segment labels that have leading icons', () => {
@@ -252,11 +252,11 @@ describe('SegmentedControl', () => {
 
     const buttonToClick = getByText('Raw').closest('button')
 
-    expect(buttonToClick?.getAttribute('aria-current')).toBe('false')
+    expect(buttonToClick?.getAttribute('aria-pressed')).toBe('false')
     if (buttonToClick) {
       await user.click(buttonToClick)
     }
-    expect(buttonToClick?.getAttribute('aria-current')).toBe('true')
+    expect(buttonToClick?.getAttribute('aria-pressed')).toBe('true')
   })
 
   it('calls segment button onClick if it is passed', async () => {

--- a/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControl.test.tsx
@@ -183,6 +183,19 @@ describe('SegmentedControl', () => {
     }
   })
 
+  it('renders IconButton with aria-pressed when selected', () => {
+    const {getByRole} = render(
+      <SegmentedControl aria-label="File view">
+        {segmentData.map(({label, icon}, index) => (
+          <SegmentedControl.IconButton icon={icon} aria-label={label} selected={index === 1} key={label} />
+        ))}
+      </SegmentedControl>,
+    )
+
+    expect(getByRole('button', {name: 'Raw'})).toHaveAttribute('aria-pressed', 'true')
+    expect(getByRole('button', {name: 'Preview'})).toHaveAttribute('aria-pressed', 'false')
+  })
+
   it('renders icon button with tooltip as label', () => {
     const {getByRole, getByText} = render(
       <SegmentedControl aria-label="File view">

--- a/packages/react/src/SegmentedControl/SegmentedControlButton.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControlButton.tsx
@@ -50,7 +50,7 @@ const SegmentedControlButton: FCWithSlotMarker<React.PropsWithChildren<Segmented
       data-component="SegmentedControl.Button"
     >
       <button
-        aria-current={selected}
+        aria-pressed={selected}
         aria-disabled={disabled || ariaDisabled || undefined}
         className={clsx(classes.Button, className)}
         type="button"

--- a/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
+++ b/packages/react/src/SegmentedControl/SegmentedControlIconButton.tsx
@@ -50,7 +50,7 @@ export const SegmentedControlIconButton: FCWithSlotMarker<React.PropsWithChildre
       >
         <button
           type="button"
-          aria-current={selected}
+          aria-pressed={selected}
           // If description is provided, we will use the tooltip to describe the button, so we need to keep the aria-label to label the button.
           aria-label={description ? ariaLabel : undefined}
           aria-disabled={disabled || ariaDisabled || undefined}


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

related issue [github/accessibility-audits#16804](https://github.com/github/accessibility-audits/issues/16804).

Note: needs https://github.com/github/github-ui/pull/27315 merged to pass integration tests

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->
 
#### Changed

`SegmentedControl.Button` and `SegmentedControl.IconButton` used `aria-current` to signal the selected segment. JAWS doesn't treat `aria-current` as a button state, so activating a segment produced no audible feedback, fails WCAG 4.1.2. Switching to `aria-pressed` (the toggle-button state) fixes the announcement. CSS selectors and tests are updated to match.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [X] Patch release

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To test these changes with github/github-ui, use the [integration workflow](https://github.com/github/github-ui/actions/workflows/primer-npm-packages-integration.yml) -->

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
