### PR TITLE
MCP: prefer text documentation endpoints

### DIFF
--- a/.changeset/mcp-text-only-documentation.md
+++ b/.changeset/mcp-text-only-documentation.md
@@ -1,0 +1,5 @@
+---
+'@primer/mcp': patch
+---
+
+MCP: Prefer Primer Style text-only documentation endpoints while retaining HTML fallback during the endpoint rollout.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -56,6 +56,12 @@ observed relationship types are deterministically limited to the three strongest
 records and report omitted counts. `get_component` remains available when full
 package documentation or complete relationship provenance is needed.
 
+## Hosted documentation
+
+Documentation tools prefer the matching Primer Style text-only `llms.txt`
+endpoint. During the hosted rollout, a missing endpoint (HTTP 404) falls back
+to the existing HTML conversion; other endpoint failures are returned as errors.
+
 ## Pattern guidance
 
 `get_pattern` returns compact structured guidance by default. Its component and

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -66,6 +66,9 @@ describe('get_component_batch', () => {
       arguments: {name, detail},
     })
   }
+  const callTool = (name: string, args: Record<string, unknown> = {}) => {
+    return client.callTool({name, arguments: args})
+  }
 
   it('requires between 2 and 10 names', async () => {
     const tooFew = await callBatch(['Button'])
@@ -74,6 +77,46 @@ describe('get_component_batch', () => {
     expect(tooFew.isError).toBe(true)
     expect(tooMany.isError).toBe(true)
     expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['init', {}, '/product/getting-started/react/llms.txt'],
+    ['get_component_examples', {name: 'Button'}, '/product/components/button/llms.txt'],
+    ['get_component_usage_guidelines', {name: 'Button'}, '/product/components/button/guidelines/llms.txt'],
+    ['get_component_accessibility_guidelines', {name: 'Button'}, '/product/components/button/accessibility/llms.txt'],
+    ['get_color_usage', {}, '/product/getting-started/foundations/color-usage/llms.txt'],
+    ['get_typography_usage', {}, '/product/getting-started/foundations/typography/llms.txt'],
+    ['get_icon', {name: 'alert', size: '16'}, '/octicons/icon/alert-16/llms.txt'],
+  ])('prefers the text-only endpoint for %s', async (name, args, path) => {
+    vi.mocked(fetch).mockResolvedValue(new Response('Text-only documentation.'))
+
+    const result = await callTool(name, args)
+
+    expect(fetch).toHaveBeenCalledExactlyOnceWith(new URL(`https://primer.style${path}`))
+    expect(getTextContent(result)).toContain('Text-only documentation.')
+  })
+
+  it('falls back to HTML conversion only when a text-only endpoint is missing', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(new Response(null, {status: 404}))
+      .mockResolvedValueOnce(new Response('<main><p>HTML fallback documentation.</p></main>'))
+
+    const result = await callTool('get_component_examples', {name: 'Button'})
+
+    expect(fetch).toHaveBeenNthCalledWith(1, new URL('https://primer.style/product/components/button/llms.txt'))
+    expect(fetch).toHaveBeenNthCalledWith(2, new URL('https://primer.style/product/components/button'))
+    expect(getTextContent(result)).toContain('HTML fallback documentation.')
+  })
+
+  it('surfaces non-404 text-only endpoint failures without requesting HTML', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, {status: 503, statusText: 'Service Unavailable'}))
+
+    const result = await callTool('get_color_usage')
+
+    expect(result.isError).toBe(true)
+    expect(fetch).toHaveBeenCalledExactlyOnceWith(
+      new URL('https://primer.style/product/getting-started/foundations/color-usage/llms.txt'),
+    )
   })
 
   it('deduplicates names case-insensitively and preserves result order', async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -69,6 +69,26 @@ const patternOutputSchema = z.object({
 // Load all tokens with guidelines from primitives
 const allTokensWithGuidelines: TokenWithGuidelines[] = loadAllTokensWithGuidelines()
 
+async function fetchTextOnlyContent(url: URL): Promise<string | undefined> {
+  const llmsUrl = new URL(`${url.pathname}/llms.txt`, url)
+  const response = await fetch(llmsUrl)
+
+  if (response.ok) return response.text()
+  if (response.status === 404) return undefined
+
+  throw new Error(`Failed to fetch ${llmsUrl}: ${response.statusText}`)
+}
+
+function convertMainHtmlToMarkdown(html: string): string | undefined {
+  if (!html) return undefined
+
+  const $ = cheerio.load(html)
+  const source = $('main').html()
+  if (!source) return undefined
+
+  return turndownService.turndown(source)
+}
+
 // -----------------------------------------------------------------------------
 // Project setup
 // -----------------------------------------------------------------------------
@@ -80,27 +100,16 @@ server.registerTool(
   },
   async () => {
     const url = new URL(`/product/getting-started/react`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
+    let text = await fetchTextOnlyContent(url)
+    if (text === undefined) {
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
       }
-    }
 
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
+      text = convertMainHtmlToMarkdown(await response.text())
     }
-
-    const text = turndownService.turndown(source)
+    if (!text) return {content: []}
 
     return {
       content: [
@@ -377,27 +386,16 @@ server.registerTool(
     }
 
     const url = new URL(`/product/components/${match.id}`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
+    let text = await fetchTextOnlyContent(url)
+    if (text === undefined) {
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
       }
-    }
 
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
+      text = convertMainHtmlToMarkdown(await response.text())
     }
-
-    const text = turndownService.turndown(source)
+    if (!text) return {content: []}
 
     return {
       content: [
@@ -438,38 +436,27 @@ server.registerTool(
     }
 
     const url = new URL(`/product/components/${match.id}/guidelines`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      if ((response.status >= 400 && response.status < 500) || (response.status >= 300 && response.status < 400)) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `There are no accessibility guidelines for the \`${name}\` component in the @primer/react package.`,
-            },
-          ],
+    let text = await fetchTextOnlyContent(url)
+    if (text === undefined) {
+      const response = await fetch(url)
+      if (!response.ok) {
+        if ((response.status >= 400 && response.status < 500) || (response.status >= 300 && response.status < 400)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `There are no accessibility guidelines for the \`${name}\` component in the @primer/react package.`,
+              },
+            ],
+          }
         }
+
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
       }
 
-      throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
+      text = convertMainHtmlToMarkdown(await response.text())
     }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
-      }
-    }
-
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
-    }
-
-    const text = turndownService.turndown(source)
+    if (!text) return {content: []}
 
     return {
       content: [
@@ -511,38 +498,27 @@ server.registerTool(
     }
 
     const url = new URL(`/product/components/${match.id}/accessibility`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      if ((response.status >= 400 && response.status < 500) || (response.status >= 300 && response.status < 400)) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `There are no accessibility guidelines for the \`${name}\` component in the @primer/react package.`,
-            },
-          ],
+    let text = await fetchTextOnlyContent(url)
+    if (text === undefined) {
+      const response = await fetch(url)
+      if (!response.ok) {
+        if ((response.status >= 400 && response.status < 500) || (response.status >= 300 && response.status < 400)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `There are no accessibility guidelines for the \`${name}\` component in the @primer/react package.`,
+              },
+            ],
+          }
         }
+
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
       }
 
-      throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
+      text = convertMainHtmlToMarkdown(await response.text())
     }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
-      }
-    }
-
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
-    }
-
-    const text = turndownService.turndown(source)
+    if (!text) return {content: []}
 
     return {
       content: [
@@ -959,27 +935,16 @@ server.registerTool(
   {description: 'Get the guidelines for how to apply color to a user interface', annotations: {readOnlyHint: true}},
   async () => {
     const url = new URL(`/product/getting-started/foundations/color-usage`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
+    let text = await fetchTextOnlyContent(url)
+    if (text === undefined) {
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
       }
-    }
 
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
+      text = convertMainHtmlToMarkdown(await response.text())
     }
-
-    const text = turndownService.turndown(source)
+    if (!text) return {content: []}
 
     return {
       content: [
@@ -1000,27 +965,16 @@ server.registerTool(
   },
   async () => {
     const url = new URL(`/product/getting-started/foundations/typography`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
+    let text = await fetchTextOnlyContent(url)
+    if (text === undefined) {
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
       }
-    }
 
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
+      text = convertMainHtmlToMarkdown(await response.text())
     }
-
-    const text = turndownService.turndown(source)
+    if (!text) return {content: []}
 
     return {
       content: [
@@ -1095,27 +1049,16 @@ server.registerTool(
     }
 
     const url = new URL(`/octicons/icon/${match.name}-${size}`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
+    let text = await fetchTextOnlyContent(url)
+    if (text === undefined) {
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
       }
-    }
 
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
+      text = convertMainHtmlToMarkdown(await response.text())
     }
-
-    const text = turndownService.turndown(source)
+    if (!text) return {content: []}
 
     return {
       content: [


### PR DESCRIPTION
Closes #

### Changelog

#### New

- None.

#### Changed

- MCP documentation tools prefer Primer Style text-only documentation endpoints, with HTML conversion retained during rollout.

#### Removed

- None.

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

PR 2 of a reviewable stack based on #8227 (`adierkens-optimize-mcp-patterns`).

- `npx --yes -p node@26.4.0 node node_modules/vitest/vitest.mjs --run packages/mcp/src/server.test.ts`
- `npm run type-check -w @primer/mcp`
- `npm run build`
- `npm run lint`
- `npm run lint:css`
- `npm run format:diff`

Review the text-only endpoint preference and the 404-only fallback to existing HTML conversion.