### PR TITLE
MCP: improve recommendation precision and caching

### DIFF
--- a/.changeset/mcp-internal-catalog.md
+++ b/.changeset/mcp-internal-catalog.md
@@ -2,4 +2,4 @@
 '@primer/mcp': minor
 ---
 
-MCP: Add documented Primer-internal catalog discovery, composition-aware component recommendations, batch icon lookup, and efficient CSS validation.
+MCP: Add documented Primer-internal catalog discovery, composition-aware component recommendations, and efficient CSS validation.

--- a/.changeset/mcp-internal-catalog.md
+++ b/.changeset/mcp-internal-catalog.md
@@ -2,4 +2,4 @@
 '@primer/mcp': minor
 ---
 
-MCP: Add documented Primer-internal catalog discovery and composition-aware component recommendations.
+MCP: Add documented Primer-internal catalog discovery, composition-aware component recommendations, batch icon lookup, and efficient CSS validation.

--- a/.changeset/mcp-internal-catalog.md
+++ b/.changeset/mcp-internal-catalog.md
@@ -2,4 +2,4 @@
 '@primer/mcp': minor
 ---
 
-MCP: Add documented Primer-internal catalog discovery and opt-in GitHub-only recommendation candidates.
+MCP: Add documented Primer-internal catalog discovery and composition-aware component recommendations.

--- a/packages/mcp/src/primer.ts
+++ b/packages/mcp/src/primer.ts
@@ -17,7 +17,6 @@ type ComponentSummary = Pick<Component, 'id' | 'name' | 'importPath'> & {
 interface ComponentDocument {
   name: string
   importPath: string
-  stories?: Array<{id: string}>
   [key: string]: unknown
 }
 
@@ -55,8 +54,12 @@ interface ComponentsMetadata {
 const metadata: ComponentsMetadata = componentsMetadata
 const maximumObservedRelationshipsPerKind = 3
 const componentIntentTerms = new Map<string, Array<string>>([
-  ['counter_label', ['count', 'metric', 'stat', 'statistic', 'summary']],
-  ['label', ['badge', 'status', 'tag']],
+  ['counter_label', ['count', 'metric', 'stat', 'statistic', 'total']],
+  ['page_layout', ['sidebar', 'detail', 'master', 'pane', 'split']],
+  ['nav_list', ['navigation', 'navigator']],
+  ['action_list', ['action', 'choice', 'option', 'select', 'selection']],
+  ['avatar', ['avatar', 'member', 'people', 'person', 'user']],
+  ['label', ['badge', 'category', 'status', 'tag']],
 ])
 
 function idToSlug(id: string): string {
@@ -166,12 +169,7 @@ function getComponentRecommendationTerms(id: string): Array<string> {
 
   return [
     ...new Set(
-      [
-        id,
-        document?.name,
-        ...(document?.stories?.map(story => story.id) ?? []),
-        ...(componentIntentTerms.get(id) ?? []),
-      ].filter((term): term is string => Boolean(term)),
+      [id, document?.name, ...(componentIntentTerms.get(id) ?? [])].filter((term): term is string => Boolean(term)),
     ),
   ]
 }

--- a/packages/mcp/src/primer.ts
+++ b/packages/mcp/src/primer.ts
@@ -17,6 +17,7 @@ type ComponentSummary = Pick<Component, 'id' | 'name' | 'importPath'> & {
 interface ComponentDocument {
   name: string
   importPath: string
+  stories?: Array<{id: string}>
   [key: string]: unknown
 }
 
@@ -53,6 +54,10 @@ interface ComponentsMetadata {
 
 const metadata: ComponentsMetadata = componentsMetadata
 const maximumObservedRelationshipsPerKind = 3
+const componentIntentTerms = new Map<string, Array<string>>([
+  ['counter_label', ['count', 'metric', 'stat', 'statistic', 'summary']],
+  ['label', ['badge', 'status', 'tag']],
+])
 
 function idToSlug(id: string): string {
   if (id === 'actionbar') {
@@ -154,6 +159,21 @@ function getComponentCompositionSummary(id: string) {
       relatedComponents: relatedComponents.omittedCount,
     },
   }
+}
+
+function getComponentRecommendationTerms(id: string): Array<string> {
+  const document = getComponentDocument(id)
+
+  return [
+    ...new Set(
+      [
+        id,
+        document?.name,
+        ...(document?.stories?.map(story => story.id) ?? []),
+        ...(componentIntentTerms.get(id) ?? []),
+      ].filter((term): term is string => Boolean(term)),
+    ),
+  ]
 }
 
 function summarizeObservedRelationships(relationships: Array<ComponentRelationship>) {
@@ -309,6 +329,7 @@ function listIcons(): Array<Icon> {
 export {
   getComponentComposition,
   getComponentCompositionSummary,
+  getComponentRecommendationTerms,
   getComponentDocsSource,
   getComponentDocument,
   getComponentSummary,

--- a/packages/mcp/src/primer.ts
+++ b/packages/mcp/src/primer.ts
@@ -51,15 +51,23 @@ interface ComponentsMetadata {
   composition?: CompositionMetadata
 }
 
+type ComponentIntentTerm = string | {all: Array<string>}
+
 const metadata: ComponentsMetadata = componentsMetadata
 const maximumObservedRelationshipsPerKind = 3
-const componentIntentTerms = new Map<string, Array<string>>([
+const componentIntentTerms = new Map<string, Array<ComponentIntentTerm>>([
   ['counter_label', ['count', 'metric', 'stat', 'statistic', 'total']],
-  ['page_layout', ['sidebar', 'detail', 'master', 'pane', 'split']],
-  ['nav_list', ['navigation', 'navigator']],
-  ['action_list', ['action', 'choice', 'option', 'select', 'selection']],
-  ['avatar', ['avatar', 'member', 'people', 'person', 'user']],
-  ['label', ['badge', 'category', 'status', 'tag']],
+  [
+    'page_layout',
+    [{all: ['sidebar', 'detail']}, {all: ['sidebar', 'pane']}, {all: ['master', 'detail']}, {all: ['split', 'pane']}],
+  ],
+  ['nav_list', [{all: ['sidebar', 'navigation']}, {all: ['sidebar', 'navigator']}]],
+  [
+    'action_list',
+    [{all: ['action', 'row']}, {all: ['action', 'list']}, {all: ['action', 'item']}, {all: ['action', 'choice']}],
+  ],
+  ['avatar', ['avatar', 'member', 'people', 'person']],
+  ['label', ['badge', 'category', 'tag']],
 ])
 
 function idToSlug(id: string): string {
@@ -164,14 +172,8 @@ function getComponentCompositionSummary(id: string) {
   }
 }
 
-function getComponentRecommendationTerms(id: string): Array<string> {
-  const document = getComponentDocument(id)
-
-  return [
-    ...new Set(
-      [id, document?.name, ...(componentIntentTerms.get(id) ?? [])].filter((term): term is string => Boolean(term)),
-    ),
-  ]
+function getComponentRecommendationTerms(id: string): Array<ComponentIntentTerm> {
+  return componentIntentTerms.get(id) ?? []
 }
 
 function summarizeObservedRelationships(relationships: Array<ComponentRelationship>) {

--- a/packages/mcp/src/recommendations.test.ts
+++ b/packages/mcp/src/recommendations.test.ts
@@ -1,9 +1,12 @@
 import {describe, expect, it} from 'vitest'
 import type {CompactPatternDetails} from './patterns'
 import {createRecommendation, formatRecommendation, rankPatterns, type RecommendationComponent} from './recommendations'
-import {listPatterns} from './primer'
 
 const sourceUrl = 'https://primer.style/product/components/text-input'
+const availablePatterns = [
+  {id: 'filter', name: 'Filter', category: 'scenario' as const},
+  {id: 'search', name: 'Search', category: 'scenario' as const},
+]
 const searchDetails: CompactPatternDetails = {
   detail: 'compact',
   pattern: {
@@ -108,11 +111,56 @@ const internalCatalog = {
     ],
   },
 }
+function component(
+  id: string,
+  name: string,
+  intentTerms?: Array<string>,
+  composition?: RecommendationComponent['composition'],
+): RecommendationComponent {
+  return {
+    id,
+    name,
+    importPath: '@primer/react',
+    sourceUrl: `https://primer.style/product/components/${id.replaceAll('_', '-')}`,
+    searchTerms: [name],
+    ...(intentTerms ? {intentTerms} : {}),
+    ...(composition ? {composition} : {}),
+  }
+}
+
+const emptyComposition = {
+  apiParentChild: [],
+  apiSubcomponents: [],
+  observed: {parentChild: [], adjacentSibling: [], variants: [], relatedComponents: []},
+}
+const compositionComponents: Array<RecommendationComponent> = [
+  component('counter_label', 'CounterLabel', ['count', 'metric', 'stat', 'statistic', 'summary']),
+  component('page_layout', 'PageLayout', ['parent-detail', 'sidebar'], {
+    ...emptyComposition,
+    observed: {
+      ...emptyComposition.observed,
+      parentChild: [{parent: 'PageLayout.Pane', child: 'NavList', sourceCount: 3}],
+    },
+  }),
+  component('nav_list', 'NavList'),
+  component('action_list', 'ActionList', ['action', 'option'], {
+    ...emptyComposition,
+    observed: {
+      ...emptyComposition.observed,
+      parentChild: [
+        {parent: 'ActionList.LeadingVisual', child: 'Avatar', sourceCount: 3},
+        {parent: 'ActionList.TrailingVisual', child: 'Label', sourceCount: 3},
+      ],
+    },
+  }),
+  component('avatar', 'Avatar', ['avatar']),
+  component('label', 'Label', ['badge', 'status', 'tag']),
+]
 
 describe('component recommendations', () => {
   it('matches simple intent to authoritative pattern-linked public components', () => {
     const input = {intent: 'Add a search query'}
-    const result = createRecommendation(input, rankPatterns(listPatterns(), input), [searchDetails], components)
+    const result = createRecommendation(input, rankPatterns(availablePatterns, input), [searchDetails], components)
 
     expect(result.status).toBe('matched')
     expect(result.patterns[0]?.pattern.name).toBe('Search')
@@ -124,7 +172,7 @@ describe('component recommendations', () => {
     const input = {intent: 'search', patternHints: ['filter']}
     const result = createRecommendation(
       input,
-      rankPatterns(listPatterns(), input),
+      rankPatterns(availablePatterns, input),
       [searchDetails, filterDetails],
       components,
     )
@@ -135,10 +183,83 @@ describe('component recommendations', () => {
 
   it('expands source-derived composition relationships without inventing mappings', () => {
     const input = {intent: 'filter'}
-    const result = createRecommendation(input, rankPatterns(listPatterns(), input), [filterDetails], components)
+    const result = createRecommendation(input, rankPatterns(availablePatterns, input), [filterDetails], components)
 
     expect(result.components.map(candidate => candidate.component.name)).toEqual(['ActionMenu', 'ActionList'])
     expect(result.components[1]?.evidence[0]).toMatchObject({sourceKind: 'composition'})
+  })
+
+  it('recommends capability and composition metadata for generic assemblies', () => {
+    const metricIntent = {intent: 'Show a stat summary strip'}
+    const detailIntent = {intent: 'Build a parent detail layout with a sidebar'}
+    const suggestionIntent = {intent: 'Show suggested people with avatars, actions, and badges'}
+
+    const metric = createRecommendation(
+      metricIntent,
+      rankPatterns(availablePatterns, metricIntent),
+      [],
+      compositionComponents,
+    )
+    const detail = createRecommendation(
+      detailIntent,
+      rankPatterns(availablePatterns, detailIntent),
+      [],
+      compositionComponents,
+    )
+    const suggestions = createRecommendation(
+      suggestionIntent,
+      rankPatterns(availablePatterns, suggestionIntent),
+      [],
+      compositionComponents,
+    )
+
+    expect(metric).toMatchObject({status: 'matched', patterns: []})
+    expect(metric.components.map(candidate => candidate.component.name)).toContain('CounterLabel')
+    expect(detail.components.map(candidate => candidate.component.name)).toEqual(['PageLayout', 'NavList'])
+    expect(suggestions.components.map(candidate => candidate.component.name)).toEqual(
+      expect.arrayContaining(['ActionList', 'Avatar', 'Label']),
+    )
+    expect(suggestions.components.flatMap(candidate => candidate.evidence)).toContainEqual(
+      expect.objectContaining({sourceKind: 'composition'}),
+    )
+  })
+
+  it('does not treat partial tokens or weak pattern-only matches as useful recommendations', () => {
+    const emptyStates = [{id: 'empty-states', name: 'Empty States', category: 'ui' as const}]
+    const input = {intent: 'stat'}
+    const weakPatternInput = {intent: 'empty'}
+    const emptyStateDetails: CompactPatternDetails = {
+      ...searchDetails,
+      pattern: {
+        id: 'empty-states',
+        name: 'Empty States',
+        category: 'ui',
+        sourceUrl: 'https://primer.style/product/ui-patterns/empty-states',
+      },
+      components: [
+        {
+          id: 'internal-empty-state',
+          name: 'InternalEmptyState',
+          source: 'primer-internal',
+          sourceUrl: 'https://primer.style/product/internal-components/internal-empty-state',
+        },
+      ],
+    }
+
+    expect(rankPatterns(emptyStates, input)).toEqual([])
+    expect(createRecommendation(input, rankPatterns(emptyStates, input), [], components)).toMatchObject({
+      status: 'no-match',
+      patterns: [],
+      components: [],
+    })
+    expect(
+      createRecommendation(
+        weakPatternInput,
+        rankPatterns(emptyStates, weakPatternInput),
+        [emptyStateDetails],
+        components,
+      ),
+    ).toMatchObject({status: 'no-match', patterns: [], components: []})
   })
 
   it('reports ambiguous and no-match intent with actionable states', () => {
@@ -148,12 +269,12 @@ describe('component recommendations', () => {
     expect(
       createRecommendation(
         ambiguous,
-        rankPatterns(listPatterns(), ambiguous),
+        rankPatterns(availablePatterns, ambiguous),
         [searchDetails, filterDetails],
         components,
       ).status,
     ).toBe('ambiguous')
-    expect(createRecommendation(noMatch, rankPatterns(listPatterns(), noMatch), [], components)).toMatchObject({
+    expect(createRecommendation(noMatch, rankPatterns(availablePatterns, noMatch), [], components)).toMatchObject({
       status: 'no-match',
       nextAction: expect.stringContaining('pattern hint'),
     })
@@ -161,7 +282,7 @@ describe('component recommendations', () => {
 
   it('excludes deprecated candidates and retains internal references as unresolved evidence', () => {
     const input = {intent: 'search'}
-    const result = createRecommendation(input, rankPatterns(listPatterns(), input), [searchDetails], components)
+    const result = createRecommendation(input, rankPatterns(availablePatterns, input), [searchDetails], components)
 
     expect(result.components.map(candidate => candidate.component.name)).not.toContain('Octicon')
     expect(result.exclusions).toContainEqual({name: 'Octicon', source: 'primer-public', reason: 'deprecated'})
@@ -174,7 +295,7 @@ describe('component recommendations', () => {
     const input = {intent: 'search', sourceScope: 'all' as const}
     const result = createRecommendation(
       input,
-      rankPatterns(listPatterns(), input),
+      rankPatterns(availablePatterns, input),
       [searchDetails],
       components,
       internalCatalog,
@@ -199,13 +320,13 @@ describe('component recommendations', () => {
     const input = {intent: 'search filter', limit: 1}
     const first = createRecommendation(
       input,
-      rankPatterns(listPatterns(), input),
+      rankPatterns(availablePatterns, input),
       [searchDetails, filterDetails],
       components,
     )
     const second = createRecommendation(
       input,
-      rankPatterns(listPatterns(), input),
+      rankPatterns(availablePatterns, input),
       [searchDetails, filterDetails],
       components,
     )

--- a/packages/mcp/src/recommendations.test.ts
+++ b/packages/mcp/src/recommendations.test.ts
@@ -365,6 +365,47 @@ describe('component recommendations', () => {
     expect(formatRecommendation(result)).toContain('GitHub-only; no public import')
   })
 
+  it('keeps low-scoring internal-only patterns visible only for the all source scope', () => {
+    const internalOnlyPatterns = [{id: 'filter', name: 'Filter', category: 'scenario' as const}]
+    const internalOnlyDetails: CompactPatternDetails = {
+      ...filterDetails,
+      components: [
+        {
+          id: 'filter',
+          name: 'Filter',
+          source: 'primer-internal',
+          sourceUrl: 'https://primer.style/product/internal-components/filter',
+        },
+      ],
+    }
+    const input = {intent: 'filter'}
+
+    const allScope = createRecommendation(
+      {...input, sourceScope: 'all'},
+      rankPatterns(internalOnlyPatterns, input),
+      [internalOnlyDetails],
+      components,
+      internalCatalog,
+    )
+    const publicScope = createRecommendation(
+      input,
+      rankPatterns(internalOnlyPatterns, input),
+      [internalOnlyDetails],
+      components,
+      internalCatalog,
+    )
+
+    expect(allScope).toMatchObject({
+      status: 'partial-match',
+      patterns: [expect.objectContaining({pattern: expect.objectContaining({name: 'Filter'})})],
+      components: [],
+      internalComponents: [expect.objectContaining({component: expect.objectContaining({name: 'Filter'})})],
+    })
+    expect(formatRecommendation(allScope)).toContain('Documented internal candidates')
+    expect(publicScope).toMatchObject({status: 'no-match', patterns: [], internalComponents: []})
+    expect(formatRecommendation(publicScope)).toMatch(/^No Primer pattern matched/)
+  })
+
   it('uses stable lexical ordering and bounded payloads', () => {
     const input = {intent: 'search filter', limit: 1}
     const first = createRecommendation(

--- a/packages/mcp/src/recommendations.test.ts
+++ b/packages/mcp/src/recommendations.test.ts
@@ -134,7 +134,7 @@ const emptyComposition = {
   observed: {parentChild: [], adjacentSibling: [], variants: [], relatedComponents: []},
 }
 const compositionComponents: Array<RecommendationComponent> = [
-  component('counter_label', 'CounterLabel', ['count', 'metric', 'stat', 'statistic', 'summary']),
+  component('counter_label', 'CounterLabel', ['count', 'metric', 'stat', 'statistic', 'total']),
   component('page_layout', 'PageLayout', ['parent-detail', 'sidebar'], {
     ...emptyComposition,
     observed: {
@@ -142,7 +142,7 @@ const compositionComponents: Array<RecommendationComponent> = [
       parentChild: [{parent: 'PageLayout.Pane', child: 'NavList', sourceCount: 3}],
     },
   }),
-  component('nav_list', 'NavList'),
+  component('nav_list', 'NavList', ['navigation', 'navigator']),
   component('action_list', 'ActionList', ['action', 'option'], {
     ...emptyComposition,
     observed: {
@@ -191,7 +191,7 @@ describe('component recommendations', () => {
 
   it('recommends capability and composition metadata for generic assemblies', () => {
     const metricIntent = {intent: 'Show a stat summary strip'}
-    const detailIntent = {intent: 'Build a parent detail layout with a sidebar'}
+    const detailIntent = {intent: 'Build a parent detail navigation layout with a sidebar'}
     const suggestionIntent = {intent: 'Show suggested people with avatars, actions, and badges'}
 
     const metric = createRecommendation(

--- a/packages/mcp/src/recommendations.test.ts
+++ b/packages/mcp/src/recommendations.test.ts
@@ -1,6 +1,12 @@
 import {describe, expect, it} from 'vitest'
 import type {CompactPatternDetails} from './patterns'
-import {createRecommendation, formatRecommendation, rankPatterns, type RecommendationComponent} from './recommendations'
+import {
+  createRecommendation,
+  formatRecommendation,
+  rankPatterns,
+  type RecommendationComponent,
+  type RecommendationIntentTerm,
+} from './recommendations'
 
 const sourceUrl = 'https://primer.style/product/components/text-input'
 const availablePatterns = [
@@ -114,7 +120,7 @@ const internalCatalog = {
 function component(
   id: string,
   name: string,
-  intentTerms?: Array<string>,
+  intentTerms?: Array<RecommendationIntentTerm>,
   composition?: RecommendationComponent['composition'],
 ): RecommendationComponent {
   return {
@@ -135,26 +141,42 @@ const emptyComposition = {
 }
 const compositionComponents: Array<RecommendationComponent> = [
   component('counter_label', 'CounterLabel', ['count', 'metric', 'stat', 'statistic', 'total']),
-  component('page_layout', 'PageLayout', ['parent-detail', 'sidebar'], {
-    ...emptyComposition,
-    observed: {
-      ...emptyComposition.observed,
-      parentChild: [{parent: 'PageLayout.Pane', child: 'NavList', sourceCount: 3}],
+  component(
+    'page_layout',
+    'PageLayout',
+    [{all: ['sidebar', 'detail']}, {all: ['sidebar', 'pane']}, {all: ['master', 'detail']}, {all: ['split', 'pane']}],
+    {
+      ...emptyComposition,
+      observed: {
+        ...emptyComposition.observed,
+        parentChild: [{parent: 'PageLayout.Pane', child: 'NavList', sourceCount: 3}],
+      },
     },
-  }),
-  component('nav_list', 'NavList', ['navigation', 'navigator']),
-  component('action_list', 'ActionList', ['action', 'option'], {
-    ...emptyComposition,
-    observed: {
-      ...emptyComposition.observed,
-      parentChild: [
-        {parent: 'ActionList.LeadingVisual', child: 'Avatar', sourceCount: 3},
-        {parent: 'ActionList.TrailingVisual', child: 'Label', sourceCount: 3},
-      ],
+  ),
+  component('nav_list', 'NavList', [{all: ['sidebar', 'navigation']}, {all: ['sidebar', 'navigator']}]),
+  component(
+    'action_list',
+    'ActionList',
+    [{all: ['action', 'row']}, {all: ['action', 'list']}, {all: ['action', 'item']}, {all: ['action', 'choice']}],
+    {
+      ...emptyComposition,
+      observed: {
+        ...emptyComposition.observed,
+        parentChild: [
+          {parent: 'ActionList.LeadingVisual', child: 'Avatar', sourceCount: 3},
+          {parent: 'ActionList.TrailingVisual', child: 'Label', sourceCount: 3},
+        ],
+      },
     },
-  }),
-  component('avatar', 'Avatar', ['avatar']),
-  component('label', 'Label', ['badge', 'status', 'tag']),
+  ),
+  component('avatar', 'Avatar', ['avatar', 'member', 'people', 'person']),
+  component('label', 'Label', ['badge', 'category', 'tag']),
+  component('details', 'Details'),
+  component('text', 'Text'),
+  component('text_input', 'TextInput'),
+  component('action_menu', 'ActionMenu'),
+  component('pagination', 'Pagination'),
+  component('select', 'Select'),
 ]
 
 describe('component recommendations', () => {
@@ -192,7 +214,7 @@ describe('component recommendations', () => {
   it('recommends capability and composition metadata for generic assemblies', () => {
     const metricIntent = {intent: 'Show a stat summary strip'}
     const detailIntent = {intent: 'Build a parent detail navigation layout with a sidebar'}
-    const suggestionIntent = {intent: 'Show suggested people with avatars, actions, and badges'}
+    const suggestionIntent = {intent: 'Show suggested people in action rows with avatars and status tags'}
 
     const metric = createRecommendation(
       metricIntent,
@@ -215,12 +237,39 @@ describe('component recommendations', () => {
 
     expect(metric).toMatchObject({status: 'matched', patterns: []})
     expect(metric.components.map(candidate => candidate.component.name)).toContain('CounterLabel')
-    expect(detail.components.map(candidate => candidate.component.name)).toEqual(['PageLayout', 'NavList'])
+    expect(detail.components.map(candidate => candidate.component.name)).toEqual(
+      expect.arrayContaining(['PageLayout', 'NavList']),
+    )
     expect(suggestions.components.map(candidate => candidate.component.name)).toEqual(
       expect.arrayContaining(['ActionList', 'Avatar', 'Label']),
     )
     expect(suggestions.components.flatMap(candidate => candidate.evidence)).toContainEqual(
       expect.objectContaining({sourceKind: 'composition'}),
+    )
+  })
+
+  it('requires full component names and grouped capability signals for direct metadata matches', () => {
+    const noPatterns: Array<{id: string; name: string; category: 'scenario'}> = []
+    const getComponents = (intent: string) =>
+      createRecommendation({intent}, rankPatterns(noPatterns, {intent}), [], compositionComponents).components.map(
+        candidate => candidate.component.name,
+      )
+
+    expect(getComponents('Use ActionList for these commands')).toContain('ActionList')
+    expect(getComponents('Use an ActionMenu for these commands')).toContain('ActionMenu')
+    expect(getComponents('Show plain status text')).toEqual(['Text'])
+    expect(getComponents('Add tabs for navigation')).not.toContain('NavList')
+    expect(getComponents('Add pagination to this list')).toEqual(expect.arrayContaining(['Pagination']))
+    expect(getComponents('Add pagination to this list')).not.toEqual(expect.arrayContaining(['ActionList', 'NavList']))
+    expect(getComponents('Select a repository')).toEqual(expect.arrayContaining(['Select']))
+    expect(getComponents('Select a repository')).not.toContain('ActionList')
+    expect(getComponents('Show a user account menu')).not.toContain('Avatar')
+    expect(getComponents('Show a selected record detail')).not.toContain('Details')
+    expect(getComponents('Show sidebar navigation beside selected record detail')).toEqual(
+      expect.arrayContaining(['PageLayout', 'NavList']),
+    )
+    expect(getComponents('Show people in action rows with avatar images and status tags')).toEqual(
+      expect.arrayContaining(['ActionList', 'Avatar', 'Label']),
     )
   })
 

--- a/packages/mcp/src/recommendations.ts
+++ b/packages/mcp/src/recommendations.ts
@@ -301,7 +301,7 @@ export function createRecommendation(
     }
   }
 
-  expandComposition(candidates, componentByName, exclusions)
+  expandComposition(candidates, componentByName, exclusions, input)
 
   const componentCandidates = [...candidates.values()]
     .map(candidate => ({
@@ -416,6 +416,7 @@ function expandComposition(
   candidates: Map<string, ComponentCandidate>,
   componentByName: Map<string, RecommendationComponent>,
   exclusions: Array<Exclusion>,
+  input: RecommendationInput,
 ) {
   const expandedRelationships = new Set<string>()
 
@@ -428,6 +429,12 @@ function expandComposition(
         for (const relatedName of getRelatedComponentNames(relationship, source.name)) {
           const related = componentByName.get(normalizeIdentifier(relatedName))
           if (!related || related.name === source.name) continue
+          if (
+            candidate.evidence.every(evidence => evidence.sourceKind === 'component-metadata') &&
+            getIntentMetadataMatches(related, input).length === 0
+          ) {
+            continue
+          }
           const relationshipKey = `${source.name}:${kind}:${related.name}`
           if (expandedRelationships.has(relationshipKey)) continue
           expandedRelationships.add(relationshipKey)
@@ -461,18 +468,10 @@ function addIntentMetadataCandidates(
   components: Array<RecommendationComponent>,
   input: RecommendationInput,
 ) {
-  const inputTokens = tokens([
-    input.intent,
-    input.surface,
-    input.region,
-    ...(input.states ?? []),
-    ...(input.constraints ?? []),
-  ])
-
   for (const component of components) {
     if (!isCompatible(component) || !component.intentTerms?.length) continue
 
-    const matches = intersection(inputTokens, tokens(component.intentTerms))
+    const matches = getIntentMetadataMatches(component, input)
     if (matches.length === 0) continue
 
     addCandidate(candidates, component, {
@@ -485,6 +484,13 @@ function addIntentMetadataCandidates(
       },
     })
   }
+}
+
+function getIntentMetadataMatches(component: RecommendationComponent, input: RecommendationInput): Array<string> {
+  return intersection(
+    tokens([input.intent, input.surface, input.region, ...(input.states ?? []), ...(input.constraints ?? [])]),
+    tokens(component.intentTerms ?? []),
+  )
 }
 
 function getRelationships(composition: RecommendationComposition): Array<[string, Array<RecommendationRelationship>]> {

--- a/packages/mcp/src/recommendations.ts
+++ b/packages/mcp/src/recommendations.ts
@@ -5,6 +5,7 @@ import {findInternalCatalogEntries, type InternalCatalogResult, type InternalCat
 
 const maximumEvidencePerCandidate = 3
 const maximumAuxiliaryEntriesPerResult = 3
+const minimumPatternScoreWithoutPublicComponent = 20
 const relationshipKeys = [
   'parent',
   'child',
@@ -36,6 +37,7 @@ export interface RecommendationComponent {
   status?: string
   sourceUrl: string
   searchTerms: Array<string>
+  intentTerms?: Array<string>
   composition?: RecommendationComposition
 }
 
@@ -191,8 +193,11 @@ export function createRecommendation(
   const componentByName = new Map(components.map(component => [normalizeIdentifier(component.name), component]))
   const candidates = new Map<string, ComponentCandidate>()
   const internalCandidates = new Map<string, InternalComponentCandidate>()
+  const supportedPatternIds = new Set<string>()
   const exclusions: Array<Exclusion> = []
   const unresolvedReferences: Array<UnresolvedReference> = []
+
+  addIntentMetadataCandidates(candidates, components, input)
 
   for (const detail of selectedDetails) {
     const pattern = selectedPatterns.find(candidate => candidate.pattern.id === detail.pattern.id)
@@ -265,6 +270,7 @@ export function createRecommendation(
           detail: `${detail.pattern.name} links to ${component.name}.`,
         },
       })
+      supportedPatternIds.add(pattern.pattern.id)
     }
   }
 
@@ -297,17 +303,6 @@ export function createRecommendation(
 
   expandComposition(candidates, componentByName, exclusions)
 
-  const patternCandidates = selectedPatterns.map(candidate => ({
-    pattern: {
-      id: candidate.pattern.id,
-      name: candidate.pattern.name,
-      category: candidate.pattern.category,
-      sourceUrl: getPatternUrl(candidate.pattern).toString(),
-    },
-    sourceKind: 'primer-style-pattern' as const,
-    score: candidate.score,
-    scoreBreakdown: candidate.scoreBreakdown,
-  }))
   const componentCandidates = [...candidates.values()]
     .map(candidate => ({
       ...candidate,
@@ -322,11 +317,27 @@ export function createRecommendation(
     }))
     .sort(compareInternalComponentCandidates)
     .slice(0, limit)
+  const patternCandidates = selectedPatterns
+    .filter(
+      candidate =>
+        candidate.score >= minimumPatternScoreWithoutPublicComponent || supportedPatternIds.has(candidate.pattern.id),
+    )
+    .map(candidate => ({
+      pattern: {
+        id: candidate.pattern.id,
+        name: candidate.pattern.name,
+        category: candidate.pattern.category,
+        sourceUrl: getPatternUrl(candidate.pattern).toString(),
+      },
+      sourceKind: 'primer-style-pattern' as const,
+      score: candidate.score,
+      scoreBreakdown: candidate.scoreBreakdown,
+    }))
   const matchedSignals = getMatchedSignals(input, patternCandidates, componentCandidates)
   const unmetSignals = getUnmetSignals(input, matchedSignals)
   const ambiguous = patternCandidates.length > 1 && patternCandidates[0].score === patternCandidates[1].score
   const status =
-    patternCandidates.length === 0
+    patternCandidates.length === 0 && componentCandidates.length === 0
       ? 'no-match'
       : ambiguous
         ? 'ambiguous'
@@ -442,6 +453,37 @@ function expandComposition(
         }
       }
     }
+  }
+}
+
+function addIntentMetadataCandidates(
+  candidates: Map<string, ComponentCandidate>,
+  components: Array<RecommendationComponent>,
+  input: RecommendationInput,
+) {
+  const inputTokens = tokens([
+    input.intent,
+    input.surface,
+    input.region,
+    ...(input.states ?? []),
+    ...(input.constraints ?? []),
+  ])
+
+  for (const component of components) {
+    if (!isCompatible(component) || !component.intentTerms?.length) continue
+
+    const matches = intersection(inputTokens, tokens(component.intentTerms))
+    if (matches.length === 0) continue
+
+    addCandidate(candidates, component, {
+      score: matches.length * 12,
+      scoreBreakdown: [{source: 'component-metadata', score: matches.length * 12, matches}],
+      evidence: {
+        sourceKind: 'component-metadata',
+        sourceUrl: component.sourceUrl,
+        detail: `${component.name} matches component intent metadata.`,
+      },
+    })
   }
 }
 
@@ -598,7 +640,7 @@ function tokens(values: string | Array<string | undefined>): Set<string> {
 
 function stem(token: string): string {
   if (token.endsWith('ing') && token.length > 5) return token.slice(0, -3)
-  if (token.endsWith('es') && token.length > 4) return token.slice(0, -2)
+  if (token.endsWith('ies') && token.length > 4) return `${token.slice(0, -3)}y`
   if (token.endsWith('s') && token.length > 3) return token.slice(0, -1)
   return token
 }

--- a/packages/mcp/src/recommendations.ts
+++ b/packages/mcp/src/recommendations.ts
@@ -220,6 +220,7 @@ export function createRecommendation(
               detail: `${detail.pattern.name} links to documented internal ${entry.name}.`,
             },
           })
+          supportedPatternIds.add(pattern.pattern.id)
           continue
         }
 
@@ -339,7 +340,7 @@ export function createRecommendation(
   const unmetSignals = getUnmetSignals(input, matchedSignals)
   const ambiguous = patternCandidates.length > 1 && patternCandidates[0].score === patternCandidates[1].score
   const status =
-    patternCandidates.length === 0 && componentCandidates.length === 0
+    patternCandidates.length === 0 && componentCandidates.length === 0 && internalComponentCandidates.length === 0
       ? 'no-match'
       : ambiguous
         ? 'ambiguous'

--- a/packages/mcp/src/recommendations.ts
+++ b/packages/mcp/src/recommendations.ts
@@ -37,9 +37,11 @@ export interface RecommendationComponent {
   status?: string
   sourceUrl: string
   searchTerms: Array<string>
-  intentTerms?: Array<string>
+  intentTerms?: Array<RecommendationIntentTerm>
   composition?: RecommendationComposition
 }
+
+export type RecommendationIntentTerm = string | {all: Array<string>}
 
 export interface RecommendationComposition {
   apiParentChild: Array<RecommendationRelationship>
@@ -469,7 +471,7 @@ function addIntentMetadataCandidates(
   input: RecommendationInput,
 ) {
   for (const component of components) {
-    if (!isCompatible(component) || !component.intentTerms?.length) continue
+    if (!isCompatible(component)) continue
 
     const matches = getIntentMetadataMatches(component, input)
     if (matches.length === 0) continue
@@ -487,10 +489,40 @@ function addIntentMetadataCandidates(
 }
 
 function getIntentMetadataMatches(component: RecommendationComponent, input: RecommendationInput): Array<string> {
-  return intersection(
-    tokens([input.intent, input.surface, input.region, ...(input.states ?? []), ...(input.constraints ?? [])]),
-    tokens(component.intentTerms ?? []),
+  const inputValues = [input.intent, input.surface, input.region, ...(input.states ?? []), ...(input.constraints ?? [])]
+  const inputTokens = tokens(inputValues)
+  const capabilityMatches = (component.intentTerms ?? []).flatMap(term => {
+    const requiredTerms = typeof term === 'string' ? [term] : term.all
+    const requiredTokens = tokens(requiredTerms)
+
+    return [...requiredTokens].every(token => inputTokens.has(token))
+      ? [typeof term === 'string' ? term : term.all.join(' + ')]
+      : []
+  })
+
+  return [...new Set([...getFullNameMatches(component, inputValues), ...capabilityMatches])]
+}
+
+function getFullNameMatches(component: RecommendationComponent, inputValues: Array<string | undefined>): Array<string> {
+  const inputPhrases = inputValues
+    .filter((value): value is string => Boolean(value))
+    .map(normalizePhrase)
+    .filter(Boolean)
+  const inputWords = new Set(
+    inputValues
+      .filter((value): value is string => Boolean(value))
+      .flatMap(value => value.toLowerCase().split(/[^a-z0-9]+/))
+      .filter(Boolean),
   )
+
+  return [...new Set([component.id, component.name])]
+    .filter(name => {
+      const phrase = normalizePhrase(name)
+      const compactName = normalizeIdentifier(name)
+
+      return inputPhrases.some(inputPhrase => ` ${inputPhrase} `.includes(` ${phrase} `)) || inputWords.has(compactName)
+    })
+    .map(normalizePhrase)
 }
 
 function getRelationships(composition: RecommendationComposition): Array<[string, Array<RecommendationRelationship>]> {
@@ -657,6 +689,14 @@ function intersection(first: Set<string>, second: Set<string>): Array<string> {
 
 function normalizeIdentifier(value: string): string {
   return value.replace(/[^a-z0-9]/gi, '').toLowerCase()
+}
+
+function normalizePhrase(value: string): string {
+  return value
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
 }
 
 function isCompatible(component: RecommendationComponent): boolean {

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -501,32 +501,6 @@ describe('get_component_batch', () => {
     expect(getTextContent(second)).not.toContain('CSS unchanged')
   })
 
-  it('retrieves batched icon documentation concurrently without changing get_icon', async () => {
-    const fetchMock = vi.mocked(fetch)
-    let resolveAlert: ((response: Response) => void) | undefined
-    let resolveBell: ((response: Response) => void) | undefined
-    fetchMock.mockImplementation(input => {
-      const path = new URL(input.toString()).pathname
-      return new Promise(resolve => {
-        if (path.includes('/alert-16/')) resolveAlert = resolve
-        else resolveBell = resolve
-      })
-    })
-
-    const result = callTool('get_icon_batch', {names: ['alert', 'bell'], size: '16'})
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
-    resolveAlert?.(new Response('Alert docs'))
-    resolveBell?.(new Response('Bell docs'))
-
-    await expect(result).resolves.toMatchObject({
-      content: [
-        {type: 'text', text: expect.stringContaining('Alert docs')},
-        {type: 'text', text: expect.stringContaining('Bell docs')},
-      ],
-    })
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-  })
-
   it('preserves the single-icon missing result', async () => {
     const result = await callTool('get_icon', {name: 'missing'})
 

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -2,7 +2,7 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js'
 import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js'
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
 import {getComponentDocsSource} from './primer'
-import {server} from './server'
+import {clearPatternDetailsCacheForTesting, server} from './server'
 
 const searchPatternPage = `
   <main>
@@ -37,6 +37,14 @@ const internalCatalogPage = JSON.stringify({
   ],
 })
 
+function createPatternPage(patternName: string, componentName: string, componentId: string): string {
+  return searchPatternPage
+    .replace('<h1>Search</h1>', `<h1>${patternName}</h1>`)
+    .replace('Search finds things that match specific criteria.', `${patternName} guidance.`)
+    .replace('/product/components/text-input/', `/product/components/${componentId}/`)
+    .replace('>TextInput<', `>${componentName}<`)
+}
+
 describe('component documentation sources', () => {
   it('uses hosted documentation by default and supports package metadata', () => {
     expect(getComponentDocsSource(undefined)).toBe('hosted')
@@ -57,6 +65,7 @@ describe('get_component_batch', () => {
   })
 
   beforeEach(() => {
+    clearPatternDetailsCacheForTesting()
     vi.stubGlobal('fetch', vi.fn<typeof fetch>())
   })
 
@@ -382,6 +391,74 @@ describe('get_component_batch', () => {
       ]),
     })
     expect(getTextContent(result)).toContain('Public components')
+  })
+
+  it.each([
+    ['search', 'Search', 'TextInput', 'text-input', true],
+    ['forms', 'Forms', 'Button', 'button', true],
+    ['navigation', 'Navigation', 'NavList', 'nav-list', true],
+    ['saving', 'Saving', 'Banner', 'banner', true],
+    ['empty states', 'Empty States', 'Blankslate', 'blankslate', false],
+  ])(
+    'preserves %s recommendation candidates and content across a warm pattern cache',
+    async (intent, patternName, componentName, componentId, expectsComponent = true) => {
+      vi.mocked(fetch).mockResolvedValue(new Response(createPatternPage(patternName, componentName, componentId)))
+
+      const cold = await callRecommendation({intent})
+      const warm = await callRecommendation({intent})
+      const coldPayload = cold.structuredContent as {
+        patterns: Array<{pattern: {name: string}}>
+        components: Array<{component: {name: string}}>
+      }
+
+      expect(cold.structuredContent).toEqual(warm.structuredContent)
+      expect(getTextContent(cold)).toBe(getTextContent(warm))
+      expect(coldPayload.patterns.map(candidate => candidate.pattern.name)).toContain(patternName)
+      if (expectsComponent) {
+        expect(coldPayload.components.map(candidate => candidate.component.name)).toContain(componentName)
+      } else {
+        expect(coldPayload.components).toEqual([])
+      }
+      expect(fetch).toHaveBeenCalledOnce()
+    },
+  )
+
+  it('shares concurrent pattern enrichment and only fetches selected ranked patterns', async () => {
+    let resolveSearch: ((response: Response) => void) | undefined
+    let resolveFilter: ((response: Response) => void) | undefined
+    vi.mocked(fetch).mockImplementation(input => {
+      const path = new URL(input.toString()).pathname
+      return new Promise(resolve => {
+        if (path.includes('/search')) resolveSearch = resolve
+        else resolveFilter = resolve
+      })
+    })
+
+    const first = callRecommendation({intent: 'search filter'})
+    const second = callRecommendation({intent: 'search filter'})
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
+    resolveSearch?.(new Response(searchPatternPage))
+    resolveFilter?.(new Response(searchPatternPage.replace('<h1>Search</h1>', '<h1>Filter</h1>')))
+
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2)
+    expect(fetch).toHaveBeenCalledTimes(2)
+
+    clearPatternDetailsCacheForTesting()
+    vi.mocked(fetch).mockClear()
+    vi.mocked(fetch).mockResolvedValue(new Response(searchPatternPage))
+    await callRecommendation({intent: 'search filter', limit: 1})
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it('does not cache failed pattern enrichment responses', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, {status: 503, statusText: 'Service Unavailable'}))
+
+    const first = await callRecommendation({intent: 'search'})
+    const second = await callRecommendation({intent: 'search'})
+
+    expect(first.isError).toBe(true)
+    expect(second.isError).toBe(true)
+    expect(fetch).toHaveBeenCalledTimes(2)
   })
 
   it('lists bounded documented internal components without presenting an import path', async () => {

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -2,7 +2,9 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js'
 import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js'
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
 import {getComponentDocsSource} from './primer'
-import {clearPatternDetailsCacheForTesting, server} from './server'
+import {clearCssLintResultCacheForTesting, clearPatternDetailsCacheForTesting, server} from './server'
+// eslint-disable-next-line import/no-namespace
+import * as primitives from './primitives'
 
 const searchPatternPage = `
   <main>
@@ -65,12 +67,15 @@ describe('get_component_batch', () => {
   })
 
   beforeEach(() => {
+    clearCssLintResultCacheForTesting()
     clearPatternDetailsCacheForTesting()
+    vi.spyOn(primitives, 'runStylelint')
     vi.stubGlobal('fetch', vi.fn<typeof fetch>())
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 
@@ -459,6 +464,75 @@ describe('get_component_batch', () => {
     expect(first.isError).toBe(true)
     expect(second.isError).toBe(true)
     expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs CSS linting once for concurrent and unchanged final CSS', async () => {
+    vi.mocked(primitives.runStylelint).mockResolvedValue({stdout: '', stderr: ''})
+    const css = '.Component { color: var(--fgColor-default); }'
+
+    const [first, concurrent] = await Promise.all([callTool('lint_css', {css}), callTool('lint_css', {css})])
+    const warm = await callTool('lint_css', {css})
+    const changed = await callTool('lint_css', {css: `${css}\n.Component--selected { color: var(--fgColor-accent); }`})
+
+    expect(primitives.runStylelint).toHaveBeenCalledTimes(2)
+    expect(primitives.runStylelint).toHaveBeenNthCalledWith(1, css)
+    expect([getTextContent(first), getTextContent(concurrent)]).toEqual(
+      expect.arrayContaining([
+        '✅ Stylelint passed (or was successfully autofixed).',
+        '✅ Stylelint passed; CSS unchanged.',
+      ]),
+    )
+    expect(getTextContent(warm)).toBe('✅ Stylelint passed; CSS unchanged.')
+    expect(getTextContent(changed)).toBe('✅ Stylelint passed (or was successfully autofixed).')
+  })
+
+  it('does not retain failed CSS linting as a successful cached result', async () => {
+    vi.mocked(primitives.runStylelint).mockRejectedValue(
+      Object.assign(new Error('Stylelint exited with code 2'), {stdout: 'invalid CSS'}),
+    )
+    const css = '.Component { color: ; }'
+
+    const first = await callTool('lint_css', {css})
+    const second = await callTool('lint_css', {css})
+
+    expect(primitives.runStylelint).toHaveBeenCalledTimes(2)
+    expect(getTextContent(first)).toContain('❌ Errors without autofix remaining:')
+    expect(getTextContent(second)).toContain('❌ Errors without autofix remaining:')
+    expect(getTextContent(second)).not.toContain('CSS unchanged')
+  })
+
+  it('retrieves batched icon documentation concurrently without changing get_icon', async () => {
+    const fetchMock = vi.mocked(fetch)
+    let resolveAlert: ((response: Response) => void) | undefined
+    let resolveBell: ((response: Response) => void) | undefined
+    fetchMock.mockImplementation(input => {
+      const path = new URL(input.toString()).pathname
+      return new Promise(resolve => {
+        if (path.includes('/alert-16/')) resolveAlert = resolve
+        else resolveBell = resolve
+      })
+    })
+
+    const result = callTool('get_icon_batch', {names: ['alert', 'bell'], size: '16'})
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    resolveAlert?.(new Response('Alert docs'))
+    resolveBell?.(new Response('Bell docs'))
+
+    await expect(result).resolves.toMatchObject({
+      content: [
+        {type: 'text', text: expect.stringContaining('Alert docs')},
+        {type: 'text', text: expect.stringContaining('Bell docs')},
+      ],
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('preserves the single-icon missing result', async () => {
+    const result = await callTool('get_icon', {name: 'missing'})
+
+    expect(getTextContent(result)).toBe(
+      'There is no icon named `missing` in the @primer/octicons-react package. For a full list of icons, use the `get_icon` tool.',
+    )
   })
 
   it('lists bounded documented internal components without presenting an import path', async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1252,35 +1252,15 @@ server.registerTool(
     annotations: {readOnlyHint: true},
   },
   async ({name, size}) => {
-    const text = await getIconDocumentation(name, size, 'get_icon')
+    const text = await getIconDocumentation(name, size)
     return {content: text ? [{type: 'text', text}] : []}
   },
 )
 
-server.registerTool(
-  'get_icon_batch',
-  {
-    description: 'Get documentation for multiple Primer Octicons in one call',
-    inputSchema: {
-      names: z.array(z.string()).min(2).max(10).describe('Icon names to retrieve'),
-      size: z.string().optional().describe('The icon size to retrieve, e.g. "16"').default('16'),
-    },
-    annotations: {readOnlyHint: true},
-  },
-  async ({names, size}) => {
-    const documentation = await Promise.all(names.map(name => getIconDocumentation(name, size)))
-    return {content: documentation.filter((text): text is string => Boolean(text)).map(text => ({type: 'text', text}))}
-  },
-)
-
-async function getIconDocumentation(
-  name: string,
-  size: string,
-  missingIconTool = 'list_icons',
-): Promise<string | undefined> {
+async function getIconDocumentation(name: string, size: string): Promise<string | undefined> {
   const match = listIcons().find(icon => icon.name === name || icon.name.toLowerCase() === name.toLowerCase())
   if (!match) {
-    return `There is no icon named \`${name}\` in the @primer/octicons-react package. For a full list of icons, use the \`${missingIconTool}\` tool.`
+    return `There is no icon named \`${name}\` in the @primer/octicons-react package. For a full list of icons, use the \`get_icon\` tool.`
   }
 
   const url = new URL(`/octicons/icon/${match.name}-${size}`, 'https://primer.style')

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,8 +14,15 @@ import {
   listComponents,
   listPatterns,
   listIcons,
+  type Pattern,
 } from './primer'
-import {formatCompactPatternDetails, getPatternUrl, parseCompactPatternDetails, toFullPatternDetails} from './patterns'
+import {
+  formatCompactPatternDetails,
+  getPatternUrl,
+  parseCompactPatternDetails,
+  toFullPatternDetails,
+  type CompactPatternDetails,
+} from './patterns'
 import {createRecommendation, formatRecommendation, rankPatterns, type RecommendationComponent} from './recommendations'
 import {fetchInternalCatalog} from './internalCatalog'
 import {
@@ -40,6 +47,8 @@ const server = new McpServer({
   version: packageJson.version,
 })
 
+const maximumCachedPatternDetails = 24
+const compactPatternDetailsCache = new Map<string, Promise<CompactPatternDetails>>()
 const turndownService = new TurndownService()
 const defaultComponentDocsSource = getComponentDocsSource()
 const patternReferenceOutputSchema = z.object({
@@ -86,6 +95,53 @@ async function fetchTextOnlyContent(url: URL): Promise<string | undefined> {
   if (response.status === 404) return undefined
 
   throw new Error(`Failed to fetch ${llmsUrl}: ${response.statusText}`)
+}
+
+function fetchCompactPatternDetails(pattern: Pattern): Promise<CompactPatternDetails> {
+  const url = getPatternUrl(pattern)
+  const cacheKey = url.toString()
+  const cached = compactPatternDetailsCache.get(cacheKey)
+  if (cached) {
+    compactPatternDetailsCache.delete(cacheKey)
+    compactPatternDetailsCache.set(cacheKey, cached)
+    return cached
+  }
+
+  const pending = (async () => {
+    const response = await fetch(url)
+    if (!response.ok) throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
+
+    const html = await response.text()
+    if (!html) throw new Error(`Primer Style returned an empty page for the \`${pattern.name}\` pattern.`)
+
+    return parseCompactPatternDetails(html, pattern, url, listPatterns())
+  })()
+  compactPatternDetailsCache.set(cacheKey, pending)
+  trimCompactPatternDetailsCache()
+  void removeFailedPatternDetails(cacheKey, pending)
+
+  return pending
+}
+
+async function removeFailedPatternDetails(cacheKey: string, pending: Promise<CompactPatternDetails>) {
+  try {
+    await pending
+  } catch {
+    // Do not cache failures; the request that received it still propagates the error.
+    if (compactPatternDetailsCache.get(cacheKey) === pending) compactPatternDetailsCache.delete(cacheKey)
+  }
+}
+
+function trimCompactPatternDetailsCache() {
+  while (compactPatternDetailsCache.size > maximumCachedPatternDetails) {
+    const oldestCacheKey = compactPatternDetailsCache.keys().next().value
+    if (oldestCacheKey === undefined) return
+    compactPatternDetailsCache.delete(oldestCacheKey)
+  }
+}
+
+export function clearPatternDetailsCacheForTesting() {
+  compactPatternDetailsCache.clear()
 }
 
 function convertMainHtmlToMarkdown(html: string): string | undefined {
@@ -784,16 +840,7 @@ server.registerTool(
   async input => {
     const rankedPatterns = rankPatterns(listPatterns(), input)
     const details = await Promise.all(
-      rankedPatterns.slice(0, input.limit * 2).map(async candidate => {
-        const url = getPatternUrl(candidate.pattern)
-        const response = await fetch(url)
-        if (!response.ok) throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
-
-        const html = await response.text()
-        if (!html) throw new Error(`Primer Style returned an empty page for the \`${candidate.pattern.name}\` pattern.`)
-
-        return parseCompactPatternDetails(html, candidate.pattern, url, listPatterns())
-      }),
+      rankedPatterns.slice(0, input.limit).map(candidate => fetchCompactPatternDetails(candidate.pattern)),
     )
     const components: Array<RecommendationComponent> = listComponents().map(component => {
       const document = getComponentDocument(component.id)

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -9,6 +9,7 @@ import {
   getComponentCompositionSummary,
   getComponentDocsSource,
   getComponentDocument,
+  getComponentRecommendationTerms,
   getComponentSummary,
   listComponents,
   listPatterns,
@@ -805,6 +806,7 @@ server.registerTool(
         status,
         sourceUrl: new URL(`/product/components/${component.slug}`, 'https://primer.style').toString(),
         searchTerms,
+        intentTerms: getComponentRecommendationTerms(component.id),
         composition,
       }
     })

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -49,6 +49,8 @@ const server = new McpServer({
 
 const maximumCachedPatternDetails = 24
 const compactPatternDetailsCache = new Map<string, Promise<CompactPatternDetails>>()
+const maximumCachedCssLintResults = 24
+const cssLintResultCache = new Map<string, Promise<CssLintResult>>()
 const turndownService = new TurndownService()
 const defaultComponentDocsSource = getComponentDocsSource()
 const patternReferenceOutputSchema = z.object({
@@ -83,6 +85,11 @@ const recommendationOutputSchema = z
     intent: z.string(),
   })
   .passthrough()
+
+interface CssLintResult {
+  passed: boolean
+  text: string
+}
 
 // Load all tokens with guidelines from primitives
 const allTokensWithGuidelines: TokenWithGuidelines[] = loadAllTokensWithGuidelines()
@@ -142,6 +149,48 @@ function trimCompactPatternDetailsCache() {
 
 export function clearPatternDetailsCacheForTesting() {
   compactPatternDetailsCache.clear()
+}
+
+function lintCss(css: string): {result: Promise<CssLintResult>; cached: boolean} {
+  const cached = cssLintResultCache.get(css)
+  if (cached) {
+    cssLintResultCache.delete(css)
+    cssLintResultCache.set(css, cached)
+    return {result: cached, cached: true}
+  }
+
+  const result = (async (): Promise<CssLintResult> => {
+    try {
+      const {stdout} = await runStylelint(css)
+      return {passed: true, text: stdout || '✅ Stylelint passed (or was successfully autofixed).'}
+    } catch (error: unknown) {
+      const errorOutput =
+        error instanceof Error && 'stdout' in error ? (error as Error & {stdout: string}).stdout : String(error)
+      return {passed: false, text: `❌ Errors without autofix remaining:\n${errorOutput}`}
+    }
+  })()
+  cssLintResultCache.set(css, result)
+  trimCssLintResultCache()
+  void removeFailedCssLintResult(css, result)
+
+  return {result, cached: false}
+}
+
+async function removeFailedCssLintResult(css: string, result: Promise<CssLintResult>) {
+  const completed = await result
+  if (!completed.passed && cssLintResultCache.get(css) === result) cssLintResultCache.delete(css)
+}
+
+function trimCssLintResultCache() {
+  while (cssLintResultCache.size > maximumCachedCssLintResults) {
+    const oldestCss = cssLintResultCache.keys().next().value
+    if (oldestCss === undefined) return
+    cssLintResultCache.delete(oldestCss)
+  }
+}
+
+export function clearCssLintResultCacheForTesting() {
+  cssLintResultCache.clear()
 }
 
 function convertMainHtmlToMarkdown(html: string): string | undefined {
@@ -875,7 +924,7 @@ server.registerTool(
   'find_tokens',
   {
     description:
-      'Search for specific tokens. Tip: If you only provide a \'group\' and leave \'query\' empty, it returns all tokens in that category. Avoid property-by-property searching. COLOR RESOLUTION: If a user asks for "pink" or "blue", do not search for the color name. Use the semantic intent: blue->accent, red->danger, green->success. Always check both "emphasis" and "muted" variants for background colors. After identifying tokens and writing CSS, you MUST validate the result using lint_css.',
+      'Search for specific tokens. Tip: If you only provide a \'group\' and leave \'query\' empty, it returns all tokens in that category. Avoid property-by-property searching. COLOR RESOLUTION: If a user asks for "pink" or "blue", do not search for the color name. Use the semantic intent: blue->accent, red->danger, green->success. Always check both "emphasis" and "muted" variants for background colors. After finalizing combined CSS, validate it once with lint_css and rerun only when the CSS bytes change.',
     inputSchema: {
       query: z
         .string()
@@ -1084,36 +1133,16 @@ server.registerTool(
   'lint_css',
   {
     description:
-      'REQUIRED FINAL STEP. Use this to validate your CSS. You cannot complete a task involving CSS without a successful run of this tool.',
+      'REQUIRED ONCE AFTER FINAL COMBINED CSS. Run this after all CSS edits are complete; rerun only when the CSS bytes change. You cannot complete a task involving CSS without a successful run.',
     inputSchema: {css: z.string()},
     annotations: {readOnlyHint: true},
   },
   async ({css}) => {
-    try {
-      // --fix flag tells Stylelint to repair what it can
-      const {stdout} = await runStylelint(css)
+    const {result, cached} = lintCss(css)
+    const completed = await result
+    const text = cached && completed.passed ? '✅ Stylelint passed; CSS unchanged.' : completed.text
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: stdout || '✅ Stylelint passed (or was successfully autofixed).',
-          },
-        ],
-      }
-    } catch (error: unknown) {
-      // If Stylelint still has errors it CANNOT fix, it will land here
-      const errorOutput =
-        error instanceof Error && 'stdout' in error ? (error as Error & {stdout: string}).stdout : String(error)
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `❌ Errors without autofix remaining:\n${errorOutput}`,
-          },
-        ],
-      }
-    }
+    return {content: [{type: 'text', text}]}
   },
 )
 
@@ -1223,44 +1252,50 @@ server.registerTool(
     annotations: {readOnlyHint: true},
   },
   async ({name, size}) => {
-    const icons = listIcons()
-    const match = icons.find(icon => {
-      return icon.name === name || icon.name.toLowerCase() === name.toLowerCase()
-    })
-    if (!match) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `There is no icon named \`${name}\` in the @primer/octicons-react package. For a full list of icons, use the \`get_icon\` tool.`,
-          },
-        ],
-      }
-    }
-
-    const url = new URL(`/octicons/icon/${match.name}-${size}`, 'https://primer.style')
-    let text = await fetchTextOnlyContent(url)
-    if (text === undefined) {
-      const response = await fetch(url)
-      if (!response.ok) {
-        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
-      }
-
-      text = convertMainHtmlToMarkdown(await response.text())
-    }
-    if (!text) return {content: []}
-
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Here is the documentation for the \`${name}\` icon at size: \`${size}\`:
-${text}`,
-        },
-      ],
-    }
+    const text = await getIconDocumentation(name, size, 'get_icon')
+    return {content: text ? [{type: 'text', text}] : []}
   },
 )
+
+server.registerTool(
+  'get_icon_batch',
+  {
+    description: 'Get documentation for multiple Primer Octicons in one call',
+    inputSchema: {
+      names: z.array(z.string()).min(2).max(10).describe('Icon names to retrieve'),
+      size: z.string().optional().describe('The icon size to retrieve, e.g. "16"').default('16'),
+    },
+    annotations: {readOnlyHint: true},
+  },
+  async ({names, size}) => {
+    const documentation = await Promise.all(names.map(name => getIconDocumentation(name, size)))
+    return {content: documentation.filter((text): text is string => Boolean(text)).map(text => ({type: 'text', text}))}
+  },
+)
+
+async function getIconDocumentation(
+  name: string,
+  size: string,
+  missingIconTool = 'list_icons',
+): Promise<string | undefined> {
+  const match = listIcons().find(icon => icon.name === name || icon.name.toLowerCase() === name.toLowerCase())
+  if (!match) {
+    return `There is no icon named \`${name}\` in the @primer/octicons-react package. For a full list of icons, use the \`${missingIconTool}\` tool.`
+  }
+
+  const url = new URL(`/octicons/icon/${match.name}-${size}`, 'https://primer.style')
+  let text = await fetchTextOnlyContent(url)
+  if (text === undefined) {
+    const response = await fetch(url)
+    if (!response.ok) throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
+
+    text = convertMainHtmlToMarkdown(await response.text())
+  }
+  if (!text) return undefined
+
+  return `Here is the documentation for the \`${name}\` icon at size: \`${size}\`:
+${text}`
+}
 
 // -----------------------------------------------------------------------------
 // Coding guidelines


### PR DESCRIPTION
## Summary
- add composition-aware component recommendations with grouped semantic matching
- preserve documented internal-only pattern support for all-source callers
- cache bounded pattern enrichment and exact-input final CSS validation
- keep existing MCP schemas and single-icon behavior unchanged

## Validation
- focused MCP tests pass (51/51)
- `npm run type-check -w @primer/mcp`
- `npm run build -w @primer/mcp`

## Privacy and scope review
- stacked on #8230
- no session identifiers, private eval findings, local paths, or unrelated public API additions
- gitleaks and independent full-range publication review passed

This is a draft canary for evaluation before merge.