### PR TITLE
chore(Link): remove unnecessary `data-hover-color` attribute

### DIFF
--- a/.changeset/remove-link-data-hover-color.md
+++ b/.changeset/remove-link-data-hover-color.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Link: Remove unnecessary `data-hover-color` attribute from rendered DOM element

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -44,7 +44,6 @@ export const UnwrappedLink = <As extends React.ElementType = 'a'>(
       data-component="Link"
       data-muted={muted}
       data-inline={inline}
-      data-hover-color={hoverColor}
       {...restProps}
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ref={mergedRef as any}

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -19,7 +19,7 @@ export const UnwrappedLink = <As extends React.ElementType = 'a'>(
   props: PolymorphicProps<As, 'a', StyledLinkProps>,
   ref: ForwardedRef<unknown>,
 ) => {
-  const {as: Component = 'a', className, inline, muted, hoverColor, ...restProps} = props
+  const {as: Component = 'a', className, inline, muted, hoverColor: _hoverColor, ...restProps} = props
   const innerRef = React.useRef<ElementRef<As>>(null)
   const mergedRef = useMergedRefs(ref, innerRef)
 

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -19,6 +19,7 @@ export const UnwrappedLink = <As extends React.ElementType = 'a'>(
   props: PolymorphicProps<As, 'a', StyledLinkProps>,
   ref: ForwardedRef<unknown>,
 ) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const {as: Component = 'a', className, inline, muted, hoverColor: _hoverColor, ...restProps} = props
   const innerRef = React.useRef<ElementRef<As>>(null)
   const mergedRef = useMergedRefs(ref, innerRef)


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Removing as per https://github.com/primer/react/pull/5319#discussion_r3603026314

Also added request for prop removal in next major here https://github.com/github/primer/issues/5430#issuecomment-5039700246

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Removed

<!-- List of things removed in this PR -->
- unneeded `data-hover-color` attribute in Link

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To test these changes with github/github-ui, use the [integration workflow](https://github.com/github/github-ui/actions/workflows/primer-npm-packages-integration.yml) -->

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
