### PR TITLE
MCP: federate documented internal components

### DIFF
--- a/.changeset/mcp-internal-catalog.md
+++ b/.changeset/mcp-internal-catalog.md
@@ -1,0 +1,5 @@
+---
+'@primer/mcp': minor
+---
+
+MCP: Add documented Primer-internal catalog discovery and opt-in GitHub-only recommendation candidates.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -91,11 +91,10 @@ mixed into the `components` collection or returned from `get_component`.
 
 `list_internal_components` retrieves the documented internal catalog directly
 from Primer Style. It exposes only safe documentation metadata: ids, names,
-canonical docs URLs, visibility, availability, installability, and
-`implementationIncluded: false`. The catalog is generated from the docs source
-and includes a source-record `revision`; an unsupported schema is reported as
-stale, while missing, invalid, and unavailable endpoints are returned
-explicitly without a fallback catalog.
+docs URLs, visibility, availability, and `implementationIncluded: false`. The
+catalog is generated from the docs source and includes a build timestamp plus a
+source-record `sourceRevision`; stale, missing, invalid, and unavailable
+endpoints are returned explicitly without a fallback catalog.
 
 Optional
 surface, region, pattern-hint, state, constraint, existing-component, and

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -82,13 +82,29 @@ guidance.
 ## Recommendations
 
 `recommend_components` maps freeform product or UI intent to a bounded set of
-Primer patterns and public `@primer/react` component candidates. Optional
+Primer patterns and public `@primer/react` component candidates. It defaults to
+`sourceScope: "public"` so external consumers receive only installable public
+candidates. Set `sourceScope: "all"` for a separate, bounded
+`internalComponents` collection of documented GitHub-only candidates. Internal
+candidates are explicitly non-installable, have no public import, and are never
+mixed into the `components` collection or returned from `get_component`.
+
+`list_internal_components` retrieves the documented internal catalog directly
+from Primer Style. It exposes only safe documentation metadata: ids, names,
+canonical docs URLs, visibility, availability, installability, and
+`implementationIncluded: false`. The catalog is generated from the docs source
+and includes a source-record `revision`; an unsupported schema is reported as
+stale, while missing, invalid, and unavailable endpoints are returned
+explicitly without a fallback catalog.
+
+Optional
 surface, region, pattern-hint, state, constraint, existing-component, and
 preferred-component signals refine deterministic lexical ranking. Results
 include the source URLs and kinds for pattern links and package-derived
-composition evidence. Deprecated, incompatible, and Primer-internal references
-are excluded from installable component candidates; unresolved internal links
-remain source-labeled evidence.
+composition evidence. Deprecated and incompatible components are excluded from
+installable candidates. Under the holistic scope, authored Primer-internal
+pattern links resolve through the catalog; otherwise they remain source-labeled
+unresolved evidence.
 
 ## 🙌 Contributing
 

--- a/packages/mcp/src/internalCatalog.test.ts
+++ b/packages/mcp/src/internalCatalog.test.ts
@@ -8,29 +8,25 @@ import {
 
 const catalog = {
   schemaVersion: 1,
-  revision: 'internal-catalog-v1',
-  count: 2,
-  items: [
+  generatedAt: '2026-07-23T00:00:00.000Z',
+  sourceRevision: 'sha256:internal-catalog-v1',
+  entries: [
     {
       id: 'filter',
-      slug: 'filter',
       name: 'Filter',
       sourceKind: 'primer-internal',
-      canonicalUrl: 'https://primer.style/product/internal-components/filter',
+      sourceUrl: 'https://primer.style/product/internal-components/filter',
       visibility: 'github-only',
       availability: 'unavailable',
-      installability: 'non-installable',
       implementationIncluded: false,
     },
     {
       id: 'action-list-items',
-      slug: 'action-list-items',
       name: 'Action list items',
       sourceKind: 'primer-internal',
-      canonicalUrl: 'https://primer.style/product/internal-components/action-list-items',
+      sourceUrl: 'https://primer.style/product/internal-components/action-list-items',
       visibility: 'github-only',
       availability: 'unavailable',
-      installability: 'non-installable',
       implementationIncluded: false,
     },
   ],
@@ -40,7 +36,7 @@ describe('internal catalog', () => {
   it('parses safe documented entries with deterministic order and reference lookup', () => {
     const parsed = parseInternalCatalog(catalog)
 
-    expect(parsed?.items.map(entry => entry.name)).toEqual(['Action list items', 'Filter'])
+    expect(parsed?.entries.map(entry => entry.name)).toEqual(['Action list items', 'Filter'])
     expect(
       findInternalCatalogEntries(
         parsed!,
@@ -61,10 +57,10 @@ describe('internal catalog', () => {
     expect(
       parseInternalCatalog({
         ...catalog,
-        items: [
+        entries: [
           {
-            ...catalog.items[0],
-            canonicalUrl: 'https://github.com/github/github-ui',
+            ...catalog.entries[0],
+            sourceUrl: 'https://github.com/github/github-ui',
             implementation: 'private source',
           },
         ],
@@ -82,14 +78,14 @@ describe('internal catalog', () => {
     expect(fetcher).toHaveBeenCalledWith(getInternalCatalogUrl())
   })
 
-  it('marks unsupported catalog schemas as stale instead of silently trusting them', async () => {
+  it('marks old generated catalogs as stale instead of silently trusting them', async () => {
     const fetcher = vi
       .fn<typeof fetch>()
-      .mockResolvedValue(new Response(JSON.stringify({...catalog, schemaVersion: 2})))
+      .mockResolvedValue(new Response(JSON.stringify({...catalog, generatedAt: '2026-01-01T00:00:00.000Z'})))
 
-    await expect(fetchInternalCatalog(fetcher)).resolves.toMatchObject({
+    await expect(fetchInternalCatalog(fetcher, new Date('2026-07-23T00:00:00.000Z'))).resolves.toMatchObject({
       status: 'stale',
-      catalog: {revision: 'internal-catalog-v1'},
+      catalog: {sourceRevision: 'sha256:internal-catalog-v1'},
     })
   })
 })

--- a/packages/mcp/src/internalCatalog.test.ts
+++ b/packages/mcp/src/internalCatalog.test.ts
@@ -1,0 +1,95 @@
+import {describe, expect, it, vi} from 'vitest'
+import {
+  fetchInternalCatalog,
+  findInternalCatalogEntries,
+  getInternalCatalogUrl,
+  parseInternalCatalog,
+} from './internalCatalog'
+
+const catalog = {
+  schemaVersion: 1,
+  revision: 'internal-catalog-v1',
+  count: 2,
+  items: [
+    {
+      id: 'filter',
+      slug: 'filter',
+      name: 'Filter',
+      sourceKind: 'primer-internal',
+      canonicalUrl: 'https://primer.style/product/internal-components/filter',
+      visibility: 'github-only',
+      availability: 'unavailable',
+      installability: 'non-installable',
+      implementationIncluded: false,
+    },
+    {
+      id: 'action-list-items',
+      slug: 'action-list-items',
+      name: 'Action list items',
+      sourceKind: 'primer-internal',
+      canonicalUrl: 'https://primer.style/product/internal-components/action-list-items',
+      visibility: 'github-only',
+      availability: 'unavailable',
+      installability: 'non-installable',
+      implementationIncluded: false,
+    },
+  ],
+} as const
+
+describe('internal catalog', () => {
+  it('parses safe documented entries with deterministic order and reference lookup', () => {
+    const parsed = parseInternalCatalog(catalog)
+
+    expect(parsed?.items.map(entry => entry.name)).toEqual(['Action list items', 'Filter'])
+    expect(
+      findInternalCatalogEntries(
+        parsed!,
+        [
+          {
+            id: 'filter',
+            name: 'Filter',
+            source: 'primer-internal',
+            sourceUrl: 'https://primer.style/product/internal-components/filter',
+          },
+        ],
+        1,
+      ),
+    ).toEqual([expect.objectContaining({name: 'Filter', implementationIncluded: false})])
+  })
+
+  it('rejects private implementation metadata and non-Primer URLs', () => {
+    expect(
+      parseInternalCatalog({
+        ...catalog,
+        items: [
+          {
+            ...catalog.items[0],
+            canonicalUrl: 'https://github.com/github/github-ui',
+            implementation: 'private source',
+          },
+        ],
+      }),
+    ).toBeUndefined()
+  })
+
+  it('reports unavailable endpoint responses without a fallback catalog', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, {status: 503}))
+
+    await expect(fetchInternalCatalog(fetcher)).resolves.toMatchObject({
+      status: 'unavailable',
+      message: expect.stringContaining('503'),
+    })
+    expect(fetcher).toHaveBeenCalledWith(getInternalCatalogUrl())
+  })
+
+  it('marks unsupported catalog schemas as stale instead of silently trusting them', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify({...catalog, schemaVersion: 2})))
+
+    await expect(fetchInternalCatalog(fetcher)).resolves.toMatchObject({
+      status: 'stale',
+      catalog: {revision: 'internal-catalog-v1'},
+    })
+  })
+})

--- a/packages/mcp/src/internalCatalog.ts
+++ b/packages/mcp/src/internalCatalog.ts
@@ -1,0 +1,170 @@
+import type {ComponentSource, PatternComponentReference} from './patterns'
+
+const catalogUrl = new URL('/product/internal-components/catalog.json', 'https://primer.style')
+const maximumCatalogEntries = 100
+
+export interface InternalCatalogEntry {
+  id: string
+  slug: string
+  name: string
+  sourceKind: Extract<ComponentSource, 'primer-internal'>
+  canonicalUrl: string
+  visibility: string
+  availability: string
+  installability: 'non-installable'
+  implementationIncluded: false
+}
+
+export interface InternalCatalog {
+  schemaVersion: number
+  revision: string
+  count: number
+  items: Array<InternalCatalogEntry>
+}
+
+export interface InternalCatalogResult {
+  status: 'available' | 'unavailable' | 'stale' | 'not-requested'
+  catalog?: InternalCatalog
+  message?: string
+}
+
+export async function fetchInternalCatalog(fetcher: typeof fetch = fetch): Promise<InternalCatalogResult> {
+  let response: Response
+  try {
+    response = await fetcher(catalogUrl)
+  } catch {
+    return {status: 'unavailable', message: 'The Primer internal catalog endpoint could not be reached.'}
+  }
+
+  if (!response.ok) {
+    return {
+      status: 'unavailable',
+      message: `The Primer internal catalog endpoint returned ${response.status}.`,
+    }
+  }
+
+  let value: unknown
+  try {
+    value = await response.json()
+  } catch {
+    return {status: 'unavailable', message: 'The Primer internal catalog endpoint returned invalid JSON.'}
+  }
+
+  const catalog = parseInternalCatalog(value)
+  if (!catalog) {
+    return {status: 'unavailable', message: 'The Primer internal catalog endpoint returned an invalid catalog.'}
+  }
+
+  if (isStale(catalog)) {
+    return {
+      status: 'stale',
+      catalog,
+      message:
+        'The Primer internal catalog uses an unsupported schema version; review its revision before relying on it.',
+    }
+  }
+
+  return {status: 'available', catalog}
+}
+
+export function parseInternalCatalog(value: unknown): InternalCatalog | undefined {
+  if (!isRecord(value)) return undefined
+  if (
+    typeof value.schemaVersion !== 'number' ||
+    !Number.isInteger(value.schemaVersion) ||
+    typeof value.revision !== 'string' ||
+    typeof value.count !== 'number' ||
+    !Number.isInteger(value.count) ||
+    !Array.isArray(value.items)
+  ) {
+    return undefined
+  }
+
+  const items = value.items.map(parseInternalCatalogEntry)
+  if (items.some((entry): entry is undefined => entry === undefined)) return undefined
+  if (value.count !== items.length) return undefined
+
+  return {
+    schemaVersion: value.schemaVersion,
+    revision: value.revision,
+    count: value.count,
+    items: items
+      .filter((entry): entry is InternalCatalogEntry => entry !== undefined)
+      .sort((first, second) => first.name.localeCompare(second.name))
+      .slice(0, maximumCatalogEntries),
+  }
+}
+
+export function findInternalCatalogEntries(
+  catalog: InternalCatalog,
+  references: Array<PatternComponentReference>,
+  limit: number,
+): Array<InternalCatalogEntry> {
+  const entryById = new Map(catalog.items.map(entry => [normalize(entry.id), entry]))
+  const entryByName = new Map(catalog.items.map(entry => [normalize(entry.name), entry]))
+
+  return references
+    .filter(reference => reference.source === 'primer-internal')
+    .flatMap(reference => {
+      const entry = entryById.get(normalize(reference.id)) ?? entryByName.get(normalize(reference.name))
+      return entry ? [entry] : []
+    })
+    .filter((entry, index, entries) => entries.findIndex(candidate => candidate.id === entry.id) === index)
+    .sort((first, second) => first.name.localeCompare(second.name))
+    .slice(0, limit)
+}
+
+export function getInternalCatalogUrl(): URL {
+  return new URL(catalogUrl)
+}
+
+function parseInternalCatalogEntry(value: unknown): InternalCatalogEntry | undefined {
+  if (!isRecord(value)) return undefined
+  if (
+    typeof value.id !== 'string' ||
+    typeof value.slug !== 'string' ||
+    typeof value.name !== 'string' ||
+    value.sourceKind !== 'primer-internal' ||
+    typeof value.canonicalUrl !== 'string' ||
+    typeof value.visibility !== 'string' ||
+    typeof value.availability !== 'string' ||
+    value.installability !== 'non-installable' ||
+    value.implementationIncluded !== false ||
+    !isPrimerInternalUrl(value.canonicalUrl)
+  ) {
+    return undefined
+  }
+
+  return {
+    id: value.id,
+    slug: value.slug,
+    name: value.name,
+    sourceKind: value.sourceKind,
+    canonicalUrl: value.canonicalUrl,
+    visibility: value.visibility,
+    availability: value.availability,
+    installability: value.installability,
+    implementationIncluded: false,
+  }
+}
+
+function isStale(catalog: InternalCatalog): boolean {
+  return catalog.schemaVersion !== 1
+}
+
+function isPrimerInternalUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.origin === 'https://primer.style' && url.pathname.startsWith('/product/internal-components/')
+  } catch {
+    return false
+  }
+}
+
+function normalize(value: string): string {
+  return value.replace(/[^a-z0-9]/gi, '').toLowerCase()
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/packages/mcp/src/internalCatalog.ts
+++ b/packages/mcp/src/internalCatalog.ts
@@ -2,24 +2,23 @@ import type {ComponentSource, PatternComponentReference} from './patterns'
 
 const catalogUrl = new URL('/product/internal-components/catalog.json', 'https://primer.style')
 const maximumCatalogEntries = 100
+const maximumCatalogAgeMilliseconds = 30 * 24 * 60 * 60 * 1000
 
 export interface InternalCatalogEntry {
   id: string
-  slug: string
   name: string
   sourceKind: Extract<ComponentSource, 'primer-internal'>
-  canonicalUrl: string
+  sourceUrl: string
   visibility: string
   availability: string
-  installability: 'non-installable'
   implementationIncluded: false
 }
 
 export interface InternalCatalog {
   schemaVersion: number
-  revision: string
-  count: number
-  items: Array<InternalCatalogEntry>
+  generatedAt: string
+  sourceRevision: string
+  entries: Array<InternalCatalogEntry>
 }
 
 export interface InternalCatalogResult {
@@ -28,7 +27,10 @@ export interface InternalCatalogResult {
   message?: string
 }
 
-export async function fetchInternalCatalog(fetcher: typeof fetch = fetch): Promise<InternalCatalogResult> {
+export async function fetchInternalCatalog(
+  fetcher: typeof fetch = fetch,
+  now: Date = new Date(),
+): Promise<InternalCatalogResult> {
   let response: Response
   try {
     response = await fetcher(catalogUrl)
@@ -55,12 +57,11 @@ export async function fetchInternalCatalog(fetcher: typeof fetch = fetch): Promi
     return {status: 'unavailable', message: 'The Primer internal catalog endpoint returned an invalid catalog.'}
   }
 
-  if (isStale(catalog)) {
+  if (isStale(catalog, now)) {
     return {
       status: 'stale',
       catalog,
-      message:
-        'The Primer internal catalog uses an unsupported schema version; review its revision before relying on it.',
+      message: 'The Primer internal catalog is older than 30 days; review its source revision before relying on it.',
     }
   }
 
@@ -72,23 +73,21 @@ export function parseInternalCatalog(value: unknown): InternalCatalog | undefine
   if (
     typeof value.schemaVersion !== 'number' ||
     !Number.isInteger(value.schemaVersion) ||
-    typeof value.revision !== 'string' ||
-    typeof value.count !== 'number' ||
-    !Number.isInteger(value.count) ||
-    !Array.isArray(value.items)
+    typeof value.generatedAt !== 'string' ||
+    typeof value.sourceRevision !== 'string' ||
+    !Array.isArray(value.entries)
   ) {
     return undefined
   }
 
-  const items = value.items.map(parseInternalCatalogEntry)
-  if (items.some((entry): entry is undefined => entry === undefined)) return undefined
-  if (value.count !== items.length) return undefined
+  const entries = value.entries.map(parseInternalCatalogEntry)
+  if (entries.some((entry): entry is undefined => entry === undefined)) return undefined
 
   return {
     schemaVersion: value.schemaVersion,
-    revision: value.revision,
-    count: value.count,
-    items: items
+    generatedAt: value.generatedAt,
+    sourceRevision: value.sourceRevision,
+    entries: entries
       .filter((entry): entry is InternalCatalogEntry => entry !== undefined)
       .sort((first, second) => first.name.localeCompare(second.name))
       .slice(0, maximumCatalogEntries),
@@ -100,8 +99,8 @@ export function findInternalCatalogEntries(
   references: Array<PatternComponentReference>,
   limit: number,
 ): Array<InternalCatalogEntry> {
-  const entryById = new Map(catalog.items.map(entry => [normalize(entry.id), entry]))
-  const entryByName = new Map(catalog.items.map(entry => [normalize(entry.name), entry]))
+  const entryById = new Map(catalog.entries.map(entry => [normalize(entry.id), entry]))
+  const entryByName = new Map(catalog.entries.map(entry => [normalize(entry.name), entry]))
 
   return references
     .filter(reference => reference.source === 'primer-internal')
@@ -122,34 +121,36 @@ function parseInternalCatalogEntry(value: unknown): InternalCatalogEntry | undef
   if (!isRecord(value)) return undefined
   if (
     typeof value.id !== 'string' ||
-    typeof value.slug !== 'string' ||
     typeof value.name !== 'string' ||
     value.sourceKind !== 'primer-internal' ||
-    typeof value.canonicalUrl !== 'string' ||
+    typeof value.sourceUrl !== 'string' ||
     typeof value.visibility !== 'string' ||
     typeof value.availability !== 'string' ||
-    value.installability !== 'non-installable' ||
     value.implementationIncluded !== false ||
-    !isPrimerInternalUrl(value.canonicalUrl)
+    !isPrimerInternalUrl(value.sourceUrl)
   ) {
     return undefined
   }
 
   return {
     id: value.id,
-    slug: value.slug,
     name: value.name,
     sourceKind: value.sourceKind,
-    canonicalUrl: value.canonicalUrl,
+    sourceUrl: value.sourceUrl,
     visibility: value.visibility,
     availability: value.availability,
-    installability: value.installability,
     implementationIncluded: false,
   }
 }
 
-function isStale(catalog: InternalCatalog): boolean {
-  return catalog.schemaVersion !== 1
+function isStale(catalog: InternalCatalog, now: Date): boolean {
+  const generatedAt = Date.parse(catalog.generatedAt)
+  return (
+    catalog.schemaVersion !== 1 ||
+    Number.isNaN(generatedAt) ||
+    generatedAt > now.getTime() ||
+    now.getTime() - generatedAt > maximumCatalogAgeMilliseconds
+  )
 }
 
 function isPrimerInternalUrl(value: string): boolean {

--- a/packages/mcp/src/patterns.ts
+++ b/packages/mcp/src/patterns.ts
@@ -11,7 +11,7 @@ const maximumSummaryLength = 480
 const maximumGuidanceItemLength = 280
 const maximumImplementationLength = 900
 
-type ComponentSource = 'primer-public' | 'primer-internal'
+export type ComponentSource = 'primer-public' | 'primer-internal'
 
 export interface PatternReference {
   id: string

--- a/packages/mcp/src/recommendations.test.ts
+++ b/packages/mcp/src/recommendations.test.ts
@@ -93,18 +93,16 @@ const internalCatalog = {
   status: 'available' as const,
   catalog: {
     schemaVersion: 1,
-    revision: 'internal-catalog-v1',
-    count: 1,
-    items: [
+    generatedAt: '2026-07-23T00:00:00.000Z',
+    sourceRevision: 'sha256:internal-catalog-v1',
+    entries: [
       {
         id: 'filter',
-        slug: 'filter',
         name: 'Filter',
         sourceKind: 'primer-internal' as const,
-        canonicalUrl: 'https://primer.style/product/internal-components/filter',
+        sourceUrl: 'https://primer.style/product/internal-components/filter',
         visibility: 'github-only',
         availability: 'unavailable',
-        installability: 'non-installable' as const,
         implementationIncluded: false as const,
       },
     ],

--- a/packages/mcp/src/recommendations.test.ts
+++ b/packages/mcp/src/recommendations.test.ts
@@ -89,6 +89,27 @@ const components: Array<RecommendationComponent> = [
     searchTerms: ['Octicon'],
   },
 ]
+const internalCatalog = {
+  status: 'available' as const,
+  catalog: {
+    schemaVersion: 1,
+    revision: 'internal-catalog-v1',
+    count: 1,
+    items: [
+      {
+        id: 'filter',
+        slug: 'filter',
+        name: 'Filter',
+        sourceKind: 'primer-internal' as const,
+        canonicalUrl: 'https://primer.style/product/internal-components/filter',
+        visibility: 'github-only',
+        availability: 'unavailable',
+        installability: 'non-installable' as const,
+        implementationIncluded: false as const,
+      },
+    ],
+  },
+}
 
 describe('component recommendations', () => {
   it('matches simple intent to authoritative pattern-linked public components', () => {
@@ -149,6 +170,31 @@ describe('component recommendations', () => {
     expect(result.unresolvedReferences).toContainEqual(
       expect.objectContaining({name: 'Filter', source: 'primer-internal', reason: 'internal-reference'}),
     )
+  })
+
+  it('resolves documented internal references separately for the all source scope', () => {
+    const input = {intent: 'search', sourceScope: 'all' as const}
+    const result = createRecommendation(
+      input,
+      rankPatterns(listPatterns(), input),
+      [searchDetails],
+      components,
+      internalCatalog,
+    )
+
+    expect(result.components.map(candidate => candidate.component.name)).toEqual(['TextInput'])
+    expect(result.internalComponents).toEqual([
+      expect.objectContaining({
+        component: expect.objectContaining({
+          name: 'Filter',
+          sourceKind: 'primer-internal',
+          installable: false,
+          implementationIncluded: false,
+        }),
+      }),
+    ])
+    expect(result.unresolvedReferences).not.toContainEqual(expect.objectContaining({name: 'Filter'}))
+    expect(formatRecommendation(result)).toContain('GitHub-only; no public import')
   })
 
   it('uses stable lexical ordering and bounded payloads', () => {

--- a/packages/mcp/src/recommendations.ts
+++ b/packages/mcp/src/recommendations.ts
@@ -1,6 +1,7 @@
 import type {CompactPatternDetails, PatternComponentReference, PatternReference} from './patterns'
 import {getPatternUrl} from './patterns'
 import type {Pattern} from './primer'
+import {findInternalCatalogEntries, type InternalCatalogResult, type InternalCatalogEntry} from './internalCatalog'
 
 const maximumEvidencePerCandidate = 3
 const maximumAuxiliaryEntriesPerResult = 3
@@ -17,6 +18,7 @@ const relationshipKeys = [
 
 export interface RecommendationInput {
   intent: string
+  sourceScope?: 'public' | 'all'
   surface?: string
   region?: string
   patternHints?: Array<string>
@@ -60,7 +62,7 @@ export interface ScoreBreakdown {
 }
 
 export interface CandidateEvidence {
-  sourceKind: 'pattern' | 'component-metadata' | 'composition' | 'input'
+  sourceKind: 'pattern' | 'component-metadata' | 'composition' | 'input' | 'internal-catalog'
   sourceUrl?: string
   detail: string
   relationship?: RecommendationRelationship
@@ -92,6 +94,16 @@ export interface PatternCandidate {
   scoreBreakdown: Array<ScoreBreakdown>
 }
 
+export interface InternalComponentCandidate {
+  component: InternalCatalogEntry & {
+    sourceUrl: string
+    installable: false
+  }
+  score: number
+  scoreBreakdown: Array<ScoreBreakdown>
+  evidence: Array<CandidateEvidence>
+}
+
 export interface Exclusion {
   name: string
   source: 'primer-public' | 'input'
@@ -104,7 +116,12 @@ export interface UnresolvedReference {
   source: PatternComponentReference['source']
   sourceUrl: string
   pattern: PatternReference
-  reason: 'internal-reference' | 'not-in-package'
+  reason:
+    | 'internal-reference'
+    | 'internal-catalog-no-match'
+    | 'internal-catalog-unavailable'
+    | 'internal-catalog-stale'
+    | 'not-in-package'
 }
 
 export interface RecommendationResult extends Record<string, unknown> {
@@ -112,6 +129,13 @@ export interface RecommendationResult extends Record<string, unknown> {
   intent: string
   patterns: Array<PatternCandidate>
   components: Array<ComponentCandidate>
+  internalComponents: Array<InternalComponentCandidate>
+  sourceScope: 'public' | 'all'
+  internalCatalog: {
+    status: InternalCatalogResult['status']
+    revision?: string
+    message?: string
+  }
   matchedSignals: Record<string, Array<string>>
   unmetSignals: Array<string>
   confidence: {
@@ -157,14 +181,17 @@ export function createRecommendation(
   rankedPatterns: Array<RankedPattern>,
   details: Array<CompactPatternDetails>,
   components: Array<RecommendationComponent>,
+  internalCatalog: InternalCatalogResult = {status: 'not-requested'},
 ): RecommendationResult {
   const limit = input.limit ?? 3
+  const sourceScope = input.sourceScope ?? 'public'
   const selectedPatterns = rankedPatterns.slice(0, limit)
   const selectedDetails = details.filter(detail =>
     selectedPatterns.some(candidate => candidate.pattern.id === detail.pattern.id),
   )
   const componentByName = new Map(components.map(component => [normalizeIdentifier(component.name), component]))
   const candidates = new Map<string, ComponentCandidate>()
+  const internalCandidates = new Map<string, InternalComponentCandidate>()
   const exclusions: Array<Exclusion> = []
   const unresolvedReferences: Array<UnresolvedReference> = []
 
@@ -174,10 +201,33 @@ export function createRecommendation(
 
     for (const reference of detail.components) {
       if (reference.source === 'primer-internal') {
+        const entry = internalCatalog.catalog
+          ? findInternalCatalogEntries(internalCatalog.catalog, [reference], limit).at(0)
+          : undefined
+        if (sourceScope === 'all' && internalCatalog.status === 'available' && entry) {
+          addInternalCandidate(internalCandidates, entry, {
+            score: pattern.score,
+            scoreBreakdown: pattern.scoreBreakdown,
+            evidence: {
+              sourceKind: 'internal-catalog',
+              sourceUrl: entry.canonicalUrl,
+              detail: `${detail.pattern.name} links to documented internal ${entry.name}.`,
+            },
+          })
+          continue
+        }
+
         unresolvedReferences.push({
           ...reference,
           pattern: detail.pattern,
-          reason: 'internal-reference',
+          reason:
+            sourceScope !== 'all'
+              ? 'internal-reference'
+              : internalCatalog.status === 'stale'
+                ? 'internal-catalog-stale'
+                : internalCatalog.status === 'unavailable'
+                  ? 'internal-catalog-unavailable'
+                  : 'internal-catalog-no-match',
         })
         continue
       }
@@ -266,6 +316,13 @@ export function createRecommendation(
     }))
     .sort(compareComponentCandidates)
     .slice(0, limit)
+  const internalComponentCandidates = [...internalCandidates.values()]
+    .map(candidate => ({
+      ...candidate,
+      evidence: candidate.evidence.slice(0, maximumEvidencePerCandidate),
+    }))
+    .sort(compareInternalComponentCandidates)
+    .slice(0, limit)
   const matchedSignals = getMatchedSignals(input, patternCandidates, componentCandidates)
   const unmetSignals = getUnmetSignals(input, matchedSignals)
   const ambiguous = patternCandidates.length > 1 && patternCandidates[0].score === patternCandidates[1].score
@@ -283,6 +340,13 @@ export function createRecommendation(
     intent: input.intent,
     patterns: patternCandidates,
     components: componentCandidates,
+    internalComponents: internalComponentCandidates,
+    sourceScope,
+    internalCatalog: {
+      status: internalCatalog.status,
+      ...(internalCatalog.catalog ? {revision: internalCatalog.catalog.revision} : {}),
+      ...(internalCatalog.message ? {message: internalCatalog.message} : {}),
+    },
     matchedSignals,
     unmetSignals,
     confidence: getConfidence(status, patternCandidates, componentCandidates),
@@ -300,7 +364,9 @@ export function createRecommendation(
         : status === 'ambiguous'
           ? 'Add a pattern hint, surface, or state to choose between the equally ranked patterns.'
           : status === 'partial-match'
-            ? 'Review the matched pattern guidance; it does not link to a compatible public Primer component.'
+            ? internalComponentCandidates.length > 0
+              ? 'Review the documented GitHub-only internal candidates; they have no public installable import.'
+              : 'Review the matched pattern guidance; it does not link to a compatible public Primer component.'
             : undefined,
   }
 }
@@ -317,11 +383,18 @@ export function formatRecommendation(result: RecommendationResult): string {
   const unresolved = result.unresolvedReferences
     .map(reference => `- ${reference.name} (${reference.source}): ${reference.sourceUrl}`)
     .join('\n')
+  const internal = result.internalComponents
+    .map(
+      candidate =>
+        `- ${candidate.component.name} (${candidate.component.visibility}; not installable): ${candidate.component.sourceUrl}`,
+    )
+    .join('\n')
 
   return [
     `Recommendation confidence: ${result.confidence.level} (${result.confidence.score}/100).`,
     patterns && `Patterns:\n${patterns}`,
     components && `Public components:\n${components}`,
+    internal && `Documented internal candidates (GitHub-only; no public import):\n${internal}`,
     unresolved && `Unresolved references:\n${unresolved}`,
     result.nextAction,
   ]
@@ -413,6 +486,28 @@ function addCandidate(
       sourceKind: 'primer-public',
       sourceUrl: component.sourceUrl,
     },
+    score: contribution.score,
+    scoreBreakdown: contribution.scoreBreakdown,
+    evidence: [contribution.evidence],
+  })
+}
+
+function addInternalCandidate(
+  candidates: Map<string, InternalComponentCandidate>,
+  component: InternalCatalogEntry,
+  contribution: CandidateContribution,
+) {
+  const key = normalizeIdentifier(component.name)
+  const current = candidates.get(key)
+  if (current) {
+    current.score += contribution.score
+    current.scoreBreakdown.push(...contribution.scoreBreakdown)
+    current.evidence.push(contribution.evidence)
+    return
+  }
+
+  candidates.set(key, {
+    component: {...component, sourceUrl: component.canonicalUrl, installable: false},
     score: contribution.score,
     scoreBreakdown: contribution.scoreBreakdown,
     evidence: [contribution.evidence],
@@ -526,6 +621,13 @@ function compareRankedPatterns(first: RankedPattern, second: RankedPattern): num
 }
 
 function compareComponentCandidates(first: ComponentCandidate, second: ComponentCandidate): number {
+  return second.score - first.score || first.component.name.localeCompare(second.component.name)
+}
+
+function compareInternalComponentCandidates(
+  first: InternalComponentCandidate,
+  second: InternalComponentCandidate,
+): number {
   return second.score - first.score || first.component.name.localeCompare(second.component.name)
 }
 

--- a/packages/mcp/src/recommendations.ts
+++ b/packages/mcp/src/recommendations.ts
@@ -96,7 +96,6 @@ export interface PatternCandidate {
 
 export interface InternalComponentCandidate {
   component: InternalCatalogEntry & {
-    sourceUrl: string
     installable: false
   }
   score: number
@@ -133,7 +132,7 @@ export interface RecommendationResult extends Record<string, unknown> {
   sourceScope: 'public' | 'all'
   internalCatalog: {
     status: InternalCatalogResult['status']
-    revision?: string
+    sourceRevision?: string
     message?: string
   }
   matchedSignals: Record<string, Array<string>>
@@ -210,7 +209,7 @@ export function createRecommendation(
             scoreBreakdown: pattern.scoreBreakdown,
             evidence: {
               sourceKind: 'internal-catalog',
-              sourceUrl: entry.canonicalUrl,
+              sourceUrl: entry.sourceUrl,
               detail: `${detail.pattern.name} links to documented internal ${entry.name}.`,
             },
           })
@@ -344,7 +343,7 @@ export function createRecommendation(
     sourceScope,
     internalCatalog: {
       status: internalCatalog.status,
-      ...(internalCatalog.catalog ? {revision: internalCatalog.catalog.revision} : {}),
+      ...(internalCatalog.catalog ? {sourceRevision: internalCatalog.catalog.sourceRevision} : {}),
       ...(internalCatalog.message ? {message: internalCatalog.message} : {}),
     },
     matchedSignals,
@@ -507,7 +506,7 @@ function addInternalCandidate(
   }
 
   candidates.set(key, {
-    component: {...component, sourceUrl: component.canonicalUrl, installable: false},
+    component: {...component, installable: false},
     score: contribution.score,
     scoreBreakdown: contribution.scoreBreakdown,
     evidence: [contribution.evidence],

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -20,6 +20,24 @@ const searchPatternPage = `
     </div>
   </main>
 `
+const internalCatalogPage = JSON.stringify({
+  schemaVersion: 1,
+  revision: 'internal-catalog-v1',
+  count: 1,
+  items: [
+    {
+      id: 'filter',
+      slug: 'filter',
+      name: 'Filter',
+      sourceKind: 'primer-internal',
+      canonicalUrl: 'https://primer.style/product/internal-components/filter',
+      visibility: 'github-only',
+      availability: 'unavailable',
+      installability: 'non-installable',
+      implementationIncluded: false,
+    },
+  ],
+})
 
 describe('component documentation sources', () => {
   it('uses hosted documentation by default and supports package metadata', () => {
@@ -366,6 +384,80 @@ describe('get_component_batch', () => {
       ]),
     })
     expect(getTextContent(result)).toContain('Public components')
+  })
+
+  it('lists bounded documented internal components without presenting an import path', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(internalCatalogPage))
+
+    const result = await callTool('list_internal_components', {query: 'filter', limit: 1})
+
+    expect(result.structuredContent).toMatchObject({
+      status: 'available',
+      sourceKind: 'primer-internal',
+      implementationIncluded: false,
+      revision: 'internal-catalog-v1',
+      entries: [
+        {
+          name: 'Filter',
+          visibility: 'github-only',
+          availability: 'unavailable',
+          implementationIncluded: false,
+        },
+      ],
+    })
+    expect(getTextContent(result)).toContain('GitHub-only; no public import')
+    expect(JSON.stringify(result.structuredContent).length).toBeLessThan(2_000)
+  })
+
+  it('reports a catalog no-match without requesting a public component fallback', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(internalCatalogPage))
+
+    const result = await callTool('list_internal_components', {query: 'missing'})
+
+    expect(result.structuredContent).toMatchObject({status: 'no-match', entries: []})
+    expect(getTextContent(result)).toContain('No documented internal component matches')
+  })
+
+  it('adds documented internal candidates only when the holistic source scope is requested', async () => {
+    vi.mocked(fetch).mockImplementation(async input => {
+      const url = new URL(input.toString())
+      return new Response(url.pathname.endsWith('/catalog.json') ? internalCatalogPage : searchPatternPage)
+    })
+
+    const result = await callRecommendation({intent: 'search', sourceScope: 'all'})
+
+    expect(result.structuredContent).toMatchObject({
+      sourceScope: 'all',
+      internalCatalog: {status: 'available', revision: 'internal-catalog-v1'},
+      internalComponents: [
+        {
+          component: {
+            name: 'Filter',
+            sourceKind: 'primer-internal',
+            installable: false,
+            implementationIncluded: false,
+          },
+        },
+      ],
+    })
+    expect(getTextContent(result)).toContain('GitHub-only; no public import')
+  })
+
+  it('reports an unavailable internal catalog without returning unresolved content as an installable component', async () => {
+    vi.mocked(fetch).mockImplementation(async input => {
+      const url = new URL(input.toString())
+      return url.pathname.endsWith('/catalog.json')
+        ? new Response(null, {status: 503})
+        : new Response(searchPatternPage)
+    })
+
+    const result = await callRecommendation({intent: 'search', sourceScope: 'all'})
+
+    expect(result.structuredContent).toMatchObject({
+      internalCatalog: {status: 'unavailable', message: expect.stringContaining('503')},
+      internalComponents: [],
+      unresolvedReferences: [expect.objectContaining({name: 'Filter', reason: 'internal-catalog-unavailable'})],
+    })
   })
 
   it('uses structured signals to distinguish patterns and expands composition evidence', async () => {

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -22,18 +22,16 @@ const searchPatternPage = `
 `
 const internalCatalogPage = JSON.stringify({
   schemaVersion: 1,
-  revision: 'internal-catalog-v1',
-  count: 1,
-  items: [
+  generatedAt: '2026-07-23T00:00:00.000Z',
+  sourceRevision: 'sha256:internal-catalog-v1',
+  entries: [
     {
       id: 'filter',
-      slug: 'filter',
       name: 'Filter',
       sourceKind: 'primer-internal',
-      canonicalUrl: 'https://primer.style/product/internal-components/filter',
+      sourceUrl: 'https://primer.style/product/internal-components/filter',
       visibility: 'github-only',
       availability: 'unavailable',
-      installability: 'non-installable',
       implementationIncluded: false,
     },
   ],
@@ -395,7 +393,7 @@ describe('get_component_batch', () => {
       status: 'available',
       sourceKind: 'primer-internal',
       implementationIncluded: false,
-      revision: 'internal-catalog-v1',
+      sourceRevision: 'sha256:internal-catalog-v1',
       entries: [
         {
           name: 'Filter',
@@ -428,7 +426,7 @@ describe('get_component_batch', () => {
 
     expect(result.structuredContent).toMatchObject({
       sourceScope: 'all',
-      internalCatalog: {status: 'available', revision: 'internal-catalog-v1'},
+      internalCatalog: {status: 'available', sourceRevision: 'sha256:internal-catalog-v1'},
       internalComponents: [
         {
           component: {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -561,7 +561,7 @@ server.registerTool(
   },
   async ({query, limit}) => {
     const catalog = await fetchInternalCatalog()
-    const entries = (catalog.catalog?.items ?? [])
+    const entries = (catalog.catalog?.entries ?? [])
       .filter(entry => `${entry.id} ${entry.name}`.toLowerCase().includes(query.toLowerCase()))
       .slice(0, limit)
     const status = catalog.status === 'available' && entries.length === 0 ? 'no-match' : catalog.status
@@ -571,7 +571,7 @@ server.registerTool(
         status,
         sourceKind: 'primer-internal',
         implementationIncluded: false,
-        revision: catalog.catalog?.revision,
+        sourceRevision: catalog.catalog?.sourceRevision,
         entries,
         ...(catalog.message ? {message: catalog.message} : {}),
       },

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -16,6 +16,7 @@ import {
 } from './primer'
 import {formatCompactPatternDetails, getPatternUrl, parseCompactPatternDetails, toFullPatternDetails} from './patterns'
 import {createRecommendation, formatRecommendation, rankPatterns, type RecommendationComponent} from './recommendations'
+import {fetchInternalCatalog} from './internalCatalog'
 import {
   listTokenGroups,
   loadAllTokensWithGuidelines,
@@ -540,6 +541,55 @@ ${text}`,
   },
 )
 
+server.registerTool(
+  'list_internal_components',
+  {
+    description:
+      'List documented Primer-internal components from Primer Style. Entries are GitHub-only documentation references, not public @primer/react components, and never include implementation source.',
+    inputSchema: {
+      query: z.string().optional().default('').describe('Optional internal component name or identifier to match'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(20)
+        .optional()
+        .default(10)
+        .describe('Maximum documented internal components to return'),
+    },
+    annotations: {readOnlyHint: true},
+  },
+  async ({query, limit}) => {
+    const catalog = await fetchInternalCatalog()
+    const entries = (catalog.catalog?.items ?? [])
+      .filter(entry => `${entry.id} ${entry.name}`.toLowerCase().includes(query.toLowerCase()))
+      .slice(0, limit)
+    const status = catalog.status === 'available' && entries.length === 0 ? 'no-match' : catalog.status
+
+    return {
+      structuredContent: {
+        status,
+        sourceKind: 'primer-internal',
+        implementationIncluded: false,
+        revision: catalog.catalog?.revision,
+        entries,
+        ...(catalog.message ? {message: catalog.message} : {}),
+      },
+      content: [
+        {
+          type: 'text',
+          text:
+            status === 'available'
+              ? `Documented internal components (GitHub-only; no public import): ${entries.map(entry => entry.name).join(', ')}`
+              : status === 'no-match'
+                ? `No documented internal component matches "${query}".`
+                : (catalog.message ?? 'The documented internal component catalog is unavailable.'),
+        },
+      ],
+    }
+  },
+)
+
 // -----------------------------------------------------------------------------
 // Patterns
 // -----------------------------------------------------------------------------
@@ -689,9 +739,16 @@ server.registerTool(
   'recommend_components',
   {
     description:
-      'Recommend public Primer patterns and components for product or UI intent. Deterministically ranks pattern names and hints, resolves authoritative pattern-linked public components, and expands with source-derived composition evidence. Deprecated, incompatible, and Primer-internal references are excluded from installable component candidates.',
+      'Recommend Primer patterns and public @primer/react components for product or UI intent. Defaults to public-only results. Set sourceScope to "all" to additionally return separate documented GitHub-only internal candidates; they are never public imports or installable components.',
     inputSchema: {
       intent: z.string().min(1).describe('The product or UI intent to match, in freeform language'),
+      sourceScope: z
+        .enum(['public', 'all'])
+        .optional()
+        .default('public')
+        .describe(
+          'Use "public" (default) for installable @primer/react candidates only, or "all" to add separate GitHub-only internal candidates',
+        ),
       surface: z.string().optional().describe('Optional product surface, such as issue list or settings page'),
       region: z.string().optional().describe('Optional UI region, such as toolbar, form, or sidebar'),
       patternHints: z
@@ -718,7 +775,7 @@ server.registerTool(
         .max(5)
         .optional()
         .default(3)
-        .describe('Maximum patterns and public components to return'),
+        .describe('Maximum patterns, public components, and separate internal candidates to return'),
     },
     outputSchema: recommendationOutputSchema,
     annotations: {readOnlyHint: true},
@@ -751,7 +808,9 @@ server.registerTool(
         composition,
       }
     })
-    const recommendation = createRecommendation(input, rankedPatterns, details, components)
+    const internalCatalog =
+      input.sourceScope === 'all' ? await fetchInternalCatalog() : {status: 'not-requested' as const}
+    const recommendation = createRecommendation(input, rankedPatterns, details, components, internalCatalog)
 
     return {
       structuredContent: recommendation,


### PR DESCRIPTION
Closes #

Final React PR (5/5) in the #8217 -> #8227 -> #8228 -> #8229 -> this PR stack. This PR targets `adierkens-recommend-primer-components` (#8229).

Depends on the docs-generated catalog endpoint in https://github.com/github/primer-docs/pull/1191.

### Changelog

#### New

- Add `list_internal_components` for documented, GitHub-only Primer-internal catalog entries.

#### Changed

- Add opt-in `sourceScope: "all"` recommendations that return documented internal candidates separately from installable public components.

#### Removed

- None.

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

The safe default is `sourceScope: "public"`: `get_component` remains exclusively for installable public `@primer/react` components. `sourceScope: "all"` adds a separate, bounded, non-installable `internalComponents` collection with visibility and availability labels. The catalog is docs-generated, revisioned, bounded, and explicitly reports unavailable, stale, and no-match states without a private fallback.

- `npx --yes -p node@26.4.0 node node_modules/vitest/vitest.mjs --run packages/mcp/src`
- `npm run type-check -w @primer/mcp`
- `npm run build -w @primer/mcp`
- `npm run lint`
- `npm run lint:css`
- `npm run format:diff`
- `npm run build`

Review the public/private boundary, the separate internal candidate collection, and the docs endpoint dependency. No private implementation, Storybook bodies, or github-ui source is exposed.