### PR TITLE
Timeline: tag Code Scanning event stories with taxonomy data-* attributes

### DIFF
--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
@@ -26,6 +26,7 @@ import {
   UserActor,
   VariantSection,
 } from './internal/timelineStoryHelpers'
+import {CODE_SCANNING_TAXONOMY, actorTypeForLogin, toEventDataAttributes, type CodeScanningEventType} from './taxonomy'
 import classes from './Timeline.code-scanning.features.stories.module.css'
 
 /**
@@ -172,6 +173,26 @@ const ConfigPill = ({category}: {category: string}) => (
  */
 const SubRow = ({children}: {children: React.ReactNode}) => <div className={classes.SubRow}>{children}</div>
 
+/**
+ * Per-row taxonomy `data-*` attributes (Phase 3 tagging, github/primer#6664,
+ * epic #6654). Projects a Code Scanning leaf event type through the shared
+ * `toEventDataAttributes` serializer from the taxonomy module (primer/react#8180),
+ * mirroring the License Compliance pilot (primer/react#8216). `category` and
+ * `visibility` are derived FROM `CODE_SCANNING_TAXONOMY` so the story never
+ * hand-maintains them. Pass the row's rendered `UserActor` login for USER events
+ * (resolves `data-actor-type` via `actorTypeForLogin`); omit it for SYSTEM rows
+ * so `data-actor-type` is left off entirely. Spread the result onto each
+ * `Timeline.Item`.
+ */
+const codeScanningAttrs = (type: CodeScanningEventType, login?: string) =>
+  toEventDataAttributes({
+    scope: 'code-scanning',
+    type,
+    category: CODE_SCANNING_TAXONOMY[type].category,
+    visibility: CODE_SCANNING_TAXONOMY[type].visibility,
+    actorType: login ? actorTypeForLogin(login) : undefined,
+  })
+
 export default {
   title: 'Components/Timeline/Events/Code Scanning',
   component: Timeline,
@@ -219,7 +240,7 @@ export const EventDetected = () => (
         sub-row, and a right-aligned tool-version Label (Timeline.Actions). */}
     <VariantSection label="First detected in commit">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('detected')}>
           <Timeline.Badge>
             <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
@@ -253,7 +274,7 @@ export const EventDetected = () => (
         card — `show_timeline_commit?` is false for this event). */}
     <VariantSection label="Appeared in branch">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('appeared')}>
           <Timeline.Badge>
             <Octicon icon={GitBranchIcon} />
           </Timeline.Badge>
@@ -283,7 +304,7 @@ export const EventDetected = () => (
         {category}" pill (rendered when the alert has more than one category). */}
     <VariantSection label="Reappeared in branch">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('reappeared')}>
           <Timeline.Badge>
             <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
@@ -314,13 +335,20 @@ export const EventDetected = () => (
  * Config-deleted renders the analysis category as an inline subtle mono pill
  * (`MonoPill`); when the category is empty the live ERB substitutes "API
  * Upload".
+ *
+ * TAXONOMY (github/primer#6664): the two "Fixed in branch" rows are the
+ * ALERT_CLOSED_BECAME_FIXED wire event and carry `data-event-type="fixed"`. The
+ * two "Configuration deleted" rows are visually grouped under Fixed here, but the
+ * taxonomy catalog folds their ALERT_CLOSED_BECAME_OUTDATED wire event into
+ * `closed` (a SYSTEM closure), so those rows carry `data-event-type="closed"`.
+ * Both are system events with no actor, so neither emits `data-actor-type`.
  */
 export const EventFixed = () => (
   <RealisticTimeline>
     {/* Fixed — selected ref → SOLID purple shield-check */}
     <VariantSection label="Fixed in branch (current ref)">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('fixed')}>
           <Timeline.Badge variant="done">
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
@@ -335,7 +363,7 @@ export const EventFixed = () => (
     {/* Fixed — non-selected ref → bare default check */}
     <VariantSection label="Fixed in branch (other ref)">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('fixed')}>
           <Timeline.Badge>
             <Octicon icon={CheckIcon} />
           </Timeline.Badge>
@@ -348,9 +376,12 @@ export const EventFixed = () => (
     </VariantSection>
 
     {/* Config deleted — selected ref → SOLID purple shield-check */}
+    {/* Config-deletion is the ALERT_CLOSED_BECAME_OUTDATED wire event, which the
+        taxonomy folds into `closed` (system closure), not `fixed` — so this row
+        carries data-event-type="closed" despite its visual "Fixed" grouping. */}
     <VariantSection label="Configuration deleted (current ref)">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed')}>
           <Timeline.Badge variant="done">
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
@@ -366,7 +397,7 @@ export const EventFixed = () => (
     {/* Config deleted — non-selected ref → bare default check */}
     <VariantSection label="Configuration deleted (other ref)">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed')}>
           <Timeline.Badge>
             <Octicon icon={CheckIcon} />
           </Timeline.Badge>
@@ -398,7 +429,7 @@ export const EventClosedByUser = () => (
     {/* Closed as false positive — with a resolution-note sub-row */}
     <VariantSection label="Closed as false positive">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
@@ -415,7 +446,7 @@ export const EventClosedByUser = () => (
     {/* Closed as used in tests */}
     <VariantSection label="Closed as used in tests">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
@@ -431,7 +462,7 @@ export const EventClosedByUser = () => (
     {/* Closed as won't fix */}
     <VariantSection label="Closed as won't fix">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
@@ -448,7 +479,7 @@ export const EventClosedByUser = () => (
         `resolution == :NO_RESOLUTION`. */}
     <VariantSection label="Closed (no resolution)">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
@@ -475,7 +506,7 @@ export const EventReopened = () => (
   <Examples>
     <VariantSection label="Reopened">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('reopened', 'monalisa')}>
           <Timeline.Badge variant="success">
             <Octicon icon={DotFillIcon} />
           </Timeline.Badge>
@@ -510,7 +541,7 @@ export const EventDismissalRequested = () => (
   <Examples>
     <VariantSection label="Requested to dismiss">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('dismissal_requested', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CommentIcon} />
           </Timeline.Badge>
@@ -550,7 +581,7 @@ export const EventDismissalReviewed = () => (
     {/* Approved — check icon + reviewer-comment sub-row */}
     <VariantSection label="Approved dismissal">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('dismissal_reviewed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CheckIcon} />
           </Timeline.Badge>
@@ -567,7 +598,7 @@ export const EventDismissalReviewed = () => (
     {/* Denied — x icon */}
     <VariantSection label="Denied dismissal">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('dismissal_reviewed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={XIcon} />
           </Timeline.Badge>


### PR DESCRIPTION
## Summary

Adds per-row `data-*` taxonomy attributes to the Code Scanning Timeline event stories. This is the Phase 3 tagging fan-out (github/primer#6664, epic github/primer#6654) applied to the Code Scanning surface, following the proven License Compliance pilot (#8216).

Every `Timeline.Item` in `Timeline.code-scanning.features.stories.tsx` now spreads a small local `codeScanningAttrs` helper that projects the row through the shared `toEventDataAttributes` serializer from the taxonomy module (#8180, docs #6888). It emits `data-event-scope`, `data-event-type`, `data-event-category`, `data-event-visibility`, and (for actor rows) `data-actor-type`.

This is the same contract as the License Compliance pilot (#8216) consuming the taxonomy module (#8180): the story derives `category` and `visibility` FROM `CODE_SCANNING_TAXONOMY` rather than hand-maintaining them, and resolves `data-actor-type` from the rendered actor login via `actorTypeForLogin`. System rows (no rendered actor) pass no login, so `data-actor-type` is omitted entirely.

Storybook-only, no visual change. This file is intentionally not wired into components-json or the docs page, so nothing consumer-facing changes.

## Per-row attributes

- Detected group (First detected, Appeared, Reappeared): system events, `data-event-type` `detected` / `appeared` / `reappeared`, category `findings`, no `data-actor-type`.
- Fixed group: the two "Fixed in branch" rows carry `data-event-type="fixed"` (category `findings`), system, no actor.
- Closed by user (false positive, used in tests, won't fix, no resolution): `data-event-type="closed"` (category `status`) with `data-actor-type="user"`.
- Reopened: `data-event-type="reopened"`, user actor.
- Dismissal requested: `data-event-type="dismissal_requested"`, user actor.
- Dismissal reviewed (approved, denied): `data-event-type="dismissal_reviewed"`, user actor.

## The one judgment call: Configuration deleted maps to closed

The `EventFixed` story visually groups two "Configuration deleted" rows alongside the "Fixed in branch" rows. These rows are the `ALERT_CLOSED_BECAME_OUTDATED` wire event, which the taxonomy catalog folds into `closed` (a system closure), not `fixed` (see the `CODE_SCANNING_TAXONOMY` comment: `closed: folds BECAME_OUTDATED (system) + CLOSED_BY_USER (user)`). So the two "Configuration deleted" rows carry `data-event-type="closed"` (category `status`), while the two "Fixed in branch" rows carry `data-event-type="fixed"`. Both are system config/fix events with no rendered actor, so neither emits `data-actor-type`. A code comment on the `EventFixed` story documents this classification. Flagging it here for reviewer confirmation.

All Code Scanning leaves are cataloged; there are no parked or shared events on this surface, so nothing is left untagged.

### Changelog

#### New

Nothing consumer-facing. Storybook-only taxonomy tagging.

#### Changed

Code Scanning Timeline event stories now render per-row `data-*` taxonomy attributes.

#### Removed

Nothing.

### Rollout strategy

- [x] None; Storybook-only change with no consumer-facing or published-package impact, so no changeset is needed.

### Testing & Reviewing

Rendered the `EventDetected`, `EventFixed`, and `EventClosedByUser` stories headlessly and asserted the emitted attributes: Detected rows have no `data-actor-type` and category `findings`; the "Fixed in branch" row is `data-event-type="fixed"` (no actor) while "Configuration deleted" is `data-event-type="closed"` (no actor); the Closed-by-user row is `data-event-type="closed"` with `data-actor-type="user"`. Zero console errors. Prettier, ESLint, Stylelint, and type-check all pass with zero new errors.