### PR TITLE
Proposal: add source-derived component composition metadata

### DIFF
--- a/.changeset/component-composition-metadata.md
+++ b/.changeset/component-composition-metadata.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': minor
+---
+
+Generated component metadata: Add source-derived composition relationship evidence.

--- a/.changeset/mcp-component-composition.md
+++ b/.changeset/mcp-component-composition.md
@@ -1,0 +1,5 @@
+---
+'@primer/mcp': minor
+---
+
+MCP: Add package-backed component composition metadata and documentation source selection.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -52,7 +52,9 @@ generated component metadata and composition instead. Set
 metadata the default; use `PRIMER_COMPONENT_DOCS_SOURCE=hosted` to retain the
 hosted default. The per-call `source` input takes precedence over the startup
 default. Package-mode batches return a compact composition-first summary;
-`get_component` remains available when full package documentation is needed.
+observed relationship types are deterministically limited to the three strongest
+records and report omitted counts. `get_component` remains available when full
+package documentation or complete relationship provenance is needed.
 
 ## 🙌 Contributing
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -51,7 +51,8 @@ generated component metadata and composition instead. Set
 `PRIMER_COMPONENT_DOCS_SOURCE=package` when starting the server to make package
 metadata the default; use `PRIMER_COMPONENT_DOCS_SOURCE=hosted` to retain the
 hosted default. The per-call `source` input takes precedence over the startup
-default.
+default. Package-mode batches return a compact composition-first summary;
+`get_component` remains available when full package documentation is needed.
 
 ## 🙌 Contributing
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -38,6 +38,20 @@ Your MCP servers configuration should look like:
 }
 ```
 
+## Component metadata sources
+
+`get_component_composition` returns source-derived composition metadata from the
+installed `@primer/react` package. It is package-backed, so a local workspace
+can exercise newly generated metadata without waiting for hosted Primer Style
+documentation to deploy.
+
+`get_component` uses hosted Primer Style documentation by default. Pass
+`source: "package"` to return the installed package's generated component
+metadata and composition instead. Set `PRIMER_COMPONENT_DOCS_SOURCE=package`
+when starting the server to make package metadata the default; use
+`PRIMER_COMPONENT_DOCS_SOURCE=hosted` to retain the hosted default. The
+per-call `source` input takes precedence over the startup default.
+
 ## 🙌 Contributing
 
 We love collaborating with folks inside and outside of GitHub and welcome contributions! If you're interested, check out our [contributing docs](contributor-docs/CONTRIBUTING.md) for more info on how to get started.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -45,12 +45,13 @@ installed `@primer/react` package. It is package-backed, so a local workspace
 can exercise newly generated metadata without waiting for hosted Primer Style
 documentation to deploy.
 
-`get_component` uses hosted Primer Style documentation by default. Pass
-`source: "package"` to return the installed package's generated component
-metadata and composition instead. Set `PRIMER_COMPONENT_DOCS_SOURCE=package`
-when starting the server to make package metadata the default; use
-`PRIMER_COMPONENT_DOCS_SOURCE=hosted` to retain the hosted default. The
-per-call `source` input takes precedence over the startup default.
+`get_component` and `get_component_batch` use hosted Primer Style documentation
+by default. Pass `source: "package"` to return the installed package's
+generated component metadata and composition instead. Set
+`PRIMER_COMPONENT_DOCS_SOURCE=package` when starting the server to make package
+metadata the default; use `PRIMER_COMPONENT_DOCS_SOURCE=hosted` to retain the
+hosted default. The per-call `source` input takes precedence over the startup
+default.
 
 ## 🙌 Contributing
 

--- a/packages/mcp/src/primer.ts
+++ b/packages/mcp/src/primer.ts
@@ -1,12 +1,53 @@
 import componentsMetadata from '@primer/react/generated/components.json' with {type: 'json'}
 import octicons from '@primer/octicons/build/data.json' with {type: 'json'}
 
+type ComponentDocsSource = 'hosted' | 'package'
+
 type Component = {
   id: string
   name: string
   importPath: string
   slug: string
 }
+
+interface ComponentDocument {
+  name: string
+  importPath: string
+  [key: string]: unknown
+}
+
+interface ComponentRelationship {
+  parent?: string
+  child?: string
+  previous?: string
+  next?: string
+  first?: string
+  second?: string
+  component?: string
+  subcomponent?: string
+  [key: string]: unknown
+}
+
+interface CompositionMetadata {
+  schemaVersion: number
+  derivation: Record<string, unknown>
+  sourceSummary: Record<string, unknown>
+  apiParentChild: Array<ComponentRelationship>
+  apiSubcomponents: Array<ComponentRelationship>
+  observed: {
+    parentChild: Array<ComponentRelationship>
+    adjacentSibling: Array<ComponentRelationship>
+    variants: Array<ComponentRelationship>
+    relatedComponents: Array<ComponentRelationship>
+  }
+}
+
+interface ComponentsMetadata {
+  components: Record<string, ComponentDocument>
+  composition?: CompositionMetadata
+}
+
+const metadata: ComponentsMetadata = componentsMetadata
 
 function idToSlug(id: string): string {
   if (id === 'actionbar') {
@@ -24,7 +65,7 @@ function idToSlug(id: string): string {
   return id.replaceAll('_', '-')
 }
 
-const components: Array<Component> = Object.entries(componentsMetadata.components).map(([id, component]) => {
+const components: Array<Component> = Object.entries(metadata.components).map(([id, component]) => {
   return {
     id,
     name: component.name,
@@ -35,6 +76,60 @@ const components: Array<Component> = Object.entries(componentsMetadata.component
 
 function listComponents(): Array<Component> {
   return components
+}
+
+function getComponentDocsSource(value = process.env.PRIMER_COMPONENT_DOCS_SOURCE): ComponentDocsSource {
+  if (value === undefined || value === 'hosted' || value === 'package') {
+    return value ?? 'hosted'
+  }
+
+  throw new Error('PRIMER_COMPONENT_DOCS_SOURCE must be either "hosted" or "package".')
+}
+
+function getComponentDocument(id: string): ComponentDocument | undefined {
+  return metadata.components[id]
+}
+
+function getComponentComposition(id: string) {
+  const component = getComponentDocument(id)
+  const composition = metadata.composition
+  if (!component || !composition) return undefined
+
+  return {
+    schemaVersion: composition.schemaVersion,
+    derivation: composition.derivation,
+    sourceSummary: composition.sourceSummary,
+    apiParentChild: composition.apiParentChild.filter(relation => includesComponent(relation, component.name)),
+    apiSubcomponents: composition.apiSubcomponents.filter(relation => includesComponent(relation, component.name)),
+    observed: {
+      parentChild: composition.observed.parentChild.filter(relation => includesComponent(relation, component.name)),
+      adjacentSibling: composition.observed.adjacentSibling.filter(relation =>
+        includesComponent(relation, component.name),
+      ),
+      variants: composition.observed.variants.filter(relation => includesComponent(relation, component.name)),
+      relatedComponents: composition.observed.relatedComponents.filter(relation =>
+        includesComponent(relation, component.name),
+      ),
+    },
+  }
+}
+
+function includesComponent(relation: ComponentRelationship, componentName: string): boolean {
+  const componentFields = [
+    'parent',
+    'child',
+    'previous',
+    'next',
+    'first',
+    'second',
+    'component',
+    'subcomponent',
+  ] as const
+
+  return componentFields.some(field => {
+    const value = relation[field]
+    return value === componentName || value?.startsWith(`${componentName}.`)
+  })
 }
 
 type Pattern = {
@@ -140,4 +235,12 @@ function listIcons(): Array<Icon> {
   return icons
 }
 
-export {listComponents, listPatterns, listIcons}
+export {
+  getComponentComposition,
+  getComponentDocsSource,
+  getComponentDocument,
+  listComponents,
+  listPatterns,
+  listIcons,
+  type ComponentDocsSource,
+}

--- a/packages/mcp/src/primer.ts
+++ b/packages/mcp/src/primer.ts
@@ -10,6 +10,10 @@ type Component = {
   slug: string
 }
 
+type ComponentSummary = Pick<Component, 'id' | 'name' | 'importPath'> & {
+  status?: string
+}
+
 interface ComponentDocument {
   name: string
   importPath: string
@@ -90,6 +94,14 @@ function getComponentDocument(id: string): ComponentDocument | undefined {
   return metadata.components[id]
 }
 
+function getComponentSummary(component: Component): ComponentSummary {
+  const status = getComponentDocument(component.id)?.status
+
+  return typeof status === 'string'
+    ? {id: component.id, name: component.name, importPath: component.importPath, status}
+    : {id: component.id, name: component.name, importPath: component.importPath}
+}
+
 function getComponentComposition(id: string) {
   const component = getComponentDocument(id)
   const composition = metadata.composition
@@ -112,6 +124,34 @@ function getComponentComposition(id: string) {
       ),
     },
   }
+}
+
+function getComponentCompositionSummary(id: string) {
+  const composition = getComponentComposition(id)
+  if (!composition) return undefined
+
+  return {
+    schemaVersion: composition.schemaVersion,
+    derivation: composition.derivation,
+    sourceSummary: composition.sourceSummary,
+    apiParentChild: composition.apiParentChild.map(compactRelationship),
+    apiSubcomponents: composition.apiSubcomponents.map(compactRelationship),
+    observed: {
+      parentChild: composition.observed.parentChild.map(compactRelationship),
+      adjacentSibling: composition.observed.adjacentSibling.map(compactRelationship),
+      variants: composition.observed.variants.map(compactRelationship),
+      relatedComponents: composition.observed.relatedComponents.map(compactRelationship),
+    },
+  }
+}
+
+function compactRelationship(relationship: ComponentRelationship): ComponentRelationship {
+  const compact: ComponentRelationship = {}
+  for (const [key, value] of Object.entries(relationship)) {
+    if (key !== 'sources') compact[key] = value
+  }
+
+  return compact
 }
 
 function includesComponent(relation: ComponentRelationship, componentName: string): boolean {
@@ -237,8 +277,10 @@ function listIcons(): Array<Icon> {
 
 export {
   getComponentComposition,
+  getComponentCompositionSummary,
   getComponentDocsSource,
   getComponentDocument,
+  getComponentSummary,
   listComponents,
   listPatterns,
   listIcons,

--- a/packages/mcp/src/primer.ts
+++ b/packages/mcp/src/primer.ts
@@ -52,6 +52,7 @@ interface ComponentsMetadata {
 }
 
 const metadata: ComponentsMetadata = componentsMetadata
+const maximumObservedRelationshipsPerKind = 3
 
 function idToSlug(id: string): string {
   if (id === 'actionbar') {
@@ -130,19 +131,49 @@ function getComponentCompositionSummary(id: string) {
   const composition = getComponentComposition(id)
   if (!composition) return undefined
 
+  const parentChild = summarizeObservedRelationships(composition.observed.parentChild)
+  const adjacentSibling = summarizeObservedRelationships(composition.observed.adjacentSibling)
+  const variants = summarizeObservedRelationships(composition.observed.variants)
+  const relatedComponents = summarizeObservedRelationships(composition.observed.relatedComponents)
+
   return {
     schemaVersion: composition.schemaVersion,
-    derivation: composition.derivation,
-    sourceSummary: composition.sourceSummary,
     apiParentChild: composition.apiParentChild.map(compactRelationship),
     apiSubcomponents: composition.apiSubcomponents.map(compactRelationship),
     observed: {
-      parentChild: composition.observed.parentChild.map(compactRelationship),
-      adjacentSibling: composition.observed.adjacentSibling.map(compactRelationship),
-      variants: composition.observed.variants.map(compactRelationship),
-      relatedComponents: composition.observed.relatedComponents.map(compactRelationship),
+      parentChild: parentChild.relationships,
+      adjacentSibling: adjacentSibling.relationships,
+      variants: variants.relationships,
+      relatedComponents: relatedComponents.relationships,
+    },
+    observedRelationshipLimit: maximumObservedRelationshipsPerKind,
+    omittedObservedRelationshipCounts: {
+      parentChild: parentChild.omittedCount,
+      adjacentSibling: adjacentSibling.omittedCount,
+      variants: variants.omittedCount,
+      relatedComponents: relatedComponents.omittedCount,
     },
   }
+}
+
+function summarizeObservedRelationships(relationships: Array<ComponentRelationship>) {
+  const orderedRelationships = [...relationships].sort((first, second) => {
+    return (
+      getRelationshipNumber(second, 'sourceCount') - getRelationshipNumber(first, 'sourceCount') ||
+      getRelationshipNumber(second, 'occurrences') - getRelationshipNumber(first, 'occurrences') ||
+      JSON.stringify(compactRelationship(first)).localeCompare(JSON.stringify(compactRelationship(second)))
+    )
+  })
+
+  return {
+    relationships: orderedRelationships.slice(0, maximumObservedRelationshipsPerKind).map(compactRelationship),
+    omittedCount: Math.max(orderedRelationships.length - maximumObservedRelationshipsPerKind, 0),
+  }
+}
+
+function getRelationshipNumber(relationship: ComponentRelationship, key: string): number {
+  const value = relationship[key]
+  return typeof value === 'number' ? value : 0
 }
 
 function compactRelationship(relationship: ComponentRelationship): ComponentRelationship {

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -37,10 +37,10 @@ describe('get_component_batch', () => {
     await server.close()
   })
 
-  const callBatch = (names: string[]) => {
+  const callBatch = (names: string[], source?: 'hosted' | 'package') => {
     return client.callTool({
       name: 'get_component_batch',
-      arguments: {names},
+      arguments: {names, source},
     })
   }
 
@@ -131,6 +131,20 @@ describe('get_component_batch', () => {
     })
   })
 
+  it('returns package metadata and composition for every batched component', async () => {
+    const result = await callBatch(['NavList', 'CounterLabel', 'SegmentedControl'], 'package')
+    const payloads = getTextContents(result).map(content => JSON.parse(content))
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(payloads.map(payload => payload.component.name)).toEqual(['NavList', 'CounterLabel', 'SegmentedControl'])
+    expect(payloads.every(payload => payload.source === 'package' && payload.composition.schemaVersion === 1)).toBe(
+      true,
+    )
+    expect(payloads[0].composition.apiSubcomponents).toEqual(
+      expect.arrayContaining([expect.objectContaining({parent: 'NavList', subcomponent: 'NavList.Item'})]),
+    )
+  })
+
   it('returns filtered package-backed composition metadata', async () => {
     const result = await client.callTool({
       name: 'get_component_composition',
@@ -172,20 +186,26 @@ describe('get_component_batch', () => {
 })
 
 function getTextContent(result: unknown): string {
+  const [content] = getTextContents(result)
+  if (!content) throw new Error('Expected text tool content')
+
+  return content
+}
+
+function getTextContents(result: unknown): Array<string> {
   if (typeof result !== 'object' || result === null || !('content' in result) || !Array.isArray(result.content)) {
     throw new Error('Expected tool content')
   }
 
-  const content = result.content.find(
-    (item): item is {type: 'text'; text: string} =>
-      typeof item === 'object' &&
-      item !== null &&
-      'type' in item &&
-      item.type === 'text' &&
-      'text' in item &&
-      typeof item.text === 'string',
-  )
-  if (!content) throw new Error('Expected text tool content')
-
-  return content.text
+  return result.content
+    .filter(
+      (item): item is {type: 'text'; text: string} =>
+        typeof item === 'object' &&
+        item !== null &&
+        'type' in item &&
+        item.type === 'text' &&
+        'text' in item &&
+        typeof item.text === 'string',
+    )
+    .map(content => content.text)
 }

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -150,9 +150,35 @@ describe('get_component_batch', () => {
       true,
     )
     expect(payloads.every(payload => !('props' in payload.component) && !('stories' in payload.component))).toBe(true)
+    expect(
+      payloads.every(payload => !('derivation' in payload.composition) && !('sourceSummary' in payload.composition)),
+    ).toBe(true)
     expect(payloads[0].composition.apiSubcomponents).toEqual(
       expect.arrayContaining([expect.objectContaining({parent: 'NavList', subcomponent: 'NavList.Item'})]),
     )
+  })
+
+  it('bounds high-connectivity package batches below MCP truncation limits', async () => {
+    const result = await callBatch(['ActionList', 'SegmentedControl'], 'package')
+    const contents = getTextContents(result)
+    const payloads = contents.map(content => JSON.parse(content))
+
+    expect(contents.join('\n').length).toBeLessThan(15_000)
+    expect(payloads.every(payload => payload.composition.observedRelationshipLimit === 3)).toBe(true)
+    expect(
+      payloads.every(payload =>
+        Object.values(payload.composition.observed).every(
+          relationships => Array.isArray(relationships) && relationships.length <= 3,
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      payloads.find(payload => payload.component.name === 'ActionList')?.composition.omittedObservedRelationshipCounts,
+    ).toMatchObject({
+      parentChild: expect.any(Number),
+      adjacentSibling: expect.any(Number),
+      relatedComponents: expect.any(Number),
+    })
   })
 
   it('returns filtered package-backed composition metadata', async () => {

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -1,7 +1,18 @@
 import {Client} from '@modelcontextprotocol/sdk/client/index.js'
 import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js'
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
+import {getComponentDocsSource} from './primer'
 import {server} from './server'
+
+describe('component documentation sources', () => {
+  it('uses hosted documentation by default and supports package metadata', () => {
+    expect(getComponentDocsSource(undefined)).toBe('hosted')
+    expect(getComponentDocsSource('package')).toBe('package')
+    expect(() => getComponentDocsSource('invalid')).toThrow(
+      'PRIMER_COMPONENT_DOCS_SOURCE must be either "hosted" or "package".',
+    )
+  })
+})
 
 describe('get_component_batch', () => {
   const client = new Client({name: 'mcp-server-test', version: '1.0.0'})
@@ -101,6 +112,42 @@ describe('get_component_batch', () => {
     ])
   })
 
+  it('returns package metadata and source-derived composition without fetching hosted documentation', async () => {
+    const result = await client.callTool({
+      name: 'get_component',
+      arguments: {name: 'ActionMenu', source: 'package'},
+    })
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(JSON.parse(getTextContent(result))).toMatchObject({
+      source: 'package',
+      component: {name: 'ActionMenu'},
+      composition: {
+        schemaVersion: 1,
+        apiSubcomponents: expect.arrayContaining([
+          expect.objectContaining({parent: 'ActionMenu', subcomponent: 'ActionMenu.Overlay'}),
+        ]),
+      },
+    })
+  })
+
+  it('returns filtered package-backed composition metadata', async () => {
+    const result = await client.callTool({
+      name: 'get_component_composition',
+      arguments: {name: 'ActionMenu'},
+    })
+
+    const payload = JSON.parse(getTextContent(result))
+    expect(payload.component).toEqual({
+      id: 'action_menu',
+      name: 'ActionMenu',
+      importPath: '@primer/react',
+    })
+    expect(payload.composition.observed.parentChild).toEqual(
+      expect.arrayContaining([expect.objectContaining({parent: 'ActionMenu.Overlay', child: 'ActionList'})]),
+    )
+  })
+
   it('times out stalled requests without leaving timers active', async () => {
     vi.useFakeTimers()
     const fetchMock = vi.mocked(fetch)
@@ -123,3 +170,22 @@ describe('get_component_batch', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 })
+
+function getTextContent(result: unknown): string {
+  if (typeof result !== 'object' || result === null || !('content' in result) || !Array.isArray(result.content)) {
+    throw new Error('Expected tool content')
+  }
+
+  const content = result.content.find(
+    (item): item is {type: 'text'; text: string} =>
+      typeof item === 'object' &&
+      item !== null &&
+      'type' in item &&
+      item.type === 'text' &&
+      'text' in item &&
+      typeof item.text === 'string',
+  )
+  if (!content) throw new Error('Expected text tool content')
+
+  return content.text
+}

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -131,15 +131,25 @@ describe('get_component_batch', () => {
     })
   })
 
-  it('returns package metadata and composition for every batched component', async () => {
-    const result = await callBatch(['NavList', 'CounterLabel', 'SegmentedControl'], 'package')
-    const payloads = getTextContents(result).map(content => JSON.parse(content))
+  it('returns compact, composition-first package metadata for every batched component', async () => {
+    const result = await callBatch(['NavList', 'SegmentedControl', 'CounterLabel', 'Avatar'], 'package')
+    const contents = getTextContents(result)
+    const payloads = contents.map(content => JSON.parse(content))
+
+    expect(contents.join('\n').length).toBeLessThan(20_000)
+    expect(contents.every(content => content.indexOf('"composition"') < 100)).toBe(true)
 
     expect(fetch).not.toHaveBeenCalled()
-    expect(payloads.map(payload => payload.component.name)).toEqual(['NavList', 'CounterLabel', 'SegmentedControl'])
+    expect(payloads.map(payload => payload.component.name)).toEqual([
+      'NavList',
+      'SegmentedControl',
+      'CounterLabel',
+      'Avatar',
+    ])
     expect(payloads.every(payload => payload.source === 'package' && payload.composition.schemaVersion === 1)).toBe(
       true,
     )
+    expect(payloads.every(payload => !('props' in payload.component) && !('stories' in payload.component))).toBe(true)
     expect(payloads[0].composition.apiSubcomponents).toEqual(
       expect.arrayContaining([expect.objectContaining({parent: 'NavList', subcomponent: 'NavList.Item'})]),
     )

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -4,7 +4,14 @@ import * as cheerio from 'cheerio'
 // eslint-disable-next-line import/no-namespace
 import * as z from 'zod'
 import TurndownService from 'turndown'
-import {listComponents, listPatterns, listIcons} from './primer'
+import {
+  getComponentComposition,
+  getComponentDocsSource,
+  getComponentDocument,
+  listComponents,
+  listPatterns,
+  listIcons,
+} from './primer'
 import {
   listTokenGroups,
   loadAllTokensWithGuidelines,
@@ -28,6 +35,7 @@ const server = new McpServer({
 })
 
 const turndownService = new TurndownService()
+const defaultComponentDocsSource = getComponentDocsSource()
 
 // Load all tokens with guidelines from primitives
 const allTokensWithGuidelines: TokenWithGuidelines[] = loadAllTokensWithGuidelines()
@@ -106,7 +114,61 @@ server.registerTool(
 
 ${components.join('\n')}
 
-You can use the \`get_component\` tool to get more information about a specific component. You can use these components from the @primer/react package.`,
+You can use the \`get_component\` tool to get more information about a specific component and \`get_component_composition\` for source-derived composition metadata. You can use these components from the @primer/react package.`,
+        },
+      ],
+    }
+  },
+)
+
+server.registerTool(
+  'get_component_composition',
+  {
+    description:
+      'Retrieve source-derived composition metadata for a Primer React component, including documented compound APIs and observed static JSX relationships.',
+    inputSchema: {
+      name: z.string().describe('The name of the component to retrieve composition metadata for'),
+    },
+    annotations: {readOnlyHint: true},
+  },
+  async ({name}) => {
+    const component = listComponents().find(candidate => {
+      return candidate.name === name || candidate.name.toLowerCase() === name.toLowerCase()
+    })
+    if (!component) {
+      return {
+        isError: true,
+        errorMessage: `There is no component named \`${name}\` in the @primer/react package. For a full list of components, use \`list_components\` for valid names.`,
+        content: [],
+      }
+    }
+
+    const composition = getComponentComposition(component.id)
+    if (!composition) {
+      return {
+        isError: true,
+        errorMessage:
+          'The installed @primer/react package does not include composition metadata. Use a version that publishes generated/components.json with composition data.',
+        content: [],
+      }
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              component: {
+                id: component.id,
+                name: component.name,
+                importPath: component.importPath,
+              },
+              composition,
+            },
+            null,
+            2,
+          ),
         },
       ],
     }
@@ -120,10 +182,14 @@ server.registerTool(
       'Retrieve documentation and usage details for a specific React component from the @primer/react package by its name. This tool provides the official Primer documentation for any listed component, making it easy to inspect, reuse, or integrate components in your project.',
     inputSchema: {
       name: z.string().describe('The name of the component to retrieve'),
+      source: z
+        .enum(['hosted', 'package'])
+        .optional()
+        .describe('Use hosted Primer Style documentation or metadata from the installed @primer/react package'),
     },
     annotations: {readOnlyHint: true},
   },
-  async ({name}) => {
+  async ({name, source}) => {
     const components = listComponents()
     const match = components.find(component => {
       return component.name === name || component.name.toLowerCase() === name.toLowerCase()
@@ -135,6 +201,21 @@ server.registerTool(
         content: [],
       }
     }
+    const docsSource = source ?? defaultComponentDocsSource
+    if (docsSource === 'package') {
+      const document = getComponentDocument(match.id)
+      const composition = getComponentComposition(match.id)
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({source: 'package', component: document, composition}, null, 2),
+          },
+        ],
+      }
+    }
+
     try {
       const llmsUrl = new URL(`/product/components/${match.slug}/llms.txt`, 'https://primer.style')
       const llmsResponse = await fetch(llmsUrl)

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -6,8 +6,10 @@ import * as z from 'zod'
 import TurndownService from 'turndown'
 import {
   getComponentComposition,
+  getComponentCompositionSummary,
   getComponentDocsSource,
   getComponentDocument,
+  getComponentSummary,
   listComponents,
   listPatterns,
   listIcons,
@@ -288,11 +290,10 @@ server.registerTool(
         }
 
         if (docsSource === 'package') {
-          const document = getComponentDocument(match.id)
-          const composition = getComponentComposition(match.id)
+          const composition = getComponentCompositionSummary(match.id)
           return {
             type: 'text' as const,
-            text: JSON.stringify({source: 'package', component: document, composition}, null, 2),
+            text: JSON.stringify({source: 'package', composition, component: getComponentSummary(match)}, null, 2),
           }
         }
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -255,10 +255,14 @@ server.registerTool(
         .min(2)
         .max(10)
         .describe('Component names to retrieve (e.g. ["ActionMenu", "Button", "Pagination"])'),
+      source: z
+        .enum(['hosted', 'package'])
+        .optional()
+        .describe('Use hosted Primer Style documentation or metadata from the installed @primer/react package'),
     },
     annotations: {readOnlyHint: true},
   },
-  async ({names}) => {
+  async ({names, source}) => {
     const seenNames = new Set<string>()
     const deduped = names.filter(name => {
       const normalizedName = name.toLowerCase()
@@ -269,6 +273,7 @@ server.registerTool(
       return true
     })
     const components = listComponents()
+    const docsSource = source ?? defaultComponentDocsSource
 
     const results = await Promise.all(
       deduped.map(async name => {
@@ -279,6 +284,15 @@ server.registerTool(
           return {
             type: 'text' as const,
             text: `## ${name}\n\nStatus: not-found. No component named \`${name}\` exists in @primer/react. Use \`list_components\` for valid names.`,
+          }
+        }
+
+        if (docsSource === 'package') {
+          const document = getComponentDocument(match.id)
+          const composition = getComponentComposition(match.id)
+          return {
+            type: 'text' as const,
+            text: JSON.stringify({source: 'package', component: document, composition}, null, 2),
           }
         }
 

--- a/packages/react/script/components-json/README.md
+++ b/packages/react/script/components-json/README.md
@@ -10,10 +10,16 @@ The artifact's `composition` field is generated from repository sources; it is
 not authored as a separate documentation surface.
 
 - `apiParentChild` identifies component references in documented `children` prop
-  types. Its `required` field reports whether that prop itself is required.
+  types. Its `childrenPropRequired` field reports whether the parent prop itself
+  is required; it does not make an individual referenced child required.
+- `apiSubcomponents` records documented compound component APIs without implying
+  that a subcomponent must be nested under its parent.
 - `observed.parentChild` and `observed.adjacentSibling` report JSX nesting and
   adjacent siblings found in colocated default, feature, and example stories,
-  plus `*.test.tsx` files.
+  `*.test.tsx` files, and component implementation files.
+- `observed.variants` reports static `variant` and `*Variant` JSX prop values.
+  `observed.relatedComponents` is an undirected structural index derived from
+  observed parent/child and adjacent-sibling relationships.
 - Every observed relation includes its occurrence count, number of distinct
   source units, confidence tier, and sorted source provenance. A relation is
   emitted only when it appears in at least two source units. Two sources are
@@ -21,13 +27,20 @@ not authored as a separate documentation surface.
 
 The generator uses docs metadata as the canonical component registry, then
 resolves JSX identifiers, aliased named imports, and namespace imports against
-that registry. It reads only this package's `src/` tree, so provenance remains
-package-relative. It intentionally records source evidence rather than
-inferring semantic validity: frequency does not make a composition required,
-accessible, or suitable for every use case. Dynamic element selection and
-runtime children are not analyzed.
+that registry. It gathers source units from each documented component's
+directory, sorts and deduplicates them before extraction, and reads only this
+package's `src/` tree, so provenance remains package-relative. It intentionally
+records source evidence rather than inferring semantic validity: frequency does
+not make a composition required, accessible, or suitable for every use case.
+Dynamic element selection and runtime children are not analyzed.
 
-Downstream consumers can use `apiParentChild` for documented type-level
-composition contracts and `observed` for source-backed examples. Both are
-structured, versioned metadata available from the same public artifact as
+Not every component has qualifying observed evidence. A missing observation
+means that the static sources did not meet the configured threshold, not that a
+relationship is invalid. When a component name is available from multiple
+entrypoints, consumers should combine source provenance with the corresponding
+component record's `importPath` when selecting an implementation.
+
+Downstream consumers can use `apiParentChild` and `apiSubcomponents` for
+documented API structure, then use `observed` as source-backed evidence. Both
+are structured, versioned metadata available from the same public artifact as
 component docs, so consumers do not need a separate documentation format.

--- a/packages/react/script/components-json/README.md
+++ b/packages/react/script/components-json/README.md
@@ -1,0 +1,33 @@
+# Component metadata generation
+
+`npm run build:components.json -w @primer/react` produces the published
+`@primer/react/generated/components.json` artifact from the canonical
+`*.docs.json` component metadata.
+
+## Composition metadata
+
+The artifact's `composition` field is generated from repository sources; it is
+not authored as a separate documentation surface.
+
+- `apiParentChild` identifies component references in documented `children` prop
+  types. Its `required` field reports whether that prop itself is required.
+- `observed.parentChild` and `observed.adjacentSibling` report JSX nesting and
+  adjacent siblings found in colocated default, feature, and example stories,
+  plus `*.test.tsx` files.
+- Every observed relation includes its occurrence count, number of distinct
+  source units, confidence tier, and sorted source provenance. A relation is
+  emitted only when it appears in at least two source units. Two sources are
+  `medium` evidence; three or more are `high`.
+
+The generator uses docs metadata as the canonical component registry, then
+resolves JSX identifiers, aliased named imports, and namespace imports against
+that registry. It reads only this package's `src/` tree, so provenance remains
+package-relative. It intentionally records source evidence rather than
+inferring semantic validity: frequency does not make a composition required,
+accessible, or suitable for every use case. Dynamic element selection and
+runtime children are not analyzed.
+
+Downstream consumers can use `apiParentChild` for documented type-level
+composition contracts and `observed` for source-backed examples. Both are
+structured, versioned metadata available from the same public artifact as
+component docs, so consumers do not need a separate documentation format.

--- a/packages/react/script/components-json/build.ts
+++ b/packages/react/script/components-json/build.ts
@@ -16,7 +16,9 @@ import chalk from 'chalk'
 import type {LintError} from 'markdownlint'
 import {lint as mdLint} from 'markdownlint/sync'
 import componentSchema from './component.schema.json'
+import compositionSchema from './composition.schema.json'
 import outputSchema from './output.schema.json'
+import {buildComposition, getCompositionSources, type DocumentedComponent} from './composition'
 
 const args = parseArgs({
   options: {
@@ -43,6 +45,8 @@ type Component = {
 const ajv = new Ajv({
   allowUnionTypes: true,
 })
+
+ajv.compile(compositionSchema)
 
 function formatMDError(lintError: LintError): string {
   let range = ''
@@ -208,7 +212,15 @@ const components = docsFiles.map(docsFilepath => {
   }
 })
 
-const data = {schemaVersion: 2, components: keyBy(components, 'id')}
+const composition = buildComposition(
+  components.map((component, index) => ({
+    ...component,
+    sourcePath: docsFiles[index],
+  })) as Array<DocumentedComponent>,
+  getCompositionSources(docsFiles),
+)
+
+const data = {schemaVersion: 2, components: keyBy(components, 'id'), composition}
 
 // Validate output
 const validate = ajv.compile(outputSchema)

--- a/packages/react/script/components-json/composition.schema.json
+++ b/packages/react/script/components-json/composition.schema.json
@@ -1,7 +1,7 @@
 {
   "$id": "composition.schema.json",
   "type": "object",
-  "required": ["schemaVersion", "derivation", "sourceSummary", "apiParentChild", "observed"],
+  "required": ["schemaVersion", "derivation", "sourceSummary", "apiParentChild", "apiSubcomponents", "observed"],
   "additionalProperties": false,
   "properties": {
     "schemaVersion": {
@@ -15,7 +15,7 @@
       "properties": {
         "sourceKinds": {
           "type": "array",
-          "items": {"type": "string", "enum": ["story", "example", "test"]}
+          "items": {"type": "string", "enum": ["story", "example", "test", "implementation"]}
         },
         "minimumSourceCount": {"type": "number"},
         "highConfidenceSourceCount": {"type": "number"}
@@ -30,12 +30,13 @@
         "sourceUnits": {"type": "number"},
         "sourceUnitsByKind": {
           "type": "object",
-          "required": ["story", "example", "test"],
+          "required": ["story", "example", "test", "implementation"],
           "additionalProperties": false,
           "properties": {
             "story": {"type": "number"},
             "example": {"type": "number"},
-            "test": {"type": "number"}
+            "test": {"type": "number"},
+            "implementation": {"type": "number"}
           }
         }
       }
@@ -44,9 +45,13 @@
       "type": "array",
       "items": {"$ref": "#/definitions/apiParentChild"}
     },
+    "apiSubcomponents": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/apiSubcomponent"}
+    },
     "observed": {
       "type": "object",
-      "required": ["parentChild", "adjacentSibling"],
+      "required": ["parentChild", "adjacentSibling", "variants", "relatedComponents"],
       "additionalProperties": false,
       "properties": {
         "parentChild": {
@@ -56,6 +61,14 @@
         "adjacentSibling": {
           "type": "array",
           "items": {"$ref": "#/definitions/observedSibling"}
+        },
+        "variants": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/observedVariant"}
+        },
+        "relatedComponents": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/observedRelatedComponents"}
         }
       }
     }
@@ -66,18 +79,18 @@
       "required": ["kind", "path"],
       "additionalProperties": false,
       "properties": {
-        "kind": {"type": "string", "enum": ["story", "example", "test"]},
+        "kind": {"type": "string", "enum": ["story", "example", "test", "implementation"]},
         "path": {"type": "string"}
       }
     },
     "apiParentChild": {
       "type": "object",
-      "required": ["parent", "child", "required", "source"],
+      "required": ["parent", "child", "childrenPropRequired", "source"],
       "additionalProperties": false,
       "properties": {
         "parent": {"type": "string"},
         "child": {"type": "string"},
-        "required": {"type": "boolean"},
+        "childrenPropRequired": {"type": "boolean"},
         "source": {
           "type": "object",
           "required": ["path", "prop", "type"],
@@ -86,6 +99,23 @@
             "path": {"type": "string"},
             "prop": {"type": "string"},
             "type": {"type": "string"}
+          }
+        }
+      }
+    },
+    "apiSubcomponent": {
+      "type": "object",
+      "required": ["parent", "subcomponent", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "parent": {"type": "string"},
+        "subcomponent": {"type": "string"},
+        "source": {
+          "type": "object",
+          "required": ["path"],
+          "additionalProperties": false,
+          "properties": {
+            "path": {"type": "string"}
           }
         }
       }
@@ -114,6 +144,43 @@
         "parent": {"type": "string"},
         "previous": {"type": "string"},
         "next": {"type": "string"},
+        "occurrences": {"type": "number"},
+        "sourceCount": {"type": "number"},
+        "confidence": {"type": "string", "enum": ["medium", "high"]},
+        "sources": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/source"}
+        }
+      }
+    },
+    "observedVariant": {
+      "type": "object",
+      "required": ["component", "prop", "value", "occurrences", "sourceCount", "confidence", "sources"],
+      "additionalProperties": false,
+      "properties": {
+        "component": {"type": "string"},
+        "prop": {"type": "string"},
+        "value": {"type": "string"},
+        "occurrences": {"type": "number"},
+        "sourceCount": {"type": "number"},
+        "confidence": {"type": "string", "enum": ["medium", "high"]},
+        "sources": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/source"}
+        }
+      }
+    },
+    "observedRelatedComponents": {
+      "type": "object",
+      "required": ["first", "second", "relationshipKinds", "occurrences", "sourceCount", "confidence", "sources"],
+      "additionalProperties": false,
+      "properties": {
+        "first": {"type": "string"},
+        "second": {"type": "string"},
+        "relationshipKinds": {
+          "type": "array",
+          "items": {"type": "string", "enum": ["parentChild", "adjacentSibling"]}
+        },
         "occurrences": {"type": "number"},
         "sourceCount": {"type": "number"},
         "confidence": {"type": "string", "enum": ["medium", "high"]},

--- a/packages/react/script/components-json/composition.schema.json
+++ b/packages/react/script/components-json/composition.schema.json
@@ -1,0 +1,127 @@
+{
+  "$id": "composition.schema.json",
+  "type": "object",
+  "required": ["schemaVersion", "derivation", "sourceSummary", "apiParentChild", "observed"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "number",
+      "enum": [1]
+    },
+    "derivation": {
+      "type": "object",
+      "required": ["sourceKinds", "minimumSourceCount", "highConfidenceSourceCount"],
+      "additionalProperties": false,
+      "properties": {
+        "sourceKinds": {
+          "type": "array",
+          "items": {"type": "string", "enum": ["story", "example", "test"]}
+        },
+        "minimumSourceCount": {"type": "number"},
+        "highConfidenceSourceCount": {"type": "number"}
+      }
+    },
+    "sourceSummary": {
+      "type": "object",
+      "required": ["componentMetadataFiles", "sourceUnits", "sourceUnitsByKind"],
+      "additionalProperties": false,
+      "properties": {
+        "componentMetadataFiles": {"type": "number"},
+        "sourceUnits": {"type": "number"},
+        "sourceUnitsByKind": {
+          "type": "object",
+          "required": ["story", "example", "test"],
+          "additionalProperties": false,
+          "properties": {
+            "story": {"type": "number"},
+            "example": {"type": "number"},
+            "test": {"type": "number"}
+          }
+        }
+      }
+    },
+    "apiParentChild": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/apiParentChild"}
+    },
+    "observed": {
+      "type": "object",
+      "required": ["parentChild", "adjacentSibling"],
+      "additionalProperties": false,
+      "properties": {
+        "parentChild": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/observedParentChild"}
+        },
+        "adjacentSibling": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/observedSibling"}
+        }
+      }
+    }
+  },
+  "definitions": {
+    "source": {
+      "type": "object",
+      "required": ["kind", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {"type": "string", "enum": ["story", "example", "test"]},
+        "path": {"type": "string"}
+      }
+    },
+    "apiParentChild": {
+      "type": "object",
+      "required": ["parent", "child", "required", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "parent": {"type": "string"},
+        "child": {"type": "string"},
+        "required": {"type": "boolean"},
+        "source": {
+          "type": "object",
+          "required": ["path", "prop", "type"],
+          "additionalProperties": false,
+          "properties": {
+            "path": {"type": "string"},
+            "prop": {"type": "string"},
+            "type": {"type": "string"}
+          }
+        }
+      }
+    },
+    "observedParentChild": {
+      "type": "object",
+      "required": ["parent", "child", "occurrences", "sourceCount", "confidence", "sources"],
+      "additionalProperties": false,
+      "properties": {
+        "parent": {"type": "string"},
+        "child": {"type": "string"},
+        "occurrences": {"type": "number"},
+        "sourceCount": {"type": "number"},
+        "confidence": {"type": "string", "enum": ["medium", "high"]},
+        "sources": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/source"}
+        }
+      }
+    },
+    "observedSibling": {
+      "type": "object",
+      "required": ["parent", "previous", "next", "occurrences", "sourceCount", "confidence", "sources"],
+      "additionalProperties": false,
+      "properties": {
+        "parent": {"type": "string"},
+        "previous": {"type": "string"},
+        "next": {"type": "string"},
+        "occurrences": {"type": "number"},
+        "sourceCount": {"type": "number"},
+        "confidence": {"type": "string", "enum": ["medium", "high"]},
+        "sources": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/source"}
+        }
+      }
+    }
+  }
+}

--- a/packages/react/script/components-json/composition.ts
+++ b/packages/react/script/components-json/composition.ts
@@ -1,13 +1,13 @@
 import {parse} from '@babel/parser'
 import {traverse} from '@babel/core'
-import type {JSXElement, JSXOpeningElement, Node} from '@babel/types'
+import type {JSXAttribute, JSXElement, JSXOpeningElement, Node} from '@babel/types'
 import fs from 'node:fs'
 import glob from 'fast-glob'
 
 const minimumSourceCount = 2
 const highConfidenceSourceCount = 3
 
-type SourceKind = 'story' | 'example' | 'test'
+type SourceKind = 'story' | 'example' | 'test' | 'implementation'
 
 interface ComponentProp {
   name: string
@@ -56,14 +56,42 @@ interface ObservedSiblingRelationship {
   sources: Array<RelationshipSource>
 }
 
+interface ObservedVariantRelationship {
+  component: string
+  prop: string
+  value: string
+  occurrences: number
+  sourceCount: number
+  confidence: 'medium' | 'high'
+  sources: Array<RelationshipSource>
+}
+
+interface ObservedRelatedComponentsRelationship {
+  first: string
+  second: string
+  relationshipKinds: Array<'parentChild' | 'adjacentSibling'>
+  occurrences: number
+  sourceCount: number
+  confidence: 'medium' | 'high'
+  sources: Array<RelationshipSource>
+}
+
 interface ApiParentChildRelationship {
   parent: string
   child: string
-  required: boolean
+  childrenPropRequired: boolean
   source: {
     path: string
     prop: string
     type: string
+  }
+}
+
+interface ApiSubcomponentRelationship {
+  parent: string
+  subcomponent: string
+  source: {
+    path: string
   }
 }
 
@@ -80,9 +108,12 @@ export interface CompositionMetadata {
     sourceUnitsByKind: Record<SourceKind, number>
   }
   apiParentChild: Array<ApiParentChildRelationship>
+  apiSubcomponents: Array<ApiSubcomponentRelationship>
   observed: {
     parentChild: Array<ObservedParentChildRelationship>
     adjacentSibling: Array<ObservedSiblingRelationship>
+    variants: Array<ObservedVariantRelationship>
+    relatedComponents: Array<ObservedRelatedComponentsRelationship>
   }
 }
 
@@ -91,7 +122,12 @@ interface RelationshipAccumulator {
   sources: Map<string, RelationshipSource>
 }
 
+interface RelatedComponentsAccumulator extends RelationshipAccumulator {
+  relationshipKinds: Set<'parentChild' | 'adjacentSibling'>
+}
+
 export function getCompositionSources(docsFiles: Array<string>): Array<CompositionSource> {
+  const componentDirectories = [...new Set(docsFiles.map(getComponentDirectory))]
   const storySources = docsFiles.flatMap(docsFile => {
     const basePath = docsFile.replace(/\.docs\.json$/, '')
 
@@ -101,15 +137,25 @@ export function getCompositionSources(docsFiles: Array<string>): Array<Compositi
       {kind: 'example' as const, path: `${basePath}.examples.stories.tsx`},
     ]
   })
+  const testSources = glob
+    .sync(componentDirectories.map(directory => `${directory}/**/*.test.tsx`))
+    .map(path => ({kind: 'test' as const, path}))
+  const implementationSources = glob
+    .sync(componentDirectories.map(directory => `${directory}/**/*.tsx`))
+    .filter(isImplementationSource)
+    .map(path => ({kind: 'implementation' as const, path}))
 
-  const testSources = glob.sync('src/**/*.test.tsx').map(path => ({kind: 'test' as const, path}))
-
-  const sources: Array<CompositionSource> = [...storySources, ...testSources]
+  const sources: Array<CompositionSource> = [...storySources, ...testSources, ...implementationSources]
 
   return sources
     .filter(source => fs.existsSync(source.path))
     .sort(compareSources)
-    .filter((source, index, sources) => index === 0 || source.path !== sources[index - 1].path)
+    .filter((source, index, sortedSources) => {
+      return (
+        index === 0 ||
+        `${source.kind}\0${source.path}` !== `${sortedSources[index - 1].kind}\0${sortedSources[index - 1].path}`
+      )
+    })
 }
 
 export function buildComposition(
@@ -126,6 +172,8 @@ export function buildComposition(
   })
   const parentChild = new Map<string, RelationshipAccumulator>()
   const adjacentSibling = new Map<string, RelationshipAccumulator>()
+  const variants = new Map<string, RelationshipAccumulator>()
+  const relatedComponents = new Map<string, RelatedComponentsAccumulator>()
 
   for (const source of uniqueSources) {
     const sourceCode = readFile(source.path)
@@ -133,10 +181,16 @@ export function buildComposition(
 
     for (const relationship of relationships.parentChild) {
       addRelationship(parentChild, `${relationship.parent}\0${relationship.child}`, source)
+      addRelatedComponents(relatedComponents, relationship.parent, relationship.child, 'parentChild', source)
     }
 
     for (const relationship of relationships.adjacentSibling) {
       addRelationship(adjacentSibling, `${relationship.parent}\0${relationship.previous}\0${relationship.next}`, source)
+      addRelatedComponents(relatedComponents, relationship.previous, relationship.next, 'adjacentSibling', source)
+    }
+
+    for (const variant of relationships.variants) {
+      addRelationship(variants, `${variant.component}\0${variant.prop}\0${variant.value}`, source)
     }
   }
 
@@ -154,14 +208,31 @@ export function buildComposition(
         story: uniqueSources.filter(source => source.kind === 'story').length,
         example: uniqueSources.filter(source => source.kind === 'example').length,
         test: uniqueSources.filter(source => source.kind === 'test').length,
+        implementation: uniqueSources.filter(source => source.kind === 'implementation').length,
       },
     },
     apiParentChild: getApiParentChildRelationships(components, componentNames),
+    apiSubcomponents: getApiSubcomponentRelationships(components),
     observed: {
       parentChild: toParentChildRelationships(parentChild),
       adjacentSibling: toSiblingRelationships(adjacentSibling),
+      variants: toVariantRelationships(variants),
+      relatedComponents: toRelatedComponentsRelationships(relatedComponents),
     },
   }
+}
+
+function getComponentDirectory(docsFile: string): string {
+  return docsFile.slice(0, docsFile.lastIndexOf('/'))
+}
+
+function isImplementationSource(path: string): boolean {
+  return (
+    !path.includes('.stories.') &&
+    !path.includes('.test.') &&
+    !path.includes('.figma.') &&
+    !path.includes('.dev.stories.')
+  )
 }
 
 function getComponentNames(components: Array<DocumentedComponent>): Set<string> {
@@ -189,7 +260,7 @@ function getApiParentChildRelationships(
         .map(child => ({
           parent: documentedComponent.name,
           child,
-          required: childrenProp.required === true,
+          childrenPropRequired: childrenProp.required === true,
           source: {
             path: component.sourcePath,
             prop: childrenProp.name,
@@ -199,11 +270,48 @@ function getApiParentChildRelationships(
     })
   })
 
-  return relationships.sort((a, b) => {
-    return (
-      a.parent.localeCompare(b.parent) || a.child.localeCompare(b.child) || a.source.path.localeCompare(b.source.path)
+  return relationships
+    .sort((a, b) => {
+      return (
+        a.parent.localeCompare(b.parent) || a.child.localeCompare(b.child) || a.source.path.localeCompare(b.source.path)
+      )
+    })
+    .filter((relationship, index, sortedRelationships) => {
+      const previous = sortedRelationships[index - 1]
+      return (
+        index === 0 ||
+        relationship.parent !== previous.parent ||
+        relationship.child !== previous.child ||
+        relationship.source.path !== previous.source.path
+      )
+    })
+}
+
+function getApiSubcomponentRelationships(components: Array<DocumentedComponent>): Array<ApiSubcomponentRelationship> {
+  return components
+    .flatMap(component =>
+      (component.subcomponents ?? []).map(subcomponent => ({
+        parent: component.name,
+        subcomponent: subcomponent.name,
+        source: {path: component.sourcePath},
+      })),
     )
-  })
+    .sort((a, b) => {
+      return (
+        a.parent.localeCompare(b.parent) ||
+        a.subcomponent.localeCompare(b.subcomponent) ||
+        a.source.path.localeCompare(b.source.path)
+      )
+    })
+    .filter((relationship, index, sortedRelationships) => {
+      const previous = sortedRelationships[index - 1]
+      return (
+        index === 0 ||
+        relationship.parent !== previous.parent ||
+        relationship.subcomponent !== previous.subcomponent ||
+        relationship.source.path !== previous.source.path
+      )
+    })
 }
 
 function getComponentReferences(type: string, componentNames: Set<string>): Array<string> {
@@ -223,16 +331,17 @@ function extractObservedRelationships(sourceCode: string, componentNames: Set<st
   const aliases = getImportAliases(ast, componentNames)
   const parentChild: Array<{parent: string; child: string}> = []
   const adjacentSibling: Array<{parent: string; previous: string; next: string}> = []
+  const variants: Array<{component: string; prop: string; value: string}> = []
 
   traverse(ast, {
     JSXElement(path) {
       if (path.findParent(parentPath => parentPath.isJSXElement())) return
 
-      walkElement(path.node, undefined, aliases, componentNames, parentChild, adjacentSibling)
+      walkElement(path.node, undefined, aliases, componentNames, parentChild, adjacentSibling, variants)
     },
   })
 
-  return {parentChild, adjacentSibling}
+  return {parentChild, adjacentSibling, variants}
 }
 
 function getImportAliases(ast: Node, componentNames: Set<string>): Map<string, string | undefined> {
@@ -264,12 +373,17 @@ function walkElement(
   componentNames: Set<string>,
   parentChild: Array<{parent: string; child: string}>,
   adjacentSibling: Array<{parent: string; previous: string; next: string}>,
+  variants: Array<{component: string; prop: string; value: string}>,
 ) {
   const component = resolveComponentName(element.openingElement.name, aliases, componentNames)
   const nearestComponent = component ?? parent
 
   if (parent && component) {
     parentChild.push({parent, child: component})
+  }
+
+  if (component) {
+    variants.push(...getStaticVariants(component, element.openingElement))
   }
 
   const directChildren = getDirectChildElements(element.children)
@@ -288,8 +402,47 @@ function walkElement(
   }
 
   for (const child of directChildren) {
-    walkElement(child, nearestComponent, aliases, componentNames, parentChild, adjacentSibling)
+    walkElement(child, nearestComponent, aliases, componentNames, parentChild, adjacentSibling, variants)
   }
+}
+
+function getStaticVariants(
+  component: string,
+  openingElement: JSXOpeningElement,
+): Array<{component: string; prop: string; value: string}> {
+  return openingElement.attributes.flatMap(attribute => {
+    if (
+      attribute.type !== 'JSXAttribute' ||
+      attribute.name.type !== 'JSXIdentifier' ||
+      (attribute.name.name !== 'variant' && !attribute.name.name.endsWith('Variant'))
+    ) {
+      return []
+    }
+
+    const value = getStaticAttributeValue(attribute.value)
+    return value === undefined ? [] : [{component, prop: attribute.name.name, value}]
+  })
+}
+
+function getStaticAttributeValue(attributeValue: JSXAttribute['value']): string | undefined {
+  if (!attributeValue) return 'true'
+  if (attributeValue.type === 'StringLiteral') return attributeValue.value
+  if (attributeValue.type !== 'JSXExpressionContainer') return undefined
+
+  const {expression} = attributeValue
+  if (
+    expression.type === 'StringLiteral' ||
+    expression.type === 'NumericLiteral' ||
+    expression.type === 'BooleanLiteral'
+  ) {
+    return String(expression.value)
+  }
+
+  if (expression.type === 'TemplateLiteral' && expression.expressions.length === 0) {
+    return expression.quasis[0]?.value.cooked ?? expression.quasis[0]?.value.raw
+  }
+
+  return undefined
 }
 
 function getDirectChildElements(children: Array<JSXElement['children'][number]>): Array<JSXElement> {
@@ -348,6 +501,24 @@ function addRelationship(relationships: Map<string, RelationshipAccumulator>, ke
   relationships.set(key, relationship)
 }
 
+function addRelatedComponents(
+  relationships: Map<string, RelatedComponentsAccumulator>,
+  first: string,
+  second: string,
+  relationshipKind: 'parentChild' | 'adjacentSibling',
+  source: RelationshipSource,
+) {
+  if (first === second) return
+
+  const [sortedFirst, sortedSecond] = [first, second].sort((a, b) => a.localeCompare(b))
+  const key = `${sortedFirst}\0${sortedSecond}`
+  const relationship = relationships.get(key) ?? {occurrences: 0, sources: new Map(), relationshipKinds: new Set()}
+  relationship.occurrences += 1
+  relationship.sources.set(`${source.kind}\0${source.path}`, {kind: source.kind, path: source.path})
+  relationship.relationshipKinds.add(relationshipKind)
+  relationships.set(key, relationship)
+}
+
 function toParentChildRelationships(
   relationships: Map<string, RelationshipAccumulator>,
 ): Array<ObservedParentChildRelationship> {
@@ -393,6 +564,54 @@ function toSiblingRelationships(
     .sort((a, b) => {
       return a.parent.localeCompare(b.parent) || a.previous.localeCompare(b.previous) || a.next.localeCompare(b.next)
     })
+}
+
+function toVariantRelationships(
+  relationships: Map<string, RelationshipAccumulator>,
+): Array<ObservedVariantRelationship> {
+  return [...relationships]
+    .flatMap(([key, relationship]) => {
+      const [component, prop, value] = key.split('\0')
+      return relationship.sources.size >= minimumSourceCount
+        ? [
+            {
+              component,
+              prop,
+              value,
+              occurrences: relationship.occurrences,
+              sourceCount: relationship.sources.size,
+              confidence: getConfidence(relationship.sources.size),
+              sources: [...relationship.sources.values()].sort(compareSources),
+            },
+          ]
+        : []
+    })
+    .sort((a, b) => {
+      return a.component.localeCompare(b.component) || a.prop.localeCompare(b.prop) || a.value.localeCompare(b.value)
+    })
+}
+
+function toRelatedComponentsRelationships(
+  relationships: Map<string, RelatedComponentsAccumulator>,
+): Array<ObservedRelatedComponentsRelationship> {
+  return [...relationships]
+    .flatMap(([key, relationship]) => {
+      const [first, second] = key.split('\0')
+      return relationship.sources.size >= minimumSourceCount
+        ? [
+            {
+              first,
+              second,
+              relationshipKinds: [...relationship.relationshipKinds].sort(),
+              occurrences: relationship.occurrences,
+              sourceCount: relationship.sources.size,
+              confidence: getConfidence(relationship.sources.size),
+              sources: [...relationship.sources.values()].sort(compareSources),
+            },
+          ]
+        : []
+    })
+    .sort((a, b) => a.first.localeCompare(b.first) || a.second.localeCompare(b.second))
 }
 
 function getConfidence(sourceCount: number): 'medium' | 'high' {

--- a/packages/react/script/components-json/composition.ts
+++ b/packages/react/script/components-json/composition.ts
@@ -1,0 +1,404 @@
+import {parse} from '@babel/parser'
+import {traverse} from '@babel/core'
+import type {JSXElement, JSXOpeningElement, Node} from '@babel/types'
+import fs from 'node:fs'
+import glob from 'fast-glob'
+
+const minimumSourceCount = 2
+const highConfidenceSourceCount = 3
+
+type SourceKind = 'story' | 'example' | 'test'
+
+interface ComponentProp {
+  name: string
+  type: string
+  required?: boolean
+}
+
+interface DocumentedSubcomponent {
+  name: string
+  props: Array<ComponentProp>
+}
+
+export interface DocumentedComponent {
+  name: string
+  props: Array<ComponentProp>
+  sourcePath: string
+  subcomponents?: Array<DocumentedSubcomponent>
+}
+
+export interface CompositionSource {
+  kind: SourceKind
+  path: string
+}
+
+interface RelationshipSource {
+  kind: SourceKind
+  path: string
+}
+
+interface ObservedParentChildRelationship {
+  parent: string
+  child: string
+  occurrences: number
+  sourceCount: number
+  confidence: 'medium' | 'high'
+  sources: Array<RelationshipSource>
+}
+
+interface ObservedSiblingRelationship {
+  parent: string
+  previous: string
+  next: string
+  occurrences: number
+  sourceCount: number
+  confidence: 'medium' | 'high'
+  sources: Array<RelationshipSource>
+}
+
+interface ApiParentChildRelationship {
+  parent: string
+  child: string
+  required: boolean
+  source: {
+    path: string
+    prop: string
+    type: string
+  }
+}
+
+export interface CompositionMetadata {
+  schemaVersion: 1
+  derivation: {
+    sourceKinds: Array<SourceKind>
+    minimumSourceCount: number
+    highConfidenceSourceCount: number
+  }
+  sourceSummary: {
+    componentMetadataFiles: number
+    sourceUnits: number
+    sourceUnitsByKind: Record<SourceKind, number>
+  }
+  apiParentChild: Array<ApiParentChildRelationship>
+  observed: {
+    parentChild: Array<ObservedParentChildRelationship>
+    adjacentSibling: Array<ObservedSiblingRelationship>
+  }
+}
+
+interface RelationshipAccumulator {
+  occurrences: number
+  sources: Map<string, RelationshipSource>
+}
+
+export function getCompositionSources(docsFiles: Array<string>): Array<CompositionSource> {
+  const storySources = docsFiles.flatMap(docsFile => {
+    const basePath = docsFile.replace(/\.docs\.json$/, '')
+
+    return [
+      {kind: 'story' as const, path: `${basePath}.stories.tsx`},
+      {kind: 'story' as const, path: `${basePath}.features.stories.tsx`},
+      {kind: 'example' as const, path: `${basePath}.examples.stories.tsx`},
+    ]
+  })
+
+  const testSources = glob.sync('src/**/*.test.tsx').map(path => ({kind: 'test' as const, path}))
+
+  const sources: Array<CompositionSource> = [...storySources, ...testSources]
+
+  return sources
+    .filter(source => fs.existsSync(source.path))
+    .sort(compareSources)
+    .filter((source, index, sources) => index === 0 || source.path !== sources[index - 1].path)
+}
+
+export function buildComposition(
+  components: Array<DocumentedComponent>,
+  sources: Array<CompositionSource>,
+  readFile: (path: string) => string = path => fs.readFileSync(path, 'utf8'),
+): CompositionMetadata {
+  const componentNames = getComponentNames(components)
+  const uniqueSources = [...sources].sort(compareSources).filter((source, index, sortedSources) => {
+    return (
+      index === 0 ||
+      `${source.kind}\0${source.path}` !== `${sortedSources[index - 1].kind}\0${sortedSources[index - 1].path}`
+    )
+  })
+  const parentChild = new Map<string, RelationshipAccumulator>()
+  const adjacentSibling = new Map<string, RelationshipAccumulator>()
+
+  for (const source of uniqueSources) {
+    const sourceCode = readFile(source.path)
+    const relationships = extractObservedRelationships(sourceCode, componentNames)
+
+    for (const relationship of relationships.parentChild) {
+      addRelationship(parentChild, `${relationship.parent}\0${relationship.child}`, source)
+    }
+
+    for (const relationship of relationships.adjacentSibling) {
+      addRelationship(adjacentSibling, `${relationship.parent}\0${relationship.previous}\0${relationship.next}`, source)
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    derivation: {
+      sourceKinds: [...new Set(uniqueSources.map(source => source.kind))].sort(),
+      minimumSourceCount,
+      highConfidenceSourceCount,
+    },
+    sourceSummary: {
+      componentMetadataFiles: components.length,
+      sourceUnits: uniqueSources.length,
+      sourceUnitsByKind: {
+        story: uniqueSources.filter(source => source.kind === 'story').length,
+        example: uniqueSources.filter(source => source.kind === 'example').length,
+        test: uniqueSources.filter(source => source.kind === 'test').length,
+      },
+    },
+    apiParentChild: getApiParentChildRelationships(components, componentNames),
+    observed: {
+      parentChild: toParentChildRelationships(parentChild),
+      adjacentSibling: toSiblingRelationships(adjacentSibling),
+    },
+  }
+}
+
+function getComponentNames(components: Array<DocumentedComponent>): Set<string> {
+  return new Set(
+    components.flatMap(component => [
+      component.name,
+      ...(component.subcomponents?.map(subcomponent => subcomponent.name) ?? []),
+    ]),
+  )
+}
+
+function getApiParentChildRelationships(
+  components: Array<DocumentedComponent>,
+  componentNames: Set<string>,
+): Array<ApiParentChildRelationship> {
+  const relationships = components.flatMap(component => {
+    const documentedComponents = [{name: component.name, props: component.props}, ...(component.subcomponents ?? [])]
+
+    return documentedComponents.flatMap(documentedComponent => {
+      const childrenProp = documentedComponent.props.find(prop => prop.name === 'children')
+      if (!childrenProp) return []
+
+      return getComponentReferences(childrenProp.type, componentNames)
+        .filter(child => child !== documentedComponent.name)
+        .map(child => ({
+          parent: documentedComponent.name,
+          child,
+          required: childrenProp.required === true,
+          source: {
+            path: component.sourcePath,
+            prop: childrenProp.name,
+            type: childrenProp.type,
+          },
+        }))
+    })
+  })
+
+  return relationships.sort((a, b) => {
+    return (
+      a.parent.localeCompare(b.parent) || a.child.localeCompare(b.child) || a.source.path.localeCompare(b.source.path)
+    )
+  })
+}
+
+function getComponentReferences(type: string, componentNames: Set<string>): Array<string> {
+  return [...componentNames]
+    .sort((a, b) => b.length - a.length || a.localeCompare(b))
+    .filter(name => {
+      const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      return new RegExp(`(^|[^A-Za-z0-9_.])${escapedName}(?=$|[^A-Za-z0-9_.])`).test(type)
+    })
+}
+
+function extractObservedRelationships(sourceCode: string, componentNames: Set<string>) {
+  const ast = parse(sourceCode, {
+    sourceType: 'module',
+    plugins: ['jsx', 'typescript'],
+  })
+  const aliases = getImportAliases(ast, componentNames)
+  const parentChild: Array<{parent: string; child: string}> = []
+  const adjacentSibling: Array<{parent: string; previous: string; next: string}> = []
+
+  traverse(ast, {
+    JSXElement(path) {
+      if (path.findParent(parentPath => parentPath.isJSXElement())) return
+
+      walkElement(path.node, undefined, aliases, componentNames, parentChild, adjacentSibling)
+    },
+  })
+
+  return {parentChild, adjacentSibling}
+}
+
+function getImportAliases(ast: Node, componentNames: Set<string>): Map<string, string | undefined> {
+  const aliases = new Map<string, string | undefined>()
+
+  traverse(ast, {
+    ImportDeclaration(path) {
+      for (const specifier of path.node.specifiers) {
+        if (specifier.type === 'ImportSpecifier' && specifier.imported.type === 'Identifier') {
+          if (componentNames.has(specifier.imported.name)) {
+            aliases.set(specifier.local.name, specifier.imported.name)
+          }
+        } else if (specifier.type === 'ImportDefaultSpecifier' && componentNames.has(specifier.local.name)) {
+          aliases.set(specifier.local.name, specifier.local.name)
+        } else if (specifier.type === 'ImportNamespaceSpecifier') {
+          aliases.set(specifier.local.name, undefined)
+        }
+      }
+    },
+  })
+
+  return aliases
+}
+
+function walkElement(
+  element: JSXElement,
+  parent: string | undefined,
+  aliases: Map<string, string | undefined>,
+  componentNames: Set<string>,
+  parentChild: Array<{parent: string; child: string}>,
+  adjacentSibling: Array<{parent: string; previous: string; next: string}>,
+) {
+  const component = resolveComponentName(element.openingElement.name, aliases, componentNames)
+  const nearestComponent = component ?? parent
+
+  if (parent && component) {
+    parentChild.push({parent, child: component})
+  }
+
+  const directChildren = getDirectChildElements(element.children)
+  if (component) {
+    const directChildComponents = directChildren
+      .map(child => resolveComponentName(child.openingElement.name, aliases, componentNames))
+      .filter((child): child is string => child !== undefined)
+
+    for (let index = 1; index < directChildComponents.length; index += 1) {
+      adjacentSibling.push({
+        parent: component,
+        previous: directChildComponents[index - 1],
+        next: directChildComponents[index],
+      })
+    }
+  }
+
+  for (const child of directChildren) {
+    walkElement(child, nearestComponent, aliases, componentNames, parentChild, adjacentSibling)
+  }
+}
+
+function getDirectChildElements(children: Array<JSXElement['children'][number]>): Array<JSXElement> {
+  return children.flatMap(child => {
+    if (child.type === 'JSXElement') return [child]
+    if (child.type === 'JSXFragment') return getDirectChildElements(child.children)
+    if (child.type === 'JSXExpressionContainer') return getJSXElements(child.expression)
+    return []
+  })
+}
+
+function getJSXElements(node: Node | null | undefined): Array<JSXElement> {
+  if (!node || typeof node !== 'object') return []
+  if (node.type === 'JSXElement') return [node]
+  if (node.type === 'JSXFragment') return getDirectChildElements(node.children)
+
+  return Object.values(node).flatMap(value => {
+    if (Array.isArray(value)) {
+      return value.flatMap(item => getJSXElements(item as Node))
+    }
+
+    return getJSXElements(value as Node)
+  })
+}
+
+function resolveComponentName(
+  name: JSXOpeningElement['name'],
+  aliases: Map<string, string | undefined>,
+  componentNames: Set<string>,
+): string | undefined {
+  const parts = getJSXNameParts(name)
+  if (!parts) return undefined
+
+  const alias = aliases.get(parts[0])
+  const [root, suffix] =
+    aliases.has(parts[0]) && alias === undefined ? [parts[1], parts.slice(2)] : [alias ?? parts[0], parts.slice(1)]
+
+  if (!root) return undefined
+
+  const componentName = [root, ...suffix].join('.')
+  return componentNames.has(componentName) ? componentName : undefined
+}
+
+function getJSXNameParts(name: JSXOpeningElement['name']): Array<string> | undefined {
+  if (name.type === 'JSXIdentifier') return [name.name]
+  if (name.type === 'JSXNamespacedName') return undefined
+
+  const objectParts = getJSXNameParts(name.object)
+  return objectParts ? [...objectParts, name.property.name] : undefined
+}
+
+function addRelationship(relationships: Map<string, RelationshipAccumulator>, key: string, source: RelationshipSource) {
+  const relationship = relationships.get(key) ?? {occurrences: 0, sources: new Map()}
+  relationship.occurrences += 1
+  relationship.sources.set(`${source.kind}\0${source.path}`, {kind: source.kind, path: source.path})
+  relationships.set(key, relationship)
+}
+
+function toParentChildRelationships(
+  relationships: Map<string, RelationshipAccumulator>,
+): Array<ObservedParentChildRelationship> {
+  return [...relationships]
+    .flatMap(([key, relationship]) => {
+      const [parent, child] = key.split('\0')
+      return relationship.sources.size >= minimumSourceCount
+        ? [
+            {
+              parent,
+              child,
+              occurrences: relationship.occurrences,
+              sourceCount: relationship.sources.size,
+              confidence: getConfidence(relationship.sources.size),
+              sources: [...relationship.sources.values()].sort(compareSources),
+            },
+          ]
+        : []
+    })
+    .sort((a, b) => a.parent.localeCompare(b.parent) || a.child.localeCompare(b.child))
+}
+
+function toSiblingRelationships(
+  relationships: Map<string, RelationshipAccumulator>,
+): Array<ObservedSiblingRelationship> {
+  return [...relationships]
+    .flatMap(([key, relationship]) => {
+      const [parent, previous, next] = key.split('\0')
+      return relationship.sources.size >= minimumSourceCount
+        ? [
+            {
+              parent,
+              previous,
+              next,
+              occurrences: relationship.occurrences,
+              sourceCount: relationship.sources.size,
+              confidence: getConfidence(relationship.sources.size),
+              sources: [...relationship.sources.values()].sort(compareSources),
+            },
+          ]
+        : []
+    })
+    .sort((a, b) => {
+      return a.parent.localeCompare(b.parent) || a.previous.localeCompare(b.previous) || a.next.localeCompare(b.next)
+    })
+}
+
+function getConfidence(sourceCount: number): 'medium' | 'high' {
+  return sourceCount >= highConfidenceSourceCount ? 'high' : 'medium'
+}
+
+function compareSources(a: CompositionSource, b: CompositionSource): number {
+  return a.path.localeCompare(b.path) || a.kind.localeCompare(b.kind)
+}

--- a/packages/react/script/components-json/output.schema.json
+++ b/packages/react/script/components-json/output.schema.json
@@ -16,6 +16,9 @@
           "$ref": "./component.schema.json#"
         }
       }
+    },
+    "composition": {
+      "$ref": "./composition.schema.json#"
     }
   }
 }

--- a/packages/react/script/components-json/output.schema.json
+++ b/packages/react/script/components-json/output.schema.json
@@ -1,7 +1,7 @@
 {
   "$id": "output.schema.json",
   "type": "object",
-  "required": ["schemaVersion", "components"],
+  "required": ["schemaVersion", "components", "composition"],
   "properties": {
     "schemaVersion": {
       "type": "number",

--- a/packages/react/src/ActionMenu/ActionMenu.docs.json
+++ b/packages/react/src/ActionMenu/ActionMenu.docs.json
@@ -14,6 +14,9 @@
       "id": "components-actionmenu-features--single-select"
     },
     {
+      "id": "components-actionmenu-features--grouped-single-select"
+    },
+    {
       "id": "components-actionmenu-features--multi-select"
     },
     {

--- a/packages/react/src/ActionMenu/ActionMenu.features.stories.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.features.stories.tsx
@@ -103,6 +103,34 @@ export const SingleSelect = () => {
   )
 }
 
+export const GroupedSingleSelect = () => {
+  const options = ['Status', 'Severity', 'Repository']
+  const [selectedOption, setSelectedOption] = React.useState(options[0])
+
+  return (
+    <ActionMenu>
+      <ActionMenu.Button>Group by: {selectedOption}</ActionMenu.Button>
+      <ActionMenu.Overlay>
+        <ActionList selectionVariant="single">
+          <ActionList.Group>
+            <ActionList.GroupHeading>Group by</ActionList.GroupHeading>
+            {options.map(option => (
+              <ActionList.Item
+                key={option}
+                role="menuitemradio"
+                selected={option === selectedOption}
+                onSelect={() => setSelectedOption(option)}
+              >
+                {option}
+              </ActionList.Item>
+            ))}
+          </ActionList.Group>
+        </ActionList>
+      </ActionMenu.Overlay>
+    </ActionMenu>
+  )
+}
+
 export const MultiSelect = () => {
   type Option = {name: string; selected: boolean}
 

--- a/packages/react/src/__tests__/component-composition.test.ts
+++ b/packages/react/src/__tests__/component-composition.test.ts
@@ -1,6 +1,10 @@
+import fs from 'node:fs'
+import {processDocsFile} from '@primer/doc-gen'
 import {describe, expect, it} from 'vitest'
 import {
   buildComposition,
+  getCompositionSources,
+  type CompositionMetadata,
   type CompositionSource,
   type DocumentedComponent,
 } from '../../script/components-json/composition'
@@ -12,6 +16,7 @@ const components: Array<DocumentedComponent> = [
     sourcePath: 'src/ActionMenu/ActionMenu.docs.json',
     subcomponents: [
       {name: 'ActionMenu.Button', props: []},
+      {name: 'ActionMenu.Overlay', props: []},
       {name: 'ActionMenu.Overlay', props: []},
     ],
   },
@@ -30,7 +35,7 @@ const sourceCode = html`
   <ActionMenu>
     <ActionMenu.Button />
     <ActionMenu.Overlay>
-      <ActionList>
+      <ActionList selectionVariant="single">
         <ActionList.Item />
         <ActionList.Divider />
         <ActionList.Item />
@@ -47,7 +52,7 @@ describe('component composition metadata', () => {
       {
         parent: 'ActionList',
         child: 'ActionList.Divider',
-        required: true,
+        childrenPropRequired: true,
         source: {
           path: 'src/ActionList/ActionList.docs.json',
           prop: 'children',
@@ -57,7 +62,7 @@ describe('component composition metadata', () => {
       {
         parent: 'ActionList',
         child: 'ActionList.Item',
-        required: true,
+        childrenPropRequired: true,
         source: {
           path: 'src/ActionList/ActionList.docs.json',
           prop: 'children',
@@ -70,6 +75,36 @@ describe('component composition metadata', () => {
         parent: 'ActionMenu',
         child: 'ActionMenu.Overlay',
         occurrences: 3,
+        sourceCount: 2,
+        confidence: 'medium',
+      }),
+    )
+    expect(composition.apiSubcomponents).toContainEqual({
+      parent: 'ActionMenu',
+      subcomponent: 'ActionMenu.Overlay',
+      source: {path: 'src/ActionMenu/ActionMenu.docs.json'},
+    })
+    expect(
+      composition.apiSubcomponents.filter(
+        relationship => relationship.parent === 'ActionMenu' && relationship.subcomponent === 'ActionMenu.Overlay',
+      ),
+    ).toHaveLength(1)
+    expect(composition.observed.variants).toContainEqual(
+      expect.objectContaining({
+        component: 'ActionList',
+        prop: 'selectionVariant',
+        value: 'single',
+        occurrences: 3,
+        sourceCount: 2,
+        confidence: 'medium',
+      }),
+    )
+    expect(composition.observed.relatedComponents).toContainEqual(
+      expect.objectContaining({
+        first: 'ActionList.Divider',
+        second: 'ActionList.Item',
+        relationshipKinds: ['adjacentSibling'],
+        occurrences: 6,
         sourceCount: 2,
         confidence: 'medium',
       }),
@@ -94,6 +129,106 @@ describe('component composition metadata', () => {
       ],
     })
   })
+
+  it('omits observations that do not meet the source threshold', () => {
+    const composition = buildComposition(
+      components,
+      [{kind: 'story', path: 'src/ActionMenu/ActionMenu.stories.tsx'}],
+      source => sourceCodeByPath[source],
+    )
+
+    expect(composition.observed).toEqual({
+      parentChild: [],
+      adjacentSibling: [],
+      variants: [],
+      relatedComponents: [],
+    })
+  })
+
+  it('derives composition evidence across public component families without component-specific rules', () => {
+    const composition = buildFamilyComposition()
+
+    expect(composition.derivation.sourceKinds).toEqual(['example', 'implementation', 'story', 'test'])
+    expect(composition.sourceSummary.sourceUnitsByKind.implementation).toBeGreaterThan(0)
+
+    expect(composition.apiParentChild).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({parent: 'ActionList', child: 'ActionList.Group', childrenPropRequired: true}),
+        expect.objectContaining({parent: 'FormControl', child: 'TextInput', childrenPropRequired: true}),
+        expect.objectContaining({parent: 'UnderlineNav', child: 'UnderlineNav.Item', childrenPropRequired: true}),
+      ]),
+    )
+    expect(composition.apiSubcomponents).toEqual(
+      expect.arrayContaining([
+        {parent: 'ActionMenu', subcomponent: 'ActionMenu.Overlay', source: {path: familyDocsFiles[1]}},
+        {parent: 'NavList', subcomponent: 'NavList.Item', source: {path: familyDocsFiles[4]}},
+        {parent: 'Dialog', subcomponent: 'Dialog.Body', source: {path: familyDocsFiles[5]}},
+        {parent: 'SelectPanel', subcomponent: 'SelectPanel.SearchInput', source: {path: familyDocsFiles[9]}},
+      ]),
+    )
+    expect(composition.observed.parentChild).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({parent: 'ActionMenu.Overlay', child: 'ActionList', confidence: 'high'}),
+        expect.objectContaining({parent: 'FormControl', child: 'TextInput', confidence: 'high'}),
+        expect.objectContaining({parent: 'NavList', child: 'NavList.Item', confidence: 'high'}),
+        expect.objectContaining({parent: 'UnderlineNav', child: 'UnderlineNav.Item', confidence: 'high'}),
+        expect.objectContaining({parent: 'AnchoredOverlay', child: 'ActionList', confidence: 'medium'}),
+        expect.objectContaining({parent: 'PageLayout', child: 'PageLayout.Content', confidence: 'high'}),
+      ]),
+    )
+    expect(composition.observed.variants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({component: 'ActionList', prop: 'selectionVariant', value: 'single'}),
+        expect.objectContaining({component: 'SelectPanel', prop: 'variant', value: 'modal'}),
+      ]),
+    )
+    expect(composition.observed.adjacentSibling).toContainEqual(
+      expect.objectContaining({
+        parent: 'UnderlineNav',
+        previous: 'UnderlineNav.Item',
+        next: 'UnderlineNav.Item',
+        confidence: 'high',
+      }),
+    )
+    expect(composition.observed.relatedComponents).toContainEqual(
+      expect.objectContaining({first: 'ActionList', second: 'ActionMenu.Overlay', confidence: 'high'}),
+    )
+
+    const actionMenuRelation = composition.observed.parentChild.find(
+      relation => relation.parent === 'ActionMenu.Overlay' && relation.child === 'ActionList',
+    )
+    expect(actionMenuRelation?.sources).toEqual(
+      expect.arrayContaining([expect.objectContaining({kind: 'implementation'})]),
+    )
+    expect(composition.apiSubcomponents).toHaveLength(
+      new Set(composition.apiSubcomponents.map(relation => `${relation.parent}\0${relation.subcomponent}`)).size,
+    )
+    expect(composition.observed.parentChild).not.toContainEqual(expect.objectContaining({parent: 'ConfirmationDialog'}))
+  })
+
+  it('includes composition metadata in the generated package artifact', async () => {
+    await import('../../script/components-json/build')
+
+    const artifact = JSON.parse(fs.readFileSync('generated/components.json', 'utf8')) as {
+      composition: CompositionMetadata
+      schemaVersion: number
+    }
+    const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8')) as {
+      exports: Record<string, string>
+      files: Array<string>
+    }
+
+    expect(artifact.schemaVersion).toBe(2)
+    expect(artifact.composition.schemaVersion).toBe(1)
+    expect(artifact.composition.apiSubcomponents).toContainEqual(
+      expect.objectContaining({parent: 'ActionMenu', subcomponent: 'ActionMenu.Overlay'}),
+    )
+    expect(artifact.composition.observed.parentChild).toContainEqual(
+      expect.objectContaining({parent: 'ActionMenu.Overlay', child: 'ActionList'}),
+    )
+    expect(packageJson.files).toContain('generated')
+    expect(packageJson.exports['./generated/components.json']).toBe('./generated/components.json')
+  }, 20_000)
 })
 
 function sources(): Array<CompositionSource> {
@@ -107,6 +242,32 @@ function sources(): Array<CompositionSource> {
 const sourceCodeByPath: Record<string, string> = {
   'src/ActionMenu/ActionMenu.stories.tsx': sourceCode,
   'src/ActionMenu/ActionMenu.test.tsx': `<>${sourceCode}${sourceCode}</>`,
+}
+
+const familyDocsFiles = [
+  'src/ActionList/ActionList.docs.json',
+  'src/ActionMenu/ActionMenu.docs.json',
+  'src/FormControl/FormControl.docs.json',
+  'src/TextInput/TextInput.docs.json',
+  'src/NavList/NavList.docs.json',
+  'src/Dialog/Dialog.docs.json',
+  'src/ConfirmationDialog/ConfirmationDialog.docs.json',
+  'src/UnderlineNav/UnderlineNav.docs.json',
+  'src/SelectPanel/SelectPanel.docs.json',
+  'src/experimental/SelectPanel2/SelectPanel.docs.json',
+  'src/AnchoredOverlay/AnchoredOverlay.docs.json',
+  'src/Autocomplete/Autocomplete.docs.json',
+  'src/PageLayout/PageLayout.docs.json',
+  'src/PageHeader/PageHeader.docs.json',
+]
+
+function buildFamilyComposition(): CompositionMetadata {
+  const documentedComponents = familyDocsFiles.map(sourcePath => {
+    const component = processDocsFile(sourcePath) as Omit<DocumentedComponent, 'sourcePath'>
+    return {...component, sourcePath}
+  })
+
+  return buildComposition(documentedComponents, getCompositionSources(familyDocsFiles))
 }
 
 function html(strings: TemplateStringsArray): string {

--- a/packages/react/src/__tests__/component-composition.test.ts
+++ b/packages/react/src/__tests__/component-composition.test.ts
@@ -1,0 +1,114 @@
+import {describe, expect, it} from 'vitest'
+import {
+  buildComposition,
+  type CompositionSource,
+  type DocumentedComponent,
+} from '../../script/components-json/composition'
+
+const components: Array<DocumentedComponent> = [
+  {
+    name: 'ActionMenu',
+    props: [{name: 'children', type: 'React.ReactElement[]', required: true}],
+    sourcePath: 'src/ActionMenu/ActionMenu.docs.json',
+    subcomponents: [
+      {name: 'ActionMenu.Button', props: []},
+      {name: 'ActionMenu.Overlay', props: []},
+    ],
+  },
+  {
+    name: 'ActionList',
+    props: [{name: 'children', type: 'ActionList.Item[] | ActionList.Divider[]', required: true}],
+    sourcePath: 'src/ActionList/ActionList.docs.json',
+    subcomponents: [
+      {name: 'ActionList.Item', props: []},
+      {name: 'ActionList.Divider', props: []},
+    ],
+  },
+]
+
+const sourceCode = html`
+  <ActionMenu>
+    <ActionMenu.Button />
+    <ActionMenu.Overlay>
+      <ActionList>
+        <ActionList.Item />
+        <ActionList.Divider />
+        <ActionList.Item />
+      </ActionList>
+    </ActionMenu.Overlay>
+  </ActionMenu>
+`
+
+describe('component composition metadata', () => {
+  it('derives documented child-type contracts separately from observed JSX relationships', () => {
+    const composition = buildComposition(components, sources(), source => sourceCodeByPath[source])
+
+    expect(composition.apiParentChild).toEqual([
+      {
+        parent: 'ActionList',
+        child: 'ActionList.Divider',
+        required: true,
+        source: {
+          path: 'src/ActionList/ActionList.docs.json',
+          prop: 'children',
+          type: 'ActionList.Item[] | ActionList.Divider[]',
+        },
+      },
+      {
+        parent: 'ActionList',
+        child: 'ActionList.Item',
+        required: true,
+        source: {
+          path: 'src/ActionList/ActionList.docs.json',
+          prop: 'children',
+          type: 'ActionList.Item[] | ActionList.Divider[]',
+        },
+      },
+    ])
+    expect(composition.observed.parentChild).toContainEqual(
+      expect.objectContaining({
+        parent: 'ActionMenu',
+        child: 'ActionMenu.Overlay',
+        occurrences: 3,
+        sourceCount: 2,
+        confidence: 'medium',
+      }),
+    )
+  })
+
+  it('counts occurrences while deduplicating source provenance and emits stable ordering', () => {
+    const composition = buildComposition(components, sources(), source => sourceCodeByPath[source])
+    const secondComposition = buildComposition(components, [...sources()].reverse(), source => sourceCodeByPath[source])
+
+    expect(composition).toEqual(secondComposition)
+    expect(composition.observed.adjacentSibling).toContainEqual({
+      parent: 'ActionList',
+      previous: 'ActionList.Item',
+      next: 'ActionList.Divider',
+      occurrences: 3,
+      sourceCount: 2,
+      confidence: 'medium',
+      sources: [
+        {kind: 'story', path: 'src/ActionMenu/ActionMenu.stories.tsx'},
+        {kind: 'test', path: 'src/ActionMenu/ActionMenu.test.tsx'},
+      ],
+    })
+  })
+})
+
+function sources(): Array<CompositionSource> {
+  return [
+    {kind: 'test', path: 'src/ActionMenu/ActionMenu.test.tsx'},
+    {kind: 'story', path: 'src/ActionMenu/ActionMenu.stories.tsx'},
+    {kind: 'story', path: 'src/ActionMenu/ActionMenu.stories.tsx'},
+  ]
+}
+
+const sourceCodeByPath: Record<string, string> = {
+  'src/ActionMenu/ActionMenu.stories.tsx': sourceCode,
+  'src/ActionMenu/ActionMenu.test.tsx': `<>${sourceCode}${sourceCode}</>`,
+}
+
+function html(strings: TemplateStringsArray): string {
+  return strings.join('')
+}

--- a/packages/react/vitest.config.mts
+++ b/packages/react/vitest.config.mts
@@ -24,7 +24,11 @@ export default defineConfig({
   },
   test: {
     name: '@primer/react (node)',
-    include: ['src/__tests__/exports.test.ts', 'src/__tests__/storybook.test.tsx'],
+    include: [
+      'src/__tests__/exports.test.ts',
+      'src/__tests__/storybook.test.tsx',
+      'src/__tests__/component-composition.test.ts',
+    ],
     environment: 'node',
     detectAsyncLeaks: true,
   },


### PR DESCRIPTION
### Changelog

#### New

- **Proposal:** publish structured, source-derived component composition metadata from `@primer/react/generated/components.json`.
- Add the read-only `get_component_composition` MCP tool and package-backed component documentation sources for `get_component` and `get_component_batch`.

#### Changed

- Package-mode batches return compact, composition-first summaries: identity/import/status, documented API relationships, and at most three highest-evidence observations per relationship type.
- Batch results include omitted-observation counts, deterministic occurrence/source-count confidence evidence, and no props, story source, global derivation, or source summary payloads.

#### Removed

- N/A

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Composition metadata is generated from canonical public Primer React sources, rather than separately maintained MCP-specific prose. API declarations describe documented availability only; observed records require at least two distinct source units and do not claim universal semantic correctness. Dynamic JSX and runtime children are excluded.

**MCP consumption:** `get_component_composition` exposes full filtered package-backed composition. `get_component` and `get_component_batch` default to hosted Primer Style documentation, or return installed metadata with `source: "package"` / `PRIMER_COMPONENT_DOCS_SOURCE=package`. Package-mode batches intentionally omit full generated documents and retain `get_component` for full documentation and provenance.

**Truncation guard:** SDK protocol tests cover NavList, SegmentedControl, CounterLabel, and Avatar below 20 KB, plus the high-connectivity ActionList plus SegmentedControl batch below 15 KB. Batch summaries cap observed rows to the three strongest records per type and surface omitted counts.

**Package/canary boundary:** packed React metadata contains composition schema version 1. The current MCP canary artifact is `primer-mcp-0.5.0.tgz` with SHA-256 `c0a4c10e23235b9dc9e4510c08828a9d183f303c52821cc4f57e0757c3900306`.

Validated with:

- `npm run build` (Node 26.4.0)
- `npm run type-check -w @primer/react`
- `npm run type-check -w @primer/mcp`
- `npm test -w @primer/mcp`
- `npm run lint`
- `npm run lint:md`
- `npm run format:diff`
- `npx vitest --config vitest.config.mts --run src/__tests__/component-composition.test.ts` (from `packages/react`)
- package builds and `npm pack` checks for `@primer/react` and `@primer/mcp`