### PR TITLE
fix(Dialog): forward id, data-testid, and other unknown attributes to root element

### DIFF
--- a/.changeset/dialog-forward-props.md
+++ b/.changeset/dialog-forward-props.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Dialog: forward `id`, `data-testid`, and other unrecognized DOM/`aria-*`/`data-*` attributes to the root `role="dialog"` element

--- a/packages/react/src/Dialog/Dialog.test.tsx
+++ b/packages/react/src/Dialog/Dialog.test.tsx
@@ -67,6 +67,19 @@ describe('Dialog', () => {
     expect(getByRole('dialog')).toHaveAttribute('data-component', 'ConfirmationDialog')
   })
 
+  it('forwards id, data-testid, and other unknown attributes to the root dialog element', () => {
+    const {getByRole, getByTestId} = render(
+      <Dialog id="my-dialog" data-testid="my-dialog" data-custom="value" aria-keyshortcuts="Escape" onClose={() => {}}>
+        Content
+      </Dialog>,
+    )
+    const dialog = getByRole('dialog')
+    expect(dialog).toHaveAttribute('id', 'my-dialog')
+    expect(dialog).toHaveAttribute('data-custom', 'value')
+    expect(dialog).toHaveAttribute('aria-keyshortcuts', 'Escape')
+    expect(getByTestId('my-dialog')).toBe(dialog)
+  })
+
   it('renders data-component hooks for Dialog subcomponents', () => {
     const {getByRole} = render(
       <Dialog

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -59,7 +59,7 @@ export type DialogButtonProps = Omit<ButtonProps, 'content'> & {
 /**
  * Props to customize the rendering of the Dialog.
  */
-export interface DialogProps {
+export interface DialogProps extends Omit<React.ComponentPropsWithoutRef<'div'>, 'title' | 'role' | 'onClose'> {
   'data-component'?: string
   /**
    * Title of the Dialog. Also serves as the aria-label for this Dialog.
@@ -293,6 +293,8 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
     initialFocusRef,
     className,
     style,
+    children,
+    ...rest
   } = props
   const dialogLabelId = useId()
   const dialogDescriptionId = useId()
@@ -314,7 +316,7 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
     },
     [onClose, lastMouseDownIsBackdrop],
   )
-  const [slots, childrenWithoutSlots] = useSlots(props.children, {
+  const [slots, childrenWithoutSlots] = useSlots(children, {
     body: Dialog.Body,
     header: Dialog.Header,
     footer: Dialog.Footer,
@@ -418,6 +420,7 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
             aria-labelledby={dialogLabelId}
             aria-describedby={dialogDescriptionId}
             aria-modal
+            {...rest}
             {...positionDataAttributes}
             {...(align && {'data-align': align})}
             data-width={isWidthMapKey(width) ? width : undefined}


### PR DESCRIPTION


Fixes a regression where the stable `Dialog` silently dropped `id`, `data-testid`, and every other arbitrary DOM/`aria-*`/`data-*` attribute passed to it. `DialogProps` was a closed interface and the root `role="dialog"` element was assembled from a hand-picked attribute list that never spread the remaining props, so migrating from the deprecated `Dialog` (which forwarded these) broke any test or integration that located the dialog by `getByTestId(...)` or by `id`, with no compile-time signal.

Now `DialogProps` extends `React.ComponentPropsWithoutRef<'div'>` (omitting the keys it intentionally narrows: `title`, `role`, `onClose`) and the component spreads unrecognized props onto the root dialog element. Component-controlled attributes (`role`, `data-width`, `data-height`, `className`, `style`, `data-component`, position data attributes) still take precedence.

### Changelog

#### Changed

- `Dialog` now forwards `id`, `data-testid`, and other unrecognized DOM/`aria-*`/`data-*` attributes to the root `role="dialog"` element, matching the deprecated `Dialog` and other Primer components.

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

A unit test in `Dialog.test.tsx` verifies that `id`, `data-testid`, `data-*`, and `aria-*` attributes land on the root dialog element. Manually verify with:

```tsx
<Dialog title="Example" onClose={noop} data-testid="my-dialog" id="my-dialog" />
```

`screen.getByTestId('my-dialog')` and `document.getElementById('my-dialog')` now resolve to the root dialog element.
