### PR TITLE
Timeline: tag Secret Scanning event stories with taxonomy data-* attributes

### DIFF
--- a/packages/react/src/Timeline/Timeline.secret-scanning.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.secret-scanning.features.stories.tsx
@@ -20,6 +20,12 @@ import {
 import {Button} from '../Button'
 import Octicon from '../Octicon'
 import {EventSubRow, MutedTime, RealisticTimeline, UserActor, VariantSection} from './internal/timelineStoryHelpers'
+import {
+  actorTypeForLogin,
+  SECRET_SCANNING_TAXONOMY,
+  toEventDataAttributes,
+  type SecretScanningEventType,
+} from './taxonomy'
 
 /**
  * Secret Scanning alert Timeline event examples (Phase 2 of github/primer#6663).
@@ -53,10 +59,18 @@ import {EventSubRow, MutedTime, RealisticTimeline, UserActor, VariantSection} fr
  * base `Timeline` component's own stories, and any docs-site representation is a
  * Phase 3 consideration via base-component story changes, out of scope here.
  *
- * FUTURE FILTERING (taxonomy still open — github/primer#6663): category
- * `data-*` attributes (e.g. `data-event-category="created"`) will attach to each
- * `Timeline.Item` below so stories can be filtered/grouped by event family. We
- * intentionally do NOT add them yet to avoid baking in a taxonomy.
+ * EVENT TAXONOMY TAGGING (github/primer#6664, Phase 3): each cataloged
+ * `Timeline.Item` below carries the `data-*` event contract
+ * (`data-event-scope` / `data-event-type` / `data-event-category` /
+ * `data-event-visibility` / `data-actor-type`), projected from the shared
+ * `SECRET_SCANNING_TAXONOMY` catalog via `toEventDataAttributes`. This mirrors
+ * the License Compliance pilot (primer/react#8216) and consumes the merged
+ * taxonomy module (#8180) documented in github/primer#6888.
+ *
+ * The catalog was scoped to the five live `switch (event.type)` cases and is
+ * NARROWER than this story set, so MANY variants have no catalog leaf and are
+ * left UNTAGGED on purpose (each such item carries a comment explaining why).
+ * We tag ONLY the seven cataloged leaves and never invent a value.
  *
  * SLOT USAGE (Phase 1 slots — same convention as the Issues / Dependabot groups):
  * - `Timeline.Avatar` (gutter slot, #6677): the 40px LEFT-GUTTER avatar.
@@ -96,6 +110,21 @@ import {EventSubRow, MutedTime, RealisticTimeline, UserActor, VariantSection} fr
 // the shared `UserActor` default avatar (monalisa).
 const SIX7_AVATAR = 'https://avatars.githubusercontent.com/u/4548309?v=4'
 const HUBOT_AVATAR = 'https://avatars.githubusercontent.com/u/480938?v=4'
+
+// Projects a cataloged Secret Scanning leaf into the event `data-*` contract
+// (github/primer#6664), same shape as the License Compliance pilot
+// (primer/react#8216). `category` and `visibility` are read FROM the catalog so
+// the story never re-declares the taxonomy; `login` is the actor rendered in the
+// row, resolved to `data-actor-type` via `actorTypeForLogin`. Omit `login` for
+// actor-less rows so no `data-actor-type` is emitted.
+const secretScanningAttrs = (type: SecretScanningEventType, login?: string) =>
+  toEventDataAttributes({
+    scope: 'secret-scanning',
+    type,
+    category: SECRET_SCANNING_TAXONOMY[type].category,
+    visibility: SECRET_SCANNING_TAXONOMY[type].visibility,
+    actorType: login ? actorTypeForLogin(login) : undefined,
+  })
 
 export default {
   title: 'Components/Timeline/Events/Secret Scanning',
@@ -137,7 +166,12 @@ export const EventCreated = () => (
     {/* Created — GitHub system actor, ShieldIcon on success (green) */}
     <VariantSection label="Created">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `detected` leaf. Renders the GitHub SYSTEM-IDENTITY actor
+            (`<UserActor login="GitHub" …>`); GitHub is not in the bot set, so
+            actorTypeForLogin('GitHub') classifies it as 'user' -> data-actor-type='user'.
+            FLAGGED: whether a system identity should classify as user vs bot is
+            worth confirming (see report). */}
+        <Timeline.Item {...secretScanningAttrs('detected', 'GitHub')}>
           <Timeline.Badge variant="success">
             <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
@@ -177,7 +211,8 @@ export const EventResolution = () => (
         badge. Shown WITH an optional resolution-comment sub-row. */}
     <VariantSection label="Closed as revoked">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf (Resolution, any non-reopened resolution.type); user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
@@ -196,7 +231,8 @@ export const EventResolution = () => (
     {/* Closed as false positive — gray (default) ShieldSlash badge. */}
     <VariantSection label="Closed as false positive">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -212,7 +248,8 @@ export const EventResolution = () => (
     {/* Closed as won't fix */}
     <VariantSection label="Closed as won't fix">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -228,7 +265,8 @@ export const EventResolution = () => (
     {/* Closed as used in tests */}
     <VariantSection label="Closed as used in tests">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -244,7 +282,8 @@ export const EventResolution = () => (
     {/* Closed as pattern deleted */}
     <VariantSection label="Closed as pattern deleted">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -260,7 +299,8 @@ export const EventResolution = () => (
     {/* Closed as pattern edited */}
     <VariantSection label="Closed as pattern edited">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -276,7 +316,8 @@ export const EventResolution = () => (
     {/* Closed as ignored by configuration (resolution type `hidden_by_config`) */}
     <VariantSection label="Closed as ignored by configuration">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -297,7 +338,9 @@ export const EventResolution = () => (
         placement rather than leaving the Break as a stray first child. */}
     <VariantSection label="Reopened">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* Context row: a `closed` leaf preceding the reopen, tagged in place
+            like the seven dedicated "Closed as …" variants; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -308,7 +351,8 @@ export const EventResolution = () => (
           </Timeline.Body>
         </Timeline.Item>
         <Timeline.Break />
-        <Timeline.Item>
+        {/* `reopened` leaf (Resolution, resolution.type === 'reopened'); user actor. */}
+        <Timeline.Item {...secretScanningAttrs('reopened', 'monalisa')}>
           <Timeline.Badge variant="success">
             <Octicon icon={SyncIcon} />
           </Timeline.Badge>
@@ -338,7 +382,8 @@ export const EventBypass = () => (
     {/* Bypassed — AlertIcon, default (gray) badge */}
     <VariantSection label="Bypassed push protection">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `bypassed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('bypassed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={AlertIcon} />
           </Timeline.Badge>
@@ -355,6 +400,9 @@ export const EventBypass = () => (
         repo has delegated bypass enabled. */}
     <VariantSection label="Bypass requested (delegated bypass enabled)">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: the delegated-BYPASS request/approve flow has no catalog
+            leaf. The catalog's dismissal_requested / dismissal_reviewed cover the
+            delegated-CLOSURE flow, a different thing. No leaf -> no data-* tag. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={CommentIcon} />
@@ -371,6 +419,8 @@ export const EventBypass = () => (
     {/* Bypass approved — CheckCircleIcon. Delegated bypass: gated as above. */}
     <VariantSection label="Bypass approved (delegated bypass enabled)">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: delegated-BYPASS flow, no catalog leaf (see the request
+            variant above). No leaf -> no data-* tag. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={CheckCircleIcon} />
@@ -403,7 +453,8 @@ export const EventValidityChange = () => (
     {/* Active — automated (GitHub), AlertIcon on danger (red) */}
     <VariantSection label="Validity: active (automated)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; automated -> GitHub system actor -> 'user'. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'GitHub')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={AlertIcon} />
           </Timeline.Badge>
@@ -419,7 +470,8 @@ export const EventValidityChange = () => (
     {/* Active — manual (user), same danger badge */}
     <VariantSection label="Validity: active (manual)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; manual -> user actor. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'monalisa')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={AlertIcon} />
           </Timeline.Badge>
@@ -435,7 +487,8 @@ export const EventValidityChange = () => (
     {/* Inactive — automated (GitHub), SkipIcon on default (gray) */}
     <VariantSection label="Validity: inactive (automated)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; automated -> GitHub system actor -> 'user'. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'GitHub')}>
           <Timeline.Badge>
             <Octicon icon={SkipIcon} />
           </Timeline.Badge>
@@ -451,7 +504,8 @@ export const EventValidityChange = () => (
     {/* Inactive — manual (user) */}
     <VariantSection label="Validity: inactive (manual)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; manual -> user actor. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={SkipIcon} />
           </Timeline.Badge>
@@ -467,7 +521,8 @@ export const EventValidityChange = () => (
     {/* Unknown — automated (GitHub), AlertIcon on attention (amber) */}
     <VariantSection label="Validity: unknown (automated)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; automated -> GitHub system actor -> 'user'. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'GitHub')}>
           <Timeline.Badge variant="attention">
             <Octicon icon={AlertIcon} />
           </Timeline.Badge>
@@ -483,7 +538,8 @@ export const EventValidityChange = () => (
     {/* Unknown — manual (user) */}
     <VariantSection label="Validity: unknown (manual)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; manual -> user actor. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'monalisa')}>
           <Timeline.Badge variant="attention">
             <Octicon icon={AlertIcon} />
           </Timeline.Badge>
@@ -511,6 +567,10 @@ export const EventReport = () => (
     {/* Reported — ShieldCheckIcon, default (gray) badge, user actor */}
     <VariantSection label="Reported">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: the catalog maps Report -> validity_changed, but
+            github/primer#6888 lists that mapping as UNCONFIRMED (open item #2).
+            Emitting an unconfirmed value would bake in a guess, so leave untagged
+            until the docs confirm the leaf. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={ShieldCheckIcon} />
@@ -545,6 +605,8 @@ export const EventMetadata = () => (
     {/* Metadata created — GitHub system actor, FileAddedIcon, default (gray) badge */}
     <VariantSection label="Extended metadata found">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: MetadataCreated is PARKED per github/primer#6888 ('Parked'
+            section), no catalog leaf. No leaf -> no data-* tag. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={FileAddedIcon} />
@@ -561,6 +623,8 @@ export const EventMetadata = () => (
     {/* Metadata removed — GitHub system actor, FileRemovedIcon, default (gray) badge */}
     <VariantSection label="Extended metadata removed">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: MetadataRemoved is PARKED per github/primer#6888 ('Parked'
+            section), no catalog leaf. No leaf -> no data-* tag. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={FileRemovedIcon} />
@@ -606,7 +670,8 @@ export const EventClosureRequest = () => (
         un-bolded `resolutionText(exemption_request.reason)`. */}
     <VariantSection label="Dismissal requested (reviewer view)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `dismissal_requested` leaf (DelegatedClosureRequestOpened); user actor. */}
+        <Timeline.Item {...secretScanningAttrs('dismissal_requested', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CommentIcon} />
           </Timeline.Badge>
@@ -630,7 +695,8 @@ export const EventClosureRequest = () => (
     {/* Requested — requester view: the invisible "Cancel request" button. */}
     <VariantSection label="Dismissal requested (requester view)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `dismissal_requested` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('dismissal_requested', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CommentIcon} />
           </Timeline.Badge>
@@ -651,7 +717,8 @@ export const EventClosureRequest = () => (
     {/* Approved — CheckCircleIcon, with a reviewer comment sub-row. */}
     <VariantSection label="Dismissal approved">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `dismissal_reviewed` leaf; reviewer user actor (six7). */}
+        <Timeline.Item {...secretScanningAttrs('dismissal_reviewed', 'six7')}>
           <Timeline.Badge>
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -670,7 +737,8 @@ export const EventClosureRequest = () => (
     {/* Denied — XIcon */}
     <VariantSection label="Dismissal denied">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `dismissal_reviewed` leaf; reviewer user actor (six7). */}
+        <Timeline.Item {...secretScanningAttrs('dismissal_reviewed', 'six7')}>
           <Timeline.Badge>
             <Octicon icon={XIcon} />
           </Timeline.Badge>
@@ -689,6 +757,8 @@ export const EventClosureRequest = () => (
     {/* Cancelled — SkipIcon */}
     <VariantSection label="Dismissal request cancelled">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: Secret Scanning has NO dismissal_cancelled leaf (unlike
+            Dependabot). No leaf -> no data-* tag. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={SkipIcon} />
@@ -717,6 +787,9 @@ export const EventClosureRequest = () => (
  */
 export const EventAssignment = () => (
   <RealisticTimeline>
+    {/* UNTAGGED (whole group): Assignment is a cross-surface SHARED event,
+        deliberately kept OUT of the per-surface Secret Scanning catalog. All five
+        variants below carry no data-* event tag. */}
     {/* Self-assigned — actor === assignee */}
     <VariantSection label="Self-assigned">
       <Timeline aria-label="Secret scanning alert timeline">


### PR DESCRIPTION
Part of the Phase 3 taxonomy tagging fan-out (github/primer#6664, epic github/primer#6654), following the License Compliance pilot (#8216). This is Storybook-only and produces no visual change.

It tags the Secret Scanning Timeline event stories with the same event `data-*` contract as the LC pilot, projected from the merged taxonomy module (#8180) and documented in github/primer#6888. A small `secretScanningAttrs(type, login)` helper reads category and visibility from `SECRET_SCANNING_TAXONOMY` and resolves the actor via `actorTypeForLogin`, then spreads the result onto each cataloged `Timeline.Item`.

The Secret Scanning catalog was scoped to the five live event-switch cases (seven leaves) and is narrower than the shipped story set, so many variants have no catalog leaf. Those are intentionally left untagged, each with an inline comment.

### Per-row attributes

Each tagged row carries `data-event-scope="secret-scanning"`, `data-event-type` (the unscoped leaf), `data-event-category` and `data-event-visibility` (from the catalog), and `data-actor-type` (from the rendered actor login, omitted when no actor).

Tagged leaves:

- EventCreated "Created" to `detected` (findings). Renders the GitHub system-identity actor.
- EventResolution: the seven "Closed as ..." variants to `closed`; the "Reopened" section's leading closed context row also `closed`; "Reopened" to `reopened`.
- EventBypass "Bypassed push protection" to `bypassed`.
- EventValidityChange: all six "Validity: ..." variants to `validity_changed` (automated rows render the GitHub system actor, manual rows a user actor).
- EventClosureRequest: both "Dismissal requested" variants to `dismissal_requested`; "Dismissal approved" and "Dismissal denied" to `dismissal_reviewed`.

### Intentionally left untagged (no catalog leaf, or parked/shared)

- EventBypass "Bypass requested" and "Bypass approved" (delegated bypass): the delegated-bypass flow has no catalog leaf. The catalog's dismissal_requested/reviewed cover the delegated-closure flow, a different thing.
- EventReport "Reported": the catalog maps Report to validity_changed, but the docs (github/primer#6888) list that mapping as unconfirmed (open item #2). Left untagged rather than emit an unconfirmed value.
- EventClosureRequest "Dismissal request cancelled": Secret Scanning has no dismissal_cancelled leaf (unlike Dependabot).
- EventMetadata ("Extended metadata found" / "removed"): parked per the docs.
- EventAssignment (all five variants): a cross-surface shared event, deliberately out of the per-surface catalog.

### Flagged judgment calls for review

- The GitHub system-identity actor classifies as `data-actor-type="user"` because `actorTypeForLogin('GitHub')` returns `user` (GitHub is not in the bot set). Whether a system identity should classify as user vs bot is worth confirming.
- The Report to validity_changed mapping is unconfirmed per github/primer#6888 open item #2, so EventReport is left untagged.

### Changelog

#### Changed

- Secret Scanning Timeline feature stories now carry taxonomy `data-*` attributes on cataloged event rows (Storybook-only).

### Rollout strategy

- [x] None; Storybook-only change with no runtime or published API impact.

### Testing & Reviewing

Ran prettier, eslint, and type-check (all pass). Rendered the stories headlessly and confirmed: EventCreated to `data-event-scope="secret-scanning"` `data-event-type="detected"` `data-event-category="findings"` `data-actor-type="user"`; an EventResolution "Closed as ..." row to `data-event-type="closed"`; an EventClosureRequest approved row to `data-event-type="dismissal_reviewed"`; six `validity_changed` rows; and that EventReport, EventMetadata, EventAssignment, the two delegated Bypass rows, and the Dismissal-cancelled row carry no `data-event-*` attributes. Zero console errors.
