### PR TITLE
Timeline: tag event stories with taxonomy data-* attributes (Code Scanning, Dependabot, Secret Scanning, Issues)

### DIFF
--- a/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.code-scanning.features.stories.tsx
@@ -26,6 +26,7 @@ import {
   UserActor,
   VariantSection,
 } from './internal/timelineStoryHelpers'
+import {CODE_SCANNING_TAXONOMY, actorTypeForLogin, toEventDataAttributes, type CodeScanningEventType} from './taxonomy'
 import classes from './Timeline.code-scanning.features.stories.module.css'
 
 /**
@@ -172,6 +173,26 @@ const ConfigPill = ({category}: {category: string}) => (
  */
 const SubRow = ({children}: {children: React.ReactNode}) => <div className={classes.SubRow}>{children}</div>
 
+/**
+ * Per-row taxonomy `data-*` attributes (Phase 3 tagging, github/primer#6664,
+ * epic #6654). Projects a Code Scanning leaf event type through the shared
+ * `toEventDataAttributes` serializer from the taxonomy module (primer/react#8180),
+ * mirroring the License Compliance pilot (primer/react#8216). `category` and
+ * `visibility` are derived FROM `CODE_SCANNING_TAXONOMY` so the story never
+ * hand-maintains them. Pass the row's rendered `UserActor` login for USER events
+ * (resolves `data-actor-type` via `actorTypeForLogin`); omit it for SYSTEM rows
+ * so `data-actor-type` is left off entirely. Spread the result onto each
+ * `Timeline.Item`.
+ */
+const codeScanningAttrs = (type: CodeScanningEventType, login?: string) =>
+  toEventDataAttributes({
+    scope: 'code-scanning',
+    type,
+    category: CODE_SCANNING_TAXONOMY[type].category,
+    visibility: CODE_SCANNING_TAXONOMY[type].visibility,
+    actorType: login ? actorTypeForLogin(login) : undefined,
+  })
+
 export default {
   title: 'Components/Timeline/Events/Code Scanning',
   component: Timeline,
@@ -219,7 +240,7 @@ export const EventDetected = () => (
         sub-row, and a right-aligned tool-version Label (Timeline.Actions). */}
     <VariantSection label="First detected in commit">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('detected')}>
           <Timeline.Badge>
             <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
@@ -253,7 +274,7 @@ export const EventDetected = () => (
         card — `show_timeline_commit?` is false for this event). */}
     <VariantSection label="Appeared in branch">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('appeared')}>
           <Timeline.Badge>
             <Octicon icon={GitBranchIcon} />
           </Timeline.Badge>
@@ -283,7 +304,7 @@ export const EventDetected = () => (
         {category}" pill (rendered when the alert has more than one category). */}
     <VariantSection label="Reappeared in branch">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('reappeared')}>
           <Timeline.Badge>
             <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
@@ -314,13 +335,20 @@ export const EventDetected = () => (
  * Config-deleted renders the analysis category as an inline subtle mono pill
  * (`MonoPill`); when the category is empty the live ERB substitutes "API
  * Upload".
+ *
+ * TAXONOMY (github/primer#6664): the two "Fixed in branch" rows are the
+ * ALERT_CLOSED_BECAME_FIXED wire event and carry `data-event-type="fixed"`. The
+ * two "Configuration deleted" rows are visually grouped under Fixed here, but the
+ * taxonomy catalog folds their ALERT_CLOSED_BECAME_OUTDATED wire event into
+ * `closed` (a SYSTEM closure), so those rows carry `data-event-type="closed"`.
+ * Both are system events with no actor, so neither emits `data-actor-type`.
  */
 export const EventFixed = () => (
   <RealisticTimeline>
     {/* Fixed — selected ref → SOLID purple shield-check */}
     <VariantSection label="Fixed in branch (current ref)">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('fixed')}>
           <Timeline.Badge variant="done">
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
@@ -335,7 +363,7 @@ export const EventFixed = () => (
     {/* Fixed — non-selected ref → bare default check */}
     <VariantSection label="Fixed in branch (other ref)">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('fixed')}>
           <Timeline.Badge>
             <Octicon icon={CheckIcon} />
           </Timeline.Badge>
@@ -348,9 +376,12 @@ export const EventFixed = () => (
     </VariantSection>
 
     {/* Config deleted — selected ref → SOLID purple shield-check */}
+    {/* Config-deletion is the ALERT_CLOSED_BECAME_OUTDATED wire event, which the
+        taxonomy folds into `closed` (system closure), not `fixed` — so this row
+        carries data-event-type="closed" despite its visual "Fixed" grouping. */}
     <VariantSection label="Configuration deleted (current ref)">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed')}>
           <Timeline.Badge variant="done">
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
@@ -366,7 +397,7 @@ export const EventFixed = () => (
     {/* Config deleted — non-selected ref → bare default check */}
     <VariantSection label="Configuration deleted (other ref)">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed')}>
           <Timeline.Badge>
             <Octicon icon={CheckIcon} />
           </Timeline.Badge>
@@ -398,7 +429,7 @@ export const EventClosedByUser = () => (
     {/* Closed as false positive — with a resolution-note sub-row */}
     <VariantSection label="Closed as false positive">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
@@ -415,7 +446,7 @@ export const EventClosedByUser = () => (
     {/* Closed as used in tests */}
     <VariantSection label="Closed as used in tests">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
@@ -431,7 +462,7 @@ export const EventClosedByUser = () => (
     {/* Closed as won't fix */}
     <VariantSection label="Closed as won't fix">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
@@ -448,7 +479,7 @@ export const EventClosedByUser = () => (
         `resolution == :NO_RESOLUTION`. */}
     <VariantSection label="Closed (no resolution)">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={ShieldXIcon} />
           </Timeline.Badge>
@@ -475,7 +506,7 @@ export const EventReopened = () => (
   <Examples>
     <VariantSection label="Reopened">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('reopened', 'monalisa')}>
           <Timeline.Badge variant="success">
             <Octicon icon={DotFillIcon} />
           </Timeline.Badge>
@@ -510,7 +541,7 @@ export const EventDismissalRequested = () => (
   <Examples>
     <VariantSection label="Requested to dismiss">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('dismissal_requested', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CommentIcon} />
           </Timeline.Badge>
@@ -550,7 +581,7 @@ export const EventDismissalReviewed = () => (
     {/* Approved — check icon + reviewer-comment sub-row */}
     <VariantSection label="Approved dismissal">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('dismissal_reviewed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CheckIcon} />
           </Timeline.Badge>
@@ -567,7 +598,7 @@ export const EventDismissalReviewed = () => (
     {/* Denied — x icon */}
     <VariantSection label="Denied dismissal">
       <Timeline aria-label="Code scanning alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...codeScanningAttrs('dismissal_reviewed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={XIcon} />
           </Timeline.Badge>

--- a/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.dependabot.features.stories.tsx
@@ -29,6 +29,7 @@ import {
   UserActor,
   VariantSection,
 } from './internal/timelineStoryHelpers'
+import {actorTypeForLogin, DEPENDABOT_TAXONOMY, toEventDataAttributes, type DependabotEventType} from './taxonomy'
 
 /**
  * Dependabot alert Timeline event examples (Phase 2 of github/primer#6663).
@@ -56,10 +57,26 @@ import {
  * base `Timeline` component's own stories, and any docs-site representation is a
  * Phase 3 consideration via base-component story changes, out of scope here.
  *
- * FUTURE FILTERING (taxonomy still open — github/primer#6663): category
- * `data-*` attributes (e.g. `data-event-category="opened"`) will attach to each
- * `Timeline.Item` below so stories can be filtered/grouped by event family. We
- * intentionally do NOT add them yet to avoid baking in a taxonomy.
+ * TAXONOMY `data-*` CONTRACT: every cataloged `Timeline.Item` below carries the
+ * event `data-*` attributes projected from the merged taxonomy module
+ * (`./taxonomy`, primer/react#8180) — the single source of truth for Timeline
+ * event categorization (github/primer#6664, docs github/primer#6888). Each row
+ * spreads the output of `toEventDataAttributes` via the local `dependabotAttrs`
+ * helper, which derives `category` / `visibility` FROM the catalog entry
+ * (`DEPENDABOT_TAXONOMY`) so the stories stay in sync with the catalog, and
+ * resolves `data-actor-type` at runtime from each row's rendered actor login
+ * (`actorTypeForLogin`): Dependabot-authored rows resolve to `bot`, user-driven
+ * rows to `user`. The contract per rendered `<li>`: `data-event-scope`,
+ * `data-event-type` (the UNSCOPED leaf), `data-event-category`,
+ * `data-event-visibility` (defaults `primary`), and `data-actor-type`. This
+ * applies the same contract proven by the License Compliance pilot
+ * (primer/react#8216).
+ *
+ * SHARED / PARKED EVENTS (left untagged): the Assignment and Copilot-work groups
+ * are cross-surface SHARED events, deliberately kept OUT of the per-surface
+ * Dependabot catalog (github/primer#6888), so they intentionally carry NO
+ * `data-*` attributes. See the code comments above `EventAssignment` and
+ * `EventCopilotWork`.
  *
  * SLOT USAGE (Phase 1 slots — same convention as the Issues group):
  * - `Timeline.Avatar` (gutter slot, #6677): the 40px LEFT-GUTTER avatar.
@@ -120,6 +137,25 @@ const PushPill = ({sha}: {sha: string}) => (
   </code>
 )
 
+/**
+ * Local projection of the taxonomy `data-*` contract for this surface. Given a
+ * Dependabot leaf `type` (and, when the row renders an actor, that actor's
+ * `login`), it returns the `data-*` attribute set to spread on the
+ * `Timeline.Item`. `category` and `visibility` come FROM the catalog entry so
+ * the stories track `DEPENDABOT_TAXONOMY`; `data-actor-type` is resolved at
+ * runtime from the login (Dependabot-authored rows pass a `…[bot]` login so they
+ * resolve to `bot`; user-driven rows pass the rendered user login). See
+ * github/primer#6664 and the taxonomy docs (github/primer#6888).
+ */
+const dependabotAttrs = (type: DependabotEventType, login?: string) =>
+  toEventDataAttributes({
+    scope: 'dependabot',
+    type,
+    category: DEPENDABOT_TAXONOMY[type].category,
+    visibility: DEPENDABOT_TAXONOMY[type].visibility,
+    actorType: login ? actorTypeForLogin(login) : undefined,
+  })
+
 export default {
   title: 'Components/Timeline/Events/Dependabot',
   component: Timeline,
@@ -160,7 +196,7 @@ export const EventOpened = () => (
     {/* Opened — no source */}
     <VariantSection label="Opened">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('opened', 'dependabot[bot]')}>
           <Timeline.Badge variant="success">
             <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
@@ -176,7 +212,7 @@ export const EventOpened = () => (
     {/* OpenedFromPR — bold `#123` pull-request link (scheme: primary, bold) */}
     <VariantSection label="Opened from pull request">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('opened', 'dependabot[bot]')}>
           <Timeline.Badge variant="success">
             <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
@@ -192,7 +228,7 @@ export const EventOpened = () => (
     {/* OpenedFromPush — blue push-pill with the 7-char `after` SHA */}
     <VariantSection label="Opened from push">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('opened', 'dependabot[bot]')}>
           <Timeline.Badge variant="success">
             <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
@@ -225,7 +261,7 @@ export const EventFixed = () => (
     {/* Fixed — no source */}
     <VariantSection label="Fixed">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('fixed', 'dependabot[bot]')}>
           <Timeline.Badge variant="done">
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
@@ -241,7 +277,7 @@ export const EventFixed = () => (
     {/* FixedViaPR — bold `#123` pull-request link */}
     <VariantSection label="Fixed via pull request">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('fixed', 'dependabot[bot]')}>
           <Timeline.Badge variant="done">
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
@@ -257,7 +293,7 @@ export const EventFixed = () => (
     {/* FixedViaPush — blue push-pill */}
     <VariantSection label="Fixed via push">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('fixed', 'dependabot[bot]')}>
           <Timeline.Badge variant="done">
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
@@ -290,7 +326,7 @@ export const EventDismissed = () => (
     {/* Manual — risk is tolerable (with an optional dismissal note) */}
     <VariantSection label="Dismissed as risk is tolerable">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -309,7 +345,7 @@ export const EventDismissed = () => (
     {/* Manual — fix started */}
     <VariantSection label="Dismissed as fix started">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -325,7 +361,7 @@ export const EventDismissed = () => (
     {/* Manual — no bandwidth to fix this */}
     <VariantSection label="Dismissed as no bandwidth">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -341,7 +377,7 @@ export const EventDismissed = () => (
     {/* Manual — vulnerable code is not actually used */}
     <VariantSection label="Dismissed as not used">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -357,7 +393,7 @@ export const EventDismissed = () => (
     {/* Manual — inaccurate */}
     <VariantSection label="Dismissed as inaccurate">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -373,7 +409,7 @@ export const EventDismissed = () => (
     {/* Auto — rule-based, no source (with optional rule comment) */}
     <VariantSection label="Auto-dismissed by alert rule">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissed', 'dependabot[bot]')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -396,7 +432,7 @@ export const EventDismissed = () => (
     {/* Auto — from a pull request */}
     <VariantSection label="Auto-dismissed from pull request">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissed', 'dependabot[bot]')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -412,7 +448,7 @@ export const EventDismissed = () => (
     {/* Auto — from a push */}
     <VariantSection label="Auto-dismissed from push">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissed', 'dependabot[bot]')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -441,7 +477,7 @@ export const EventReopened = () => (
     {/* Manual reopen — user actor */}
     <VariantSection label="Reopened">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('reopened', 'monalisa')}>
           <Timeline.Badge variant="success">
             <Octicon icon={SyncIcon} />
           </Timeline.Badge>
@@ -457,7 +493,7 @@ export const EventReopened = () => (
     {/* Reintroduced — no source */}
     <VariantSection label="Reintroduced">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('reopened', 'dependabot[bot]')}>
           <Timeline.Badge variant="success">
             <Octicon icon={SyncIcon} />
           </Timeline.Badge>
@@ -473,7 +509,7 @@ export const EventReopened = () => (
     {/* Reintroduced — from a pull request */}
     <VariantSection label="Reintroduced from pull request">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('reopened', 'dependabot[bot]')}>
           <Timeline.Badge variant="success">
             <Octicon icon={SyncIcon} />
           </Timeline.Badge>
@@ -489,7 +525,7 @@ export const EventReopened = () => (
     {/* Reintroduced — from a push */}
     <VariantSection label="Reintroduced from push">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('reopened', 'dependabot[bot]')}>
           <Timeline.Badge variant="success">
             <Octicon icon={SyncIcon} />
           </Timeline.Badge>
@@ -505,7 +541,7 @@ export const EventReopened = () => (
     {/* Auto-reopened — rule change (with optional rule comment) */}
     <VariantSection label="Auto-reopened by rule change">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('reopened', 'dependabot[bot]')}>
           <Timeline.Badge variant="success">
             <Octicon icon={SyncIcon} />
           </Timeline.Badge>
@@ -560,7 +596,7 @@ export const EventDismissalRequest = () => (
         place that right-aligned control in the `Timeline.Actions` slot. */}
     <VariantSection label="Dismissal requested">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissal_requested', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CommentIcon} className={classes.BadgeIconAttention} />
           </Timeline.Badge>
@@ -584,7 +620,7 @@ export const EventDismissalRequest = () => (
     {/* Dismissal approved — circle user actor, success/check badge */}
     <VariantSection label="Dismissal approved">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissal_reviewed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CheckIcon} className={classes.BadgeIconSuccess} />
           </Timeline.Badge>
@@ -601,7 +637,7 @@ export const EventDismissalRequest = () => (
     {/* Dismissal denied — circle user actor, danger/x badge */}
     <VariantSection label="Dismissal denied">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissal_reviewed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={XIcon} className={classes.BadgeIconDanger} />
           </Timeline.Badge>
@@ -619,7 +655,7 @@ export const EventDismissalRequest = () => (
         "x")` (no bg) → a bare default badge, not a danger/emphasis one. */}
     <VariantSection label="Dismissal cancelled">
       <Timeline aria-label="Dependabot alert timeline">
-        <Timeline.Item>
+        <Timeline.Item {...dependabotAttrs('dismissal_cancelled', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={XIcon} className={classes.BadgeIconMuted} />
           </Timeline.Badge>
@@ -651,6 +687,12 @@ export const EventDismissalRequest = () => (
  * The five variants mirror the Secret scanning assignment story: self-assign,
  * assign another, self-unassign, unassign another, and a combined assign +
  * unassign example.
+ *
+ * SHARED / PARKED — NO `data-*` TAXONOMY: assignment is a cross-surface SHARED
+ * event, deliberately kept OUT of the per-surface Dependabot catalog
+ * (`DEPENDABOT_TAXONOMY` has no assignment leaf), per the taxonomy docs
+ * (github/primer#6888). It has no per-surface taxonomy leaf yet, so these rows
+ * intentionally carry NO `data-*` attributes.
  */
 export const EventAssignment = () => (
   <Examples>
@@ -758,6 +800,12 @@ export const EventAssignment = () => (
  *   button above.
  * - Work finished (`with_badge(icon: "repo-push")`): default (gray) badge, no
  *   right control.
+ *
+ * SHARED / PARKED — NO `data-*` TAXONOMY: Copilot-agent work is a cross-surface
+ * SHARED event, deliberately kept OUT of the per-surface Dependabot catalog
+ * (`DEPENDABOT_TAXONOMY` has no copilot leaf), per the taxonomy docs
+ * (github/primer#6888). It has no per-surface taxonomy leaf yet, so these rows
+ * intentionally carry NO `data-*` attributes.
  */
 export const EventCopilotWork = () => (
   <Examples>

--- a/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.issues.features.stories.tsx
@@ -40,6 +40,8 @@ import Octicon from '../Octicon'
 import Token from '../Token'
 import classes from './Timeline.issues.features.stories.module.css'
 import {BoldLink, Examples, MutedTime, UserActor, VariantSection} from './internal/timelineStoryHelpers'
+import {actorTypeForLogin, ISSUE_TAXONOMY, toEventDataAttributes} from './taxonomy'
+import type {IssueEventType} from './taxonomy'
 
 /**
  * Issue Timeline event examples (Phase 2 of github/primer#6663).
@@ -105,6 +107,23 @@ export default {
 } as Meta<ComponentProps<typeof Timeline>>
 
 /**
+ * Serialize the taxonomy `data-*` contract (github/primer#6664) for one Issues
+ * event row. `type` is an ISSUE_TAXONOMY leaf; `category` + `visibility` are read
+ * from the catalog, so metadata leaves (labels, assignees, milestones, project
+ * fields, issue types, rename) pick up `visibility: 'auditOnly'` automatically.
+ * Pass the row's rendered actor login so `data-actor-type` resolves (every Issues
+ * event carries an actor).
+ */
+const issueAttrs = (type: IssueEventType, login?: string) =>
+  toEventDataAttributes({
+    scope: 'issue',
+    type,
+    category: ISSUE_TAXONOMY[type].category,
+    visibility: ISSUE_TAXONOMY[type].visibility,
+    actorType: login ? actorTypeForLogin(login) : undefined,
+  })
+
+/**
  * The Closed event group — `IssueTimeline.eventClosed` (audit § 2).
  *
  * All seven variants are stacked in a single `<Timeline>` so they can be
@@ -118,7 +137,7 @@ export const EventClosed = () => (
     {/* Closed as completed */}
     <VariantSection label="Closed as completed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -139,7 +158,7 @@ export const EventClosed = () => (
           (portable for docs copy-paste; matches production `TimelineRow`). */}
     <VariantSection label="Closed as not planned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge
             style={
               {
@@ -165,7 +184,7 @@ export const EventClosed = () => (
     {/* Closed via pull request */}
     <VariantSection label="Closed via pull request">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -185,7 +204,7 @@ export const EventClosed = () => (
     {/* Closed via commit */}
     <VariantSection label="Closed via commit">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -210,7 +229,7 @@ export const EventClosed = () => (
           equivalent for github-ui's `ProjectV2` closer link. */}
     <VariantSection label="Closed via project">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -233,7 +252,7 @@ export const EventClosed = () => (
           composed here from Primer primitives. */}
     <VariantSection label="Closed as duplicate">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge
             style={
               {
@@ -265,7 +284,7 @@ export const EventClosed = () => (
     {/* Closed with no state reason */}
     <VariantSection label="Closed (no reason)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -293,7 +312,7 @@ export const EventState = () => (
     {/* Reopened — open (green) badge via useIssueState (ReopenedEvent.tsx) */}
     <VariantSection label="Reopened">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('reopened', 'monalisa')}>
           <Timeline.Badge variant="open">
             <Octicon icon={IssueReopenedIcon} />
           </Timeline.Badge>
@@ -310,7 +329,7 @@ export const EventState = () => (
           plain inline Link (the audit shows it bold; live code is canonical). */}
     <VariantSection label="Transferred">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('transferred', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
@@ -329,7 +348,7 @@ export const EventState = () => (
     {/* Pinned */}
     <VariantSection label="Pinned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('pinned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
@@ -345,7 +364,7 @@ export const EventState = () => (
     {/* Unpinned */}
     <VariantSection label="Unpinned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unpinned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
@@ -362,7 +381,7 @@ export const EventState = () => (
           the resulting discussion by number. */}
     <VariantSection label="Converted to discussion">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('converted_to_discussion', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CommentDiscussionIcon} />
           </Timeline.Badge>
@@ -378,6 +397,7 @@ export const EventState = () => (
     {/* Converted from draft */}
     <VariantSection label="Converted from draft">
       <Timeline aria-label="Issue timeline">
+        {/* Untagged: a metadata/auditOnly event that ISSUE_TAXONOMY does not yet enumerate as a distinct leaf (candidate leaf to add in a follow-up, not a defect). Emitting a data-event-type without a real catalog leaf would break the taxonomy single source of truth. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={IssueDraftIcon} />
@@ -407,7 +427,7 @@ export const EventReferences = () => (
           open PR state icon inline before the PR title). */}
     <VariantSection label="Linked pull request">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('connected', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CrossReferenceIcon} />
           </Timeline.Badge>
@@ -431,7 +451,7 @@ export const EventReferences = () => (
           icon is behind the live code here. */}
     <VariantSection label="Unlinked pull request">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('disconnected', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={GitPullRequestIcon} className={classes.BadgeIconOpen} />
           </Timeline.Badge>
@@ -451,7 +471,7 @@ export const EventReferences = () => (
           inline (showAgoTimestamp={false}) and the commit card is sub-content. */}
     <VariantSection label="Single commit reference">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('referenced', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={GitCommitIcon} />
           </Timeline.Badge>
@@ -482,7 +502,7 @@ export const EventReferences = () => (
     {/* Multiple commit references — same event, pluralized copy + N cards. */}
     <VariantSection label="Multiple commit references">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('referenced', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={GitCommitIcon} />
           </Timeline.Badge>
@@ -538,7 +558,7 @@ export const EventDuplicates = () => (
           IssueLink uses the open (green) state icon. */}
     <VariantSection label="Marked as duplicate">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('marked_as_duplicate', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={DuplicateIcon} />
           </Timeline.Badge>
@@ -562,6 +582,7 @@ export const EventDuplicates = () => (
     {/* Marked <canonical> as a duplicate of this issue — no right controls. */}
     <VariantSection label="Marked as canonical">
       <Timeline aria-label="Issue timeline">
+        {/* Untagged: a metadata/auditOnly event that ISSUE_TAXONOMY does not yet enumerate as a distinct leaf (the catalog has only 'marked_as_duplicate'); candidate leaf to add in a follow-up, not a defect. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={DuplicateIcon} />
@@ -584,6 +605,7 @@ export const EventDuplicates = () => (
     {/* Unmarked this as a duplicate of <canonical>. */}
     <VariantSection label="Unmarked as duplicate">
       <Timeline aria-label="Issue timeline">
+        {/* Untagged: a metadata/auditOnly event that ISSUE_TAXONOMY does not yet enumerate as a distinct leaf (the catalog has only 'marked_as_duplicate'); candidate leaf to add in a follow-up, not a defect. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={DuplicateIcon} />
@@ -605,6 +627,7 @@ export const EventDuplicates = () => (
     {/* Unmarked <canonical> as a duplicate of this issue. */}
     <VariantSection label="Unmarked as canonical">
       <Timeline aria-label="Issue timeline">
+        {/* Untagged: a metadata/auditOnly event that ISSUE_TAXONOMY does not yet enumerate as a distinct leaf (the catalog has only 'marked_as_duplicate'); candidate leaf to add in a follow-up, not a defect. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={DuplicateIcon} />
@@ -638,7 +661,7 @@ export const EventModeration = () => (
     {/* User blocked (permanent) */}
     <VariantSection label="User blocked">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('user_blocked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -654,7 +677,7 @@ export const EventModeration = () => (
     {/* User temporarily blocked */}
     <VariantSection label="User temporarily blocked">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('user_blocked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -670,7 +693,7 @@ export const EventModeration = () => (
     {/* Comment pinned — IssueCommentPinnedEvent.tsx links the pinned comment. */}
     <VariantSection label="Comment pinned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('comment_pinned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
@@ -689,7 +712,7 @@ export const EventModeration = () => (
     {/* Comment unpinned */}
     <VariantSection label="Comment unpinned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('comment_unpinned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PinIcon} />
           </Timeline.Badge>
@@ -720,7 +743,7 @@ export const EventIssueTypes = () => (
     {/* Type added */}
     <VariantSection label="Issue type added">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('issue_type_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
@@ -750,7 +773,7 @@ export const EventIssueTypes = () => (
     {/* Type removed */}
     <VariantSection label="Issue type removed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('issue_type_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
@@ -780,7 +803,7 @@ export const EventIssueTypes = () => (
     {/* Type changed */}
     <VariantSection label="Issue type changed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('issue_type_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueOpenedIcon} />
           </Timeline.Badge>
@@ -840,7 +863,7 @@ export const EventIssueHierarchy = () => (
     {/* Sub-issue added (single) */}
     <VariantSection label="Sub-issue added (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('sub_issue_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
@@ -865,7 +888,7 @@ export const EventIssueHierarchy = () => (
     {/* Sub-issue added (multiple) — plural copy + N reference rows */}
     <VariantSection label="Sub-issues added (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('sub_issue_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
@@ -897,7 +920,7 @@ export const EventIssueHierarchy = () => (
     {/* Sub-issue removed (single) */}
     <VariantSection label="Sub-issue removed (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('sub_issue_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
@@ -922,7 +945,7 @@ export const EventIssueHierarchy = () => (
     {/* Sub-issues removed (multiple) */}
     <VariantSection label="Sub-issues removed (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('sub_issue_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTracksIcon} />
           </Timeline.Badge>
@@ -954,7 +977,7 @@ export const EventIssueHierarchy = () => (
     {/* Parent issue added (single) */}
     <VariantSection label="Parent issue added (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('parent_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
@@ -979,7 +1002,7 @@ export const EventIssueHierarchy = () => (
     {/* Parent issues added (multiple) */}
     <VariantSection label="Parent issues added (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('parent_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
@@ -1011,7 +1034,7 @@ export const EventIssueHierarchy = () => (
     {/* Parent issue removed (single) */}
     <VariantSection label="Parent issue removed (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('parent_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
@@ -1036,7 +1059,7 @@ export const EventIssueHierarchy = () => (
     {/* Parent issues removed (multiple) */}
     <VariantSection label="Parent issues removed (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('parent_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={IssueTrackedByIcon} />
           </Timeline.Badge>
@@ -1084,7 +1107,7 @@ export const EventDependencies = () => (
     {/* Blocked by (single) */}
     <VariantSection label="Blocked by (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocked_by_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1109,7 +1132,7 @@ export const EventDependencies = () => (
     {/* Blocked by (multiple) — count in copy + N rows */}
     <VariantSection label="Blocked by (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocked_by_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1141,7 +1164,7 @@ export const EventDependencies = () => (
     {/* Blocked by removed (single) */}
     <VariantSection label="Blocked by removed (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocked_by_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1166,7 +1189,7 @@ export const EventDependencies = () => (
     {/* Blocked by removed (multiple) */}
     <VariantSection label="Blocked by removed (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocked_by_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1198,7 +1221,7 @@ export const EventDependencies = () => (
     {/* Blocking (single) */}
     <VariantSection label="Blocking (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocking_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1223,7 +1246,7 @@ export const EventDependencies = () => (
     {/* Blocking (multiple) */}
     <VariantSection label="Blocking (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocking_added', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1255,7 +1278,7 @@ export const EventDependencies = () => (
     {/* Blocking removed (single) */}
     <VariantSection label="Blocking removed (single)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocking_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1280,7 +1303,7 @@ export const EventDependencies = () => (
     {/* Blocking removed (multiple) */}
     <VariantSection label="Blocking removed (multiple)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('blocking_removed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={BlockedIcon} />
           </Timeline.Badge>
@@ -1332,7 +1355,7 @@ export const EventIssueFields = () => (
     {/* Set text field */}
     <VariantSection label="Set · text">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1353,7 +1376,7 @@ export const EventIssueFields = () => (
     {/* Set number field */}
     <VariantSection label="Set · number">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={NumberIcon} />
           </Timeline.Badge>
@@ -1374,7 +1397,7 @@ export const EventIssueFields = () => (
     {/* Set date field */}
     <VariantSection label="Set · date">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
@@ -1395,7 +1418,7 @@ export const EventIssueFields = () => (
     {/* Set single-select field — value is a colored token */}
     <VariantSection label="Set · single select">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
@@ -1429,7 +1452,7 @@ export const EventIssueFields = () => (
     {/* Changed text field */}
     <VariantSection label="Changed · text">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1450,7 +1473,7 @@ export const EventIssueFields = () => (
     {/* Changed number field */}
     <VariantSection label="Changed · number">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={NumberIcon} />
           </Timeline.Badge>
@@ -1471,7 +1494,7 @@ export const EventIssueFields = () => (
     {/* Changed date field */}
     <VariantSection label="Changed · date">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
@@ -1492,7 +1515,7 @@ export const EventIssueFields = () => (
     {/* Changed single-select field */}
     <VariantSection label="Changed · single select">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
@@ -1523,7 +1546,7 @@ export const EventIssueFields = () => (
     {/* Cleared text field — no value */}
     <VariantSection label="Cleared · text">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1540,7 +1563,7 @@ export const EventIssueFields = () => (
     {/* Cleared number field */}
     <VariantSection label="Cleared · number">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={NumberIcon} />
           </Timeline.Badge>
@@ -1557,7 +1580,7 @@ export const EventIssueFields = () => (
     {/* Cleared date field */}
     <VariantSection label="Cleared · date">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CalendarIcon} />
           </Timeline.Badge>
@@ -1574,7 +1597,7 @@ export const EventIssueFields = () => (
     {/* Cleared single-select field */}
     <VariantSection label="Cleared · single select">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={SingleSelectIcon} />
           </Timeline.Badge>
@@ -1591,7 +1614,7 @@ export const EventIssueFields = () => (
     {/* Rollup: updated only — multiple field updates collapsed into one row */}
     <VariantSection label="Rollup · updated">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1616,7 +1639,7 @@ export const EventIssueFields = () => (
     {/* Rollup: removed only */}
     <VariantSection label="Rollup · removed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1635,7 +1658,7 @@ export const EventIssueFields = () => (
     {/* Rollup: updated and also removed — combined row joined by "and also" */}
     <VariantSection label="Rollup · updated and removed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TypographyIcon} />
           </Timeline.Badge>
@@ -1687,7 +1710,7 @@ export const EventProject = () => (
     {/* Added to project */}
     <VariantSection label="Added to project">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('added_to_project', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
@@ -1708,7 +1731,7 @@ export const EventProject = () => (
     {/* Removed from project */}
     <VariantSection label="Removed from project">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('removed_from_project', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
@@ -1732,7 +1755,7 @@ export const EventProject = () => (
         strings are PLAIN TEXT (not bold). Both forms shown under one caption. */}
     <VariantSection label="Project status changed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
@@ -1746,7 +1769,7 @@ export const EventProject = () => (
             <MutedTime date={new Date('2022-07-24T16:40:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('project_field_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TableIcon} />
           </Timeline.Badge>
@@ -1786,7 +1809,7 @@ export const EventLabels = () => (
     {/* Label added */}
     <VariantSection label="Label added">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('labeled', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TagIcon} />
           </Timeline.Badge>
@@ -1815,7 +1838,7 @@ export const EventLabels = () => (
     {/* Label removed */}
     <VariantSection label="Label removed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unlabeled', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TagIcon} />
           </Timeline.Badge>
@@ -1845,6 +1868,7 @@ export const EventLabels = () => (
         with "and" between them. */}
     <VariantSection label="Labels added and removed">
       <Timeline aria-label="Issue timeline">
+        {/* Untagged: a metadata/auditOnly rolled-up event (labeled + unlabeled in one row) that ISSUE_TAXONOMY does not yet enumerate as a distinct leaf; candidate leaf to add in a follow-up, not a defect. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={TagIcon} />
@@ -1905,7 +1929,7 @@ export const EventTitle = () => (
     {/* Title changed */}
     <VariantSection label="Title changed">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('renamed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PencilIcon} />
           </Timeline.Badge>
@@ -1940,7 +1964,7 @@ export const EventMilestones = () => (
     {/* Added to milestone */}
     <VariantSection label="Added to milestone">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('milestoned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={MilestoneIcon} />
           </Timeline.Badge>
@@ -1960,7 +1984,7 @@ export const EventMilestones = () => (
     {/* Removed from milestone */}
     <VariantSection label="Removed from milestone">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('demilestoned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={MilestoneIcon} />
           </Timeline.Badge>
@@ -1999,7 +2023,7 @@ export const EventAssignments = () => (
     {/* Self-assigned */}
     <VariantSection label="Self-assigned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('assigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2015,7 +2039,7 @@ export const EventAssignments = () => (
     {/* Assigned someone else — assignee is a bold link, no avatar. */}
     <VariantSection label="Assigned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('assigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2031,7 +2055,7 @@ export const EventAssignments = () => (
     {/* Assigned multiple — joined with "and". */}
     <VariantSection label="Assigned multiple">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('assigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2049,7 +2073,7 @@ export const EventAssignments = () => (
     {/* Self-unassigned */}
     <VariantSection label="Self-unassigned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unassigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2065,7 +2089,7 @@ export const EventAssignments = () => (
     {/* Unassigned someone else */}
     <VariantSection label="Unassigned">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unassigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2081,7 +2105,7 @@ export const EventAssignments = () => (
     {/* Unassigned multiple — joined with "and". */}
     <VariantSection label="Unassigned multiple">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unassigned', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={PersonIcon} />
           </Timeline.Badge>
@@ -2118,7 +2142,7 @@ export const EventLockUnlock = () => (
         too heated). */}
     <VariantSection label="Locked (with reason)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('locked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
@@ -2128,7 +2152,7 @@ export const EventLockUnlock = () => (
             <MutedTime date={new Date('2022-07-26T11:46:07Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('locked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
@@ -2138,7 +2162,7 @@ export const EventLockUnlock = () => (
             <MutedTime date={new Date('2022-07-26T11:47:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('locked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
@@ -2148,7 +2172,7 @@ export const EventLockUnlock = () => (
             <MutedTime date={new Date('2022-07-26T11:48:00Z')} href="#" />
           </Timeline.Body>
         </Timeline.Item>
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('locked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
@@ -2164,7 +2188,7 @@ export const EventLockUnlock = () => (
     {/* Locked (no reason) */}
     <VariantSection label="Locked (no reason)">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('locked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LockIcon} />
           </Timeline.Badge>
@@ -2180,7 +2204,7 @@ export const EventLockUnlock = () => (
     {/* Unlocked — UnlockIcon badge (not LockIcon). */}
     <VariantSection label="Unlocked">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('unlocked', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={UnlockIcon} />
           </Timeline.Badge>
@@ -2211,7 +2235,7 @@ export const EventCommentDeleted = () => (
     {/* Comment deleted */}
     <VariantSection label="Comment deleted">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('comment_deleted', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={TrashIcon} />
           </Timeline.Badge>
@@ -2249,7 +2273,7 @@ export const EventCrossReferences = () => (
     {/* Mentioned from an issue */}
     <VariantSection label="Mentioned in an issue">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('cross_referenced', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
@@ -2274,7 +2298,7 @@ export const EventCrossReferences = () => (
     {/* Mentioned from a pull request */}
     <VariantSection label="Mentioned in a pull request">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('cross_referenced', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>
@@ -2299,7 +2323,7 @@ export const EventCrossReferences = () => (
     {/* Linked a closing pull request */}
     <VariantSection label="Linked a closing pull request">
       <Timeline aria-label="Issue timeline">
-        <Timeline.Item>
+        <Timeline.Item {...issueAttrs('cross_referenced', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={LinkExternalIcon} />
           </Timeline.Badge>

--- a/packages/react/src/Timeline/Timeline.secret-scanning.features.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.secret-scanning.features.stories.tsx
@@ -20,6 +20,12 @@ import {
 import {Button} from '../Button'
 import Octicon from '../Octicon'
 import {EventSubRow, MutedTime, RealisticTimeline, UserActor, VariantSection} from './internal/timelineStoryHelpers'
+import {
+  actorTypeForLogin,
+  SECRET_SCANNING_TAXONOMY,
+  toEventDataAttributes,
+  type SecretScanningEventType,
+} from './taxonomy'
 
 /**
  * Secret Scanning alert Timeline event examples (Phase 2 of github/primer#6663).
@@ -53,10 +59,18 @@ import {EventSubRow, MutedTime, RealisticTimeline, UserActor, VariantSection} fr
  * base `Timeline` component's own stories, and any docs-site representation is a
  * Phase 3 consideration via base-component story changes, out of scope here.
  *
- * FUTURE FILTERING (taxonomy still open — github/primer#6663): category
- * `data-*` attributes (e.g. `data-event-category="created"`) will attach to each
- * `Timeline.Item` below so stories can be filtered/grouped by event family. We
- * intentionally do NOT add them yet to avoid baking in a taxonomy.
+ * EVENT TAXONOMY TAGGING (github/primer#6664, Phase 3): each cataloged
+ * `Timeline.Item` below carries the `data-*` event contract
+ * (`data-event-scope` / `data-event-type` / `data-event-category` /
+ * `data-event-visibility` / `data-actor-type`), projected from the shared
+ * `SECRET_SCANNING_TAXONOMY` catalog via `toEventDataAttributes`. This mirrors
+ * the License Compliance pilot (primer/react#8216) and consumes the merged
+ * taxonomy module (#8180) documented in github/primer#6888.
+ *
+ * The catalog was scoped to the five live `switch (event.type)` cases and is
+ * NARROWER than this story set, so MANY variants have no catalog leaf and are
+ * left UNTAGGED on purpose (each such item carries a comment explaining why).
+ * We tag ONLY the seven cataloged leaves and never invent a value.
  *
  * SLOT USAGE (Phase 1 slots — same convention as the Issues / Dependabot groups):
  * - `Timeline.Avatar` (gutter slot, #6677): the 40px LEFT-GUTTER avatar.
@@ -96,6 +110,21 @@ import {EventSubRow, MutedTime, RealisticTimeline, UserActor, VariantSection} fr
 // the shared `UserActor` default avatar (monalisa).
 const SIX7_AVATAR = 'https://avatars.githubusercontent.com/u/4548309?v=4'
 const HUBOT_AVATAR = 'https://avatars.githubusercontent.com/u/480938?v=4'
+
+// Projects a cataloged Secret Scanning leaf into the event `data-*` contract
+// (github/primer#6664), same shape as the License Compliance pilot
+// (primer/react#8216). `category` and `visibility` are read FROM the catalog so
+// the story never re-declares the taxonomy; `login` is the actor rendered in the
+// row, resolved to `data-actor-type` via `actorTypeForLogin`. Omit `login` for
+// actor-less rows so no `data-actor-type` is emitted.
+const secretScanningAttrs = (type: SecretScanningEventType, login?: string) =>
+  toEventDataAttributes({
+    scope: 'secret-scanning',
+    type,
+    category: SECRET_SCANNING_TAXONOMY[type].category,
+    visibility: SECRET_SCANNING_TAXONOMY[type].visibility,
+    actorType: login ? actorTypeForLogin(login) : undefined,
+  })
 
 export default {
   title: 'Components/Timeline/Events/Secret Scanning',
@@ -137,7 +166,12 @@ export const EventCreated = () => (
     {/* Created — GitHub system actor, ShieldIcon on success (green) */}
     <VariantSection label="Created">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `detected` leaf. Renders the GitHub SYSTEM-IDENTITY actor
+            (`<UserActor login="GitHub" …>`); GitHub is not in the bot set, so
+            actorTypeForLogin('GitHub') classifies it as 'user' -> data-actor-type='user'.
+            FLAGGED: whether a system identity should classify as user vs bot is
+            worth confirming (see report). */}
+        <Timeline.Item {...secretScanningAttrs('detected', 'GitHub')}>
           <Timeline.Badge variant="success">
             <Octicon icon={ShieldIcon} />
           </Timeline.Badge>
@@ -177,7 +211,8 @@ export const EventResolution = () => (
         badge. Shown WITH an optional resolution-comment sub-row. */}
     <VariantSection label="Closed as revoked">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf (Resolution, any non-reopened resolution.type); user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge variant="done">
             <Octicon icon={ShieldCheckIcon} />
           </Timeline.Badge>
@@ -196,7 +231,8 @@ export const EventResolution = () => (
     {/* Closed as false positive — gray (default) ShieldSlash badge. */}
     <VariantSection label="Closed as false positive">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -212,7 +248,8 @@ export const EventResolution = () => (
     {/* Closed as won't fix */}
     <VariantSection label="Closed as won't fix">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -228,7 +265,8 @@ export const EventResolution = () => (
     {/* Closed as used in tests */}
     <VariantSection label="Closed as used in tests">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -244,7 +282,8 @@ export const EventResolution = () => (
     {/* Closed as pattern deleted */}
     <VariantSection label="Closed as pattern deleted">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -260,7 +299,8 @@ export const EventResolution = () => (
     {/* Closed as pattern edited */}
     <VariantSection label="Closed as pattern edited">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -276,7 +316,8 @@ export const EventResolution = () => (
     {/* Closed as ignored by configuration (resolution type `hidden_by_config`) */}
     <VariantSection label="Closed as ignored by configuration">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `closed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -297,7 +338,9 @@ export const EventResolution = () => (
         placement rather than leaving the Break as a stray first child. */}
     <VariantSection label="Reopened">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* Context row: a `closed` leaf preceding the reopen, tagged in place
+            like the seven dedicated "Closed as …" variants; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('closed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={ShieldSlashIcon} />
           </Timeline.Badge>
@@ -308,7 +351,8 @@ export const EventResolution = () => (
           </Timeline.Body>
         </Timeline.Item>
         <Timeline.Break />
-        <Timeline.Item>
+        {/* `reopened` leaf (Resolution, resolution.type === 'reopened'); user actor. */}
+        <Timeline.Item {...secretScanningAttrs('reopened', 'monalisa')}>
           <Timeline.Badge variant="success">
             <Octicon icon={SyncIcon} />
           </Timeline.Badge>
@@ -338,7 +382,8 @@ export const EventBypass = () => (
     {/* Bypassed — AlertIcon, default (gray) badge */}
     <VariantSection label="Bypassed push protection">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `bypassed` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('bypassed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={AlertIcon} />
           </Timeline.Badge>
@@ -355,6 +400,9 @@ export const EventBypass = () => (
         repo has delegated bypass enabled. */}
     <VariantSection label="Bypass requested (delegated bypass enabled)">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: the delegated-BYPASS request/approve flow has no catalog
+            leaf. The catalog's dismissal_requested / dismissal_reviewed cover the
+            delegated-CLOSURE flow, a different thing. No leaf -> no data-* tag. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={CommentIcon} />
@@ -371,6 +419,8 @@ export const EventBypass = () => (
     {/* Bypass approved — CheckCircleIcon. Delegated bypass: gated as above. */}
     <VariantSection label="Bypass approved (delegated bypass enabled)">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: delegated-BYPASS flow, no catalog leaf (see the request
+            variant above). No leaf -> no data-* tag. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={CheckCircleIcon} />
@@ -403,7 +453,8 @@ export const EventValidityChange = () => (
     {/* Active — automated (GitHub), AlertIcon on danger (red) */}
     <VariantSection label="Validity: active (automated)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; automated -> GitHub system actor -> 'user'. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'GitHub')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={AlertIcon} />
           </Timeline.Badge>
@@ -419,7 +470,8 @@ export const EventValidityChange = () => (
     {/* Active — manual (user), same danger badge */}
     <VariantSection label="Validity: active (manual)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; manual -> user actor. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'monalisa')}>
           <Timeline.Badge variant="danger">
             <Octicon icon={AlertIcon} />
           </Timeline.Badge>
@@ -435,7 +487,8 @@ export const EventValidityChange = () => (
     {/* Inactive — automated (GitHub), SkipIcon on default (gray) */}
     <VariantSection label="Validity: inactive (automated)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; automated -> GitHub system actor -> 'user'. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'GitHub')}>
           <Timeline.Badge>
             <Octicon icon={SkipIcon} />
           </Timeline.Badge>
@@ -451,7 +504,8 @@ export const EventValidityChange = () => (
     {/* Inactive — manual (user) */}
     <VariantSection label="Validity: inactive (manual)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; manual -> user actor. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={SkipIcon} />
           </Timeline.Badge>
@@ -467,7 +521,8 @@ export const EventValidityChange = () => (
     {/* Unknown — automated (GitHub), AlertIcon on attention (amber) */}
     <VariantSection label="Validity: unknown (automated)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; automated -> GitHub system actor -> 'user'. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'GitHub')}>
           <Timeline.Badge variant="attention">
             <Octicon icon={AlertIcon} />
           </Timeline.Badge>
@@ -483,7 +538,8 @@ export const EventValidityChange = () => (
     {/* Unknown — manual (user) */}
     <VariantSection label="Validity: unknown (manual)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `validity_changed` leaf; manual -> user actor. */}
+        <Timeline.Item {...secretScanningAttrs('validity_changed', 'monalisa')}>
           <Timeline.Badge variant="attention">
             <Octicon icon={AlertIcon} />
           </Timeline.Badge>
@@ -511,6 +567,10 @@ export const EventReport = () => (
     {/* Reported — ShieldCheckIcon, default (gray) badge, user actor */}
     <VariantSection label="Reported">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: the catalog maps Report -> validity_changed, but
+            github/primer#6888 lists that mapping as UNCONFIRMED (open item #2).
+            Emitting an unconfirmed value would bake in a guess, so leave untagged
+            until the docs confirm the leaf. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={ShieldCheckIcon} />
@@ -545,6 +605,8 @@ export const EventMetadata = () => (
     {/* Metadata created — GitHub system actor, FileAddedIcon, default (gray) badge */}
     <VariantSection label="Extended metadata found">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: MetadataCreated is PARKED per github/primer#6888 ('Parked'
+            section), no catalog leaf. No leaf -> no data-* tag. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={FileAddedIcon} />
@@ -561,6 +623,8 @@ export const EventMetadata = () => (
     {/* Metadata removed — GitHub system actor, FileRemovedIcon, default (gray) badge */}
     <VariantSection label="Extended metadata removed">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: MetadataRemoved is PARKED per github/primer#6888 ('Parked'
+            section), no catalog leaf. No leaf -> no data-* tag. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={FileRemovedIcon} />
@@ -606,7 +670,8 @@ export const EventClosureRequest = () => (
         un-bolded `resolutionText(exemption_request.reason)`. */}
     <VariantSection label="Dismissal requested (reviewer view)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `dismissal_requested` leaf (DelegatedClosureRequestOpened); user actor. */}
+        <Timeline.Item {...secretScanningAttrs('dismissal_requested', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CommentIcon} />
           </Timeline.Badge>
@@ -630,7 +695,8 @@ export const EventClosureRequest = () => (
     {/* Requested — requester view: the invisible "Cancel request" button. */}
     <VariantSection label="Dismissal requested (requester view)">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `dismissal_requested` leaf; user actor. */}
+        <Timeline.Item {...secretScanningAttrs('dismissal_requested', 'monalisa')}>
           <Timeline.Badge>
             <Octicon icon={CommentIcon} />
           </Timeline.Badge>
@@ -651,7 +717,8 @@ export const EventClosureRequest = () => (
     {/* Approved — CheckCircleIcon, with a reviewer comment sub-row. */}
     <VariantSection label="Dismissal approved">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `dismissal_reviewed` leaf; reviewer user actor (six7). */}
+        <Timeline.Item {...secretScanningAttrs('dismissal_reviewed', 'six7')}>
           <Timeline.Badge>
             <Octicon icon={CheckCircleIcon} />
           </Timeline.Badge>
@@ -670,7 +737,8 @@ export const EventClosureRequest = () => (
     {/* Denied — XIcon */}
     <VariantSection label="Dismissal denied">
       <Timeline aria-label="Secret scanning alert timeline">
-        <Timeline.Item>
+        {/* `dismissal_reviewed` leaf; reviewer user actor (six7). */}
+        <Timeline.Item {...secretScanningAttrs('dismissal_reviewed', 'six7')}>
           <Timeline.Badge>
             <Octicon icon={XIcon} />
           </Timeline.Badge>
@@ -689,6 +757,8 @@ export const EventClosureRequest = () => (
     {/* Cancelled — SkipIcon */}
     <VariantSection label="Dismissal request cancelled">
       <Timeline aria-label="Secret scanning alert timeline">
+        {/* UNTAGGED: Secret Scanning has NO dismissal_cancelled leaf (unlike
+            Dependabot). No leaf -> no data-* tag. */}
         <Timeline.Item>
           <Timeline.Badge>
             <Octicon icon={SkipIcon} />
@@ -717,6 +787,9 @@ export const EventClosureRequest = () => (
  */
 export const EventAssignment = () => (
   <RealisticTimeline>
+    {/* UNTAGGED (whole group): Assignment is a cross-surface SHARED event,
+        deliberately kept OUT of the per-surface Secret Scanning catalog. All five
+        variants below carry no data-* event tag. */}
     {/* Self-assigned — actor === assignee */}
     <VariantSection label="Self-assigned">
       <Timeline aria-label="Secret scanning alert timeline">


### PR DESCRIPTION
Part of github/primer#6664 (epic github/primer#6654).

This PR tags four Timeline event story surfaces with the taxonomy `data-*`
attribute contract: Code Scanning, Dependabot, Secret Scanning, and Issues.
It applies the same approach proven in the License Compliance pilot
(primer/react#8216), so the two together cover all five surfaces.

The change is Storybook-only and adds no consumer-facing behavior. It only
adds attributes to the rendered `<li>` rows, so visuals are unchanged. Each
surface lives in its own file, so the four changes are independent.

## How it works

Every `<Timeline.Item>` for a cataloged event now spreads the `data-*`
attribute set produced by the taxonomy module (primer/react#8180,
`packages/react/src/Timeline/taxonomy/`), documented in github/primer#6888.
Each file adds a small local helper that calls the module's
`toEventDataAttributes` serializer and derives `category` and `visibility`
from that surface's catalog, so the stories stay in sync with the source of
truth rather than hand-typing values. `data-actor-type` resolves at runtime
from each row's rendered actor login via `actorTypeForLogin`, and is omitted
when a row renders no actor.

`Timeline.Item` forwards arbitrary props to its `<li>`, so the attributes
land directly on the row element.

## What each surface tags

- Code Scanning: 15 rows. Detection group (`detected`, `appeared`,
  `reappeared`) and `fixed` are system events with no actor. Closures,
  reopen, and the delegated-dismissal pair carry user actors.
- Dependabot: 23 rows. `opened` and `fixed` render the Dependabot bot actor;
  `dismissed` and `reopened` fold manual (user) and automated (bot) paths;
  the delegated-dismissal group is `reviews`.
- Secret Scanning: 21 rows tagged, 11 left untagged (see below).
- Issues: 80 rows tagged, 5 left untagged. Metadata events (labels,
  assignees, milestones, project fields, issue types, rename) carry
  `data-event-visibility="auditOnly"` straight from the catalog.

## Judgment calls and untagged rows for review

These are the places where the mapping was not a clean 1:1, called out so a
reviewer can confirm each one.

Code Scanning, configuration-deleted maps to `closed`: the two
"Configuration deleted" rows in `EventFixed` are the
`ALERT_CLOSED_BECAME_OUTDATED` event, which the catalog folds into `closed`
(a system closure), not `fixed`. They carry `data-event-type="closed"` and
no actor. The two "Fixed in branch" rows carry `data-event-type="fixed"`.

Secret Scanning, GitHub system actor resolves to `user`: the system
"GitHub" identity on `detected` and the automated validity-change rows
resolves to `data-actor-type="user"`, because `actorTypeForLogin("GitHub")`
returns `user` (GitHub is not in the bot set). Whether a system identity
should classify as `user` or `bot` is worth confirming.

Secret Scanning, rows left untagged because they have no catalog leaf or are
parked or shared:

- "Bypass requested" and "Bypass approved" (the delegated-bypass flow, which
  has no catalog leaf; the catalog's dismissal leaves are the separate
  delegated-closure flow)
- "Reported" (`EventReport`): the catalog maps Report to `validity_changed`,
  but github/primer#6888 flags that mapping as unconfirmed (open item 2), so
  the row is left untagged rather than emit an unconfirmed value
- "Dismissal request cancelled" (Secret Scanning has no `dismissal_cancelled`
  leaf, unlike Dependabot)
- `EventMetadata` "Extended metadata found" and "removed" (parked per
  github/primer#6888)
- `EventAssignment` (all five variants): a cross-surface shared event,
  deliberately out of the per-surface catalog

Issues, five variants left untagged. Each is a metadata or audit-only event
the taxonomy does not yet enumerate as a distinct leaf, so it is a candidate
leaf to add in a follow-up, not a defect. Tagging one now would mean emitting
a `data-event-type` with no catalog backing, which would break the single
source of truth:

- "Converted from draft"
- "Marked as canonical", "Unmarked as duplicate", "Unmarked as canonical"
  (the catalog has only `marked_as_duplicate`)
- "Labels added and removed" (one row representing two events, `labeled`
  plus `unlabeled`)

Dependabot's `EventAssignment` and `EventCopilotWork` are also left untagged
as shared and parked events, consistent with Secret Scanning.

## Testing

Validated on the combined branch with the repo's own gates: prettier,
eslint, and type-check (15/15 tasks) all pass with zero new errors. Each
surface was additionally rendered headlessly in real Chromium on its own
branch, confirming the `<li>` rows carry the expected attributes and that
the untagged rows carry none, with zero console errors.

These files stay out of `Timeline.docs.json` and `build.ts` by design.
