### PR TITLE
Add mergeProps ESLint migration tooling

### DIFF
--- a/.github/workflows/migration-status.yml
+++ b/.github/workflows/migration-status.yml
@@ -5,6 +5,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  merge-props:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: install dependencies
+        run: npm ci
+      - name: run migration script
+        run: node script/merge-props-migration-status.mts >> $GITHUB_STEP_SUMMARY
+
   react-compiler:
     runs-on: ubuntu-latest
     steps:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import {fileURLToPath} from 'node:url'
 import {fixupConfigRules, fixupPluginRules} from '@eslint/compat'
 import {FlatCompat} from '@eslint/eslintrc'
 import js from '@eslint/js'
+import primerConfig from '@primer/eslint-config'
 import eslintReact from '@eslint-react/eslint-plugin'
 import vitest from '@vitest/eslint-plugin'
 import {defineConfig, globalIgnores} from 'eslint/config'
@@ -58,6 +59,7 @@ const config = defineConfig([
   ]),
 
   js.configs.recommended,
+  primerConfig,
 
   ...fixupConfigRules([react.configs.flat.recommended, react.configs.flat['jsx-runtime']]),
   reactHooks.configs.flat['recommended-latest'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6627,6 +6627,10 @@
       "resolved": "packages/doc-gen",
       "link": true
     },
+    "node_modules/@primer/eslint-config": {
+      "resolved": "packages/eslint-config",
+      "link": true
+    },
     "node_modules/@primer/mcp": {
       "resolved": "packages/mcp",
       "link": true
@@ -28956,6 +28960,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/eslint-config": {
+      "name": "@primer/eslint-config",
+      "version": "0.0.0",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.59.1"
+      },
+      "devDependencies": {
+        "@primer/vitest-config": "^0.0.0",
+        "eslint": "^10.7.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.9"
+      },
+      "peerDependencies": {
+        "eslint": "^10.7.0"
       }
     },
     "packages/mcp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28970,6 +28970,7 @@
       },
       "devDependencies": {
         "@primer/vitest-config": "^0.0.0",
+        "@typescript-eslint/parser": "8.59.1",
         "eslint": "^10.7.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@primer/eslint-config",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": "./src/index.ts",
+  "scripts": {
+    "test": "vitest --run",
+    "type-check": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "eslint": "^10.7.0"
+  },
+  "dependencies": {
+    "@typescript-eslint/utils": "^8.59.1"
+  },
+  "devDependencies": {
+    "@primer/vitest-config": "^0.0.0",
+    "eslint": "^10.7.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@primer/vitest-config": "^0.0.0",
+    "@typescript-eslint/parser": "8.59.1",
     "eslint": "^10.7.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/packages/eslint-config/src/index.test.ts
+++ b/packages/eslint-config/src/index.test.ts
@@ -1,0 +1,9 @@
+import {describe, expect, test} from 'vitest'
+import {config, plugin} from './index.ts'
+
+describe('@primer/eslint-config', () => {
+  test('exports the prefer-merge-props rule disabled by default', () => {
+    expect(plugin.rules?.['prefer-merge-props']).toBeDefined()
+    expect(config.rules?.['primer/prefer-merge-props']).toBe('off')
+  })
+})

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -1,0 +1,24 @@
+import type {TSESLint} from '@typescript-eslint/utils'
+import {preferMergeProps} from './rules/preferMergeProps.ts'
+
+const plugin: TSESLint.FlatConfig.Plugin = {
+  meta: {
+    name: '@primer/eslint-config',
+  },
+  rules: {
+    'prefer-merge-props': preferMergeProps,
+  },
+}
+
+const config: TSESLint.FlatConfig.Config = {
+  name: '@primer/eslint-config',
+  plugins: {
+    primer: plugin,
+  },
+  rules: {
+    'primer/prefer-merge-props': 'off',
+  },
+}
+
+export {config, plugin, preferMergeProps}
+export default config

--- a/packages/eslint-config/src/rules/preferMergeProps.test.ts
+++ b/packages/eslint-config/src/rules/preferMergeProps.test.ts
@@ -21,43 +21,45 @@ const ruleTester = new RuleTester({
 ruleTester.run('prefer-merge-props', preferMergeProps as unknown as Parameters<RuleTester['run']>[1], {
   valid: [
     {
-      name: 'accepts outermost props merged with mergeProps',
-      code: `const example = <button {...mergeProps(componentProps, props)} />`,
+      name: 'accepts component root props merged with mergeProps',
+      code: `function Example() { return <button {...mergeProps(componentProps, props)} /> }`,
     },
     {
       name: 'accepts a namespaced mergeProps utility',
-      code: `const example = <button {...utils.mergeProps(componentProps, props)} />`,
+      code: `function Example() { return <button {...utils.mergeProps(componentProps, props)} /> }`,
     },
     {
       name: 'accepts props previously merged with mergeProps',
       code: `
-        const mergedProps = mergeProps(componentProps, props)
-        const example = <button {...mergedProps} />
+        function Example() {
+          const mergedProps = mergeProps(componentProps, props)
+          return <button {...mergedProps} />
+        }
       `,
     },
     {
       name: 'ignores elements without spread props',
-      code: `const example = <button type="button" />`,
+      code: `function Example() { return <button type="button" /> }`,
     },
     {
       name: 'ignores spread props on nested elements',
-      code: `const example = <div><button {...props} /></div>`,
+      code: `function Example() { return <div><button {...props} /></div> }`,
     },
     {
-      name: 'ignores spread props inside an outermost fragment',
-      code: `const example = <><button {...props} /></>`,
+      name: 'ignores spread props inside a root fragment',
+      code: `function Example() { return <><button {...props} /></> }`,
     },
     {
       name: 'ignores spread props on elements nested in conditional content',
-      code: `const example = <div>{condition ? <button {...props} /> : null}</div>`,
+      code: `function Example() { return <div>{condition ? <button {...props} /> : null}</div> }`,
     },
     {
       name: 'ignores spread props on elements nested in mapped content',
-      code: `const example = <ul>{items.map(item => <li {...item} />)}</ul>`,
+      code: `function Example() { return <ul>{items.map(item => <li {...item} />)}</ul> }`,
     },
     {
       name: 'ignores spread props on elements nested in a render prop',
-      code: `const example = <Component render={() => <button {...props} />} />`,
+      code: `function Example() { return <Component render={() => <button {...props} />} /> }`,
     },
     {
       name: 'ignores object spread expressions outside JSX',
@@ -66,51 +68,114 @@ ruleTester.run('prefer-merge-props', preferMergeProps as unknown as Parameters<R
         const example = <button type="button" />
       `,
     },
+    {
+      name: 'ignores JSX assigned outside a component',
+      code: `const example = <button {...props} />`,
+    },
+    {
+      name: 'ignores JSX returned by a lowercase helper',
+      code: `function renderButton() { return <button {...props} /> }`,
+    },
+    {
+      name: 'ignores JSX returned by an unrelated callback',
+      code: `const buttons = items.map(props => <button {...props} />)`,
+    },
+    {
+      name: 'ignores component roots in test files',
+      filename: 'Example.test.jsx',
+      code: `function Example() { return <button {...props} /> }`,
+    },
+    {
+      name: 'ignores component roots in story files',
+      filename: 'Example.stories.jsx',
+      code: `function Example() { return <button {...props} /> }`,
+    },
+    {
+      name: 'ignores component roots in test directories',
+      filename: '__tests__/Example.jsx',
+      code: `function Example() { return <button {...props} /> }`,
+    },
   ],
   invalid: [
     {
-      name: 'reports direct props spread on an outermost element',
-      code: `const example = <button {...props} />`,
+      name: 'reports direct props spread on a function component root',
+      code: `function Example(props) { return <button {...props} type="button" /> }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
-      name: 'reports each unmerged spread on an outermost element',
-      code: `const example = <button {...componentProps} {...props} />`,
-      errors: [{messageId: 'preferMergeProps'}, {messageId: 'preferMergeProps'}],
-    },
-    {
-      name: 'reports outermost elements in conditional branches',
-      code: `const example = condition ? <button {...props} /> : <a {...props} />`,
-      errors: [{messageId: 'preferMergeProps'}, {messageId: 'preferMergeProps'}],
-    },
-    {
-      name: 'reports unmerged props on an outermost custom component',
-      code: `const example = <Button {...props} />`,
+      name: 'reports rest props composed with an explicit handler',
+      code: `
+        function Example({onClick, ...rest}) {
+          return <button {...rest} type="button" onClick={event => onClick?.(event)} />
+        }
+      `,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
-      name: 'reports unmerged props on an outermost member component',
-      code: `const example = <ActionList.Item {...props} />`,
+      name: 'reports each unmerged spread on a component root',
+      code: `function Example() { return <button {...componentProps} {...props} /> }`,
+      errors: [{messageId: 'preferMergeProps'}, {messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports component roots in separate return branches',
+      code: `
+        function Example({foo, ...rest}) {
+          if (foo) {
+            return <a {...rest} href="#" />
+          }
+          return <button {...rest} type="button" />
+        }
+      `,
+      errors: [{messageId: 'preferMergeProps'}, {messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports component roots in conditional expression branches',
+      code: `function Example() { return condition ? <button {...props} /> : <a {...props} /> }`,
+      errors: [{messageId: 'preferMergeProps'}, {messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports unmerged props on a root custom component',
+      code: `function Example() { return <Button {...props} /> }`,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports unmerged props on a root member component',
+      code: `function Example() { return <ActionList.Item {...props} /> }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
       name: 'reports spread props returned from a function call',
-      code: `const example = <button {...getProps()} />`,
+      code: `function Example() { return <button {...getProps()} /> }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
       name: 'reports props copied into an object expression',
-      code: `const example = <button {...{...props}} />`,
+      code: `function Example() { return <button {...{...props}} /> }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
       name: 'reports only the unmerged spread alongside merged props',
-      code: `const example = <button {...mergeProps(componentProps, props)} {...otherProps} />`,
+      code: `function Example() { return <button {...mergeProps(componentProps, props)} {...otherProps} /> }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
-      name: 'reports props on outermost elements in logical expressions',
-      code: `const example = condition && <button {...props} />`,
+      name: 'reports props on component roots in logical expressions',
+      code: `function Example() { return condition && <button {...props} /> }`,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports props on a concise arrow component root',
+      code: `const Example = props => <button {...props} />`,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports props on a forwardRef component root',
+      code: `const Example = React.forwardRef((props, ref) => <button {...props} ref={ref} />)`,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports props on a class component root',
+      code: `class Example extends React.Component { render() { return <button {...this.props} /> } }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
   ],

--- a/packages/eslint-config/src/rules/preferMergeProps.test.ts
+++ b/packages/eslint-config/src/rules/preferMergeProps.test.ts
@@ -1,0 +1,68 @@
+import {RuleTester} from 'eslint'
+import {describe, it} from 'vitest'
+import {preferMergeProps} from './preferMergeProps.ts'
+
+RuleTester.describe = describe
+RuleTester.it = it
+RuleTester.itOnly = it
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+})
+
+ruleTester.run('prefer-merge-props', preferMergeProps as unknown as Parameters<RuleTester['run']>[1], {
+  valid: [
+    {
+      name: 'accepts outermost props merged with mergeProps',
+      code: `const example = <button {...mergeProps(componentProps, props)} />`,
+    },
+    {
+      name: 'accepts a namespaced mergeProps utility',
+      code: `const example = <button {...utils.mergeProps(componentProps, props)} />`,
+    },
+    {
+      name: 'accepts props previously merged with mergeProps',
+      code: `
+        const mergedProps = mergeProps(componentProps, props)
+        const example = <button {...mergedProps} />
+      `,
+    },
+    {
+      name: 'ignores elements without spread props',
+      code: `const example = <button type="button" />`,
+    },
+    {
+      name: 'ignores spread props on nested elements',
+      code: `const example = <div><button {...props} /></div>`,
+    },
+    {
+      name: 'ignores spread props inside an outermost fragment',
+      code: `const example = <><button {...props} /></>`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'reports direct props spread on an outermost element',
+      code: `const example = <button {...props} />`,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports each unmerged spread on an outermost element',
+      code: `const example = <button {...componentProps} {...props} />`,
+      errors: [{messageId: 'preferMergeProps'}, {messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports outermost elements in conditional branches',
+      code: `const example = condition ? <button {...props} /> : <a {...props} />`,
+      errors: [{messageId: 'preferMergeProps'}, {messageId: 'preferMergeProps'}],
+    },
+  ],
+})

--- a/packages/eslint-config/src/rules/preferMergeProps.test.ts
+++ b/packages/eslint-config/src/rules/preferMergeProps.test.ts
@@ -47,6 +47,25 @@ ruleTester.run('prefer-merge-props', preferMergeProps as unknown as Parameters<R
       name: 'ignores spread props inside an outermost fragment',
       code: `const example = <><button {...props} /></>`,
     },
+    {
+      name: 'ignores spread props on elements nested in conditional content',
+      code: `const example = <div>{condition ? <button {...props} /> : null}</div>`,
+    },
+    {
+      name: 'ignores spread props on elements nested in mapped content',
+      code: `const example = <ul>{items.map(item => <li {...item} />)}</ul>`,
+    },
+    {
+      name: 'ignores spread props on elements nested in a render prop',
+      code: `const example = <Component render={() => <button {...props} />} />`,
+    },
+    {
+      name: 'ignores object spread expressions outside JSX',
+      code: `
+        const copiedProps = {...props}
+        const example = <button type="button" />
+      `,
+    },
   ],
   invalid: [
     {
@@ -63,6 +82,36 @@ ruleTester.run('prefer-merge-props', preferMergeProps as unknown as Parameters<R
       name: 'reports outermost elements in conditional branches',
       code: `const example = condition ? <button {...props} /> : <a {...props} />`,
       errors: [{messageId: 'preferMergeProps'}, {messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports unmerged props on an outermost custom component',
+      code: `const example = <Button {...props} />`,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports unmerged props on an outermost member component',
+      code: `const example = <ActionList.Item {...props} />`,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports props returned from another utility',
+      code: `const example = <button {...getProps()} />`,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports props copied into an object expression',
+      code: `const example = <button {...{...props}} />`,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports only the unmerged spread alongside merged props',
+      code: `const example = <button {...mergeProps(componentProps, props)} {...otherProps} />`,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports props on outermost elements in logical expressions',
+      code: `const example = condition && <button {...props} />`,
+      errors: [{messageId: 'preferMergeProps'}],
     },
   ],
 })

--- a/packages/eslint-config/src/rules/preferMergeProps.test.ts
+++ b/packages/eslint-config/src/rules/preferMergeProps.test.ts
@@ -44,6 +44,18 @@ ruleTester.run('prefer-merge-props', preferMergeProps as unknown as Parameters<R
       code: `function Example() { return <button type="button" /> }`,
     },
     {
+      name: 'ignores a component that only forwards consumer props',
+      code: `function Example(props) { return <button {...props} /> }`,
+    },
+    {
+      name: 'ignores a component that forwards consumer props and composes a ref separately',
+      code: `const Example = React.forwardRef((props, ref) => <button {...props} ref={ref} />)`,
+    },
+    {
+      name: 'ignores a component that only forwards props to a custom component',
+      code: `function Example(props) { return <Button {...props} /> }`,
+    },
+    {
       name: 'ignores spread props on nested elements',
       code: `function Example() { return <div><button {...props} /></div> }`,
     },
@@ -132,27 +144,27 @@ ruleTester.run('prefer-merge-props', preferMergeProps as unknown as Parameters<R
     },
     {
       name: 'reports component roots in conditional expression branches',
-      code: `function Example() { return condition ? <button {...props} /> : <a {...props} /> }`,
+      code: `function Example() { return condition ? <button type="button" {...props} /> : <a href="#" {...props} /> }`,
       errors: [{messageId: 'preferMergeProps'}, {messageId: 'preferMergeProps'}],
     },
     {
       name: 'reports unmerged props on a root custom component',
-      code: `function Example() { return <Button {...props} /> }`,
+      code: `function Example() { return <Button variant="primary" {...props} /> }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
       name: 'reports unmerged props on a root member component',
-      code: `function Example() { return <ActionList.Item {...props} /> }`,
+      code: `function Example() { return <ActionList.Item role="menuitem" {...props} /> }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
       name: 'reports spread props returned from a function call',
-      code: `function Example() { return <button {...getProps()} /> }`,
+      code: `function Example() { return <button type="button" {...getProps()} /> }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
       name: 'reports props copied into an object expression',
-      code: `function Example() { return <button {...{...props}} /> }`,
+      code: `function Example() { return <button type="button" {...{...props}} /> }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
@@ -162,24 +174,24 @@ ruleTester.run('prefer-merge-props', preferMergeProps as unknown as Parameters<R
     },
     {
       name: 'reports props on component roots in logical expressions',
-      code: `function Example() { return condition && <button {...props} /> }`,
+      code: `function Example() { return condition && <button type="button" {...props} /> }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
       name: 'reports props on a concise arrow component root',
-      code: `const Example = props => <button {...props} />`,
+      code: `const Example = props => <button type="button" {...props} />`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
       name: 'reports props on a forwardRef component root',
-      code: `const Example = React.forwardRef((props, ref) => <button {...props} ref={ref} />)`,
+      code: `const Example = React.forwardRef((props, ref) => <button type="button" {...props} ref={ref} />)`,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
       name: 'reports props on an asserted forwardRef component root',
       code: `
         const Example = React.forwardRef(
-          (props, ref) => <button {...props} ref={ref} />
+          (props, ref) => <button type="button" {...props} ref={ref} />
         ) as PolymorphicForwardRefComponent
       `,
       errors: [{messageId: 'preferMergeProps'}],
@@ -188,14 +200,14 @@ ruleTester.run('prefer-merge-props', preferMergeProps as unknown as Parameters<R
       name: 'reports props on a forwardRef component root using satisfies',
       code: `
         const Example = React.forwardRef(
-          (props, ref) => <button {...props} ref={ref} />
+          (props, ref) => <button type="button" {...props} ref={ref} />
         ) satisfies PolymorphicForwardRefComponent
       `,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
       name: 'reports props on a class component root',
-      code: `class Example extends React.Component { render() { return <button {...this.props} /> } }`,
+      code: `class Example extends React.Component { render() { return <button type="button" {...this.props} /> } }`,
       errors: [{messageId: 'preferMergeProps'}],
     },
   ],

--- a/packages/eslint-config/src/rules/preferMergeProps.test.ts
+++ b/packages/eslint-config/src/rules/preferMergeProps.test.ts
@@ -94,7 +94,7 @@ ruleTester.run('prefer-merge-props', preferMergeProps as unknown as Parameters<R
       errors: [{messageId: 'preferMergeProps'}],
     },
     {
-      name: 'reports props returned from another utility',
+      name: 'reports spread props returned from a function call',
       code: `const example = <button {...getProps()} />`,
       errors: [{messageId: 'preferMergeProps'}],
     },

--- a/packages/eslint-config/src/rules/preferMergeProps.test.ts
+++ b/packages/eslint-config/src/rules/preferMergeProps.test.ts
@@ -1,4 +1,5 @@
 import {RuleTester} from 'eslint'
+import tsParser from '@typescript-eslint/parser'
 import {describe, it} from 'vitest'
 import {preferMergeProps} from './preferMergeProps.ts'
 
@@ -9,6 +10,7 @@ RuleTester.itOnly = it
 const ruleTester = new RuleTester({
   languageOptions: {
     ecmaVersion: 'latest',
+    parser: tsParser,
     sourceType: 'module',
     parserOptions: {
       ecmaFeatures: {
@@ -171,6 +173,24 @@ ruleTester.run('prefer-merge-props', preferMergeProps as unknown as Parameters<R
     {
       name: 'reports props on a forwardRef component root',
       code: `const Example = React.forwardRef((props, ref) => <button {...props} ref={ref} />)`,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports props on an asserted forwardRef component root',
+      code: `
+        const Example = React.forwardRef(
+          (props, ref) => <button {...props} ref={ref} />
+        ) as PolymorphicForwardRefComponent
+      `,
+      errors: [{messageId: 'preferMergeProps'}],
+    },
+    {
+      name: 'reports props on a forwardRef component root using satisfies',
+      code: `
+        const Example = React.forwardRef(
+          (props, ref) => <button {...props} ref={ref} />
+        ) satisfies PolymorphicForwardRefComponent
+      `,
       errors: [{messageId: 'preferMergeProps'}],
     },
     {

--- a/packages/eslint-config/src/rules/preferMergeProps.ts
+++ b/packages/eslint-config/src/rules/preferMergeProps.ts
@@ -23,7 +23,7 @@ const preferMergeProps: TSESLint.RuleModule<MessageIds> = {
 
     return {
       JSXOpeningElement(node) {
-        if (!isComponentRoot(node.parent)) {
+        if (!isComponentRoot(node.parent) || !hasPropsToMerge(node)) {
           return
         }
 
@@ -41,6 +41,22 @@ const preferMergeProps: TSESLint.RuleModule<MessageIds> = {
       },
     }
   },
+}
+
+function hasPropsToMerge(node: TSESTree.JSXOpeningElement): boolean {
+  const spreadCount = node.attributes.filter(attribute => attribute.type === 'JSXSpreadAttribute').length
+  if (spreadCount > 1) {
+    return true
+  }
+
+  return node.attributes.some(attribute => {
+    return (
+      attribute.type === 'JSXAttribute' &&
+      attribute.name.type === 'JSXIdentifier' &&
+      attribute.name.name !== 'key' &&
+      attribute.name.name !== 'ref'
+    )
+  })
 }
 
 function isTestOrStoryFile(filename: string): boolean {

--- a/packages/eslint-config/src/rules/preferMergeProps.ts
+++ b/packages/eslint-config/src/rules/preferMergeProps.ts
@@ -6,20 +6,24 @@ const preferMergeProps: TSESLint.RuleModule<MessageIds> = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Require spread props on outermost JSX elements to use mergeProps',
+      description: 'Require spread props on component root elements to use mergeProps',
     },
     messages: {
       preferMergeProps:
-        'Spread props on an outermost JSX element with mergeProps so component and consumer props are merged intentionally.',
+        'Spread props on a component root element with mergeProps so component and consumer props are merged intentionally.',
     },
     schema: [],
   },
   create(context) {
     const {sourceCode} = context
 
+    if (isTestOrStoryFile(context.filename)) {
+      return {}
+    }
+
     return {
       JSXOpeningElement(node) {
-        if (!isOutermostElement(node.parent)) {
+        if (!isComponentRoot(node.parent)) {
           return
         }
 
@@ -39,17 +43,174 @@ const preferMergeProps: TSESLint.RuleModule<MessageIds> = {
   },
 }
 
-function isOutermostElement(element: TSESTree.JSXElement): boolean {
-  let ancestor: TSESTree.Node | undefined = element.parent
+function isTestOrStoryFile(filename: string): boolean {
+  const normalizedFilename = filename.replaceAll('\\', '/')
+  return (
+    /(?:^|\/)__(?:tests|stories)__(?:\/|$)/u.test(normalizedFilename) ||
+    /\.(?:spec|test|stories|story)\.[cm]?[jt]sx?$/u.test(normalizedFilename)
+  )
+}
 
-  while (ancestor) {
-    if (ancestor.type === 'JSXElement' || ancestor.type === 'JSXFragment') {
+function isComponentRoot(element: TSESTree.JSXElement): boolean {
+  let expression: TSESTree.Node = element
+
+  for (;;) {
+    const parent: TSESTree.Node = expression.parent
+
+    if (
+      parent.type === 'ConditionalExpression' &&
+      (parent.consequent === expression || parent.alternate === expression)
+    ) {
+      expression = parent
+      continue
+    }
+
+    if (parent.type === 'LogicalExpression' && parent.right === expression) {
+      expression = parent
+      continue
+    }
+
+    if (
+      parent.type === 'TSAsExpression' ||
+      parent.type === 'TSNonNullExpression' ||
+      parent.type === 'TSSatisfiesExpression' ||
+      parent.type === 'TSTypeAssertion'
+    ) {
+      expression = parent
+      continue
+    }
+
+    if (parent.type === 'ReturnStatement' && parent.argument === expression) {
+      return isReturnedByComponent(parent)
+    }
+
+    if (parent.type === 'ArrowFunctionExpression' && parent.body === expression) {
+      return isComponentFunction(parent)
+    }
+
+    if (parent.type === 'JSXElement' || parent.type === 'JSXFragment') {
       return false
+    }
+
+    return false
+  }
+}
+
+function isReturnedByComponent(statement: TSESTree.ReturnStatement): boolean {
+  let ancestor = statement.parent
+
+  while (ancestor.type !== 'Program') {
+    if (isFunction(ancestor)) {
+      return isComponentFunction(ancestor)
     }
     ancestor = ancestor.parent
   }
 
-  return true
+  return false
+}
+
+function isFunction(node: TSESTree.Node): node is ComponentFunction {
+  return (
+    node.type === 'ArrowFunctionExpression' || node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression'
+  )
+}
+
+type ComponentFunction = TSESTree.ArrowFunctionExpression | TSESTree.FunctionDeclaration | TSESTree.FunctionExpression
+
+function isComponentFunction(node: ComponentFunction): boolean {
+  const name = getFunctionName(node)
+  if (name !== null) {
+    return isComponentName(name)
+  }
+
+  if (node.parent.type === 'ExportDefaultDeclaration') {
+    return true
+  }
+
+  return isWrappedComponent(node)
+}
+
+function getFunctionName(node: ComponentFunction): string | null {
+  if (node.parent.type === 'VariableDeclarator' && node.parent.init === node && node.parent.id.type === 'Identifier') {
+    return node.parent.id.name
+  }
+
+  if (
+    node.parent.type === 'AssignmentExpression' &&
+    node.parent.right === node &&
+    node.parent.left.type === 'Identifier'
+  ) {
+    return node.parent.left.name
+  }
+
+  if (node.type !== 'ArrowFunctionExpression' && node.id !== null) {
+    return node.id.name
+  }
+
+  if (
+    node.type === 'FunctionExpression' &&
+    node.parent.type === 'MethodDefinition' &&
+    node.parent.value === node &&
+    node.parent.key.type === 'Identifier' &&
+    node.parent.key.name === 'render'
+  ) {
+    return getClassName(node.parent.parent.parent)
+  }
+
+  return null
+}
+
+function getClassName(node: TSESTree.ClassDeclaration | TSESTree.ClassExpression): string | null {
+  if (node.id !== null) {
+    return node.id.name
+  }
+
+  if (node.parent.type === 'VariableDeclarator' && node.parent.init === node && node.parent.id.type === 'Identifier') {
+    return node.parent.id.name
+  }
+
+  if (node.parent.type === 'ExportDefaultDeclaration') {
+    return 'DefaultExport'
+  }
+
+  return null
+}
+
+function isWrappedComponent(node: ComponentFunction): boolean {
+  let expression: TSESTree.Node = node
+
+  while (
+    expression.parent.type === 'CallExpression' &&
+    expression.parent.arguments.includes(expression as TSESTree.Expression) &&
+    isComponentWrapper(expression.parent.callee)
+  ) {
+    expression = expression.parent
+  }
+
+  return (
+    (expression.parent.type === 'VariableDeclarator' &&
+      expression.parent.init === expression &&
+      expression.parent.id.type === 'Identifier' &&
+      isComponentName(expression.parent.id.name)) ||
+    expression.parent.type === 'ExportDefaultDeclaration'
+  )
+}
+
+function isComponentWrapper(callee: TSESTree.Expression): boolean {
+  if (callee.type === 'Identifier') {
+    return callee.name === 'forwardRef' || callee.name === 'fixedForwardRef' || callee.name === 'memo'
+  }
+
+  return (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property.type === 'Identifier' &&
+    (callee.property.name === 'forwardRef' || callee.property.name === 'memo')
+  )
+}
+
+function isComponentName(name: string): boolean {
+  return /^[A-Z]/u.test(name)
 }
 
 function isMergedProps(argument: TSESTree.Expression, scope: TSESLint.Scope.Scope): boolean {

--- a/packages/eslint-config/src/rules/preferMergeProps.ts
+++ b/packages/eslint-config/src/rules/preferMergeProps.ts
@@ -70,12 +70,7 @@ function isComponentRoot(element: TSESTree.JSXElement): boolean {
       continue
     }
 
-    if (
-      parent.type === 'TSAsExpression' ||
-      parent.type === 'TSNonNullExpression' ||
-      parent.type === 'TSSatisfiesExpression' ||
-      parent.type === 'TSTypeAssertion'
-    ) {
+    if (isTypeScriptWrapper(parent)) {
       expression = parent
       continue
     }
@@ -94,6 +89,21 @@ function isComponentRoot(element: TSESTree.JSXElement): boolean {
 
     return false
   }
+}
+
+function isTypeScriptWrapper(
+  node: TSESTree.Node,
+): node is
+  | TSESTree.TSAsExpression
+  | TSESTree.TSNonNullExpression
+  | TSESTree.TSSatisfiesExpression
+  | TSESTree.TSTypeAssertion {
+  return (
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSNonNullExpression' ||
+    node.type === 'TSSatisfiesExpression' ||
+    node.type === 'TSTypeAssertion'
+  )
 }
 
 function isReturnedByComponent(statement: TSESTree.ReturnStatement): boolean {
@@ -179,12 +189,24 @@ function getClassName(node: TSESTree.ClassDeclaration | TSESTree.ClassExpression
 function isWrappedComponent(node: ComponentFunction): boolean {
   let expression: TSESTree.Node = node
 
-  while (
-    expression.parent.type === 'CallExpression' &&
-    expression.parent.arguments.includes(expression as TSESTree.Expression) &&
-    isComponentWrapper(expression.parent.callee)
-  ) {
-    expression = expression.parent
+  for (;;) {
+    const parent: TSESTree.Node = expression.parent
+
+    if (isTypeScriptWrapper(parent)) {
+      expression = parent
+      continue
+    }
+
+    if (
+      parent.type === 'CallExpression' &&
+      parent.arguments.includes(expression as TSESTree.Expression) &&
+      isComponentWrapper(parent.callee)
+    ) {
+      expression = parent
+      continue
+    }
+
+    break
   }
 
   return (

--- a/packages/eslint-config/src/rules/preferMergeProps.ts
+++ b/packages/eslint-config/src/rules/preferMergeProps.ts
@@ -1,0 +1,95 @@
+import {ASTUtils, type TSESLint, type TSESTree} from '@typescript-eslint/utils'
+
+type MessageIds = 'preferMergeProps'
+
+const preferMergeProps: TSESLint.RuleModule<MessageIds> = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Require spread props on outermost JSX elements to use mergeProps',
+    },
+    messages: {
+      preferMergeProps:
+        'Spread props on an outermost JSX element with mergeProps so component and consumer props are merged intentionally.',
+    },
+    schema: [],
+  },
+  create(context) {
+    const {sourceCode} = context
+
+    return {
+      JSXOpeningElement(node) {
+        if (!isOutermostElement(node.parent)) {
+          return
+        }
+
+        for (const attribute of node.attributes) {
+          if (
+            attribute.type === 'JSXSpreadAttribute' &&
+            !isMergedProps(attribute.argument, sourceCode.getScope(attribute))
+          ) {
+            context.report({
+              node: attribute,
+              messageId: 'preferMergeProps',
+            })
+          }
+        }
+      },
+    }
+  },
+}
+
+function isOutermostElement(element: TSESTree.JSXElement): boolean {
+  let ancestor: TSESTree.Node | undefined = element.parent
+
+  while (ancestor) {
+    if (ancestor.type === 'JSXElement' || ancestor.type === 'JSXFragment') {
+      return false
+    }
+    ancestor = ancestor.parent
+  }
+
+  return true
+}
+
+function isMergedProps(argument: TSESTree.Expression, scope: TSESLint.Scope.Scope): boolean {
+  if (isMergePropsCall(argument)) {
+    return true
+  }
+
+  if (argument.type !== 'Identifier') {
+    return false
+  }
+
+  const variable = ASTUtils.findVariable(scope, argument)
+  return (
+    variable?.defs.some(definition => {
+      return (
+        definition.type === 'Variable' &&
+        definition.parent.kind === 'const' &&
+        definition.node.init !== null &&
+        isMergePropsCall(definition.node.init)
+      )
+    }) ?? false
+  )
+}
+
+function isMergePropsCall(argument: TSESTree.Expression): boolean {
+  if (argument.type !== 'CallExpression') {
+    return false
+  }
+
+  const {callee} = argument
+  if (callee.type === 'Identifier') {
+    return callee.name === 'mergeProps'
+  }
+
+  return (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'mergeProps'
+  )
+}
+
+export {preferMergeProps}

--- a/packages/eslint-config/tsconfig.json
+++ b/packages/eslint-config/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src", "vitest.config.ts"]
+}

--- a/packages/eslint-config/vitest.config.ts
+++ b/packages/eslint-config/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from '@primer/vitest-config/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/script/merge-props-migration-status.mts
+++ b/script/merge-props-migration-status.mts
@@ -34,11 +34,11 @@ const violationCount = affectedResults.reduce((count, result) => {
 write(`
 # mergeProps Migration
 
-This report tracks outermost JSX prop spreads that should migrate to \`mergeProps\`.
+This report tracks component root prop spreads that should migrate to \`mergeProps\`.
 
 ## Status
 
-**Outermost prop spreads to migrate:** ${violationCount}
+**Component root prop spreads to migrate:** ${violationCount}
 
 **Affected files:** ${affectedResults.length} of ${results.length}
 `)

--- a/script/merge-props-migration-status.mts
+++ b/script/merge-props-migration-status.mts
@@ -34,11 +34,11 @@ const violationCount = affectedResults.reduce((count, result) => {
 write(`
 # mergeProps Migration
 
-This report tracks component root prop spreads that should migrate to \`mergeProps\`.
+This report tracks component roots that combine authored props with unmerged spread props.
 
 ## Status
 
-**Component root prop spreads to migrate:** ${violationCount}
+**Unmerged component root prop spreads to migrate:** ${violationCount}
 
 **Affected files:** ${affectedResults.length} of ${results.length}
 `)

--- a/script/merge-props-migration-status.mts
+++ b/script/merge-props-migration-status.mts
@@ -1,0 +1,65 @@
+import path from 'node:path'
+import {ESLint} from 'eslint'
+
+const directory = path.resolve(import.meta.dirname, '..')
+const ruleId = 'primer/prefer-merge-props'
+const eslint = new ESLint({
+  cwd: directory,
+  overrideConfig: [
+    {
+      rules: {
+        [ruleId]: 'error',
+      },
+    },
+  ],
+})
+const results = await eslint.lintFiles(['packages/react/src/**/*.{ts,tsx}'])
+const fatalMessages = results.flatMap(result => {
+  return result.messages
+    .filter(message => message.fatal)
+    .map(message => `${result.filePath}:${message.line} ${message.message}`)
+})
+
+if (fatalMessages.length > 0) {
+  throw new Error(`Unable to generate the mergeProps migration report:\n${fatalMessages.join('\n')}`)
+}
+
+const affectedResults = results.filter(result => {
+  return result.messages.some(message => message.ruleId === ruleId)
+})
+const violationCount = affectedResults.reduce((count, result) => {
+  return count + result.messages.filter(message => message.ruleId === ruleId).length
+}, 0)
+
+write(`
+# mergeProps Migration
+
+This report tracks outermost JSX prop spreads that should migrate to \`mergeProps\`.
+
+## Status
+
+**Outermost prop spreads to migrate:** ${violationCount}
+
+**Affected files:** ${affectedResults.length} of ${results.length}
+`)
+
+write(`
+## Affected Files (${affectedResults.length})
+
+| Filepath | Locations | Violations |
+| :------- | :-------- | :--------- |`)
+
+for (const result of affectedResults) {
+  const relativePath = path.relative(directory, result.filePath)
+  const messages = result.messages.filter(message => message.ruleId === ruleId)
+  const locations = messages.map(
+    message => `[L${message.line}](https://github.com/primer/react/blob/main/${relativePath}#L${message.line})`,
+  )
+  const link = `[\`${relativePath}\`](https://github.com/primer/react/blob/main/${relativePath})`
+
+  write(`| ${link} | ${locations.join(', ')} | ${messages.length} |`)
+}
+
+function write(value: string): void {
+  process.stdout.write(`${value}\n`)
+}


### PR DESCRIPTION
Closes #

This PR adds the tooling used to identify and track component roots that should adopt `mergeProps`. It introduces a private ESLint package, the migration report script, and the workflow that keeps the report current.

### Changelog

#### New

- Add `@primer/eslint-config` with the `primer/prefer-merge-props` rule.
- Add the merge props migration-status report and workflow integration.

#### Changed

- Register the local Primer ESLint plugin in the root configuration.

#### Removed

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

This is internal migration tooling and has no public-facing impact.

### Testing & Reviewing

Please review the rule boundary and report output. Pure prop-forwarding wrappers should be ignored, while component roots that combine authored and consumer props should remain findings.