### PR TITLE
Update MCP server to SDK v2

### DIFF
--- a/.changeset/bright-mice-upgrade.md
+++ b/.changeset/bright-mice-upgrade.md
@@ -1,0 +1,5 @@
+---
+'@primer/mcp': major
+---
+
+MCP server: Upgrade to the MCP TypeScript SDK v2 and support the 2026-07-28 protocol over stdio.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3917,6 +3917,7 @@
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -4875,6 +4876,45 @@
       "version": "2.2.0",
       "license": "BSD-2-Clause"
     },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client/node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@modelcontextprotocol/inspector": {
       "version": "0.16.6",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector/-/inspector-0.16.6.tgz",
@@ -5166,6 +5206,7 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -5206,6 +5247,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -5223,9 +5265,23 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -10385,6 +10441,7 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -10396,6 +10453,7 @@
     },
     "node_modules/accepts/node_modules/mime-db": {
       "version": "1.54.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10405,6 +10463,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -10479,6 +10538,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -11271,6 +11331,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -11295,6 +11356,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11308,6 +11370,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -11497,6 +11560,7 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11553,6 +11617,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11564,6 +11629,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -12252,6 +12318,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12263,6 +12330,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12276,6 +12344,7 @@
     },
     "node_modules/cookie": {
       "version": "0.7.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12283,6 +12352,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -12391,6 +12461,7 @@
     },
     "node_modules/cors": {
       "version": "2.8.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -13035,6 +13106,7 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -13203,6 +13275,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -13225,6 +13298,7 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -13250,6 +13324,7 @@
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -13421,6 +13496,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13428,6 +13504,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13468,6 +13545,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -13567,6 +13645,7 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -15235,6 +15314,7 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -15287,6 +15367,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -15330,6 +15411,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
       "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -15347,6 +15429,7 @@
     },
     "node_modules/express/node_modules/mime-db": {
       "version": "1.54.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -15356,6 +15439,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -15401,6 +15485,7 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -15454,6 +15539,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
       "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15563,6 +15649,7 @@
     },
     "node_modules/finalhandler": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -15701,6 +15788,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -15719,6 +15807,7 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -15771,6 +15860,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15847,6 +15937,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -15879,6 +15970,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -16154,6 +16246,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16234,6 +16327,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16273,6 +16367,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -16318,6 +16413,7 @@
       "version": "4.12.31",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
       "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -16398,6 +16494,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -16584,6 +16681,7 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -16608,6 +16706,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -16615,6 +16714,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -17008,6 +17108,7 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -17444,12 +17545,14 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -18455,6 +18558,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -18671,6 +18775,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -18691,6 +18796,7 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -19583,6 +19689,7 @@
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -19881,6 +19988,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -19992,6 +20100,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -20002,6 +20111,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -20402,6 +20512,7 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -20473,6 +20584,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -22354,6 +22466,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -22493,6 +22606,7 @@
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -22553,6 +22667,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -22566,6 +22681,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -22581,6 +22697,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -22994,6 +23111,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23338,6 +23456,7 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -23552,6 +23671,7 @@
     },
     "node_modules/send": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
@@ -23572,6 +23692,7 @@
     },
     "node_modules/send/node_modules/mime-db": {
       "version": "1.54.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -23581,6 +23702,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -23671,6 +23793,7 @@
     },
     "node_modules/serve-static": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -23727,6 +23850,7 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/shallow-clone": {
@@ -23837,6 +23961,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -23856,6 +23981,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -23870,6 +23996,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -23886,6 +24013,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -24234,6 +24362,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -25773,6 +25902,7 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -26050,6 +26180,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",
@@ -26068,6 +26199,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -26081,6 +26213,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -26090,6 +26223,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -26819,6 +26953,7 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -27017,6 +27152,7 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -28122,6 +28258,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -28352,6 +28489,7 @@
       "version": "3.25.2",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
@@ -28621,9 +28759,10 @@
     },
     "packages/mcp": {
       "name": "@primer/mcp",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/client": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "@primer/octicons": "^19.15.5",
         "@primer/primitives": "10.x || 11.x",
         "@primer/react": "^38.33.0",
@@ -28642,6 +28781,9 @@
         "rolldown": "^1.2.0",
         "rolldown-plugin-dts": "^0.26.0",
         "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/mcp/node_modules/balanced-match": {
@@ -28815,7 +28957,7 @@
         "@storybook/addon-links": "10.5.3",
         "@storybook/addon-mcp": "^0.7.0",
         "@storybook/icons": "^2.1.0",
-        "@storybook/react-vite": "^10.5.3",
+        "@storybook/react-vite": "10.5.3",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.4.5",
         "@testing-library/react": "^16.3.0",
@@ -29797,7 +29939,7 @@
         "@primer/primitives": "10.x || 11.x",
         "@primer/react": "^38.26.0",
         "@rolldown/plugin-babel": "^0.2.3",
-        "@storybook/react-vite": "^10.5.3",
+        "@storybook/react-vite": "10.5.3",
         "@types/babel__core": "^7.20.5",
         "@types/react": "18.3.11",
         "@types/react-dom": "18.3.1",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -8,6 +8,8 @@
 
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=Primer&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40primer%2Fmcp%40latest%22%5D%7D) [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=Primer&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40primer%2Fmcp%40latest%22%5D%7D&quality=insiders)
 
+Node.js 20 or newer is required.
+
 The `@primer/mcp` package provides a server that can be run in your local
 development environment or can be setup in tools like GitHub Actions to be used
 by AI agents.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,6 +26,9 @@
     "type": "git",
     "url": "git+https://github.com/primer/react.git"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "clean": "rimraf dist",
     "build": "rolldown -c",
@@ -34,7 +37,8 @@
     "watch": "rolldown -c -w"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/client": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@primer/octicons": "^19.15.5",
     "@primer/primitives": "10.x || 11.x",
     "@primer/react": "^38.33.0",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,1 +1,1 @@
-export {server} from './server'
+export {createServer, server} from './server'

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -1,12 +1,29 @@
-import {Client} from '@modelcontextprotocol/sdk/client/index.js'
-import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js'
+import {Client, InMemoryTransport} from '@modelcontextprotocol/client'
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
 import {server} from './server'
 
-describe('get_component_batch', () => {
-  const client = new Client({name: 'mcp-server-test', version: '1.0.0'})
+describe('MCP server', () => {
+  const client = new Client(
+    {name: 'mcp-server-test', version: '1.0.0'},
+    {
+      capabilities: {
+        sampling: {},
+      },
+    },
+  )
 
   beforeAll(async () => {
+    client.setRequestHandler('sampling/createMessage', async () => {
+      return {
+        model: 'test-model',
+        role: 'assistant',
+        content: {
+          type: 'text',
+          text: 'The alt text is descriptive and relevant.',
+        },
+      }
+    })
+
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
     await server.connect(serverTransport)
     await client.connect(clientTransport)
@@ -143,5 +160,21 @@ describe('get_component_batch', () => {
       ],
     })
     expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('reviews alt text through the multi-round-trip sampling flow', async () => {
+    const result = await client.callTool({
+      name: 'review_alt_text',
+      arguments: {
+        surroundingText: 'A pull request description',
+        alt: 'Screenshot of a successful test run',
+        image: 'test-results.png',
+      },
+    })
+
+    expect(result.content).toContainEqual({
+      type: 'text',
+      text: 'The alt text is descriptive and relevant.',
+    })
   })
 })

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,4 +1,5 @@
-import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js'
+import {inputRequired, inputResponse, McpServer} from '@modelcontextprotocol/server'
+
 // eslint-disable-next-line import/no-namespace
 import * as cheerio from 'cheerio'
 // eslint-disable-next-line import/no-namespace
@@ -22,54 +23,55 @@ import {
 } from './primitives'
 import packageJson from '../package.json' with {type: 'json'}
 
-const server = new McpServer({
-  name: 'Primer',
-  version: packageJson.version,
-})
-
 const turndownService = new TurndownService()
 
 // Load all tokens with guidelines from primitives
 const allTokensWithGuidelines: TokenWithGuidelines[] = loadAllTokensWithGuidelines()
 
-// -----------------------------------------------------------------------------
-// Project setup
-// -----------------------------------------------------------------------------
-server.registerTool(
-  'init',
-  {
-    description: 'Setup or create a project that includes Primer React',
-    annotations: {readOnlyHint: true},
-  },
-  async () => {
-    const url = new URL(`/product/getting-started/react`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
-    }
+function createServer() {
+  const server = new McpServer({
+    name: 'Primer',
+    version: packageJson.version,
+  })
 
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
+  // -----------------------------------------------------------------------------
+  // Project setup
+  // -----------------------------------------------------------------------------
+  server.registerTool(
+    'init',
+    {
+      description: 'Setup or create a project that includes Primer React',
+      annotations: {readOnlyHint: true},
+    },
+    async () => {
+      const url = new URL(`/product/getting-started/react`, 'https://primer.style')
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
       }
-    }
 
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
+      const html = await response.text()
+      if (!html) {
+        return {
+          content: [],
+        }
       }
-    }
 
-    const text = turndownService.turndown(source)
+      const $ = cheerio.load(html)
+      const source = $('main').html()
+      if (!source) {
+        return {
+          content: [],
+        }
+      }
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `The getting started documentation for Primer React is included below. It's important that the project:
+      const text = turndownService.turndown(source)
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `The getting started documentation for Primer React is included below. It's important that the project:
 
 - Is using a tool like Vite, Next.js, etc that supports TypeScript and React. If the project does not have support for that, generate an appropriate project scaffold
 - Installs the latest version of \`@primer/react\` from \`npm\`
@@ -82,375 +84,375 @@ server.registerTool(
 
 ${text}
 `,
-        },
-      ],
-    }
-  },
-)
+          },
+        ],
+      }
+    },
+  )
 
-// -----------------------------------------------------------------------------
-// Components
-// -----------------------------------------------------------------------------
-server.registerTool(
-  'list_components',
-  {description: 'List all of the components available from Primer React', annotations: {readOnlyHint: true}},
-  async () => {
-    const components = listComponents().map(component => {
-      return `- ${component.name}`
-    })
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `The following components are available in the @primer/react in TypeScript projects:
+  // -----------------------------------------------------------------------------
+  // Components
+  // -----------------------------------------------------------------------------
+  server.registerTool(
+    'list_components',
+    {description: 'List all of the components available from Primer React', annotations: {readOnlyHint: true}},
+    async () => {
+      const components = listComponents().map(component => {
+        return `- ${component.name}`
+      })
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `The following components are available in the @primer/react in TypeScript projects:
 
 ${components.join('\n')}
 
 Use \`get_component\` for exactly one component and \`get_component_batch\` for 2 to 10 components. You can use these components from the @primer/react package.`,
-        },
-      ],
-    }
-  },
-)
-
-server.registerTool(
-  'get_component',
-  {
-    description:
-      'Retrieve official documentation and usage details for exactly one React component from the @primer/react package. Use get_component_batch for 2 to 10 components.',
-    inputSchema: {
-      name: z.string().describe('The name of the component to retrieve'),
+          },
+        ],
+      }
     },
-    annotations: {readOnlyHint: true},
-  },
-  async ({name}) => {
-    const components = listComponents()
-    const match = components.find(component => {
-      return component.name === name || component.name.toLowerCase() === name.toLowerCase()
-    })
-    if (!match) {
+  )
+
+  server.registerTool(
+    'get_component',
+    {
+      description:
+        'Retrieve official documentation and usage details for exactly one React component from the @primer/react package. Use get_component_batch for 2 to 10 components.',
+      inputSchema: z.object({
+        name: z.string().describe('The name of the component to retrieve'),
+      }),
+      annotations: {readOnlyHint: true},
+    },
+    async ({name}) => {
+      const components = listComponents()
+      const match = components.find(component => {
+        return component.name === name || component.name.toLowerCase() === name.toLowerCase()
+      })
+      if (!match) {
+        return {
+          isError: true,
+          errorMessage: `There is no component named \`${name}\` in the @primer/react package. For a full list of components, use the \`list_components\` tool.`,
+          content: [],
+        }
+      }
+      try {
+        const llmsUrl = new URL(`/product/components/${match.slug}/llms.txt`, 'https://primer.style')
+        const llmsResponse = await fetch(llmsUrl)
+        if (llmsResponse.ok) {
+          const llmsText = await llmsResponse.text()
+          return {
+            content: [
+              {
+                type: 'text',
+                text: llmsText,
+              },
+            ],
+          }
+        }
+      } catch (_: unknown) {
+        // If there's an error fetching or processing the llms.txt, we fall back to a generic error message.
+      }
+
       return {
         isError: true,
-        errorMessage: `There is no component named \`${name}\` in the @primer/react package. For a full list of components, use the \`list_components\` tool.`,
+        errorMessage: `There was an error fetching documentation for ${name}. Ensure the component exists.`,
         content: [],
       }
-    }
-    try {
-      const llmsUrl = new URL(`/product/components/${match.slug}/llms.txt`, 'https://primer.style')
-      const llmsResponse = await fetch(llmsUrl)
-      if (llmsResponse.ok) {
-        const llmsText = await llmsResponse.text()
-        return {
-          content: [
-            {
-              type: 'text',
-              text: llmsText,
-            },
-          ],
-        }
-      }
-    } catch (_: unknown) {
-      // If there's an error fetching or processing the llms.txt, we fall back to a generic error message.
-    }
-
-    return {
-      isError: true,
-      errorMessage: `There was an error fetching documentation for ${name}. Ensure the component exists.`,
-      content: [],
-    }
-  },
-)
-
-server.registerTool(
-  'get_component_batch',
-  {
-    description:
-      'Retrieve official documentation and usage details for 2 to 10 React components from the @primer/react package in one call. Use get_component for exactly one component.',
-    inputSchema: {
-      names: z
-        .array(z.string())
-        .min(2)
-        .max(10)
-        .describe('Component names to retrieve (e.g. ["ActionMenu", "Button", "Pagination"])'),
     },
-    annotations: {readOnlyHint: true},
-  },
-  async ({names}) => {
-    const seenNames = new Set<string>()
-    const deduped = names.filter(name => {
-      const normalizedName = name.toLowerCase()
-      if (seenNames.has(normalizedName)) {
-        return false
-      }
-      seenNames.add(normalizedName)
-      return true
-    })
-    const components = listComponents()
+  )
 
-    const results = await Promise.all(
-      deduped.map(async name => {
-        const match = components.find(
-          component => component.name === name || component.name.toLowerCase() === name.toLowerCase(),
-        )
-        if (!match) {
+  server.registerTool(
+    'get_component_batch',
+    {
+      description:
+        'Retrieve official documentation and usage details for 2 to 10 React components from the @primer/react package in one call. Use get_component for exactly one component.',
+      inputSchema: z.object({
+        names: z
+          .array(z.string())
+          .min(2)
+          .max(10)
+          .describe('Component names to retrieve (e.g. ["ActionMenu", "Button", "Pagination"])'),
+      }),
+      annotations: {readOnlyHint: true},
+    },
+    async ({names}) => {
+      const seenNames = new Set<string>()
+      const deduped = names.filter(name => {
+        const normalizedName = name.toLowerCase()
+        if (seenNames.has(normalizedName)) {
+          return false
+        }
+        seenNames.add(normalizedName)
+        return true
+      })
+      const components = listComponents()
+
+      const results = await Promise.all(
+        deduped.map(async name => {
+          const match = components.find(
+            component => component.name === name || component.name.toLowerCase() === name.toLowerCase(),
+          )
+          if (!match) {
+            return {
+              type: 'text' as const,
+              text: `## ${name}\n\nStatus: not-found. No component named \`${name}\` exists in @primer/react. Use \`list_components\` for valid names.`,
+            }
+          }
+
+          const controller = new AbortController()
+          const timeout = setTimeout(() => controller.abort(), 10_000)
+
+          try {
+            const llmsUrl = new URL(`/product/components/${match.slug}/llms.txt`, 'https://primer.style')
+            const llmsResponse = await fetch(llmsUrl, {signal: controller.signal})
+            if (llmsResponse.ok) {
+              const text = await llmsResponse.text()
+              return {type: 'text' as const, text}
+            }
+          } catch (_: unknown) {
+            // Fall through to the in-band error result so other component requests can succeed.
+          } finally {
+            clearTimeout(timeout)
+          }
+
           return {
             type: 'text' as const,
-            text: `## ${name}\n\nStatus: not-found. No component named \`${name}\` exists in @primer/react. Use \`list_components\` for valid names.`,
+            text: `## ${match.name}\n\nStatus: fetch-error. Failed to load documentation for ${match.name}.`,
           }
-        }
+        }),
+      )
 
-        const controller = new AbortController()
-        const timeout = setTimeout(() => controller.abort(), 10_000)
+      return {content: results}
+    },
+  )
 
-        try {
-          const llmsUrl = new URL(`/product/components/${match.slug}/llms.txt`, 'https://primer.style')
-          const llmsResponse = await fetch(llmsUrl, {signal: controller.signal})
-          if (llmsResponse.ok) {
-            const text = await llmsResponse.text()
-            return {type: 'text' as const, text}
-          }
-        } catch (_: unknown) {
-          // Fall through to the in-band error result so other component requests can succeed.
-        } finally {
-          clearTimeout(timeout)
-        }
-
-        return {
-          type: 'text' as const,
-          text: `## ${match.name}\n\nStatus: fetch-error. Failed to load documentation for ${match.name}.`,
-        }
+  server.registerTool(
+    'get_component_examples',
+    {
+      description: 'Get examples for how to use a component from Primer React',
+      inputSchema: z.object({
+        name: z.string().describe('The name of the component to retrieve'),
       }),
-    )
-
-    return {content: results}
-  },
-)
-
-server.registerTool(
-  'get_component_examples',
-  {
-    description: 'Get examples for how to use a component from Primer React',
-    inputSchema: {
-      name: z.string().describe('The name of the component to retrieve'),
+      annotations: {readOnlyHint: true},
     },
-    annotations: {readOnlyHint: true},
-  },
-  async ({name}) => {
-    const components = listComponents()
-    const match = components.find(component => {
-      return component.name === name
-    })
-    if (!match) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `There is no component named \`${name}\` in the @primer/react package. For a full list of components, use the \`get_components\` tool.`,
-          },
-        ],
-      }
-    }
-
-    const url = new URL(`/product/components/${match.id}`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
-      }
-    }
-
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
-    }
-
-    const text = turndownService.turndown(source)
-
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Here are some examples of how to use the \`${name}\` component from the @primer/react package:
-
-${text}`,
-        },
-      ],
-    }
-  },
-)
-
-server.registerTool(
-  'get_component_usage_guidelines',
-  {
-    description: 'Get usage information for how to use a component from Primer',
-    inputSchema: {
-      name: z.string().describe('The name of the component to retrieve'),
-    },
-    annotations: {readOnlyHint: true},
-  },
-  async ({name}) => {
-    const components = listComponents()
-    const match = components.find(component => {
-      return component.name === name
-    })
-    if (!match) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `There is no component named \`${name}\` in the @primer/react package. For a full list of components, use the \`get_components\` tool.`,
-          },
-        ],
-      }
-    }
-
-    const url = new URL(`/product/components/${match.id}/guidelines`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      if ((response.status >= 400 && response.status < 500) || (response.status >= 300 && response.status < 400)) {
+    async ({name}) => {
+      const components = listComponents()
+      const match = components.find(component => {
+        return component.name === name
+      })
+      if (!match) {
         return {
           content: [
             {
               type: 'text',
-              text: `There are no accessibility guidelines for the \`${name}\` component in the @primer/react package.`,
+              text: `There is no component named \`${name}\` in the @primer/react package. For a full list of components, use the \`get_components\` tool.`,
             },
           ],
         }
       }
 
-      throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
+      const url = new URL(`/product/components/${match.id}`, 'https://primer.style')
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
       }
-    }
 
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
+      const html = await response.text()
+      if (!html) {
+        return {
+          content: [],
+        }
       }
-    }
 
-    const text = turndownService.turndown(source)
+      const $ = cheerio.load(html)
+      const source = $('main').html()
+      if (!source) {
+        return {
+          content: [],
+        }
+      }
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Here are the usage guidelines for the \`${name}\` component from the @primer/react package:
+      const text = turndownService.turndown(source)
 
-${text}`,
-        },
-      ],
-    }
-  },
-)
-
-server.registerTool(
-  'get_component_accessibility_guidelines',
-  {
-    description:
-      'Retrieve accessibility guidelines and best practices for a specific component from the @primer/react package by its name. Use this tool to get official accessibility recommendations, usage tips, and requirements to ensure your UI components are inclusive and meet accessibility standards.',
-    inputSchema: {
-      name: z.string().describe('The name of the component to retrieve'),
-    },
-    annotations: {readOnlyHint: true},
-  },
-  async ({name}) => {
-    const components = listComponents()
-    const match = components.find(component => {
-      return component.name === name
-    })
-    if (!match) {
       return {
         content: [
           {
             type: 'text',
-            text: `There is no component named \`${name}\` in the @primer/react package. For a full list of components, use the \`list_components\` tool.`,
+            text: `Here are some examples of how to use the \`${name}\` component from the @primer/react package:
+
+${text}`,
           },
         ],
       }
-    }
+    },
+  )
 
-    const url = new URL(`/product/components/${match.id}/accessibility`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      if ((response.status >= 400 && response.status < 500) || (response.status >= 300 && response.status < 400)) {
+  server.registerTool(
+    'get_component_usage_guidelines',
+    {
+      description: 'Get usage information for how to use a component from Primer',
+      inputSchema: z.object({
+        name: z.string().describe('The name of the component to retrieve'),
+      }),
+      annotations: {readOnlyHint: true},
+    },
+    async ({name}) => {
+      const components = listComponents()
+      const match = components.find(component => {
+        return component.name === name
+      })
+      if (!match) {
         return {
           content: [
             {
               type: 'text',
-              text: `There are no accessibility guidelines for the \`${name}\` component in the @primer/react package.`,
+              text: `There is no component named \`${name}\` in the @primer/react package. For a full list of components, use the \`get_components\` tool.`,
             },
           ],
         }
       }
 
-      throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
-    }
+      const url = new URL(`/product/components/${match.id}/guidelines`, 'https://primer.style')
+      const response = await fetch(url)
+      if (!response.ok) {
+        if ((response.status >= 400 && response.status < 500) || (response.status >= 300 && response.status < 400)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `There are no accessibility guidelines for the \`${name}\` component in the @primer/react package.`,
+              },
+            ],
+          }
+        }
 
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
       }
-    }
 
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
+      const html = await response.text()
+      if (!html) {
+        return {
+          content: [],
+        }
       }
-    }
 
-    const text = turndownService.turndown(source)
+      const $ = cheerio.load(html)
+      const source = $('main').html()
+      if (!source) {
+        return {
+          content: [],
+        }
+      }
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Here are the accessibility guidelines for the \`${name}\` component from the @primer/react package:
+      const text = turndownService.turndown(source)
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Here are the usage guidelines for the \`${name}\` component from the @primer/react package:
 
 ${text}`,
-        },
-      ],
-    }
-  },
-)
+          },
+        ],
+      }
+    },
+  )
 
-// -----------------------------------------------------------------------------
-// Patterns
-// -----------------------------------------------------------------------------
-server.registerTool(
-  'list_patterns',
-  {
-    description:
-      'List all of the patterns available from Primer React. Scenario patterns describe specific user tasks (copy, delete, filter, search). Prefer a scenario pattern when one fits the task, and fall back to the more generic UI patterns otherwise.',
-    annotations: {readOnlyHint: true},
-  },
-  async () => {
-    const all = listPatterns()
-    const scenario = all.filter(pattern => pattern.category === 'scenario').map(pattern => `- ${pattern.name}`)
-    const ui = all.filter(pattern => pattern.category === 'ui').map(pattern => `- ${pattern.name}`)
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `The following patterns are available from \`@primer/react\` for use in TypeScript projects. Scenario patterns describe specific user tasks. Prefer a scenario pattern when one fits the task, and fall back to the UI patterns otherwise.
+  server.registerTool(
+    'get_component_accessibility_guidelines',
+    {
+      description:
+        'Retrieve accessibility guidelines and best practices for a specific component from the @primer/react package by its name. Use this tool to get official accessibility recommendations, usage tips, and requirements to ensure your UI components are inclusive and meet accessibility standards.',
+      inputSchema: z.object({
+        name: z.string().describe('The name of the component to retrieve'),
+      }),
+      annotations: {readOnlyHint: true},
+    },
+    async ({name}) => {
+      const components = listComponents()
+      const match = components.find(component => {
+        return component.name === name
+      })
+      if (!match) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `There is no component named \`${name}\` in the @primer/react package. For a full list of components, use the \`list_components\` tool.`,
+            },
+          ],
+        }
+      }
+
+      const url = new URL(`/product/components/${match.id}/accessibility`, 'https://primer.style')
+      const response = await fetch(url)
+      if (!response.ok) {
+        if ((response.status >= 400 && response.status < 500) || (response.status >= 300 && response.status < 400)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `There are no accessibility guidelines for the \`${name}\` component in the @primer/react package.`,
+              },
+            ],
+          }
+        }
+
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
+      }
+
+      const html = await response.text()
+      if (!html) {
+        return {
+          content: [],
+        }
+      }
+
+      const $ = cheerio.load(html)
+      const source = $('main').html()
+      if (!source) {
+        return {
+          content: [],
+        }
+      }
+
+      const text = turndownService.turndown(source)
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Here are the accessibility guidelines for the \`${name}\` component from the @primer/react package:
+
+${text}`,
+          },
+        ],
+      }
+    },
+  )
+
+  // -----------------------------------------------------------------------------
+  // Patterns
+  // -----------------------------------------------------------------------------
+  server.registerTool(
+    'list_patterns',
+    {
+      description:
+        'List all of the patterns available from Primer React. Scenario patterns describe specific user tasks (copy, delete, filter, search). Prefer a scenario pattern when one fits the task, and fall back to the more generic UI patterns otherwise.',
+      annotations: {readOnlyHint: true},
+    },
+    async () => {
+      const all = listPatterns()
+      const scenario = all.filter(pattern => pattern.category === 'scenario').map(pattern => `- ${pattern.name}`)
+      const ui = all.filter(pattern => pattern.category === 'ui').map(pattern => `- ${pattern.name}`)
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `The following patterns are available from \`@primer/react\` for use in TypeScript projects. Scenario patterns describe specific user tasks. Prefer a scenario pattern when one fits the task, and fall back to the UI patterns otherwise.
 
 ## Scenario patterns
 
@@ -459,155 +461,155 @@ ${scenario.join('\n')}
 ## UI patterns
 
 ${ui.join('\n')}`,
-        },
-      ],
-    }
-  },
-)
-
-server.registerTool(
-  'get_pattern',
-  {
-    description:
-      'Get a specific pattern by name. Scenario patterns describe specific user tasks (copy, delete, filter, search). Prefer a scenario pattern when one fits the task, and fall back to the more generic UI patterns otherwise.',
-    inputSchema: {
-      name: z.string().describe('The name of the pattern to retrieve'),
+          },
+        ],
+      }
     },
-    annotations: {readOnlyHint: true},
-  },
-  async ({name}) => {
-    const patterns = listPatterns()
-    // Resolve scenario patterns first so a name clash favours the scenario pattern.
-    const match =
-      patterns.find(pattern => pattern.category === 'scenario' && pattern.name === name) ??
-      patterns.find(pattern => pattern.name === name)
-    if (!match) {
+  )
+
+  server.registerTool(
+    'get_pattern',
+    {
+      description:
+        'Get a specific pattern by name. Scenario patterns describe specific user tasks (copy, delete, filter, search). Prefer a scenario pattern when one fits the task, and fall back to the more generic UI patterns otherwise.',
+      inputSchema: z.object({
+        name: z.string().describe('The name of the pattern to retrieve'),
+      }),
+      annotations: {readOnlyHint: true},
+    },
+    async ({name}) => {
+      const patterns = listPatterns()
+      // Resolve scenario patterns first so a name clash favours the scenario pattern.
+      const match =
+        patterns.find(pattern => pattern.category === 'scenario' && pattern.name === name) ??
+        patterns.find(pattern => pattern.name === name)
+      if (!match) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `There is no pattern named \`${name}\` in the @primer/react package. For a full list of patterns, use the \`list_patterns\` tool.`,
+            },
+          ],
+        }
+      }
+
+      const basePath = match.category === 'scenario' ? 'scenario-patterns' : 'ui-patterns'
+      const url = new URL(`/product/${basePath}/${match.id}`, 'https://primer.style')
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
+      }
+
+      const html = await response.text()
+      if (!html) {
+        return {
+          content: [],
+        }
+      }
+
+      const $ = cheerio.load(html)
+      const source = $('main').html()
+      if (!source) {
+        return {
+          content: [],
+        }
+      }
+
+      const text = turndownService.turndown(source)
+
       return {
         content: [
           {
             type: 'text',
-            text: `There is no pattern named \`${name}\` in the @primer/react package. For a full list of patterns, use the \`list_patterns\` tool.`,
-          },
-        ],
-      }
-    }
-
-    const basePath = match.category === 'scenario' ? 'scenario-patterns' : 'ui-patterns'
-    const url = new URL(`/product/${basePath}/${match.id}`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
-      }
-    }
-
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
-    }
-
-    const text = turndownService.turndown(source)
-
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Here are the guidelines for the \`${name}\` pattern for Primer:
+            text: `Here are the guidelines for the \`${name}\` pattern for Primer:
 
 ${text}`,
-        },
-      ],
-    }
-  },
-)
-
-// -----------------------------------------------------------------------------
-// Design Tokens
-// -----------------------------------------------------------------------------
-server.registerTool(
-  'find_tokens',
-  {
-    description:
-      'Search for specific tokens. Tip: If you only provide a \'group\' and leave \'query\' empty, it returns all tokens in that category. Avoid property-by-property searching. COLOR RESOLUTION: If a user asks for "pink" or "blue", do not search for the color name. Use the semantic intent: blue->accent, red->danger, green->success. Always check both "emphasis" and "muted" variants for background colors. After identifying tokens and writing CSS, you MUST validate the result using lint_css.',
-    inputSchema: {
-      query: z
-        .string()
-        .optional()
-        .default('')
-        .describe('Search keywords (e.g., "danger border", "success background")'),
-      group: z.string().optional().describe('Filter by group (e.g., "fgColor", "border")'),
-      limit: z
-        .number()
-        .int()
-        .min(1)
-        .max(100)
-        .optional()
-        .default(15)
-        .describe('Maximum results to return to stay within context limits'),
-    },
-    annotations: {readOnlyHint: true},
-  },
-  async ({query, group, limit}) => {
-    // Resolve group via aliases
-    const resolvedGroup = group ? GROUP_ALIASES[group.toLowerCase().replace(/\s+/g, '')] || group : undefined
-
-    // Split query into keywords and extract any that match a known group
-    const rawKeywords = query
-      .toLowerCase()
-      .split(/\s+/)
-      .filter(k => k.length > 0)
-
-    let effectiveGroup = resolvedGroup
-    const filteredKeywords: string[] = []
-
-    for (const kw of rawKeywords) {
-      const normalized = kw.replace(/\s+/g, '')
-      const aliasMatch = GROUP_ALIASES[normalized]
-      if (aliasMatch && !effectiveGroup) {
-        effectiveGroup = aliasMatch
-      } else {
-        filteredKeywords.push(kw)
-      }
-    }
-
-    // Guard: no query and no group → ask user to provide at least one
-    if (filteredKeywords.length === 0 && !effectiveGroup) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: 'Please provide a query, a group, or both. Call `get_design_token_specs` to see available token groups.',
           },
         ],
       }
-    }
+    },
+  )
 
-    // Group-only search: return all tokens in the group
-    const isGroupOnly = filteredKeywords.length === 0 && effectiveGroup
-    let results: TokenWithGuidelines[]
+  // -----------------------------------------------------------------------------
+  // Design Tokens
+  // -----------------------------------------------------------------------------
+  server.registerTool(
+    'find_tokens',
+    {
+      description:
+        'Search for specific tokens. Tip: If you only provide a \'group\' and leave \'query\' empty, it returns all tokens in that category. Avoid property-by-property searching. COLOR RESOLUTION: If a user asks for "pink" or "blue", do not search for the color name. Use the semantic intent: blue->accent, red->danger, green->success. Always check both "emphasis" and "muted" variants for background colors. After identifying tokens and writing CSS, you MUST validate the result using lint_css.',
+      inputSchema: z.object({
+        query: z
+          .string()
+          .optional()
+          .default('')
+          .describe('Search keywords (e.g., "danger border", "success background")'),
+        group: z.string().optional().describe('Filter by group (e.g., "fgColor", "border")'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .default(15)
+          .describe('Maximum results to return to stay within context limits'),
+      }),
+      annotations: {readOnlyHint: true},
+    },
+    async ({query, group, limit}) => {
+      // Resolve group via aliases
+      const resolvedGroup = group ? GROUP_ALIASES[group.toLowerCase().replace(/\s+/g, '')] || group : undefined
 
-    if (isGroupOnly) {
-      results = allTokensWithGuidelines.filter(token => tokenMatchesGroup(token, effectiveGroup!))
-    } else {
-      results = searchTokens(allTokensWithGuidelines, filteredKeywords.join(' '), effectiveGroup)
-    }
+      // Split query into keywords and extract any that match a known group
+      const rawKeywords = query
+        .toLowerCase()
+        .split(/\s+/)
+        .filter(k => k.length > 0)
 
-    if (results.length === 0) {
-      const validGroups = getValidGroupsList(allTokensWithGuidelines)
+      let effectiveGroup = resolvedGroup
+      const filteredKeywords: string[] = []
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `No tokens found matching "${query}"${effectiveGroup ? ` in group "${effectiveGroup}"` : ''}. 
+      for (const kw of rawKeywords) {
+        const normalized = kw.replace(/\s+/g, '')
+        const aliasMatch = GROUP_ALIASES[normalized]
+        if (aliasMatch && !effectiveGroup) {
+          effectiveGroup = aliasMatch
+        } else {
+          filteredKeywords.push(kw)
+        }
+      }
+
+      // Guard: no query and no group → ask user to provide at least one
+      if (filteredKeywords.length === 0 && !effectiveGroup) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Please provide a query, a group, or both. Call `get_design_token_specs` to see available token groups.',
+            },
+          ],
+        }
+      }
+
+      // Group-only search: return all tokens in the group
+      const isGroupOnly = filteredKeywords.length === 0 && effectiveGroup
+      let results: TokenWithGuidelines[]
+
+      if (isGroupOnly) {
+        results = allTokensWithGuidelines.filter(token => tokenMatchesGroup(token, effectiveGroup!))
+      } else {
+        results = searchTokens(allTokensWithGuidelines, filteredKeywords.join(' '), effectiveGroup)
+      }
+
+      if (results.length === 0) {
+        const validGroups = getValidGroupsList(allTokensWithGuidelines)
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `No tokens found matching "${query}"${effectiveGroup ? ` in group "${effectiveGroup}"` : ''}.
 
 ### 💡 Available Groups:
 ${validGroups}
@@ -617,360 +619,360 @@ ${validGroups}
 2. **Property Mismatch**: Do not search for CSS properties like "offset", "padding", or "font-size". Use semantic intent keywords: "danger", "muted", "emphasis".
 3. **Typography**: Remember that \`caption\`, \`display\`, and \`code\` groups do NOT support size suffixes. Use the base shorthand only.
 4. **Group Intent**: Use the \`group\` parameter instead of putting group names in the \`query\` string (e.g., use group: "stack" instead of query: "stack padding").`,
-          },
-        ],
+            },
+          ],
+        }
       }
-    }
 
-    const limitedResults = results.slice(0, limit)
+      const limitedResults = results.slice(0, limit)
 
-    let output: string
+      let output: string
 
-    if (!query) {
-      output = `Found ${results.length} token(s). Showing top ${limitedResults.length}:\n\n`
-    } else {
-      output = `Found ${results.length} token(s) matching "${query}". Showing top ${limitedResults.length}:\n\n`
-    }
-    output += formatBundle(limitedResults)
-
-    if (results.length > limit) {
-      output += `\n\n*...and ${results.length - limit} more matches. Use more specific keywords to narrow the search.*`
-    }
-
-    return {
-      content: [{type: 'text', text: output}],
-    }
-  },
-)
-
-server.registerTool(
-  'get_token_group_bundle',
-  {
-    description:
-      "PREFERRED FOR COMPONENTS. Fetch all tokens for complex UI (e.g., Dialogs, Cards) in one call by providing an array of groups like ['overlay', 'shadow']. Use this instead of multiple find_tokens calls to save context.",
-    inputSchema: {
-      groups: z.array(z.string()).describe('Array of group names (e.g., ["overlay", "shadow", "focus"])'),
-    },
-    annotations: {readOnlyHint: true},
-  },
-  async ({groups}) => {
-    // Normalize and resolve aliases
-    const resolvedGroups = groups.map(g => {
-      const normalized = g.toLowerCase().replace(/\s+/g, '')
-      return GROUP_ALIASES[normalized] || g
-    })
-
-    // Filter tokens matching any of the resolved groups
-    const matched = allTokensWithGuidelines.filter(token => resolvedGroups.some(rg => tokenMatchesGroup(token, rg)))
-
-    if (matched.length === 0) {
-      const validGroups = getValidGroupsList(allTokensWithGuidelines)
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `No tokens found for groups: ${groups.join(', ')}.\n\n### Valid Groups:\n${validGroups}`,
-          },
-        ],
-      }
-    }
-
-    let text = `Found ${matched.length} token(s) across ${resolvedGroups.length} group(s):\n\n${formatBundle(matched)}`
-
-    const activeHints = resolvedGroups.map(g => groupHints[g]).filter(Boolean)
-
-    if (activeHints.length > 0) {
-      text += `\n\n### ⚠️ Usage Guidance:\n${activeHints.map(h => `- ${h}`).join('\n')}`
-    }
-
-    return {
-      content: [{type: 'text', text}],
-    }
-  },
-)
-
-server.registerTool(
-  'get_design_token_specs',
-  {
-    description:
-      'CRITICAL: CALL THIS FIRST. Provides the logic matrix and the list of valid group names. You cannot search accurately without this map.',
-    annotations: {readOnlyHint: true},
-  },
-  async () => {
-    const groups = listTokenGroups()
-    const customRules = getDesignTokenSpecsText(groups)
-    let text: string
-    try {
-      const upstreamGuide = loadDesignTokensGuide()
-      text = `${customRules}\n\n---\n\n${upstreamGuide}`
-    } catch {
-      text = customRules
-    }
-
-    return {
-      content: [{type: 'text', text}],
-    }
-  },
-)
-
-server.registerTool(
-  'get_token_usage_patterns',
-  {
-    description:
-      'Provides "Golden Example" CSS for core patterns: Button (Interactions) and Stack (Layout). Use this to understand how to apply the Logic Matrix, Motion, and Spacing scales.',
-    annotations: {readOnlyHint: true},
-  },
-  async () => {
-    const customPatterns = getTokenUsagePatternsText()
-    let text: string
-    try {
-      const guide = loadDesignTokensGuide()
-      const goldenExampleMatch = guide.match(/## Golden Example[\s\S]*?(?=\n## |$)/)
-      if (goldenExampleMatch) {
-        text = `${customPatterns}\n\n---\n\n${goldenExampleMatch[0].trim()}`
+      if (!query) {
+        output = `Found ${results.length} token(s). Showing top ${limitedResults.length}:\n\n`
       } else {
+        output = `Found ${results.length} token(s) matching "${query}". Showing top ${limitedResults.length}:\n\n`
+      }
+      output += formatBundle(limitedResults)
+
+      if (results.length > limit) {
+        output += `\n\n*...and ${results.length - limit} more matches. Use more specific keywords to narrow the search.*`
+      }
+
+      return {
+        content: [{type: 'text', text: output}],
+      }
+    },
+  )
+
+  server.registerTool(
+    'get_token_group_bundle',
+    {
+      description:
+        "PREFERRED FOR COMPONENTS. Fetch all tokens for complex UI (e.g., Dialogs, Cards) in one call by providing an array of groups like ['overlay', 'shadow']. Use this instead of multiple find_tokens calls to save context.",
+      inputSchema: z.object({
+        groups: z.array(z.string()).describe('Array of group names (e.g., ["overlay", "shadow", "focus"])'),
+      }),
+      annotations: {readOnlyHint: true},
+    },
+    async ({groups}) => {
+      // Normalize and resolve aliases
+      const resolvedGroups = groups.map(g => {
+        const normalized = g.toLowerCase().replace(/\s+/g, '')
+        return GROUP_ALIASES[normalized] || g
+      })
+
+      // Filter tokens matching any of the resolved groups
+      const matched = allTokensWithGuidelines.filter(token => resolvedGroups.some(rg => tokenMatchesGroup(token, rg)))
+
+      if (matched.length === 0) {
+        const validGroups = getValidGroupsList(allTokensWithGuidelines)
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `No tokens found for groups: ${groups.join(', ')}.\n\n### Valid Groups:\n${validGroups}`,
+            },
+          ],
+        }
+      }
+
+      let text = `Found ${matched.length} token(s) across ${resolvedGroups.length} group(s):\n\n${formatBundle(matched)}`
+
+      const activeHints = resolvedGroups.map(g => groupHints[g]).filter(Boolean)
+
+      if (activeHints.length > 0) {
+        text += `\n\n### ⚠️ Usage Guidance:\n${activeHints.map(h => `- ${h}`).join('\n')}`
+      }
+
+      return {
+        content: [{type: 'text', text}],
+      }
+    },
+  )
+
+  server.registerTool(
+    'get_design_token_specs',
+    {
+      description:
+        'CRITICAL: CALL THIS FIRST. Provides the logic matrix and the list of valid group names. You cannot search accurately without this map.',
+      annotations: {readOnlyHint: true},
+    },
+    async () => {
+      const groups = listTokenGroups()
+      const customRules = getDesignTokenSpecsText(groups)
+      let text: string
+      try {
+        const upstreamGuide = loadDesignTokensGuide()
+        text = `${customRules}\n\n---\n\n${upstreamGuide}`
+      } catch {
+        text = customRules
+      }
+
+      return {
+        content: [{type: 'text', text}],
+      }
+    },
+  )
+
+  server.registerTool(
+    'get_token_usage_patterns',
+    {
+      description:
+        'Provides "Golden Example" CSS for core patterns: Button (Interactions) and Stack (Layout). Use this to understand how to apply the Logic Matrix, Motion, and Spacing scales.',
+      annotations: {readOnlyHint: true},
+    },
+    async () => {
+      const customPatterns = getTokenUsagePatternsText()
+      let text: string
+      try {
+        const guide = loadDesignTokensGuide()
+        const goldenExampleMatch = guide.match(/## Golden Example[\s\S]*?(?=\n## |$)/)
+        if (goldenExampleMatch) {
+          text = `${customPatterns}\n\n---\n\n${goldenExampleMatch[0].trim()}`
+        } else {
+          text = customPatterns
+        }
+      } catch {
         text = customPatterns
       }
-    } catch {
-      text = customPatterns
-    }
 
-    return {
-      content: [{type: 'text', text}],
-    }
-  },
-)
+      return {
+        content: [{type: 'text', text}],
+      }
+    },
+  )
 
-server.registerTool(
-  'lint_css',
-  {
-    description:
-      'REQUIRED FINAL STEP. Use this to validate your CSS. You cannot complete a task involving CSS without a successful run of this tool.',
-    inputSchema: {css: z.string()},
-    annotations: {readOnlyHint: true},
-  },
-  async ({css}) => {
-    try {
-      // --fix flag tells Stylelint to repair what it can
-      const {stdout} = await runStylelint(css)
+  server.registerTool(
+    'lint_css',
+    {
+      description:
+        'REQUIRED FINAL STEP. Use this to validate your CSS. You cannot complete a task involving CSS without a successful run of this tool.',
+      inputSchema: z.object({css: z.string()}),
+      annotations: {readOnlyHint: true},
+    },
+    async ({css}) => {
+      try {
+        // --fix flag tells Stylelint to repair what it can
+        const {stdout} = await runStylelint(css)
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: stdout || '✅ Stylelint passed (or was successfully autofixed).',
+            },
+          ],
+        }
+      } catch (error: unknown) {
+        // If Stylelint still has errors it CANNOT fix, it will land here
+        const errorOutput =
+          error instanceof Error && 'stdout' in error ? (error as Error & {stdout: string}).stdout : String(error)
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `❌ Errors without autofix remaining:\n${errorOutput}`,
+            },
+          ],
+        }
+      }
+    },
+  )
+
+  // -----------------------------------------------------------------------------
+  // Foundations
+  // -----------------------------------------------------------------------------
+  server.registerTool(
+    'get_color_usage',
+    {description: 'Get the guidelines for how to apply color to a user interface', annotations: {readOnlyHint: true}},
+    async () => {
+      const url = new URL(`/product/getting-started/foundations/color-usage`, 'https://primer.style')
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
+      }
+
+      const html = await response.text()
+      if (!html) {
+        return {
+          content: [],
+        }
+      }
+
+      const $ = cheerio.load(html)
+      const source = $('main').html()
+      if (!source) {
+        return {
+          content: [],
+        }
+      }
+
+      const text = turndownService.turndown(source)
 
       return {
         content: [
           {
             type: 'text',
-            text: stdout || '✅ Stylelint passed (or was successfully autofixed).',
+            text: `Here is the documentation for color usage in Primer:\n\n${text}`,
           },
         ],
       }
-    } catch (error: unknown) {
-      // If Stylelint still has errors it CANNOT fix, it will land here
-      const errorOutput =
-        error instanceof Error && 'stdout' in error ? (error as Error & {stdout: string}).stdout : String(error)
+    },
+  )
+
+  server.registerTool(
+    'get_typography_usage',
+    {
+      description: 'Get the guidelines for how to apply typography to a user interface',
+      annotations: {readOnlyHint: true},
+    },
+    async () => {
+      const url = new URL(`/product/getting-started/foundations/typography`, 'https://primer.style')
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
+      }
+
+      const html = await response.text()
+      if (!html) {
+        return {
+          content: [],
+        }
+      }
+
+      const $ = cheerio.load(html)
+      const source = $('main').html()
+      if (!source) {
+        return {
+          content: [],
+        }
+      }
+
+      const text = turndownService.turndown(source)
+
       return {
         content: [
           {
             type: 'text',
-            text: `❌ Errors without autofix remaining:\n${errorOutput}`,
+            text: `Here is the documentation for typography usage in Primer:\n\n${text}`,
           },
         ],
       }
-    }
-  },
-)
+    },
+  )
 
-// -----------------------------------------------------------------------------
-// Foundations
-// -----------------------------------------------------------------------------
-server.registerTool(
-  'get_color_usage',
-  {description: 'Get the guidelines for how to apply color to a user interface', annotations: {readOnlyHint: true}},
-  async () => {
-    const url = new URL(`/product/getting-started/foundations/color-usage`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
-      }
-    }
-
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
-    }
-
-    const text = turndownService.turndown(source)
-
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Here is the documentation for color usage in Primer:\n\n${text}`,
-        },
-      ],
-    }
-  },
-)
-
-server.registerTool(
-  'get_typography_usage',
-  {
-    description: 'Get the guidelines for how to apply typography to a user interface',
-    annotations: {readOnlyHint: true},
-  },
-  async () => {
-    const url = new URL(`/product/getting-started/foundations/typography`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${url} - ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (!html) {
-      return {
-        content: [],
-      }
-    }
-
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
-    }
-
-    const text = turndownService.turndown(source)
-
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Here is the documentation for typography usage in Primer:\n\n${text}`,
-        },
-      ],
-    }
-  },
-)
-
-// -----------------------------------------------------------------------------
-// Icons
-// -----------------------------------------------------------------------------
-server.registerTool(
-  'list_icons',
-  {
-    description: 'List all of the icons (octicons) available from Primer Octicons React',
-    annotations: {readOnlyHint: true},
-  },
-  async () => {
-    const icons = listIcons().map(icon => {
-      const keywords = icon.keywords.map(keyword => {
-        return `<keyword>${keyword}</keyword>`
+  // -----------------------------------------------------------------------------
+  // Icons
+  // -----------------------------------------------------------------------------
+  server.registerTool(
+    'list_icons',
+    {
+      description: 'List all of the icons (octicons) available from Primer Octicons React',
+      annotations: {readOnlyHint: true},
+    },
+    async () => {
+      const icons = listIcons().map(icon => {
+        const keywords = icon.keywords.map(keyword => {
+          return `<keyword>${keyword}</keyword>`
+        })
+        const sizes = icon.heights.map(height => {
+          return `<size value="${height}"></size>`
+        })
+        return [`<icon name="${icon.name}">`, ...keywords, ...sizes, `</icon>`].join('\n')
       })
-      const sizes = icon.heights.map(height => {
-        return `<size value="${height}"></size>`
-      })
-      return [`<icon name="${icon.name}">`, ...keywords, ...sizes, `</icon>`].join('\n')
-    })
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `The following icons are available in the @primer/octicons-react package in TypeScript projects:
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `The following icons are available in the @primer/octicons-react package in TypeScript projects:
 
 ${icons.join('\n')}
 
 You can use the \`get_icon\` tool to get more information about a specific icon. You can use these components from the @primer/octicons-react package.`,
-        },
-      ],
-    }
-  },
-)
-
-server.registerTool(
-  'get_icon',
-  {
-    description: 'Get a specific icon (octicon) by name from Primer',
-    inputSchema: {
-      name: z.string().describe('The name of the icon to retrieve'),
-      size: z.string().optional().describe('The size of the icon to retrieve, e.g. "16"').default('16'),
+          },
+        ],
+      }
     },
-    annotations: {readOnlyHint: true},
-  },
-  async ({name, size}) => {
-    const icons = listIcons()
-    const match = icons.find(icon => {
-      return icon.name === name || icon.name.toLowerCase() === name.toLowerCase()
-    })
-    if (!match) {
+  )
+
+  server.registerTool(
+    'get_icon',
+    {
+      description: 'Get a specific icon (octicon) by name from Primer',
+      inputSchema: z.object({
+        name: z.string().describe('The name of the icon to retrieve'),
+        size: z.string().optional().describe('The size of the icon to retrieve, e.g. "16"').default('16'),
+      }),
+      annotations: {readOnlyHint: true},
+    },
+    async ({name, size}) => {
+      const icons = listIcons()
+      const match = icons.find(icon => {
+        return icon.name === name || icon.name.toLowerCase() === name.toLowerCase()
+      })
+      if (!match) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `There is no icon named \`${name}\` in the @primer/octicons-react package. For a full list of icons, use the \`get_icon\` tool.`,
+            },
+          ],
+        }
+      }
+
+      const url = new URL(`/octicons/icon/${match.name}-${size}`, 'https://primer.style')
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
+      }
+
+      const html = await response.text()
+      if (!html) {
+        return {
+          content: [],
+        }
+      }
+
+      const $ = cheerio.load(html)
+      const source = $('main').html()
+      if (!source) {
+        return {
+          content: [],
+        }
+      }
+
+      const text = turndownService.turndown(source)
+
       return {
         content: [
           {
             type: 'text',
-            text: `There is no icon named \`${name}\` in the @primer/octicons-react package. For a full list of icons, use the \`get_icon\` tool.`,
+            text: `Here is the documentation for the \`${name}\` icon at size: \`${size}\`:
+${text}`,
           },
         ],
       }
-    }
+    },
+  )
 
-    const url = new URL(`/octicons/icon/${match.name}-${size}`, 'https://primer.style')
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (!html) {
+  // -----------------------------------------------------------------------------
+  // Coding guidelines
+  // -----------------------------------------------------------------------------
+  server.registerTool(
+    'primer_coding_guidelines',
+    {
+      description: 'Get the guidelines when writing code that uses Primer or for UI code that you are creating',
+      annotations: {readOnlyHint: true},
+    },
+    async () => {
       return {
-        content: [],
-      }
-    }
-
-    const $ = cheerio.load(html)
-    const source = $('main').html()
-    if (!source) {
-      return {
-        content: [],
-      }
-    }
-
-    const text = turndownService.turndown(source)
-
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Here is the documentation for the \`${name}\` icon at size: \`${size}\`:
-${text}`,
-        },
-      ],
-    }
-  },
-)
-
-// -----------------------------------------------------------------------------
-// Coding guidelines
-// -----------------------------------------------------------------------------
-server.registerTool(
-  'primer_coding_guidelines',
-  {
-    description: 'Get the guidelines when writing code that uses Primer or for UI code that you are creating',
-    annotations: {readOnlyHint: true},
-  },
-  async () => {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `When writing code that uses Primer, follow these guidelines:
+        content: [
+          {
+            type: 'text',
+            text: `When writing code that uses Primer, follow these guidelines:
 
 ## Design Tokens
 
@@ -992,64 +994,82 @@ The following list of coding guidelines must be followed:
 - Do not use the sx prop for styling components. Instead, use CSS Modules.
 - Do not use the Box component for styling components. Instead, use CSS Modules.
 `,
-        },
-      ],
-    }
-  },
-)
-
-// -----------------------------------------------------------------------------
-// Accessibility
-// -----------------------------------------------------------------------------
-
-/**
- * The `review_alt_text` tool is experimental and may be removed in future versions.
- *
- * The intent of this tool is to assist products like Copilot Code Review and Copilot Coding Agent
- * in reviewing both user- and AI-generated alt text for images, ensuring compliance with accessibility guidelines.
- * This tool is not intended to replace human-generated alt text; rather, it supports the review process
- * by providing suggestions for improvement. It should be used alongside human review, not as a substitute.
- *
- *
- **/
-server.registerTool(
-  'review_alt_text',
-  {
-    description: 'Evaluates image alt text against accessibility best practices and context relevance.',
-    inputSchema: {
-      surroundingText: z.string().describe('Text surrounding the image, relevant to the image.'),
-      alt: z.string().describe('The alt text of the image being evaluated'),
-      image: z.string().describe('The image URL or file path being evaluated'),
-    },
-    annotations: {readOnlyHint: true},
-  },
-  async ({surroundingText, alt, image}) => {
-    // Call the LLM through MCP sampling
-    const response = await server.server.createMessage({
-      messages: [
-        {
-          role: 'user',
-          content: {
-            type: 'text',
-            text: `Does this alt text: '${alt}' meet accessibility guidelines and describe the image: ${image} accurately in context of this surrounding text: '${surroundingText}'?\n\n`,
           },
-        },
-      ],
-      temperature: 0.4,
-      maxTokens: 500,
-    })
+        ],
+      }
+    },
+  )
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: response.content.type === 'text' ? response.content.text : 'Unable to generate summary',
-        },
-      ],
-      altTextEvaluation: response.content.type === 'text' ? response.content.text : 'Unable to generate summary',
-      nextSteps: `If the evaluation indicates issues with the alt text, provide more meaningful alt text based on the feedback. DO NOT run this tool repeatedly on the same image - evaluations may vary slightly with each run.`,
-    }
-  },
-)
+  // -----------------------------------------------------------------------------
+  // Accessibility
+  // -----------------------------------------------------------------------------
 
-export {server}
+  /**
+   * The `review_alt_text` tool is experimental and may be removed in future versions.
+   *
+   * The intent of this tool is to assist products like Copilot Code Review and Copilot Coding Agent
+   * in reviewing both user- and AI-generated alt text for images, ensuring compliance with accessibility guidelines.
+   * This tool is not intended to replace human-generated alt text; rather, it supports the review process
+   * by providing suggestions for improvement. It should be used alongside human review, not as a substitute.
+   *
+   *
+   **/
+  server.registerTool(
+    'review_alt_text',
+    {
+      description: 'Evaluates image alt text against accessibility best practices and context relevance.',
+      inputSchema: z.object({
+        surroundingText: z.string().describe('Text surrounding the image, relevant to the image.'),
+        alt: z.string().describe('The alt text of the image being evaluated'),
+        image: z.string().describe('The image URL or file path being evaluated'),
+      }),
+      annotations: {readOnlyHint: true},
+    },
+    async ({surroundingText, alt, image}, context) => {
+      const response = inputResponse(context.mcpReq.inputResponses, 'altTextEvaluation')
+      if (response.kind !== 'sampling') {
+        return inputRequired({
+          inputRequests: {
+            altTextEvaluation: inputRequired.createMessage({
+              messages: [
+                {
+                  role: 'user',
+                  content: {
+                    type: 'text',
+                    text: `Does this alt text: '${alt}' meet accessibility guidelines and describe the image: ${image} accurately in context of this surrounding text: '${surroundingText}'?\n\n`,
+                  },
+                },
+              ],
+              temperature: 0.4,
+              maxTokens: 500,
+            }),
+          },
+        })
+      }
+
+      const content = Array.isArray(response.result.content) ? response.result.content : [response.result.content]
+      const evaluation =
+        content
+          .filter(block => block.type === 'text')
+          .map(block => block.text)
+          .join('\n') || 'Unable to generate summary'
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: evaluation,
+          },
+        ],
+        altTextEvaluation: evaluation,
+        nextSteps: `If the evaluation indicates issues with the alt text, provide more meaningful alt text based on the feedback. DO NOT run this tool repeatedly on the same image - evaluations may vary slightly with each run.`,
+      }
+    },
+  )
+
+  return server
+}
+
+const server = createServer()
+
+export {createServer, server}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -247,7 +247,7 @@ Use \`get_component\` for exactly one component and \`get_component_batch\` for 
           content: [
             {
               type: 'text',
-              text: `There is no component named \`${name}\` in the @primer/react package. For a full list of components, use the \`get_components\` tool.`,
+              text: `There is no component named \`${name}\` in the @primer/react package. For a full list of components, use the \`list_components\` tool.`,
             },
           ],
         }

--- a/packages/mcp/src/transports/stdio.ts
+++ b/packages/mcp/src/transports/stdio.ts
@@ -1,6 +1,4 @@
-import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js'
-import {server} from '../server'
+import {serveStdio} from '@modelcontextprotocol/server/stdio'
+import {createServer} from '../server'
 
-const transport = new StdioServerTransport()
-
-await server.connect(transport)
+serveStdio(createServer)


### PR DESCRIPTION
This PR updates `@primer/mcp` to the MCP TypeScript SDK v2 and opts the stdio server into 2026-07-28 protocol negotiation.

### Changelog

#### New

- Add a `createServer` factory for serving fresh MCP server instances.
- Add support for the 2026-07-28 protocol over stdio.

#### Changed

- Update MCP dependencies and imports to the v2 client and server packages.
- Update `review_alt_text` to use the multi-round-trip sampling flow across legacy and modern protocol clients.
- Require Node.js 20 or newer.

#### Removed

- Remove the direct dependency on the v1 `@modelcontextprotocol/sdk` package.

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [x] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

This is a major release because the package now requires Node.js 20 and the exported server uses MCP SDK v2 types. CLI consumers should update their runtime before upgrading. Programmatic consumers should update SDK imports and types to the v2 packages; the new `createServer` export can be used with v2 serving entries. The stdio entry continues to serve legacy clients by default while allowing modern clients to negotiate the 2026-07-28 revision.

### Testing & Reviewing

- `npm run type-check -w @primer/mcp`
- `npm test -w @primer/mcp`
- `npm run build -w @primer/mcp`
- Verify a modern stdio client negotiates the `modern` protocol era and can list tools.
- Verify `review_alt_text` completes its sampling request through the multi-round-trip flow.
