### PR TITLE
Timeline: tag Issues event stories with taxonomy data-* attributes

### DIFF
--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -40,6 +40,8 @@ import Octicon from '../Octicon'
 import Token from '../Token'
 import classes from './Timeline.issues.features.stories.module.css'
 import {BoldLink, Examples, MutedTime, UserActor, VariantSection} from './internal/timelineStoryHelpers'
+import {actorTypeForLogin, ISSUE_TAXONOMY, toEventDataAttributes} from './taxonomy'
+import type {IssueEventType} from './taxonomy'
 
 /**
  * Issue Timeline event examples (Phase 2 of github/primer#6663).
@@ -105,6 +107,23 @@ export default {
 } as Meta<ComponentProps<typeof Timeline>>
 
 /**
+ * Serialize the taxonomy `data-*` contract (github/primer#6664) for one Issues
+ * event row. `type` is an ISSUE_TAXONOMY leaf; `category` + `visibility` are read
+ * from the catalog, so metadata leaves (labels, assignees, milestones, project
+ * fields, issue types, rename) pick up `visibility: 'auditOnly'` automatically.
+ * Pass the row's rendered actor login so `data-actor-type` resolves (every Issues
+ * event carries an actor).
+ */
+const issueAttrs = (type: IssueEventType, login?: string) =>
+  toEventDataAttributes({
+    scope: 'issue',
+    type,
+    category: ISSUE_TAXONOMY[type].category,
+    visibility: ISSUE_TAXONOMY[type].visibility,
+    actorType: login ? actorTypeForLogin(login) : undefined,
+  })
+
+/**
  * The Closed event group — `IssueTimeline.eventClosed` (audit § 2).
  *
  * All seven variants are stacked in a single `<Timeline>` so they can be
@@ -118,7 +137,7 @@ export const EventClosed = () => (
     {/* Closed as completed */}
     <VariantSection label="Closed as completed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -139,7 +158,7 @@ export const EventClosed = () => (
           (portable for docs copy-paste; matches production `TimelineRow`). */}
     <VariantSection label="Closed as not planned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge
             style={
               {
@@ -165,7 +184,7 @@ export const EventClosed = () => (
     {/* Closed via pull request */}
     <VariantSection label="Closed via pull request">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -185,7 +204,7 @@ export const EventClosed = () => (
     {/* Closed via commit */}
     <VariantSection label="Closed via commit">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -210,7 +229,7 @@ export const EventClosed = () => (
           equivalent for github-ui's `ProjectV2` closer link. */}
     <VariantSection label="Closed via project">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -233,7 +252,7 @@ export const EventClosed = () => (
           composed here from Primer primitives. */}
     <VariantSection label="Closed as duplicate">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge
             style={
               {
@@ -265,7 +284,7 @@ export const EventClosed = () => (
     {/* Closed with no state reason */}
     <VariantSection label="Closed (no reason)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -293,7 +312,7 @@ export const EventState = () => (
     {/* Reopened — open (green) badge via useIssueState (ReopenedEvent.tsx) */}
     <VariantSection label="Reopened">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('reopened', 'monalisa')}>
           <Timeline.Badge variant="open">
             <Octicon icon={IssueReopenedIcon} />
           </Timeline.Badge>
@@ -310,7 +329,7 @@ export const EventState = () => (
           plain inline Link (the audit shows it bold; live code is canonical). */}
     <VariantSection label="Transferred">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('transferred', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
@@ -329,7 +348,7 @@ export const EventState = () => (
     {/* Pinned */}
     <VariantSection label="Pinned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('pinned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
@@ -345,7 +364,7 @@ export const EventState = () => (
     {/* Unpinned */}
     <VariantSection label="Unpinned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unpinned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
@@ -362,7 +381,7 @@ export const EventState = () => (
           the resulting discussion by number. */}
     <VariantSection label="Converted to discussion">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('converted_to_discussion', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CommentDiscussionIcon} />
           </Timeline.Badge>
@@ -378,6 +397,7 @@ export const EventState = () => (
     {/* Converted from draft */}
     <VariantSection label="Converted from draft">
       <Timeline aria-label="Issue timeline">
+        {/* 'Converted from draft' has no ISSUE_TAXONOMY leaf (a draft-conversion verb the Issues catalog excludes); left untagged. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={IssueDraftIcon} />
@@ -407,7 +427,7 @@ export const EventReferences = () => (
           open PR state icon inline before the PR title). */}
     <VariantSection label="Linked pull request">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('connected', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CrossReferenceIcon} />
           </Timeline.Badge>
@@ -431,7 +451,7 @@ export const EventReferences = () => (
           icon is behind the live code here. */}
     <VariantSection label="Unlinked pull request">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('disconnected', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={GitPullRequestIcon} className={classes.BadgeIconOpen} />
           </Timeline.Badge>
@@ -451,7 +471,7 @@ export const EventReferences = () => (
           inline (showAgoTimestamp={false}) and the commit card is sub-content. */}
     <VariantSection label="Single commit reference">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('referenced', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={GitCommitIcon} />
           </Timeline.Badge>
@@ -482,7 +502,7 @@ export const EventReferences = () => (
     {/* Multiple commit references — same event, pluralized copy + N cards. */}
     <VariantSection label="Multiple commit references">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('referenced', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={GitCommitIcon} />
           </Timeline.Badge>
@@ -538,7 +558,7 @@ export const EventDuplicates = () => (
           IssueLink uses the open (green) state icon. */}
     <VariantSection label="Marked as duplicate">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('marked_as_duplicate', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={DuplicateIcon} />
           </Timeline.Badge>
@@ -562,6 +582,7 @@ export const EventDuplicates = () => (
     {/* Marked <canonical> as a duplicate of this issue — no right controls. */}
     <VariantSection label="Marked as canonical">
       <Timeline aria-label="Issue timeline">
+        {/* 'Marked as canonical' has no ISSUE_TAXONOMY leaf (only 'marked_as_duplicate' exists); left untagged. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={DuplicateIcon} />
@@ -584,6 +605,7 @@ export const EventDuplicates = () => (
     {/* Unmarked this as a duplicate of <canonical>. */}
     <VariantSection label="Unmarked as duplicate">
       <Timeline aria-label="Issue timeline">
+        {/* 'Unmarked as duplicate' has no ISSUE_TAXONOMY leaf (only 'marked_as_duplicate' exists); left untagged. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={DuplicateIcon} />
@@ -605,6 +627,7 @@ export const EventDuplicates = () => (
     {/* Unmarked <canonical> as a duplicate of this issue. */}
     <VariantSection label="Unmarked as canonical">
       <Timeline aria-label="Issue timeline">
+        {/* 'Unmarked as canonical' has no ISSUE_TAXONOMY leaf (only 'marked_as_duplicate' exists); left untagged. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={DuplicateIcon} />
@@ -638,7 +661,7 @@ export const EventModeration = () => (
     {/* User blocked (permanent) */}
     <VariantSection label="User blocked">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('user_blocked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -654,7 +677,7 @@ export const EventModeration = () => (
     {/* User temporarily blocked */}
     <VariantSection label="User temporarily blocked">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('user_blocked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -670,7 +693,7 @@ export const EventModeration = () => (
     {/* Comment pinned — IssueCommentPinnedEvent.tsx links the pinned comment. */}
     <VariantSection label="Comment pinned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('comment_pinned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
@@ -689,7 +712,7 @@ export const EventModeration = () => (
     {/* Comment unpinned */}
     <VariantSection label="Comment unpinned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('comment_unpinned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
@@ -720,7 +743,7 @@ export const EventIssueTypes = () => (
     {/* Type added */}
     <VariantSection label="Issue type added">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('issue_type_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
@@ -750,7 +773,7 @@ export const EventIssueTypes = () => (
     {/* Type removed */}
     <VariantSection label="Issue type removed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('issue_type_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
@@ -780,7 +803,7 @@ export const EventIssueTypes = () => (
     {/* Type changed */}
     <VariantSection label="Issue type changed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('issue_type_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
@@ -840,7 +863,7 @@ export const EventIssueHierarchy = () => (
     {/* Sub-issue added (single) */}
     <VariantSection label="Sub-issue added (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('sub_issue_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
@@ -865,7 +888,7 @@ export const EventIssueHierarchy = () => (
     {/* Sub-issue added (multiple) — plural copy + N reference rows */}
     <VariantSection label="Sub-issues added (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('sub_issue_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
@@ -897,7 +920,7 @@ export const EventIssueHierarchy = () => (
     {/* Sub-issue removed (single) */}
     <VariantSection label="Sub-issue removed (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('sub_issue_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
@@ -922,7 +945,7 @@ export const EventIssueHierarchy = () => (
     {/* Sub-issues removed (multiple) */}
     <VariantSection label="Sub-issues removed (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('sub_issue_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
@@ -954,7 +977,7 @@ export const EventIssueHierarchy = () => (
     {/* Parent issue added (single) */}
     <VariantSection label="Parent issue added (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('parent_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
@@ -979,7 +1002,7 @@ export const EventIssueHierarchy = () => (
     {/* Parent issues added (multiple) */}
     <VariantSection label="Parent issues added (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('parent_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
@@ -1011,7 +1034,7 @@ export const EventIssueHierarchy = () => (
     {/* Parent issue removed (single) */}
     <VariantSection label="Parent issue removed (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('parent_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
@@ -1036,7 +1059,7 @@ export const EventIssueHierarchy = () => (
     {/* Parent issues removed (multiple) */}
     <VariantSection label="Parent issues removed (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('parent_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
@@ -1084,7 +1107,7 @@ export const EventDependencies = () => (
     {/* Blocked by (single) */}
     <VariantSection label="Blocked by (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocked_by_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1109,7 +1132,7 @@ export const EventDependencies = () => (
     {/* Blocked by (multiple) — count in copy + N rows */}
     <VariantSection label="Blocked by (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocked_by_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1141,7 +1164,7 @@ export const EventDependencies = () => (
     {/* Blocked by removed (single) */}
     <VariantSection label="Blocked by removed (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocked_by_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1166,7 +1189,7 @@ export const EventDependencies = () => (
     {/* Blocked by removed (multiple) */}
     <VariantSection label="Blocked by removed (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocked_by_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1198,7 +1221,7 @@ export const EventDependencies = () => (
     {/* Blocking (single) */}
     <VariantSection label="Blocking (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocking_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1223,7 +1246,7 @@ export const EventDependencies = () => (
     {/* Blocking (multiple) */}
     <VariantSection label="Blocking (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocking_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1255,7 +1278,7 @@ export const EventDependencies = () => (
     {/* Blocking removed (single) */}
     <VariantSection label="Blocking removed (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocking_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1280,7 +1303,7 @@ export const EventDependencies = () => (
     {/* Blocking removed (multiple) */}
     <VariantSection label="Blocking removed (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocking_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1332,7 +1355,7 @@ export const EventIssueFields = () => (
     {/* Set text field */}
     <VariantSection label="Set · text">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1353,7 +1376,7 @@ export const EventIssueFields = () => (
     {/* Set number field */}
     <VariantSection label="Set · number">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={NumberIcon} />
           </Timeline.Badge>
@@ -1374,7 +1397,7 @@ export const EventIssueFields = () => (
     {/* Set date field */}
     <VariantSection label="Set · date">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
@@ -1395,7 +1418,7 @@ export const EventIssueFields = () => (
     {/* Set single-select field — value is a colored token */}
     <VariantSection label="Set · single select">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
@@ -1429,7 +1452,7 @@ export const EventIssueFields = () => (
     {/* Changed text field */}
     <VariantSection label="Changed · text">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1450,7 +1473,7 @@ export const EventIssueFields = () => (
     {/* Changed number field */}
     <VariantSection label="Changed · number">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={NumberIcon} />
           </Timeline.Badge>
@@ -1471,7 +1494,7 @@ export const EventIssueFields = () => (
     {/* Changed date field */}
     <VariantSection label="Changed · date">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
@@ -1492,7 +1515,7 @@ export const EventIssueFields = () => (
     {/* Changed single-select field */}
     <VariantSection label="Changed · single select">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
@@ -1523,7 +1546,7 @@ export const EventIssueFields = () => (
     {/* Cleared text field — no value */}
     <VariantSection label="Cleared · text">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1540,7 +1563,7 @@ export const EventIssueFields = () => (
     {/* Cleared number field */}
     <VariantSection label="Cleared · number">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={NumberIcon} />
           </Timeline.Badge>
@@ -1557,7 +1580,7 @@ export const EventIssueFields = () => (
     {/* Cleared date field */}
     <VariantSection label="Cleared · date">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
@@ -1574,7 +1597,7 @@ export const EventIssueFields = () => (
     {/* Cleared single-select field */}
     <VariantSection label="Cleared · single select">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
@@ -1591,7 +1614,7 @@ export const EventIssueFields = () => (
     {/* Rollup: updated only — multiple field updates collapsed into one row */}
     <VariantSection label="Rollup · updated">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1616,7 +1639,7 @@ export const EventIssueFields = () => (
     {/* Rollup: removed only */}
     <VariantSection label="Rollup · removed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1635,7 +1658,7 @@ export const EventIssueFields = () => (
     {/* Rollup: updated and also removed — combined row joined by "and also" */}
     <VariantSection label="Rollup · updated and removed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1687,7 +1710,7 @@ export const EventProject = () => (
     {/* Added to project */}
     <VariantSection label="Added to project">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('added_to_project', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
@@ -1708,7 +1731,7 @@ export const EventProject = () => (
     {/* Removed from project */}
     <VariantSection label="Removed from project">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('removed_from_project', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
@@ -1732,7 +1755,7 @@ export const EventProject = () => (
         strings are PLAIN TEXT (not bold). Both forms shown under one caption. */}
     <VariantSection label="Project status changed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
@@ -1746,7 +1769,7 @@ export const EventProject = () => (
             <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
@@ -1786,7 +1809,7 @@ export const EventLabels = () => (
     {/* Label added */}
     <VariantSection label="Label added">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('labeled', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TagIcon} />
           </Timeline.Badge>
@@ -1815,7 +1838,7 @@ export const EventLabels = () => (
     {/* Label removed */}
     <VariantSection label="Label removed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unlabeled', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TagIcon} />
           </Timeline.Badge>
@@ -1845,6 +1868,7 @@ export const EventLabels = () => (
         with "and" between them. */}
     <VariantSection label="Labels added and removed">
       <Timeline aria-label="Issue timeline">
+        {/* 'Labels added and removed' is one row representing two events (labeled + unlabeled); a single row cannot carry two event types, so left untagged. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={TagIcon} />
@@ -1905,7 +1929,7 @@ export const EventTitle = () => (
     {/* Title changed */}
     <VariantSection label="Title changed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('renamed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PencilIcon} />
           </Timeline.Badge>
@@ -1940,7 +1964,7 @@ export const EventMilestones = () => (
     {/* Added to milestone */}
     <VariantSection label="Added to milestone">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('milestoned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={MilestoneIcon} />
           </Timeline.Badge>
@@ -1960,7 +1984,7 @@ export const EventMilestones = () => (
     {/* Removed from milestone */}
     <VariantSection label="Removed from milestone">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('demilestoned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={MilestoneIcon} />
           </Timeline.Badge>
@@ -1999,7 +2023,7 @@ export const EventAssignments = () => (
     {/* Self-assigned */}
     <VariantSection label="Self-assigned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('assigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2015,7 +2039,7 @@ export const EventAssignments = () => (
     {/* Assigned someone else — assignee is a bold link, no avatar. */}
     <VariantSection label="Assigned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('assigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2031,7 +2055,7 @@ export const EventAssignments = () => (
     {/* Assigned multiple — joined with "and". */}
     <VariantSection label="Assigned multiple">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('assigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2049,7 +2073,7 @@ export const EventAssignments = () => (
     {/* Self-unassigned */}
     <VariantSection label="Self-unassigned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unassigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2065,7 +2089,7 @@ export const EventAssignments = () => (
     {/* Unassigned someone else */}
     <VariantSection label="Unassigned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unassigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2081,7 +2105,7 @@ export const EventAssignments = () => (
     {/* Unassigned multiple — joined with "and". */}
     <VariantSection label="Unassigned multiple">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unassigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2118,7 +2142,7 @@ export const EventLockUnlock = () => (
         too heated). */}
     <VariantSection label="Locked (with reason)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('locked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
@@ -2128,7 +2152,7 @@ export const EventLockUnlock = () => (
             <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('locked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
@@ -2138,7 +2162,7 @@ export const EventLockUnlock = () => (
             <MutedTime date={new Date('2022-07-26T11:47:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('locked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
@@ -2148,7 +2172,7 @@ export const EventLockUnlock = () => (
             <MutedTime date={new Date('2022-07-26T11:48:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('locked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
@@ -2164,7 +2188,7 @@ export const EventLockUnlock = () => (
     {/* Locked (no reason) */}
     <VariantSection label="Locked (no reason)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('locked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
@@ -2180,7 +2204,7 @@ export const EventLockUnlock = () => (
     {/* Unlocked — UnlockIcon badge (not LockIcon). */}
     <VariantSection label="Unlocked">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unlocked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={UnlockIcon} />
           </Timeline.Badge>
@@ -2211,7 +2235,7 @@ export const EventCommentDeleted = () => (
     {/* Comment deleted */}
     <VariantSection label="Comment deleted">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('comment_deleted', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TrashIcon} />
           </Timeline.Badge>
@@ -2249,7 +2273,7 @@ export const EventCrossReferences = () => (
     {/* Mentioned from an issue */}
     <VariantSection label="Mentioned in an issue">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('cross_referenced', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
@@ -2274,7 +2298,7 @@ export const EventCrossReferences = () => (
     {/* Mentioned from a pull request */}
     <VariantSection label="Mentioned in a pull request">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('cross_referenced', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
@@ -2299,7 +2323,7 @@ export const EventCrossReferences = () => (
     {/* Linked a closing pull request */}
     <VariantSection label="Linked a closing pull request">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('cross_referenced', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>


### PR DESCRIPTION
## Summary

This is the Phase 3 tagging fan-out for the Issues surface (github/primer#6664, epic #6654), following the License Compliance pilot (#8216). It adds the taxonomy `data-*` attributes to every cataloged Issues event story so the stories can be filtered and grouped by event family. Issues is the largest surface, with 38 catalog leaves.

The change is Storybook-only and produces no visual change. It edits a single file, `packages/react/src/Timeline/Timeline.issues.features.stories.tsx`, and tags each `Timeline.Item` in place without restructuring, reordering, or regrouping any stories.

It uses the same contract as the License Compliance pilot (#8216): the consuming taxonomy module (#8180) plus its docs (#6888). A small local `issueAttrs` helper calls `toEventDataAttributes` with `scope: 'issue'` (singular), and reads `category` and `visibility` from `ISSUE_TAXONOMY` so the values always come from the catalog rather than being hand-written per row. Each item passes its rendered actor login so `data-actor-type` resolves (every Issues event carries an actor).

Because category and visibility are read from the catalog, the metadata events (labels, assignees, milestones, project fields, issue types, and rename) carry `data-event-visibility='auditOnly'` automatically. The status, references, and moderation events default to `data-event-visibility='primary'`.

### Variants left untagged

Five story variants have no matching leaf in `ISSUE_TAXONOMY`, so they are intentionally left untagged (no `data-event-*` attributes) with an inline code comment explaining why:

- Converted from draft (a draft-conversion verb the Issues catalog excludes)
- Marked as canonical (only `marked_as_duplicate` exists)
- Unmarked as duplicate (only `marked_as_duplicate` exists)
- Unmarked as canonical (only `marked_as_duplicate` exists)
- Labels added and removed (one row representing two events, `labeled` + `unlabeled`, which a single row cannot carry cleanly)

### Changelog

#### New

- `data-event-scope`, `data-event-type`, `data-event-category`, `data-event-visibility`, and `data-actor-type` attributes on the cataloged Issues Timeline event stories.

#### Changed

- None (Storybook-only stories; no component or public API change).

#### Removed

- None.

### Rollout strategy

- [x] None; Storybook-only story metadata with no consumer-facing package change, so no changeset is needed.

### Testing & Reviewing

All repo gates pass with zero new errors: prettier, eslint, stylelint, and type-check (15/15 tasks).

A headless render pass (with console-error enforcement on, 0 console errors) confirmed the sample rows:

- EventClosed item: `data-event-scope='issue'` `data-event-type='closed'` `data-event-category='status'` `data-event-visibility='primary'` `data-actor-type='user'`
- EventLabels "Label added" item: `data-event-type='labeled'` `data-event-category='metadata'` `data-event-visibility='auditOnly'` `data-actor-type='user'`
- EventReferences "Linked pull request" item: `data-event-type='connected'` `data-event-category='references'`

It also confirmed the flagged variants (Converted from draft; Marked as canonical; Unmarked as duplicate; Unmarked as canonical; Labels added and removed) carry no `data-event-*` attributes.

To review, open the `Components/Timeline/Events/Issues` stories in Storybook and inspect the rendered `Timeline.Item` DOM nodes.