### PR TITLE
Migrate Button roots to mergeProps

### DIFF
--- a/.changeset/bright-buttons-merge.md
+++ b/.changeset/bright-buttons-merge.md
@@ -1,5 +1,0 @@
----
-'@primer/react': patch
----
-
-Button: Preserve component behavior and styling when merging consumer props

--- a/.changeset/bright-buttons-merge.md
+++ b/.changeset/bright-buttons-merge.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Button: Preserve component behavior and styling when merging consumer props

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -2,10 +2,11 @@ import {forwardRef, type JSX} from 'react'
 import type {ButtonProps} from './types'
 import {ButtonBase} from './ButtonBase'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
+import {mergeProps} from '../utils/mergeProps'
 
 const ButtonComponent = forwardRef(({children, ...props}, forwardedRef): JSX.Element => {
   return (
-    <ButtonBase ref={forwardedRef} as="button" type="button" {...props}>
+    <ButtonBase {...mergeProps({as: 'button', type: 'button'}, props)} ref={forwardedRef}>
       {children}
     </ButtonBase>
   )

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -6,7 +6,7 @@ import {mergeProps} from '../utils/mergeProps'
 
 const ButtonComponent = forwardRef(({children, ...props}, forwardedRef): JSX.Element => {
   return (
-    <ButtonBase {...mergeProps({as: 'button', type: 'button'}, props)} ref={forwardedRef}>
+    <ButtonBase ref={forwardedRef} {...mergeProps({as: 'button', type: 'button'}, props)}>
       {children}
     </ButtonBase>
   )

--- a/packages/react/src/Button/IconButton.tsx
+++ b/packages/react/src/Button/IconButton.tsx
@@ -7,6 +7,7 @@ import {TooltipContext} from '../TooltipV2/TooltipContext'
 import {TooltipContext as TooltipContextV1} from '../Tooltip/TooltipContext'
 import classes from './ButtonBase.module.css'
 import {mergeProps} from '../utils/mergeProps'
+import {clsx} from 'clsx'
 
 const IconButton = forwardRef(
   (
@@ -20,6 +21,7 @@ const IconButton = forwardRef(
       unsafeDisableTooltip = false,
       keyshortcuts,
       keybindingHint,
+      className,
       ...props
     },
     forwardedRef,
@@ -42,10 +44,12 @@ const IconButton = forwardRef(
     if (withoutTooltip) {
       return (
         <ButtonBase
+          // @ts-expect-error StyledButton wants both Anchor and Button refs
+          ref={forwardedRef}
           {...mergeProps(
             {
               icon: Icon,
-              className: classes.IconButton,
+              className: clsx(classes.IconButton, className),
               'data-component': 'IconButton',
               type: 'button',
               'aria-label': ariaLabel,
@@ -53,8 +57,6 @@ const IconButton = forwardRef(
             },
             props,
           )}
-          // @ts-expect-error StyledButton wants both Anchor and Button refs
-          ref={forwardedRef}
         />
       )
     } else {
@@ -72,7 +74,7 @@ const IconButton = forwardRef(
             {...mergeProps(
               {
                 icon: Icon,
-                className: classes.IconButton,
+                className: clsx(classes.IconButton, className),
                 'data-component': 'IconButton',
                 type: 'button',
                 'aria-keyshortcuts': keyshortcuts ?? undefined,

--- a/packages/react/src/Button/IconButton.tsx
+++ b/packages/react/src/Button/IconButton.tsx
@@ -6,7 +6,7 @@ import {Tooltip} from '../TooltipV2/Tooltip'
 import {TooltipContext} from '../TooltipV2/TooltipContext'
 import {TooltipContext as TooltipContextV1} from '../Tooltip/TooltipContext'
 import classes from './ButtonBase.module.css'
-import {clsx} from 'clsx'
+import {mergeProps} from '../utils/mergeProps'
 
 const IconButton = forwardRef(
   (
@@ -20,7 +20,6 @@ const IconButton = forwardRef(
       unsafeDisableTooltip = false,
       keyshortcuts,
       keybindingHint,
-      className,
       ...props
     },
     forwardedRef,
@@ -43,13 +42,17 @@ const IconButton = forwardRef(
     if (withoutTooltip) {
       return (
         <ButtonBase
-          icon={Icon}
-          className={clsx(className, classes.IconButton)}
-          data-component="IconButton"
-          type="button"
-          aria-label={ariaLabel}
-          disabled={disabled}
-          {...props}
+          {...mergeProps(
+            {
+              icon: Icon,
+              className: classes.IconButton,
+              'data-component': 'IconButton',
+              type: 'button',
+              'aria-label': ariaLabel,
+              disabled,
+            },
+            props,
+          )}
           // @ts-expect-error StyledButton wants both Anchor and Button refs
           ref={forwardedRef}
         />
@@ -66,14 +69,18 @@ const IconButton = forwardRef(
           _privateDisableTooltip={hasActivePopup}
         >
           <ButtonBase
-            icon={Icon}
-            className={clsx(className, classes.IconButton)}
-            data-component="IconButton"
-            type="button"
-            aria-keyshortcuts={keyshortcuts ?? undefined}
-            // If description is provided, we will use the tooltip to describe the button, so we need to keep the aria-label to label the button.
-            aria-label={description ? ariaLabel : undefined}
-            {...props}
+            {...mergeProps(
+              {
+                icon: Icon,
+                className: classes.IconButton,
+                'data-component': 'IconButton',
+                type: 'button',
+                'aria-keyshortcuts': keyshortcuts ?? undefined,
+                // If description is provided, we will use the tooltip to describe the button, so we need to keep the aria-label to label the button.
+                'aria-label': description ? ariaLabel : undefined,
+              },
+              props,
+            )}
           />
         </Tooltip>
       )

--- a/packages/react/src/Button/LinkButton.tsx
+++ b/packages/react/src/Button/LinkButton.tsx
@@ -8,7 +8,7 @@ export type LinkButtonProps = BaseLinkButtonProps & ButtonProps
 
 const LinkButton = forwardRef(({children, as: Component = 'a', ...props}, forwardedRef): JSX.Element => {
   return (
-    <ButtonBase {...mergeProps({as: Component, 'data-component': 'LinkButton'}, props)} ref={forwardedRef}>
+    <ButtonBase ref={forwardedRef} {...mergeProps({as: Component, 'data-component': 'LinkButton'}, props)}>
       {children}
     </ButtonBase>
   )

--- a/packages/react/src/Button/LinkButton.tsx
+++ b/packages/react/src/Button/LinkButton.tsx
@@ -2,12 +2,13 @@ import {forwardRef, type JSX} from 'react'
 import type {LinkButtonProps as BaseLinkButtonProps, ButtonProps} from './types'
 import {ButtonBase} from './ButtonBase'
 import type {ForwardRefComponent as PolymorphicForwardRefComponent} from '../utils/polymorphic'
+import {mergeProps} from '../utils/mergeProps'
 
 export type LinkButtonProps = BaseLinkButtonProps & ButtonProps
 
 const LinkButton = forwardRef(({children, as: Component = 'a', ...props}, forwardedRef): JSX.Element => {
   return (
-    <ButtonBase as={Component} ref={forwardedRef} data-component="LinkButton" {...props}>
+    <ButtonBase {...mergeProps({as: Component, 'data-component': 'LinkButton'}, props)} ref={forwardedRef}>
       {children}
     </ButtonBase>
   )


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Migrates Button, IconButton, and LinkButton roots to the ADR-025 prop-merging convention without changing existing prop behavior.

### Changelog

#### New

None.

#### Changed

None; this is a behavior-preserving refactor.

#### Removed

None.

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; if selected, include a brief description as to why

This migration preserves the existing public contract and does not require release notes.

### Testing & Reviewing

Review inline class-name composition, ref ordering, and polymorphic consumer prop precedence.