### PR TITLE
Migrate initial components to mergeProps

### DIFF
--- a/packages/react/src/Radio/Radio.test.tsx
+++ b/packages/react/src/Radio/Radio.test.tsx
@@ -21,6 +21,7 @@ describe('Radio', () => {
     const radio = getByRole('radio')
 
     expect(radio).toBeDefined()
+    expect(radio).toHaveAttribute('type', 'radio')
   })
 
   it('renders data-component attribute', () => {

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -40,17 +40,7 @@ export type RadioProps = {
  */
 const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
   (
-    {
-      checked,
-      disabled,
-      name: nameProp,
-      onChange,
-      required,
-      value,
-      className,
-      'aria-hidden': ariaHidden = false,
-      ...rest
-    }: RadioProps,
+    {checked, name: nameProp, 'aria-hidden': ariaHidden, ...rest}: RadioProps,
     ref,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): ReactElement<any> => {
@@ -74,17 +64,11 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
             onChange: handleOnChange,
             className: clsx(sharedClasses.Input, classes.Radio),
             'aria-checked': checked ? ('true' as const) : ('false' as const),
-          },
-          {
-            ...rest,
-            ...(onChange ? {onChange} : {}),
-            value,
-            name,
-            disabled,
+            'aria-hidden': ariaHidden,
             checked,
-            required,
-            className,
+            name,
           },
+          rest,
         )}
         ref={ref}
         type="radio"

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -5,6 +5,7 @@ import {clsx} from 'clsx'
 import sharedClasses from '../Checkbox/shared.module.css'
 import classes from './Radio.module.css'
 import type {WithSlotMarker} from '../utils/types'
+import {mergeProps} from '../utils/mergeProps'
 
 export type RadioProps = {
   /**
@@ -32,7 +33,7 @@ export type RadioProps = {
    * Indicates whether the radio button must be checked before the form can be submitted
    */
   required?: boolean
-} & InputHTMLAttributes<HTMLInputElement>
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>
 
 /**
  * An accessible, native radio component for selecting one option from a list.
@@ -56,7 +57,6 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
     const radioGroupContext = useContext(RadioGroupContext)
     const handleOnChange: ChangeEventHandler<HTMLInputElement> = e => {
       radioGroupContext?.onChange && radioGroupContext.onChange(e)
-      onChange && onChange(e)
     }
     const name = nameProp || radioGroupContext?.name
 
@@ -69,17 +69,25 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
 
     return (
       <input
-        type="radio"
-        value={value}
-        name={name}
+        {...mergeProps(
+          {
+            onChange: handleOnChange,
+            className: clsx(sharedClasses.Input, classes.Radio),
+            'aria-checked': checked ? ('true' as const) : ('false' as const),
+          },
+          {
+            ...rest,
+            ...(onChange ? {onChange} : {}),
+            value,
+            name,
+            disabled,
+            checked,
+            required,
+            className,
+          },
+        )}
         ref={ref}
-        disabled={disabled}
-        checked={checked}
-        aria-checked={checked ? 'true' : 'false'}
-        required={required}
-        onChange={handleOnChange}
-        className={clsx(className, sharedClasses.Input, classes.Radio)}
-        {...rest}
+        type="radio"
         data-component="Radio"
       />
     )

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -40,7 +40,7 @@ export type RadioProps = {
  */
 const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
   (
-    {checked, name: nameProp, 'aria-hidden': ariaHidden, ...rest}: RadioProps,
+    {checked, name: nameProp, className, 'aria-hidden': ariaHidden, ...rest}: RadioProps,
     ref,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): ReactElement<any> => {
@@ -59,10 +59,11 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
 
     return (
       <input
+        ref={ref}
         {...mergeProps(
           {
             onChange: handleOnChange,
-            className: clsx(sharedClasses.Input, classes.Radio),
+            className: clsx(sharedClasses.Input, classes.Radio, className),
             'aria-checked': checked ? ('true' as const) : ('false' as const),
             'aria-hidden': ariaHidden,
             checked,
@@ -70,7 +71,6 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
           },
           rest,
         )}
-        ref={ref}
         type="radio"
         data-component="Radio"
       />

--- a/packages/react/src/Radio/Radio.types.test.tsx
+++ b/packages/react/src/Radio/Radio.types.test.tsx
@@ -1,0 +1,6 @@
+import Radio from '.'
+
+export function doesNotAcceptType() {
+  // @ts-expect-error Radio always renders an input with type="radio"
+  return <Radio name="example" value="example" type="checkbox" />
+}

--- a/packages/react/src/Token/TokenBase.tsx
+++ b/packages/react/src/Token/TokenBase.tsx
@@ -42,24 +42,18 @@ export interface TokenBaseProps
 }
 
 const TokenBase = React.forwardRef<HTMLButtonElement | HTMLAnchorElement | HTMLSpanElement | undefined, TokenBaseProps>(
-  (
-    {
-      onRemove,
-      onKeyDown,
-      id,
-      className,
-      size = defaultTokenSize,
-      isSelected: _isSelected,
-      as: Component = 'span',
-      ...rest
-    },
-    forwardedRef,
-  ) => {
+  ({onRemove, id, size = defaultTokenSize, isSelected: _isSelected, as: Component = 'span', ...rest}, forwardedRef) => {
     const handleKeyDown = (event: KeyboardEvent<HTMLSpanElement & HTMLAnchorElement & HTMLButtonElement>) => {
       if ((event.key === 'Backspace' || event.key === 'Delete') && onRemove) {
         onRemove()
       }
     }
+    const consumerProps =
+      Component === 'button'
+        ? (rest as React.ButtonHTMLAttributes<HTMLButtonElement>)
+        : Component === 'a'
+          ? (rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)
+          : (rest as React.HTMLAttributes<HTMLSpanElement>)
 
     return (
       <Component
@@ -75,17 +69,9 @@ const TokenBase = React.forwardRef<HTMLButtonElement | HTMLAnchorElement | HTMLS
               disabled: rest.disabled,
             }),
             'data-size': size,
-          },
-          {
-            ...(Component === 'button'
-              ? (rest as React.ButtonHTMLAttributes<HTMLButtonElement>)
-              : Component === 'a'
-                ? (rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)
-                : (rest as React.HTMLAttributes<HTMLSpanElement>)),
-            ...(onKeyDown ? {onKeyDown} : {}),
-            className,
             id: id?.toString(),
           },
+          consumerProps,
         )}
         // TypeScript cannot resolve polymorphic ref types at compile time
         // This assertion is safe because the ref will match the actual rendered element

--- a/packages/react/src/Token/TokenBase.tsx
+++ b/packages/react/src/Token/TokenBase.tsx
@@ -1,10 +1,10 @@
 import type {KeyboardEvent} from 'react'
 import React from 'react'
-import {clsx} from 'clsx'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 import classes from './TokenBase.module.css'
 import {defaultTokenSize, type TokenSizeKeys} from './constants'
 import {isTokenInteractive} from './utils'
+import {mergeProps} from '../utils/mergeProps'
 
 export type {TokenSizeKeys}
 
@@ -55,30 +55,38 @@ const TokenBase = React.forwardRef<HTMLButtonElement | HTMLAnchorElement | HTMLS
     },
     forwardedRef,
   ) => {
+    const handleKeyDown = (event: KeyboardEvent<HTMLSpanElement & HTMLAnchorElement & HTMLButtonElement>) => {
+      if ((event.key === 'Backspace' || event.key === 'Delete') && onRemove) {
+        onRemove()
+      }
+    }
+
     return (
       <Component
-        onKeyDown={(event: KeyboardEvent<HTMLSpanElement & HTMLAnchorElement & HTMLButtonElement>) => {
-          onKeyDown && onKeyDown(event)
-
-          if ((event.key === 'Backspace' || event.key === 'Delete') && onRemove) {
-            onRemove()
-          }
-        }}
-        className={clsx(classes.TokenBase, className)}
-        data-cursor-is-interactive={isTokenInteractive({
-          as: Component,
-          onClick: rest.onClick,
-          onFocus: rest.onFocus,
-          tabIndex: rest.tabIndex,
-          disabled: rest.disabled,
-        })}
-        data-size={size}
-        id={id?.toString()}
-        {...(Component === 'button'
-          ? (rest as React.ButtonHTMLAttributes<HTMLButtonElement>)
-          : Component === 'a'
-            ? (rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)
-            : (rest as React.HTMLAttributes<HTMLSpanElement>))}
+        {...mergeProps(
+          {
+            onKeyDown: handleKeyDown,
+            className: classes.TokenBase,
+            'data-cursor-is-interactive': isTokenInteractive({
+              as: Component,
+              onClick: rest.onClick,
+              onFocus: rest.onFocus,
+              tabIndex: rest.tabIndex,
+              disabled: rest.disabled,
+            }),
+            'data-size': size,
+          },
+          {
+            ...(Component === 'button'
+              ? (rest as React.ButtonHTMLAttributes<HTMLButtonElement>)
+              : Component === 'a'
+                ? (rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)
+                : (rest as React.HTMLAttributes<HTMLSpanElement>)),
+            ...(onKeyDown ? {onKeyDown} : {}),
+            className,
+            id: id?.toString(),
+          },
+        )}
         // TypeScript cannot resolve polymorphic ref types at compile time
         // This assertion is safe because the ref will match the actual rendered element
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/react/src/Token/TokenBase.tsx
+++ b/packages/react/src/Token/TokenBase.tsx
@@ -1,5 +1,6 @@
 import type {KeyboardEvent} from 'react'
 import React from 'react'
+import {clsx} from 'clsx'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
 import classes from './TokenBase.module.css'
 import {defaultTokenSize, type TokenSizeKeys} from './constants'
@@ -42,7 +43,10 @@ export interface TokenBaseProps
 }
 
 const TokenBase = React.forwardRef<HTMLButtonElement | HTMLAnchorElement | HTMLSpanElement | undefined, TokenBaseProps>(
-  ({onRemove, id, size = defaultTokenSize, isSelected: _isSelected, as: Component = 'span', ...rest}, forwardedRef) => {
+  (
+    {onRemove, id, className, size = defaultTokenSize, isSelected: _isSelected, as: Component = 'span', ...rest},
+    forwardedRef,
+  ) => {
     const handleKeyDown = (event: KeyboardEvent<HTMLSpanElement & HTMLAnchorElement & HTMLButtonElement>) => {
       if ((event.key === 'Backspace' || event.key === 'Delete') && onRemove) {
         onRemove()
@@ -57,10 +61,14 @@ const TokenBase = React.forwardRef<HTMLButtonElement | HTMLAnchorElement | HTMLS
 
     return (
       <Component
+        // TypeScript cannot resolve polymorphic ref types at compile time
+        // This assertion is safe because the ref will match the actual rendered element
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ref={forwardedRef as any}
         {...mergeProps(
           {
             onKeyDown: handleKeyDown,
-            className: classes.TokenBase,
+            className: clsx(classes.TokenBase, className),
             'data-cursor-is-interactive': isTokenInteractive({
               as: Component,
               onClick: rest.onClick,
@@ -73,10 +81,6 @@ const TokenBase = React.forwardRef<HTMLButtonElement | HTMLAnchorElement | HTMLS
           },
           consumerProps,
         )}
-        // TypeScript cannot resolve polymorphic ref types at compile time
-        // This assertion is safe because the ref will match the actual rendered element
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ref={forwardedRef as any}
       />
     )
   },

--- a/packages/react/src/Token/__tests__/Token.test.tsx
+++ b/packages/react/src/Token/__tests__/Token.test.tsx
@@ -63,6 +63,17 @@ const testTokenComponent = (Component: React.ComponentType<React.PropsWithChildr
     expect(onRemoveMock).toHaveBeenCalled()
   })
 
+  it('calls onRemove before the consumer onKeyDown handler', () => {
+    const calls: string[] = []
+    const {getByText} = HTMLRender(
+      <Component text="token" onRemove={() => calls.push('remove')} onKeyDown={() => calls.push('consumer')} />,
+    )
+
+    fireEvent.keyDown(getByText('token'), {key: 'Backspace'})
+
+    expect(calls).toEqual(['remove', 'consumer'])
+  })
+
   it('adds className to rendered component', () => {
     const {getByText} = HTMLRender(<Component text="token" className="testing-class" />)
     const domNode = getByText('token')

--- a/packages/react/src/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/VisuallyHidden/VisuallyHidden.tsx
@@ -1,6 +1,6 @@
-import {clsx} from 'clsx'
 import type React from 'react'
 import {type HTMLAttributes} from 'react'
+import {mergeProps} from '../utils/mergeProps'
 import classes from './VisuallyHidden.module.css'
 
 /**
@@ -13,12 +13,8 @@ import classes from './VisuallyHidden.module.css'
  *
  * @see https://www.scottohara.me/blog/2023/03/21/visually-hidden-hack.html
  */
-export const VisuallyHidden = ({className, children, ...rest}: VisuallyHiddenProps) => {
-  return (
-    <span className={clsx(className, classes.VisuallyHidden)} {...rest}>
-      {children}
-    </span>
-  )
+export const VisuallyHidden = ({children, ...rest}: VisuallyHiddenProps) => {
+  return <span {...mergeProps({className: classes.VisuallyHidden}, rest)}>{children}</span>
 }
 
 export type VisuallyHiddenProps = React.PropsWithChildren<

--- a/packages/react/src/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/VisuallyHidden/VisuallyHidden.tsx
@@ -1,3 +1,4 @@
+import {clsx} from 'clsx'
 import type React from 'react'
 import {type HTMLAttributes} from 'react'
 import {mergeProps} from '../utils/mergeProps'
@@ -13,8 +14,8 @@ import classes from './VisuallyHidden.module.css'
  *
  * @see https://www.scottohara.me/blog/2023/03/21/visually-hidden-hack.html
  */
-export const VisuallyHidden = ({children, ...rest}: VisuallyHiddenProps) => {
-  return <span {...mergeProps({className: classes.VisuallyHidden}, rest)}>{children}</span>
+export const VisuallyHidden = ({className, children, ...rest}: VisuallyHiddenProps) => {
+  return <span {...mergeProps({className: clsx(classes.VisuallyHidden, className)}, rest)}>{children}</span>
 }
 
 export type VisuallyHiddenProps = React.PropsWithChildren<


### PR DESCRIPTION
This PR contains the first bounded ADR-025 implementation batch. It migrates three reviewed component patterns without mixing changes into the tooling foundation or migration driver.

### Changelog

#### New

#### Changed

- Update `VisuallyHidden` to merge component and consumer class names through `mergeProps`.
- Update `TokenBase` to run component keyboard behavior before consumer handlers while keeping refs separate.
- Update `Radio` to preserve radio semantics and compose context and consumer change handlers.

#### Removed

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

These changes correct existing component behavior to match the intended contracts. They do not add a supported public capability, so this batch does not include release notes.

### Testing & Reviewing

Please review class-name ordering, optional handler composition, ref handling, and the `Radio` type invariant. The migration report should no longer list the three assigned source files.