### PR TITLE
MCP: recommend Primer components

### DIFF
--- a/.changeset/recommend-mcp-components.md
+++ b/.changeset/recommend-mcp-components.md
@@ -1,0 +1,5 @@
+---
+'@primer/mcp': minor
+---
+
+MCP: Add deterministic Primer pattern and public component recommendations for product UI intent.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -79,6 +79,17 @@ conversion. The compact parser intentionally fails when it cannot identify the
 page's guidance body, rather than returning navigation content as pattern
 guidance.
 
+## Recommendations
+
+`recommend_components` maps freeform product or UI intent to a bounded set of
+Primer patterns and public `@primer/react` component candidates. Optional
+surface, region, pattern-hint, state, constraint, existing-component, and
+preferred-component signals refine deterministic lexical ranking. Results
+include the source URLs and kinds for pattern links and package-derived
+composition evidence. Deprecated, incompatible, and Primer-internal references
+are excluded from installable component candidates; unresolved internal links
+remain source-labeled evidence.
+
 ## 🙌 Contributing
 
 We love collaborating with folks inside and outside of GitHub and welcome contributions! If you're interested, check out our [contributing docs](contributor-docs/CONTRIBUTING.md) for more info on how to get started.

--- a/packages/mcp/src/recommendations.test.ts
+++ b/packages/mcp/src/recommendations.test.ts
@@ -1,0 +1,174 @@
+import {describe, expect, it} from 'vitest'
+import type {CompactPatternDetails} from './patterns'
+import {createRecommendation, formatRecommendation, rankPatterns, type RecommendationComponent} from './recommendations'
+import {listPatterns} from './primer'
+
+const sourceUrl = 'https://primer.style/product/components/text-input'
+const searchDetails: CompactPatternDetails = {
+  detail: 'compact',
+  pattern: {
+    id: 'search',
+    name: 'Search',
+    category: 'scenario',
+    sourceUrl: 'https://primer.style/product/scenario-patterns/search',
+  },
+  summary: 'Search guidance.',
+  components: [
+    {id: 'text-input', name: 'TextInput', source: 'primer-public', sourceUrl},
+    {
+      id: 'filter',
+      name: 'Filter',
+      source: 'primer-internal',
+      sourceUrl: 'https://primer.style/product/internal-components/filter',
+    },
+    {
+      id: 'octicon',
+      name: 'Octicon',
+      source: 'primer-public',
+      sourceUrl: 'https://primer.style/product/components/octicon',
+    },
+  ],
+  relatedPatterns: [],
+  guidance: {implementation: '', accessibility: [], states: []},
+}
+const filterDetails: CompactPatternDetails = {
+  ...searchDetails,
+  pattern: {
+    id: 'filter',
+    name: 'Filter',
+    category: 'scenario',
+    sourceUrl: 'https://primer.style/product/scenario-patterns/filter',
+  },
+  components: [
+    {
+      id: 'action-menu',
+      name: 'ActionMenu',
+      source: 'primer-public',
+      sourceUrl: 'https://primer.style/product/components/action-menu',
+    },
+  ],
+}
+const components: Array<RecommendationComponent> = [
+  {
+    id: 'text_input',
+    name: 'TextInput',
+    importPath: '@primer/react',
+    sourceUrl,
+    searchTerms: ['TextInput', 'query', 'search'],
+  },
+  {
+    id: 'action_menu',
+    name: 'ActionMenu',
+    importPath: '@primer/react',
+    sourceUrl: 'https://primer.style/product/components/action-menu',
+    searchTerms: ['ActionMenu', 'filter'],
+    composition: {
+      apiParentChild: [],
+      apiSubcomponents: [],
+      observed: {
+        parentChild: [{parent: 'ActionMenu.Overlay', child: 'ActionList', sourceCount: 2}],
+        adjacentSibling: [],
+        variants: [],
+        relatedComponents: [],
+      },
+    },
+  },
+  {
+    id: 'action_list',
+    name: 'ActionList',
+    importPath: '@primer/react',
+    sourceUrl: 'https://primer.style/product/components/action-list',
+    searchTerms: ['ActionList'],
+  },
+  {
+    id: 'octicon',
+    name: 'Octicon',
+    importPath: '@primer/react/deprecated',
+    status: 'deprecated',
+    sourceUrl: 'https://primer.style/product/components/octicon',
+    searchTerms: ['Octicon'],
+  },
+]
+
+describe('component recommendations', () => {
+  it('matches simple intent to authoritative pattern-linked public components', () => {
+    const input = {intent: 'Add a search query'}
+    const result = createRecommendation(input, rankPatterns(listPatterns(), input), [searchDetails], components)
+
+    expect(result.status).toBe('matched')
+    expect(result.patterns[0]?.pattern.name).toBe('Search')
+    expect(result.components[0]?.component).toMatchObject({name: 'TextInput', sourceKind: 'primer-public'})
+    expect(formatRecommendation(result)).toContain('Public components')
+  })
+
+  it('lets structured pattern hints outweigh freeform intent', () => {
+    const input = {intent: 'search', patternHints: ['filter']}
+    const result = createRecommendation(
+      input,
+      rankPatterns(listPatterns(), input),
+      [searchDetails, filterDetails],
+      components,
+    )
+
+    expect(result.patterns[0]?.pattern.name).toBe('Filter')
+    expect(result.matchedSignals.patternHints).toEqual(['filter'])
+  })
+
+  it('expands source-derived composition relationships without inventing mappings', () => {
+    const input = {intent: 'filter'}
+    const result = createRecommendation(input, rankPatterns(listPatterns(), input), [filterDetails], components)
+
+    expect(result.components.map(candidate => candidate.component.name)).toEqual(['ActionMenu', 'ActionList'])
+    expect(result.components[1]?.evidence[0]).toMatchObject({sourceKind: 'composition'})
+  })
+
+  it('reports ambiguous and no-match intent with actionable states', () => {
+    const ambiguous = {intent: 'search filter'}
+    const noMatch = {intent: 'calendar'}
+
+    expect(
+      createRecommendation(
+        ambiguous,
+        rankPatterns(listPatterns(), ambiguous),
+        [searchDetails, filterDetails],
+        components,
+      ).status,
+    ).toBe('ambiguous')
+    expect(createRecommendation(noMatch, rankPatterns(listPatterns(), noMatch), [], components)).toMatchObject({
+      status: 'no-match',
+      nextAction: expect.stringContaining('pattern hint'),
+    })
+  })
+
+  it('excludes deprecated candidates and retains internal references as unresolved evidence', () => {
+    const input = {intent: 'search'}
+    const result = createRecommendation(input, rankPatterns(listPatterns(), input), [searchDetails], components)
+
+    expect(result.components.map(candidate => candidate.component.name)).not.toContain('Octicon')
+    expect(result.exclusions).toContainEqual({name: 'Octicon', source: 'primer-public', reason: 'deprecated'})
+    expect(result.unresolvedReferences).toContainEqual(
+      expect.objectContaining({name: 'Filter', source: 'primer-internal', reason: 'internal-reference'}),
+    )
+  })
+
+  it('uses stable lexical ordering and bounded payloads', () => {
+    const input = {intent: 'search filter', limit: 1}
+    const first = createRecommendation(
+      input,
+      rankPatterns(listPatterns(), input),
+      [searchDetails, filterDetails],
+      components,
+    )
+    const second = createRecommendation(
+      input,
+      rankPatterns(listPatterns(), input),
+      [searchDetails, filterDetails],
+      components,
+    )
+
+    expect(first).toEqual(second)
+    expect(first.patterns).toHaveLength(1)
+    expect(first.components).toHaveLength(1)
+    expect(JSON.stringify(first).length).toBeLessThan(5_000)
+  })
+})

--- a/packages/mcp/src/recommendations.ts
+++ b/packages/mcp/src/recommendations.ts
@@ -1,0 +1,534 @@
+import type {CompactPatternDetails, PatternComponentReference, PatternReference} from './patterns'
+import {getPatternUrl} from './patterns'
+import type {Pattern} from './primer'
+
+const maximumEvidencePerCandidate = 3
+const maximumAuxiliaryEntriesPerResult = 3
+const relationshipKeys = [
+  'parent',
+  'child',
+  'previous',
+  'next',
+  'first',
+  'second',
+  'component',
+  'subcomponent',
+] as const
+
+export interface RecommendationInput {
+  intent: string
+  surface?: string
+  region?: string
+  patternHints?: Array<string>
+  states?: Array<string>
+  constraints?: Array<string>
+  existingComponents?: Array<string>
+  preferredComponents?: Array<string>
+  limit?: number
+}
+
+export interface RecommendationComponent {
+  id: string
+  name: string
+  importPath: string
+  status?: string
+  sourceUrl: string
+  searchTerms: Array<string>
+  composition?: RecommendationComposition
+}
+
+export interface RecommendationComposition {
+  apiParentChild: Array<RecommendationRelationship>
+  apiSubcomponents: Array<RecommendationRelationship>
+  observed: Record<string, Array<RecommendationRelationship>>
+}
+
+export interface RecommendationRelationship {
+  [key: string]: unknown
+}
+
+export interface RankedPattern {
+  pattern: Pattern
+  score: number
+  scoreBreakdown: Array<ScoreBreakdown>
+}
+
+export interface ScoreBreakdown {
+  source: string
+  score: number
+  matches: Array<string>
+}
+
+export interface CandidateEvidence {
+  sourceKind: 'pattern' | 'component-metadata' | 'composition' | 'input'
+  sourceUrl?: string
+  detail: string
+  relationship?: RecommendationRelationship
+}
+
+interface CandidateContribution {
+  score: number
+  scoreBreakdown: Array<ScoreBreakdown>
+  evidence: CandidateEvidence
+}
+
+export interface ComponentCandidate {
+  component: {
+    id: string
+    name: string
+    importPath: string
+    sourceKind: 'primer-public'
+    sourceUrl: string
+  }
+  score: number
+  scoreBreakdown: Array<ScoreBreakdown>
+  evidence: Array<CandidateEvidence>
+}
+
+export interface PatternCandidate {
+  pattern: PatternReference
+  sourceKind: 'primer-style-pattern'
+  score: number
+  scoreBreakdown: Array<ScoreBreakdown>
+}
+
+export interface Exclusion {
+  name: string
+  source: 'primer-public' | 'input'
+  reason: 'deprecated' | 'incompatible'
+}
+
+export interface UnresolvedReference {
+  name: string
+  id: string
+  source: PatternComponentReference['source']
+  sourceUrl: string
+  pattern: PatternReference
+  reason: 'internal-reference' | 'not-in-package'
+}
+
+export interface RecommendationResult extends Record<string, unknown> {
+  status: 'matched' | 'ambiguous' | 'partial-match' | 'no-match'
+  intent: string
+  patterns: Array<PatternCandidate>
+  components: Array<ComponentCandidate>
+  matchedSignals: Record<string, Array<string>>
+  unmetSignals: Array<string>
+  confidence: {
+    level: 'high' | 'medium' | 'low' | 'none'
+    score: number
+    scoreBreakdown: Array<ScoreBreakdown>
+  }
+  exclusions: Array<Exclusion>
+  unresolvedReferences: Array<UnresolvedReference>
+  nextAction?: string
+}
+
+export function rankPatterns(patterns: Array<Pattern>, input: RecommendationInput): Array<RankedPattern> {
+  const intentTokens = tokens(input.intent)
+  const hintTokens = tokens(input.patternHints ?? [])
+  const contextTokens = tokens([input.surface, input.region, ...(input.states ?? []), ...(input.constraints ?? [])])
+
+  return patterns
+    .map(pattern => {
+      const patternTokens = tokens([pattern.id, pattern.name])
+      const intentMatches = intersection(intentTokens, patternTokens)
+      const hintMatches = intersection(hintTokens, patternTokens)
+      const contextMatches = intersection(contextTokens, patternTokens)
+      const scoreBreakdown = [
+        score('intent', intentMatches, 10),
+        score('pattern-hint', hintMatches, 20),
+        score('context', contextMatches, 4),
+      ].filter((entry): entry is ScoreBreakdown => entry !== undefined)
+      const matchScore = scoreBreakdown.reduce((total, entry) => total + entry.score, 0)
+
+      return {
+        pattern,
+        score: matchScore === 0 ? 0 : matchScore + (pattern.category === 'scenario' ? 1 : 0),
+        scoreBreakdown,
+      }
+    })
+    .filter(candidate => candidate.score > 0)
+    .sort(compareRankedPatterns)
+}
+
+export function createRecommendation(
+  input: RecommendationInput,
+  rankedPatterns: Array<RankedPattern>,
+  details: Array<CompactPatternDetails>,
+  components: Array<RecommendationComponent>,
+): RecommendationResult {
+  const limit = input.limit ?? 3
+  const selectedPatterns = rankedPatterns.slice(0, limit)
+  const selectedDetails = details.filter(detail =>
+    selectedPatterns.some(candidate => candidate.pattern.id === detail.pattern.id),
+  )
+  const componentByName = new Map(components.map(component => [normalizeIdentifier(component.name), component]))
+  const candidates = new Map<string, ComponentCandidate>()
+  const exclusions: Array<Exclusion> = []
+  const unresolvedReferences: Array<UnresolvedReference> = []
+
+  for (const detail of selectedDetails) {
+    const pattern = selectedPatterns.find(candidate => candidate.pattern.id === detail.pattern.id)
+    if (!pattern) continue
+
+    for (const reference of detail.components) {
+      if (reference.source === 'primer-internal') {
+        unresolvedReferences.push({
+          ...reference,
+          pattern: detail.pattern,
+          reason: 'internal-reference',
+        })
+        continue
+      }
+
+      const component = componentByName.get(normalizeIdentifier(reference.name))
+      if (!component) {
+        unresolvedReferences.push({
+          ...reference,
+          pattern: detail.pattern,
+          reason: 'not-in-package',
+        })
+        continue
+      }
+
+      if (!isCompatible(component)) {
+        exclusions.push({
+          name: component.name,
+          source: 'primer-public',
+          reason: component.status === 'deprecated' ? 'deprecated' : 'incompatible',
+        })
+        continue
+      }
+
+      const metadataMatches = intersection(
+        tokens([input.intent, input.surface, input.region, ...(input.states ?? []), ...(input.constraints ?? [])]),
+        tokens(component.searchTerms),
+      )
+      addCandidate(candidates, component, {
+        score: pattern.score,
+        scoreBreakdown: [...pattern.scoreBreakdown, score('component-metadata', metadataMatches, 2)].filter(
+          (entry): entry is ScoreBreakdown => entry !== undefined,
+        ),
+        evidence: {
+          sourceKind: 'pattern',
+          sourceUrl: reference.sourceUrl,
+          detail: `${detail.pattern.name} links to ${component.name}.`,
+        },
+      })
+    }
+  }
+
+  for (const [signal, names] of [
+    ['existing-component', input.existingComponents ?? []],
+    ['preferred-component', input.preferredComponents ?? []],
+  ] as const) {
+    for (const name of names) {
+      const component = componentByName.get(normalizeIdentifier(name))
+      if (!component) continue
+      if (!isCompatible(component)) {
+        exclusions.push({
+          name: component.name,
+          source: 'input',
+          reason: component.status === 'deprecated' ? 'deprecated' : 'incompatible',
+        })
+        continue
+      }
+
+      addCandidate(candidates, component, {
+        score: signal === 'preferred-component' ? 12 : 8,
+        scoreBreakdown: [{source: signal, score: signal === 'preferred-component' ? 12 : 8, matches: [component.name]}],
+        evidence: {
+          sourceKind: 'input',
+          detail: `${component.name} was supplied as an ${signal.replace('-', ' ')}.`,
+        },
+      })
+    }
+  }
+
+  expandComposition(candidates, componentByName, exclusions)
+
+  const patternCandidates = selectedPatterns.map(candidate => ({
+    pattern: {
+      id: candidate.pattern.id,
+      name: candidate.pattern.name,
+      category: candidate.pattern.category,
+      sourceUrl: getPatternUrl(candidate.pattern).toString(),
+    },
+    sourceKind: 'primer-style-pattern' as const,
+    score: candidate.score,
+    scoreBreakdown: candidate.scoreBreakdown,
+  }))
+  const componentCandidates = [...candidates.values()]
+    .map(candidate => ({
+      ...candidate,
+      evidence: candidate.evidence.slice(0, maximumEvidencePerCandidate),
+    }))
+    .sort(compareComponentCandidates)
+    .slice(0, limit)
+  const matchedSignals = getMatchedSignals(input, patternCandidates, componentCandidates)
+  const unmetSignals = getUnmetSignals(input, matchedSignals)
+  const ambiguous = patternCandidates.length > 1 && patternCandidates[0].score === patternCandidates[1].score
+  const status =
+    patternCandidates.length === 0
+      ? 'no-match'
+      : ambiguous
+        ? 'ambiguous'
+        : componentCandidates.length === 0
+          ? 'partial-match'
+          : 'matched'
+
+  return {
+    status,
+    intent: input.intent,
+    patterns: patternCandidates,
+    components: componentCandidates,
+    matchedSignals,
+    unmetSignals,
+    confidence: getConfidence(status, patternCandidates, componentCandidates),
+    exclusions: uniqueBy(exclusions, exclusion => `${exclusion.name}:${exclusion.source}:${exclusion.reason}`).slice(
+      0,
+      maximumAuxiliaryEntriesPerResult,
+    ),
+    unresolvedReferences: uniqueBy(
+      unresolvedReferences,
+      reference => `${reference.pattern.id}:${reference.source}:${reference.id}:${reference.sourceUrl}`,
+    ).slice(0, maximumAuxiliaryEntriesPerResult),
+    nextAction:
+      status === 'no-match'
+        ? 'Try a known Primer pattern name or add a pattern hint.'
+        : status === 'ambiguous'
+          ? 'Add a pattern hint, surface, or state to choose between the equally ranked patterns.'
+          : status === 'partial-match'
+            ? 'Review the matched pattern guidance; it does not link to a compatible public Primer component.'
+            : undefined,
+  }
+}
+
+export function formatRecommendation(result: RecommendationResult): string {
+  if (result.status === 'no-match') {
+    return `No Primer pattern matched "${result.intent}". ${result.nextAction}`
+  }
+
+  const patterns = result.patterns.map(candidate => `- ${candidate.pattern.name} (${candidate.score})`).join('\n')
+  const components = result.components
+    .map(candidate => `- ${candidate.component.name} (${candidate.score}): ${candidate.component.sourceUrl}`)
+    .join('\n')
+  const unresolved = result.unresolvedReferences
+    .map(reference => `- ${reference.name} (${reference.source}): ${reference.sourceUrl}`)
+    .join('\n')
+
+  return [
+    `Recommendation confidence: ${result.confidence.level} (${result.confidence.score}/100).`,
+    patterns && `Patterns:\n${patterns}`,
+    components && `Public components:\n${components}`,
+    unresolved && `Unresolved references:\n${unresolved}`,
+    result.nextAction,
+  ]
+    .filter((section): section is string => Boolean(section))
+    .join('\n\n')
+}
+
+function expandComposition(
+  candidates: Map<string, ComponentCandidate>,
+  componentByName: Map<string, RecommendationComponent>,
+  exclusions: Array<Exclusion>,
+) {
+  const expandedRelationships = new Set<string>()
+
+  for (const candidate of [...candidates.values()]) {
+    const source = componentByName.get(normalizeIdentifier(candidate.component.name))
+    if (!source?.composition) continue
+
+    for (const [kind, relationships] of getRelationships(source.composition)) {
+      for (const relationship of relationships.slice(0, maximumEvidencePerCandidate)) {
+        for (const relatedName of getRelatedComponentNames(relationship, source.name)) {
+          const related = componentByName.get(normalizeIdentifier(relatedName))
+          if (!related || related.name === source.name) continue
+          const relationshipKey = `${source.name}:${kind}:${related.name}`
+          if (expandedRelationships.has(relationshipKey)) continue
+          expandedRelationships.add(relationshipKey)
+
+          if (!isCompatible(related)) {
+            exclusions.push({
+              name: related.name,
+              source: 'primer-public',
+              reason: related.status === 'deprecated' ? 'deprecated' : 'incompatible',
+            })
+            continue
+          }
+
+          addCandidate(candidates, related, {
+            score: 1,
+            scoreBreakdown: [{source: `composition:${kind}`, score: 1, matches: [source.name, related.name]}],
+            evidence: {
+              sourceKind: 'composition',
+              detail: `${kind} relates ${source.name} and ${related.name}.`,
+              relationship,
+            },
+          })
+        }
+      }
+    }
+  }
+}
+
+function getRelationships(composition: RecommendationComposition): Array<[string, Array<RecommendationRelationship>]> {
+  return [
+    ['api-parent-child', composition.apiParentChild],
+    ['api-subcomponents', composition.apiSubcomponents],
+    ...Object.entries(composition.observed).map(
+      ([kind, relationships]): [string, Array<RecommendationRelationship>] => [`observed:${kind}`, relationships],
+    ),
+  ]
+}
+
+function getRelatedComponentNames(relationship: RecommendationRelationship, componentName: string): Array<string> {
+  return relationshipKeys
+    .map(key => relationship[key])
+    .filter((value): value is string => typeof value === 'string')
+    .map(value => value.split('.')[0] ?? value)
+    .filter(name => name !== componentName)
+}
+
+function addCandidate(
+  candidates: Map<string, ComponentCandidate>,
+  component: RecommendationComponent,
+  contribution: CandidateContribution,
+) {
+  const key = normalizeIdentifier(component.name)
+  const current = candidates.get(key)
+  if (current) {
+    current.score += contribution.score
+    current.scoreBreakdown.push(...contribution.scoreBreakdown)
+    current.evidence.push(contribution.evidence)
+    return
+  }
+
+  candidates.set(key, {
+    component: {
+      id: component.id,
+      name: component.name,
+      importPath: component.importPath,
+      sourceKind: 'primer-public',
+      sourceUrl: component.sourceUrl,
+    },
+    score: contribution.score,
+    scoreBreakdown: contribution.scoreBreakdown,
+    evidence: [contribution.evidence],
+  })
+}
+
+function getMatchedSignals(
+  input: RecommendationInput,
+  patterns: Array<PatternCandidate>,
+  components: Array<ComponentCandidate>,
+): Record<string, Array<string>> {
+  const selectedPatternTerms = tokens(patterns.map(candidate => `${candidate.pattern.id} ${candidate.pattern.name}`))
+  const selectedComponentTerms = tokens([
+    ...components.map(candidate => candidate.component.name),
+    ...components.flatMap(candidate => candidate.scoreBreakdown.flatMap(breakdown => breakdown.matches)),
+  ])
+  const selectedTerms = new Set([...selectedPatternTerms, ...selectedComponentTerms])
+  const match = (values: Array<string>) => values.filter(value => intersection(tokens(value), selectedTerms).length > 0)
+
+  return {
+    intent: intersection(tokens(input.intent), selectedTerms),
+    surface: match([input.surface, input.region].filter((value): value is string => Boolean(value))),
+    patternHints: match(input.patternHints ?? []),
+    states: match(input.states ?? []),
+    constraints: match(input.constraints ?? []),
+    existingComponents: match(input.existingComponents ?? []),
+    preferredComponents: match(input.preferredComponents ?? []),
+  }
+}
+
+function getUnmetSignals(input: RecommendationInput, matched: Record<string, Array<string>>): Array<string> {
+  const signals = [
+    ['surface', [input.surface, input.region].filter((value): value is string => Boolean(value))],
+    ['pattern hint', input.patternHints ?? []],
+    ['state', input.states ?? []],
+    ['constraint', input.constraints ?? []],
+    ['existing component', input.existingComponents ?? []],
+    ['preferred component', input.preferredComponents ?? []],
+  ] as const
+
+  return signals.flatMap(([label, values]) => {
+    const key =
+      label === 'pattern hint'
+        ? 'patternHints'
+        : label === 'existing component'
+          ? 'existingComponents'
+          : label === 'preferred component'
+            ? 'preferredComponents'
+            : label
+    const matchedValues = matched[key] ?? []
+    return values.filter(value => !matchedValues.includes(value)).map(value => `${label}: ${value}`)
+  })
+}
+
+function getConfidence(
+  status: RecommendationResult['status'],
+  patterns: Array<PatternCandidate>,
+  components: Array<ComponentCandidate>,
+): RecommendationResult['confidence'] {
+  if (status === 'no-match') return {level: 'none', score: 0, scoreBreakdown: []}
+
+  const topPattern = patterns.at(0)
+  const topComponent = components.at(0)
+  const score = Math.min(100, (topPattern?.score ?? 0) + (topComponent ? 20 : 0))
+  const level = score >= 40 ? 'high' : score >= 20 ? 'medium' : 'low'
+
+  return {
+    level,
+    score,
+    scoreBreakdown: [...(topPattern?.scoreBreakdown ?? []), ...(topComponent?.scoreBreakdown ?? [])],
+  }
+}
+
+function score(source: string, matches: Array<string>, weight: number): ScoreBreakdown | undefined {
+  return matches.length > 0 ? {source, score: matches.length * weight, matches} : undefined
+}
+
+function tokens(values: string | Array<string | undefined>): Set<string> {
+  const text = Array.isArray(values) ? values.filter((value): value is string => Boolean(value)).join(' ') : values
+  return new Set(
+    text
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .flatMap(token => [token, stem(token)])
+      .filter(token => token.length > 1),
+  )
+}
+
+function stem(token: string): string {
+  if (token.endsWith('ing') && token.length > 5) return token.slice(0, -3)
+  if (token.endsWith('es') && token.length > 4) return token.slice(0, -2)
+  if (token.endsWith('s') && token.length > 3) return token.slice(0, -1)
+  return token
+}
+
+function intersection(first: Set<string>, second: Set<string>): Array<string> {
+  return [...first].filter(value => second.has(value)).sort((a, b) => a.localeCompare(b))
+}
+
+function normalizeIdentifier(value: string): string {
+  return value.replace(/[^a-z0-9]/gi, '').toLowerCase()
+}
+
+function isCompatible(component: RecommendationComponent): boolean {
+  return component.importPath === '@primer/react' && component.status !== 'deprecated'
+}
+
+function compareRankedPatterns(first: RankedPattern, second: RankedPattern): number {
+  return second.score - first.score || first.pattern.name.localeCompare(second.pattern.name)
+}
+
+function compareComponentCandidates(first: ComponentCandidate, second: ComponentCandidate): number {
+  return second.score - first.score || first.component.name.localeCompare(second.component.name)
+}
+
+function uniqueBy<Value>(values: Array<Value>, key: (value: Value) => string): Array<Value> {
+  return [...new Map(values.map(value => [key(value), value])).values()]
+}

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -69,6 +69,12 @@ describe('get_component_batch', () => {
   const callTool = (name: string, args: Record<string, unknown> = {}) => {
     return client.callTool({name, arguments: args})
   }
+  const callRecommendation = (arguments_: Record<string, unknown>) => {
+    return client.callTool({
+      name: 'recommend_components',
+      arguments: arguments_,
+    })
+  }
 
   it('requires between 2 and 10 names', async () => {
     const tooFew = await callBatch(['Button'])
@@ -339,6 +345,94 @@ describe('get_component_batch', () => {
 
     expect(empty.isError).toBe(true)
     expect(getTextContent(empty)).toContain('Primer Style returned an empty page')
+  })
+
+  it('recommends public components from compact pattern links and retains internal links as unresolved evidence', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(searchPatternPage))
+
+    const result = await callRecommendation({intent: 'Add a search query'})
+    const payload = result.structuredContent as Record<string, unknown>
+
+    expect(payload).toMatchObject({
+      status: 'matched',
+      patterns: [expect.objectContaining({pattern: expect.objectContaining({name: 'Search'})})],
+      components: expect.arrayContaining([
+        expect.objectContaining({
+          component: expect.objectContaining({name: 'TextInput', sourceKind: 'primer-public'}),
+        }),
+      ]),
+      unresolvedReferences: expect.arrayContaining([
+        expect.objectContaining({name: 'Filter', source: 'primer-internal', reason: 'internal-reference'}),
+      ]),
+    })
+    expect(getTextContent(result)).toContain('Public components')
+  })
+
+  it('uses structured signals to distinguish patterns and expands composition evidence', async () => {
+    const filterPatternPage = searchPatternPage
+      .replace('<h1>Search</h1>', '<h1>Filter</h1>')
+      .replace('Search finds things that match specific criteria.', 'Filter narrows a list.')
+      .replace(
+        '<a href="/product/components/text-input/">TextInput</a>',
+        '<a href="/product/components/action-menu/">ActionMenu</a>',
+      )
+    vi.mocked(fetch).mockImplementation(async input => {
+      const url = new URL(input.toString())
+      return new Response(url.pathname.includes('/filter') ? filterPatternPage : searchPatternPage)
+    })
+
+    const filtered = await callRecommendation({intent: 'search', patternHints: ['filter']})
+    const filterPayload = filtered.structuredContent as {patterns: Array<{pattern: {name: string}}>}
+    expect(filterPayload.patterns[0]?.pattern.name).toBe('Filter')
+
+    const composed = await callRecommendation({intent: 'filter'})
+    const compositionPayload = composed.structuredContent as {
+      components: Array<{component: {name: string}; evidence: Array<{sourceKind: string}>}>
+    }
+    expect(compositionPayload.components.map(candidate => candidate.component.name)).toContain('ActionMenu')
+    expect(compositionPayload.components).toContainEqual(
+      expect.objectContaining({component: expect.objectContaining({name: 'ActionList'})}),
+    )
+    expect(compositionPayload.components.flatMap(candidate => candidate.evidence)).toContainEqual(
+      expect.objectContaining({sourceKind: 'composition'}),
+    )
+  })
+
+  it('reports ambiguous and no-match recommendations without requesting unrelated pattern pages', async () => {
+    vi.mocked(fetch).mockImplementation(async () => new Response(searchPatternPage))
+
+    const ambiguous = await callRecommendation({intent: 'search filter'})
+    const noMatch = await callRecommendation({intent: 'calendar planner'})
+
+    expect(ambiguous.structuredContent).toMatchObject({
+      status: 'ambiguous',
+      nextAction: expect.stringContaining('pattern hint'),
+    })
+    expect(noMatch.structuredContent).toMatchObject({
+      status: 'no-match',
+      confidence: {level: 'none', score: 0},
+    })
+  })
+
+  it('excludes deprecated results, has stable ordering, and bounds recommendation payloads', async () => {
+    const deprecatedPatternPage = searchPatternPage.replace(
+      '</p>\n        <p>Use the <a href="/product/internal-components/filter/',
+      '</p>\n        <p>Use <a href="/product/components/octicon/">Octicon</a>.</p>\n        <p>Use the <a href="/product/internal-components/filter/',
+    )
+    vi.mocked(fetch).mockImplementation(async () => new Response(deprecatedPatternPage))
+
+    const first = await callRecommendation({intent: 'search', limit: 1})
+    const second = await callRecommendation({intent: 'search', limit: 1})
+    const payload = first.structuredContent as {
+      components: Array<{component: {name: string}}>
+      exclusions: Array<{name: string; reason: string}>
+    }
+
+    expect(first.structuredContent).toEqual(second.structuredContent)
+    expect(payload.components).toHaveLength(1)
+    expect(payload.components.map(candidate => candidate.component.name)).not.toContain('Octicon')
+    expect(payload.exclusions).toContainEqual({name: 'Octicon', source: 'primer-public', reason: 'deprecated'})
+    expect(JSON.stringify(first.structuredContent).length).toBeLessThan(5_000)
   })
 
   it('times out stalled requests without leaving timers active', async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -15,6 +15,7 @@ import {
   listIcons,
 } from './primer'
 import {formatCompactPatternDetails, getPatternUrl, parseCompactPatternDetails, toFullPatternDetails} from './patterns'
+import {createRecommendation, formatRecommendation, rankPatterns, type RecommendationComponent} from './recommendations'
 import {
   listTokenGroups,
   loadAllTokensWithGuidelines,
@@ -65,6 +66,12 @@ const patternOutputSchema = z.object({
     })
     .optional(),
 })
+const recommendationOutputSchema = z
+  .object({
+    status: z.enum(['matched', 'ambiguous', 'partial-match', 'no-match']),
+    intent: z.string(),
+  })
+  .passthrough()
 
 // Load all tokens with guidelines from primitives
 const allTokensWithGuidelines: TokenWithGuidelines[] = loadAllTokensWithGuidelines()
@@ -674,6 +681,81 @@ ${text}`,
           text: formatCompactPatternDetails(details),
         },
       ],
+    }
+  },
+)
+
+server.registerTool(
+  'recommend_components',
+  {
+    description:
+      'Recommend public Primer patterns and components for product or UI intent. Deterministically ranks pattern names and hints, resolves authoritative pattern-linked public components, and expands with source-derived composition evidence. Deprecated, incompatible, and Primer-internal references are excluded from installable component candidates.',
+    inputSchema: {
+      intent: z.string().min(1).describe('The product or UI intent to match, in freeform language'),
+      surface: z.string().optional().describe('Optional product surface, such as issue list or settings page'),
+      region: z.string().optional().describe('Optional UI region, such as toolbar, form, or sidebar'),
+      patternHints: z
+        .array(z.string())
+        .max(8)
+        .optional()
+        .describe('Optional likely Primer pattern names or interaction hints'),
+      states: z
+        .array(z.string())
+        .max(8)
+        .optional()
+        .describe('Optional relevant states, such as loading, empty, or error'),
+      constraints: z.array(z.string()).max(8).optional().describe('Optional product or implementation constraints'),
+      existingComponents: z
+        .array(z.string())
+        .max(8)
+        .optional()
+        .describe('Optional existing public component names to retain'),
+      preferredComponents: z.array(z.string()).max(8).optional().describe('Optional public component names to prefer'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(5)
+        .optional()
+        .default(3)
+        .describe('Maximum patterns and public components to return'),
+    },
+    outputSchema: recommendationOutputSchema,
+    annotations: {readOnlyHint: true},
+  },
+  async input => {
+    const rankedPatterns = rankPatterns(listPatterns(), input)
+    const details = await Promise.all(
+      rankedPatterns.slice(0, input.limit * 2).map(async candidate => {
+        const url = getPatternUrl(candidate.pattern)
+        const response = await fetch(url)
+        if (!response.ok) throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
+
+        const html = await response.text()
+        if (!html) throw new Error(`Primer Style returned an empty page for the \`${candidate.pattern.name}\` pattern.`)
+
+        return parseCompactPatternDetails(html, candidate.pattern, url, listPatterns())
+      }),
+    )
+    const components: Array<RecommendationComponent> = listComponents().map(component => {
+      const document = getComponentDocument(component.id)
+      const status = typeof document?.status === 'string' ? document.status : undefined
+      const searchTerms = [component.id, component.name, JSON.stringify(document?.props ?? [])]
+      const composition = getComponentCompositionSummary(component.id)
+
+      return {
+        ...component,
+        status,
+        sourceUrl: new URL(`/product/components/${component.slug}`, 'https://primer.style').toString(),
+        searchTerms,
+        composition,
+      }
+    })
+    const recommendation = createRecommendation(input, rankedPatterns, details, components)
+
+    return {
+      structuredContent: recommendation,
+      content: [{type: 'text', text: formatRecommendation(recommendation)}],
     }
   },
 )


### PR DESCRIPTION
Closes #

PR 2 of the MCP recommendation stack. Stacked on #8227, which is stacked on #8217.

### Changelog

#### New

- Add deterministic `recommend_components` recommendations from product/UI intent to Primer patterns, public components, and source-derived composition evidence.

#### Changed

- Exclude deprecated, incompatible, and unresolved Primer-internal references from installable component candidates while retaining source-labeled evidence.

#### Removed

- None.

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

- `npm run test -w @primer/mcp`
- `npm run type-check -w @primer/mcp`
- `npm run build -w @primer/mcp`
- `npm run lint`
- `npm run format:diff`
- `npm run build`

The tool has pure helper and in-memory SDK coverage for simple and structured searches, composition expansion, ambiguity and no-match states, exclusions, deterministic ordering, payload bounds, and unresolved internal references.