### PR TITLE
Update `AvatarStack` to not reserve extra layout space when collapsed

### DIFF
--- a/.changeset/fresh-ideas-worry.md
+++ b/.changeset/fresh-ideas-worry.md
@@ -1,0 +1,5 @@
+---
+"@primer/react": patch
+---
+
+Update `AvatarStack` to not reserve space when collapsed

--- a/packages/react/src/AvatarStack/AvatarStack.module.css
+++ b/packages/react/src/AvatarStack/AvatarStack.module.css
@@ -241,7 +241,8 @@
   }
 
   &:nth-child(n + 6) {
-    display: none;
+    position: absolute;
+    visibility: hidden;
     opacity: 0;
   }
 }
@@ -253,7 +254,7 @@
   .AvatarItem {
     --mask-size: 100%; /* reset size of the mask to prevent unintentially clipping due to the additional size created by the border width */
 
-    display: flex;
+    position: relative;
     margin-inline-start: var(--base-size-4);
     visibility: visible;
     opacity: 1;

--- a/packages/react/src/AvatarStack/AvatarStack.module.css
+++ b/packages/react/src/AvatarStack/AvatarStack.module.css
@@ -252,7 +252,7 @@
   width: auto;
 
   .AvatarItem {
-    --mask-size: 100%; /* reset size of the mask to prevent unintentially clipping due to the additional size created by the border width */
+    --mask-size: 100%; /* reset size of the mask to prevent unintentionally clipping due to the additional size created by the border width */
 
     position: relative;
     margin-inline-start: var(--base-size-4);

--- a/packages/react/src/AvatarStack/AvatarStack.module.css
+++ b/packages/react/src/AvatarStack/AvatarStack.module.css
@@ -241,7 +241,7 @@
   }
 
   &:nth-child(n + 6) {
-    visibility: hidden;
+    display: none;
     opacity: 0;
   }
 }
@@ -253,6 +253,7 @@
   .AvatarItem {
     --mask-size: 100%; /* reset size of the mask to prevent unintentially clipping due to the additional size created by the border width */
 
+    display: flex;
     margin-inline-start: var(--base-size-4);
     visibility: visible;
     opacity: 1;


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/github/primer/issues/6922

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

#### Changed

Update `AvatarStack` `&:nth-child(n + 6)` CSS block to include `position: absolute` so that the hidden Avatars don't reserve layout space when collapsed (including when `disableExpand` is true).

**Demo:**

https://github.com/user-attachments/assets/a5dfce04-c33e-4b36-bcf2-37878218be1a

_(Temporary story used for testing/demo only; not added in this PR.)_

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Reviewers, please let me know if you foresee any potential issues (a11y or otherwise) with this solution. I could not think of any, and testing didn't reveal anything.

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->
