### PR TITLE
Migrate `UnderlinePanels` to the new `Tabs` component

### DIFF
--- a/.changeset/underlinepanels-tabs-migration.md
+++ b/.changeset/underlinepanels-tabs-migration.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+UnderlinePanels: The experimental `UnderlinePanels` component is now built on the experimental `Tabs` component instead of `@github/tab-container-element`. Its public API and behavior are unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3913,10 +3913,6 @@
       "integrity": "sha512-L/2r0DNR/rMbmHWcsdmhtOiy2gESoGOhItNFD4zJ3nZfHl79Dx3N18Vfx/pYr2lruMOdk1cJZb4wEumm+Dxm1w==",
       "license": "MIT"
     },
-    "node_modules/@github/tab-container-element": {
-      "version": "4.8.2",
-      "license": "MIT"
-    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -28477,7 +28473,6 @@
       "dependencies": {
         "@github/mini-throttle": "^2.1.1",
         "@github/relative-time-element": "^5.0.0",
-        "@github/tab-container-element": "^4.8.2",
         "@lit-labs/react": "1.2.1",
         "@oddbird/popover-polyfill": "^0.5.2",
         "@primer/behaviors": "^1.10.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -77,7 +77,6 @@
   "dependencies": {
     "@github/mini-throttle": "^2.1.1",
     "@github/relative-time-element": "^5.0.0",
-    "@github/tab-container-element": "^4.8.2",
     "@lit-labs/react": "1.2.1",
     "@oddbird/popover-polyfill": "^0.5.2",
     "@primer/behaviors": "^1.10.3",

--- a/packages/react/src/experimental/Tabs/Tabs.tsx
+++ b/packages/react/src/experimental/Tabs/Tabs.tsx
@@ -16,7 +16,8 @@ import {useTabPanel} from './useTabPanel'
  */
 function Tabs(props: TabsProps) {
   const {children, onValueChange} = props
-  const groupId = useId()
+  const generatedId = useId()
+  const groupId = props.id ?? generatedId
 
   const [selectedValue, setSelectedValue] = useControllableState<string>({
     name: 'tab-selection',

--- a/packages/react/src/experimental/Tabs/types.ts
+++ b/packages/react/src/experimental/Tabs/types.ts
@@ -43,7 +43,15 @@ type UncontrolledTabsProps = {
   onValueChange?: ({value}: {value: string}) => void
 }
 
-export type TabsProps = PropsWithChildren<ControlledTabsProps | UncontrolledTabsProps>
+type CommonTabsProps = {
+  /**
+   * Optional id used as the base for generated tab and panel ids. If omitted, a
+   * unique id is generated automatically.
+   */
+  id?: string
+}
+
+export type TabsProps = PropsWithChildren<(ControlledTabsProps | UncontrolledTabsProps) & CommonTabsProps>
 
 type Label = {
   'aria-label': string

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.dev.stories.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.dev.stories.tsx
@@ -1,6 +1,9 @@
+import {useState} from 'react'
 import type {ComponentProps} from '../../utils/types'
 import type {Meta, StoryFn} from '@storybook/react-vite'
 import UnderlinePanels from './UnderlinePanels'
+import {AnchoredOverlay} from '../../AnchoredOverlay'
+import {Button} from '../../Button'
 
 export default {
   title: 'Experimental/Components/UnderlinePanels/Dev',
@@ -44,4 +47,28 @@ SingleTabPlayground.argTypes = {
       type: 'text',
     },
   },
+}
+
+export const InOverlay = () => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <AnchoredOverlay
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      renderAnchor={props => <Button {...props}>Open panels</Button>}
+      overlayProps={{role: 'dialog', 'aria-modal': true, 'aria-label': 'Select a tab', style: {width: '320px'}}}
+      focusZoneSettings={{disabled: true}}
+    >
+      <UnderlinePanels aria-label="Select a tab">
+        <UnderlinePanels.Tab aria-selected={true}>Tab 1</UnderlinePanels.Tab>
+        <UnderlinePanels.Tab>Tab 2</UnderlinePanels.Tab>
+        <UnderlinePanels.Tab>Tab 3</UnderlinePanels.Tab>
+        <UnderlinePanels.Panel>Panel 1</UnderlinePanels.Panel>
+        <UnderlinePanels.Panel>Panel 2</UnderlinePanels.Panel>
+        <UnderlinePanels.Panel>Panel 3</UnderlinePanels.Panel>
+      </UnderlinePanels>
+    </AnchoredOverlay>
+  )
 }

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.test.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.test.tsx
@@ -1,16 +1,16 @@
-// Most of the functionality is already tested in [@github/tab-container-element](https://github.com/github/tab-container-element)
+// Most of the underlying tab behavior is provided by the experimental `Tabs`
+// component and its hooks (see ../Tabs). These tests cover the UnderlinePanels
+// public API and its integration with Tabs.
 
 import type React from 'react'
 import {act} from 'react'
 import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {describe, it, afterEach, beforeEach, expect, vi} from 'vitest'
 import {CodeIcon, EyeIcon} from '@primer/octicons-react'
 import UnderlinePanels from './UnderlinePanels'
-import TabContainerElement from '@github/tab-container-element'
 import {implementsClassName, withExpectedConsoleError} from '../../utils/testing'
 import classes from './UnderlinePanels.module.css'
-
-TabContainerElement.prototype.selectTab = vi.fn()
 
 const UnderlinePanelsMockComponent = (props: {'aria-label'?: string; 'aria-labelledby'?: string; id?: string}) => (
   <UnderlinePanels {...props}>
@@ -25,10 +25,32 @@ const UnderlinePanelsMockComponent = (props: {'aria-label'?: string; 'aria-label
 
 describe('UnderlinePanels', () => {
   implementsClassName(UnderlinePanels, classes.StyledUnderlineWrapper)
-  implementsClassName(UnderlinePanels.Tab)
-  implementsClassName(UnderlinePanels.Panel)
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  // Tab/Panel require the Tabs context, so they're rendered inside
+  // UnderlinePanels rather than via `implementsClassName` (which renders alone).
+  it('UnderlinePanels.Tab renders with a custom className', () => {
+    const Tab = UnderlinePanels.Tab as React.ElementType
+    render(
+      <UnderlinePanels aria-label="Select a tab">
+        <Tab className="test-class">Tab 1</Tab>
+        <UnderlinePanels.Panel>Panel 1</UnderlinePanels.Panel>
+      </UnderlinePanels>,
+    )
+
+    expect(screen.getByRole('tab', {name: 'Tab 1'})).toHaveClass('test-class')
+  })
+  it('UnderlinePanels.Panel renders with a custom className', () => {
+    render(
+      <UnderlinePanels aria-label="Select a tab">
+        <UnderlinePanels.Tab>Tab 1</UnderlinePanels.Tab>
+        <UnderlinePanels.Panel className="test-class">Panel 1</UnderlinePanels.Panel>
+      </UnderlinePanels>,
+    )
+
+    expect(screen.getByText('Panel 1')).toHaveClass('test-class')
   })
 
   it('renders with a custom ID', () => {
@@ -104,6 +126,27 @@ describe('UnderlinePanels', () => {
     tab.click()
 
     expect(onSelect).toHaveBeenCalled()
+  })
+
+  it('selects the first tab by default and hides the other panels', () => {
+    render(<UnderlinePanelsMockComponent aria-label="Select a tab" />)
+
+    expect(screen.getByRole('tab', {name: 'Tab 1'})).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByText('Panel 1')).toBeVisible()
+    expect(screen.getByText('Panel 2')).not.toBeVisible()
+    expect(screen.getByText('Panel 3')).not.toBeVisible()
+  })
+
+  it('switches the visible panel when a tab is selected (uncontrolled)', async () => {
+    const user = userEvent.setup()
+    render(<UnderlinePanelsMockComponent aria-label="Select a tab" />)
+
+    await user.click(screen.getByRole('tab', {name: 'Tab 2'}))
+
+    expect(screen.getByRole('tab', {name: 'Tab 2'})).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', {name: 'Tab 1'})).toHaveAttribute('aria-selected', 'false')
+    expect(screen.getByText('Panel 2')).toBeVisible()
+    expect(screen.getByText('Panel 1')).not.toBeVisible()
   })
 
   it('throws an error when the number of tabs does not match the number of panels', () => {

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.tsx
@@ -262,9 +262,9 @@ const TabImpl: FC<TabProps & WithValue> = ({onSelect, value, ...itemProps}) => {
   return (
     <UnderlineItem
       as="button"
-      type="button"
       {...itemProps}
       {...restTabProps}
+      type="button"
       onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
         if (!event.defaultPrevented && typeof onSelect === 'function') {
           onSelect(event)

--- a/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.tsx
+++ b/packages/react/src/experimental/UnderlinePanels/UnderlinePanels.tsx
@@ -9,17 +9,9 @@ import React, {
   type FC,
   type PropsWithChildren,
   useMemo,
-  type ElementType,
 } from 'react'
-import {TabContainerElement} from '@github/tab-container-element'
 import type {IconProps} from '@primer/octicons-react'
-import {createComponent} from '../../utils/create-component'
-import {
-  UnderlineItemList,
-  UnderlineWrapper,
-  UnderlineItem,
-  type UnderlineItemProps,
-} from '../../internal/components/UnderlineTabbedInterface'
+import {UnderlineItemList, UnderlineWrapper, UnderlineItem} from '../../internal/components/UnderlineTabbedInterface'
 import {useId} from '../../hooks'
 import {invariant} from '../../utils/invariant'
 import {useResizeObserver, type ResizeObserverEntry} from '../../hooks/useResizeObserver'
@@ -28,6 +20,8 @@ import classes from './UnderlinePanels.module.css'
 import {clsx} from 'clsx'
 import {isSlot} from '../../utils/is-slot'
 import type {FCWithSlotMarker} from '../../utils/types'
+import {Tabs, useTab, useTabList, useTabPanel} from '../Tabs'
+import type {TabListHookProps} from '../Tabs/types'
 
 export type UnderlinePanelsProps = {
   /**
@@ -81,7 +75,9 @@ export type TabProps = PropsWithChildren<{
 
 export type PanelProps = React.HTMLAttributes<HTMLDivElement>
 
-const TabContainerComponent = createComponent(TabContainerElement, 'tab-container')
+// Internal-only positional value injected via cloneElement to pair the Nth tab
+// with the Nth panel. Not part of the public Tab/Panel API.
+type WithValue = {value?: string}
 
 // Carries flags that affect every Tab's rendering but that don't belong on the
 // consumer-facing Tab API. Passing them via context (instead of cloneElement)
@@ -112,43 +108,64 @@ const UnderlinePanels: FCWithSlotMarker<UnderlinePanelsProps> = ({
   // called in the exact same order in every component render
   const parentId = useId(props.id)
 
-  const [tabs, tabPanels, tabsHaveIcons] = useMemo(() => {
-    // Walk children, clone each Tab with a generated id, and each Panel with a
-    // matching aria-labelledby. Derive in render so we never ship a
-    // "before-the-effect-ran" empty-tablist frame and so that re-renders of
-    // UnderlinePanels don't churn through an extra commit cycle.
-    //
-    // iconsVisible / loadingCounters are NOT baked into the cloned Tab
-    // elements — they flow through UnderlinePanelsContext, so this memo's deps
-    // can stay tight ([children, parentId]) and Tab elements stay
-    // referentially stable across resize-driven iconsVisible toggles.
+  const [tabs, tabPanels, tabsHaveIcons, selectedFromProps] = useMemo(() => {
+    // Clone each Tab/Panel with a positional `value` so the Tabs hooks can pair
+    // the Nth tab with the Nth panel. Derived in render (not an effect) to avoid
+    // an empty-tablist frame; iconsVisible/loadingCounters flow via context so
+    // this memo can stay keyed on [children].
     let tabIndex = 0
     let panelIndex = 0
 
     const childrenWithProps = Children.map(children, child => {
-      if (isValidElement<UnderlineItemProps<ElementType>>(child) && (child.type === Tab || isSlot(child, Tab))) {
-        return cloneElement(child, {id: `${parentId}-tab-${tabIndex++}`})
+      if (isValidElement<TabProps & WithValue>(child) && (child.type === Tab || isSlot(child, Tab))) {
+        return cloneElement(child, {value: `${tabIndex++}`})
       }
 
-      if (isValidElement<PanelProps>(child) && (child.type === Panel || isSlot(child, Panel))) {
-        const childPanel = child as React.ReactElement<PanelProps>
-        return cloneElement(childPanel, {'aria-labelledby': `${parentId}-tab-${panelIndex++}`})
+      if (isValidElement<PanelProps & WithValue>(child) && (child.type === Panel || isSlot(child, Panel))) {
+        return cloneElement(child, {value: `${panelIndex++}`})
       }
       return child
     })
 
     const tabs: React.ReactNode[] = []
     const tabPanels: React.ReactNode[] = []
+    let selectedFromProps: string | undefined
     for (const child of Children.toArray(childrenWithProps)) {
       if (!isValidElement(child)) continue
-      if (child.type === Tab || isSlot(child, Tab)) tabs.push(child)
-      else if (child.type === Panel || isSlot(child, Panel)) tabPanels.push(child)
+      if (child.type === Tab || isSlot(child, Tab)) {
+        const ariaSelected = (child.props as {'aria-selected'?: boolean | string})['aria-selected']
+        if (ariaSelected === true || ariaSelected === 'true') {
+          selectedFromProps = `${tabs.length}`
+        }
+        tabs.push(child)
+      } else if (child.type === Panel || isSlot(child, Panel)) {
+        tabPanels.push(child)
+      }
     }
 
     const tabsHaveIcons = tabs.some(tab => React.isValidElement(tab) && tab.props.icon)
 
-    return [tabs, tabPanels, tabsHaveIcons] as const
-  }, [children, parentId])
+    return [tabs, tabPanels, tabsHaveIcons, selectedFromProps] as const
+  }, [children])
+
+  // Hybrid selection: seed from the consumer's `aria-selected` prop, but let
+  // clicks/keyboard update selection internally (mirrors the previous
+  // tab-container-element behavior). Re-sync via React's "adjust state during
+  // render" pattern when the selected prop changes.
+  const [selectedValue, setSelectedValue] = useState<string>(() => selectedFromProps ?? '0')
+  const [prevSelectedFromProps, setPrevSelectedFromProps] = useState(selectedFromProps)
+  if (selectedFromProps !== prevSelectedFromProps) {
+    setPrevSelectedFromProps(selectedFromProps)
+    if (selectedFromProps !== undefined && selectedFromProps !== selectedValue) {
+      setSelectedValue(selectedFromProps)
+    }
+  }
+
+  const {tabListProps} = useTabList<HTMLUListElement>({
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+    ref: listRef,
+  } as TabListHookProps<HTMLUListElement>)
 
   const contextValue = useMemo<UnderlinePanelsContextValue>(
     () => ({iconsVisible, loadingCounters}),
@@ -213,74 +230,79 @@ const UnderlinePanels: FCWithSlotMarker<UnderlinePanelsProps> = ({
 
   return (
     <UnderlinePanelsContext.Provider value={contextValue}>
-      <TabContainerComponent>
+      <Tabs id={parentId} value={selectedValue} onValueChange={({value}) => setSelectedValue(value)}>
         <UnderlineWrapper
           ref={wrapperRef}
-          slot="tablist-wrapper"
           data-icons-visible={iconsVisible}
           className={clsx(className, classes.StyledUnderlineWrapper)}
           {...props}
         >
-          <UnderlineItemList ref={listRef} aria-label={ariaLabel} aria-labelledby={ariaLabelledBy} role="tablist">
+          <UnderlineItemList
+            ref={listRef}
+            role={tabListProps.role}
+            aria-label={tabListProps['aria-label']}
+            aria-labelledby={tabListProps['aria-labelledby']}
+            aria-orientation={tabListProps['aria-orientation']}
+            onKeyDown={tabListProps.onKeyDown}
+          >
             {tabs}
           </UnderlineItemList>
         </UnderlineWrapper>
         {tabPanels}
-      </TabContainerComponent>
+      </Tabs>
     </UnderlinePanelsContext.Provider>
   )
 }
 
-const TabImpl: FCWithSlotMarker<TabProps> = ({'aria-selected': ariaSelected, onSelect, ...props}) => {
+const TabImpl: FC<TabProps & WithValue> = ({onSelect, value, ...itemProps}) => {
   const {loadingCounters} = useContext(UnderlinePanelsContext)
-  const clickHandler = React.useCallback(
-    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      if (!event.defaultPrevented && typeof onSelect === 'function') {
-        onSelect(event)
-      }
-    },
-    [onSelect],
-  )
-  const keyDownHandler = React.useCallback(
-    (event: React.KeyboardEvent<HTMLButtonElement>) => {
-      if ((event.key === ' ' || event.key === 'Enter') && !event.defaultPrevented && typeof onSelect === 'function') {
-        onSelect(event)
-      }
-    },
-    [onSelect],
-  )
+  const {tabProps} = useTab<HTMLButtonElement>({value: value ?? ''})
+  const {onKeyDown: tabOnKeyDown, onMouseDown: tabOnMouseDown, onFocus: tabOnFocus, ...restTabProps} = tabProps
 
   return (
     <UnderlineItem
       as="button"
-      role="tab"
-      tabIndex={ariaSelected ? 0 : -1}
-      aria-selected={ariaSelected}
       type="button"
-      onClick={clickHandler}
-      onKeyDown={keyDownHandler}
+      {...itemProps}
+      {...restTabProps}
+      onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+        if (!event.defaultPrevented && typeof onSelect === 'function') {
+          onSelect(event)
+        }
+      }}
+      onKeyDown={(event: React.KeyboardEvent<HTMLButtonElement>) => {
+        tabOnKeyDown?.(event)
+        if ((event.key === ' ' || event.key === 'Enter') && !event.defaultPrevented && typeof onSelect === 'function') {
+          onSelect(event)
+        }
+      }}
+      onMouseDown={tabOnMouseDown}
+      onFocus={tabOnFocus}
       loadingCounters={loadingCounters}
-      {...props}
     />
   )
 }
 
-// Memoized so that UnderlinePanels re-rendering (e.g. when iconsVisible flips)
-// only re-renders Tabs whose own props actually changed. iconsVisible and
-// loadingCounters reach Tab via UnderlinePanelsContext, so Tabs still react
-// to those changes through context propagation.
+// Memoized so an UnderlinePanels re-render (e.g. iconsVisible flipping) only
+// re-renders Tabs whose own props changed; iconsVisible/loadingCounters reach
+// Tab via context.
 TabImpl.displayName = 'UnderlinePanels.Tab'
 const Tab = React.memo(TabImpl) as unknown as FCWithSlotMarker<TabProps>
 
 Tab.displayName = 'UnderlinePanels.Tab'
 
-const Panel: FCWithSlotMarker<PanelProps> = ({children, ...rest}) => {
+const PanelImpl: FC<PanelProps & WithValue> = ({children, value, ...panelRest}) => {
+  const {tabPanelProps} = useTabPanel<HTMLDivElement>({value: value ?? ''})
+
   return (
-    <div role="tabpanel" {...rest}>
+    <div {...panelRest} {...tabPanelProps}>
       {children}
     </div>
   )
 }
+
+PanelImpl.displayName = 'UnderlinePanels.Panel'
+const Panel = PanelImpl as unknown as FCWithSlotMarker<PanelProps>
 
 Panel.displayName = 'UnderlinePanels.Panel'
 


### PR DESCRIPTION
Closes github/primer#6899

Migrates the experimental `UnderlinePanels` component to build on the React-first `Tabs` primitive (`Tabs` + `useTab` / `useTabList` / `useTabPanel`) instead of the imperative `@github/tab-container-element` web component. The public API and behavior are unchanged.

`UnderlinePanels` still matches tabs and panels by DOM order (no `value` in the public API) — an internal positional `value` is injected via `cloneElement`. Selection stays hybrid: it is seeded/re-synced from the consumer's `aria-selected` prop while clicks/keyboard update it internally, mirroring the previous `tab-container-element` behavior (including defaulting to the first tab when none is selected).

https://github.com/user-attachments/assets/7c727c66-a52b-4151-a758-f9cdeb20ae4d


### Changelog

#### New

- Optional `id` prop on the experimental `Tabs` component to control the base id used for generated tab/panel ids (falls back to an auto-generated id).
- `InOverlay` dev story showing `UnderlinePanels` inside an `AnchoredOverlay`.

#### Changed

- `UnderlinePanels` is now built on the experimental `Tabs` component and hooks instead of `@github/tab-container-element`.

#### Removed

- Direct dependency on `@github/tab-container-element` (it was the only consumer).

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- Public API and rendered behavior are unchanged; existing unit tests pass, plus new regression tests for default first-tab selection and uncontrolled panel switching.
- Verified against the `tab-container-element` source that it defaults to the first tab when none is `aria-selected`, so the no-`aria-selected` stories keep visual parity (only the first panel is shown).
- `tsc`, ESLint, `@primer/react` build, and the exports snapshot test all pass.
- Please run the `@vrt` and `@avt` Playwright suites in CI to confirm visual/accessibility parity.