### PR TITLE
fix(AnchoredOverlay): use position-visibility:always to keep overlay visible when anchor is hidden in Firefox

### DIFF
--- a/packages/react/src/AnchoredOverlay/AnchoredOverlay.module.css
+++ b/packages/react/src/AnchoredOverlay/AnchoredOverlay.module.css
@@ -22,7 +22,7 @@
     --inline-start-center,
     --fit-block-bottom,
     --fit-block-top;
-  position-visibility: anchors-visible;
+  position-visibility: always;
   z-index: 100;
   position: fixed !important;
 


### PR DESCRIPTION
## Summary

Firefox defaults `position-visibility` to `anchors-visible`, which hides CSS-anchored elements when their anchor scrolls off-screen. This causes anchored overlays (ActionMenu, SelectPanel, Tooltip, etc.) to disappear in Firefox when the trigger element is scrolled out of view, while Chrome keeps them visible.

Setting `position-visibility: always` on `.AnchoredOverlay` ensures the overlay stays visible even when its anchor is hidden, matching Chrome behavior.

## Changes

- `packages/react/src/AnchoredOverlay/AnchoredOverlay.module.css`: `position-visibility: always`

## Test Plan

- [x] Verified the CSS property change is correct per the [CSS Anchor Positioning spec](https://drafts.csswg.org/css-anchor-position-1/#position-visibility)
- Overlay behavior in Chrome is unchanged (Chrome already shows the overlay when anchor is hidden)
- Fixes Firefox parity issue

Closes #8247