### PR TITLE
Add default Esc-to-dismiss support to `Popover` component

### DIFF
--- a/.changeset/real-teeth-tie.md
+++ b/.changeset/real-teeth-tie.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": minor
+---
+
+Add default Esc-to-dismiss support to `Popover` component

--- a/packages/react/src/Popover/Popover.docs.json
+++ b/packages/react/src/Popover/Popover.docs.json
@@ -69,6 +69,11 @@
           "description": "Callback fired when a click is detected outside the popover content"
         },
         {
+          "name": "onEscape",
+          "type": "(event: KeyboardEvent) => void",
+          "description": "Callback fired when the Escape key is pressed while the popover is open"
+        },
+        {
           "name": "ignoreClickRefs",
           "type": "React.RefObject<HTMLElement>[]",
           "description": "Refs to elements that should be ignored when detecting outside clicks"

--- a/packages/react/src/Popover/Popover.features.stories.tsx
+++ b/packages/react/src/Popover/Popover.features.stories.tsx
@@ -36,3 +36,25 @@ export const CloseOnClickOutside = () => {
     </>
   )
 }
+
+export const CloseOnEscape = () => {
+  const [open, setOpen] = React.useState(true)
+
+  return (
+    <>
+      <Button
+        style={{marginLeft: 'auto', marginRight: 'auto', marginBottom: 'var(--base-size-4)'}}
+        onClick={() => setOpen(prev => !prev)}
+      >
+        Toggle Popover
+      </Button>
+      <Popover relative open={open} caret="top">
+        <Popover.Content style={{marginTop: 'var(--base-size-8)'}} onEscape={() => setOpen(false)}>
+          <Heading style={{fontSize: 'var(--text-title-size-small)'}}>Popover heading</Heading>
+          <Text as="p">Press Escape to dismiss this popover.</Text>
+          <Button>Got it!</Button>
+        </Popover.Content>
+      </Popover>
+    </>
+  )
+}

--- a/packages/react/src/Popover/Popover.test.tsx
+++ b/packages/react/src/Popover/Popover.test.tsx
@@ -1,9 +1,10 @@
-import {describe, expect, it} from 'vitest'
-import {render} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+import {fireEvent, render} from '@testing-library/react'
 import type {PopoverProps} from '../Popover'
 import Popover from '../Popover'
 import classes from './Popover.module.css'
 import {implementsClassName} from '../utils/testing'
+import {useOnEscapePress} from '../hooks'
 
 describe('Popover', () => {
   implementsClassName(Popover, classes.Popover)
@@ -51,5 +52,52 @@ describe('Popover', () => {
     const {container: contentContainer} = render(<Popover.Content />)
     expect((popoverContainer.firstChild as Element).tagName).toEqual('DIV')
     expect((contentContainer.firstChild as Element).tagName).toEqual('DIV')
+  })
+
+  it('calls onEscape when the popover is open', () => {
+    const onEscape = vi.fn()
+    render(
+      <Popover open>
+        <Popover.Content onEscape={onEscape} />
+      </Popover>,
+    )
+
+    fireEvent.keyDown(document, {key: 'Escape'})
+
+    expect(onEscape).toHaveBeenCalledExactlyOnceWith(expect.any(KeyboardEvent))
+  })
+
+  it('does not call onEscape when the popover is closed', () => {
+    const onEscape = vi.fn()
+    render(
+      <Popover open={false}>
+        <Popover.Content onEscape={onEscape} />
+      </Popover>,
+    )
+
+    fireEvent.keyDown(document, {key: 'Escape'})
+
+    expect(onEscape).not.toHaveBeenCalled()
+  })
+
+  it('prevents lower overlays from handling Escape', () => {
+    const onEscape = vi.fn()
+    const onParentEscape = vi.fn()
+
+    const ParentOverlay = () => {
+      useOnEscapePress(onParentEscape)
+
+      return (
+        <Popover open>
+          <Popover.Content onEscape={onEscape} />
+        </Popover>
+      )
+    }
+
+    render(<ParentOverlay />)
+    fireEvent.keyDown(document, {key: 'Escape'})
+
+    expect(onEscape).toHaveBeenCalledOnce()
+    expect(onParentEscape).not.toHaveBeenCalled()
   })
 })

--- a/packages/react/src/Popover/Popover.tsx
+++ b/packages/react/src/Popover/Popover.tsx
@@ -2,10 +2,11 @@ import {clsx} from 'clsx'
 import classes from './Popover.module.css'
 import type {HTMLProps} from 'react'
 import React, {useRef} from 'react'
-import {useOnOutsideClick} from '../hooks'
+import {useOnEscapePress, useOnOutsideClick} from '../hooks'
 
 // Stable empty array reference to avoid unnecessary re-renders
 const EMPTY_IGNORE_CLICK_REFS: React.RefObject<HTMLElement>[] = []
+const PopoverContext = React.createContext(false)
 
 type CaretPosition =
   | 'top'
@@ -38,15 +39,17 @@ const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function Popover(
   forwardRef,
 ) {
   return (
-    <div
-      {...props}
-      ref={forwardRef}
-      data-component="Popover"
-      data-open={open ? '' : undefined}
-      data-relative={relative ? '' : undefined}
-      data-caret={caret}
-      className={clsx(className, classes.Popover)}
-    />
+    <PopoverContext.Provider value={open ?? false}>
+      <div
+        {...props}
+        ref={forwardRef}
+        data-component="Popover"
+        data-open={open ? '' : undefined}
+        data-relative={relative ? '' : undefined}
+        data-caret={caret}
+        className={clsx(className, classes.Popover)}
+      />
+    </PopoverContext.Provider>
   )
 })
 Popover.displayName = 'Popover'
@@ -61,6 +64,10 @@ export type PopoverContentProps = {
    */
   onClickOutside?: (event: MouseEvent | TouchEvent) => void
   /*
+   * Callback fired when the Escape key is pressed while the popover is open
+   */
+  onEscape?: (event: KeyboardEvent) => void
+  /*
    * Refs to elements that should be ignored when detecting outside clicks
    */
   ignoreClickRefs?: React.RefObject<HTMLElement>[]
@@ -71,10 +78,12 @@ const PopoverContent: React.FC<React.PropsWithChildren<PopoverContentProps>> = (
   width = 'small',
   height = 'fit-content',
   onClickOutside,
+  onEscape,
   ignoreClickRefs,
   ...props
 }) => {
   const divRef = useRef(null)
+  const open = React.useContext(PopoverContext)
 
   const outsideClickHandler = onClickOutside ?? (() => {})
 
@@ -83,6 +92,16 @@ const PopoverContent: React.FC<React.PropsWithChildren<PopoverContentProps>> = (
     containerRef: divRef,
     ignoreClickRefs: ignoreClickRefs ?? EMPTY_IGNORE_CLICK_REFS,
   })
+
+  useOnEscapePress(
+    event => {
+      if (open && onEscape) {
+        onEscape(event)
+        event.preventDefault()
+      }
+    },
+    [open, onEscape],
+  )
 
   return (
     <div


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/6736

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

- Added `useOnEscapePress` hook to `Popover` to enable default esc-to-dismiss behavior, eliminating the need for consumers to wire up this behavior manually
- Added `Close On Escape` Storybook story to demo this new functionality
- Updated docs and tests

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To test these changes with github/github-ui, use the [integration workflow](https://github.com/github/github-ui/actions/workflows/primer-npm-packages-integration.yml) -->

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
