### PR TITLE
Clarify MCP component tool selection

### DIFF
--- a/.changeset/mcp-component-tool-selection.md
+++ b/.changeset/mcp-component-tool-selection.md
@@ -1,0 +1,5 @@
+---
+'@primer/mcp': patch
+---
+
+Components: Clarify when agents should use single-component and batch documentation tools.

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -33,6 +33,28 @@ describe('get_component_batch', () => {
     })
   }
 
+  it('documents which component tool to use for each supported count', async () => {
+    const {tools} = await client.listTools()
+    const getComponent = tools.find(tool => tool.name === 'get_component')
+    const getComponentBatch = tools.find(tool => tool.name === 'get_component_batch')
+    const listResult = await client.callTool({name: 'list_components'})
+
+    expect(getComponent?.description).toBe(
+      'Retrieve official documentation and usage details for exactly one React component from the @primer/react package. Use get_component_batch for 2 to 10 components.',
+    )
+    expect(getComponentBatch?.description).toBe(
+      'Retrieve official documentation and usage details for 2 to 10 React components from the @primer/react package in one call. Use get_component for exactly one component.',
+    )
+    expect(listResult.content).toContainEqual(
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining(
+          'Use `get_component` for exactly one component and `get_component_batch` for 2 to 10 components.',
+        ),
+      }),
+    )
+  })
+
   it('requires between 2 and 10 names', async () => {
     const tooFew = await callBatch(['Button'])
     const tooMany = await callBatch(Array.from({length: 11}, (_, index) => `Component${index}`))

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -106,7 +106,7 @@ server.registerTool(
 
 ${components.join('\n')}
 
-You can use the \`get_component\` tool to get more information about a specific component. You can use these components from the @primer/react package.`,
+Use \`get_component\` for exactly one component and \`get_component_batch\` for 2 to 10 components. You can use these components from the @primer/react package.`,
         },
       ],
     }
@@ -117,7 +117,7 @@ server.registerTool(
   'get_component',
   {
     description:
-      'Retrieve documentation and usage details for a specific React component from the @primer/react package by its name. This tool provides the official Primer documentation for any listed component, making it easy to inspect, reuse, or integrate components in your project.',
+      'Retrieve official documentation and usage details for exactly one React component from the @primer/react package. Use get_component_batch for 2 to 10 components.',
     inputSchema: {
       name: z.string().describe('The name of the component to retrieve'),
     },
@@ -165,9 +165,7 @@ server.registerTool(
   'get_component_batch',
   {
     description:
-      'Retrieve documentation for multiple Primer React components in one call. ' +
-      'Pass all component names you need at once. Docs are fetched in parallel to avoid repeated MCP round-trips when resolving several components. ' +
-      'For a single component, prefer get_component instead.',
+      'Retrieve official documentation and usage details for 2 to 10 React components from the @primer/react package in one call. Use get_component for exactly one component.',
     inputSchema: {
       names: z
         .array(z.string())


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes # N/A

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Primer MCP currently directs agents from `list_components` to the singular component documentation tool even when several components are needed. This change gives consistent count-based guidance across component discovery and both documentation tool descriptions.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

N/A

#### Changed

- Direct agents to `get_component` for exactly one component and `get_component_batch` for 2 to 10 components.
- Give both documentation tools equally explicit descriptions.

#### Removed

N/A

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To test these changes with github/github-ui, use the [integration workflow](https://github.com/github/github-ui/actions/workflows/primer-npm-packages-integration.yml) -->

The regression test checks the descriptions returned by MCP tool discovery and the guidance returned by `list_components`.

- `npm run test --workspace=@primer/mcp`
- `npm run type-check --workspace=@primer/mcp`
- `npx turbo run build --filter=@primer/mcp`

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->