### PR TITLE
Force box-sizing on underline wrapper in wrap mode

### DIFF
--- a/.changeset/underline-wrapper-force-box-sizing.md
+++ b/.changeset/underline-wrapper-force-box-sizing.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Pin `box-sizing` with `!important` on the underline tabbed interface wrapper in wrap mode so external overrides can no longer offset its height budget and incorrectly trigger the overflow "more" menu

--- a/packages/react/src/internal/components/UnderlineTabbedInterface.module.css
+++ b/packages/react/src/internal/components/UnderlineTabbedInterface.module.css
@@ -23,8 +23,8 @@
     overflow: hidden;
     max-height: var(--control-xlarge-size);
 
-    /* Pin the vertical box model so external border/padding overrides can't change the height budget and incorrectly trigger the overflow "more" menu */
-    box-sizing: border-box;
+    /* Pin the vertical box model so external box-sizing/border/padding overrides can't change the height budget and incorrectly trigger the overflow "more" menu */
+    box-sizing: border-box !important;
     border-block: 0 !important;
     padding-block: var(--base-size-8) 0 !important;
 


### PR DESCRIPTION
Closes #

Adds `box-sizing: border-box !important` to the underline tabbed interface wrapper's wrap-mode rule, matching the `!important` already applied to `border-block` and `padding-block` in the same rule.

While investigating the border override issue fixed for the [github-ui] more-menu overflow bug, we noticed `box-sizing` in this same rule wasn't pinned with `!important`. An external `box-sizing: content-box` override could still change the wrapper's effective height budget used for overflow detection (via `IntersectionObserver`), incorrectly triggering the overflow "more" menu the same way the unpinned `border` did previously.

### Changelog

#### Changed

- `UnderlineNav` / `UnderlinePanels` wrap-mode wrapper CSS now also forces `box-sizing: border-box !important`.

### Rollout strategy

- [x] Patch release

### Testing & Reviewing

No visible/functional change under normal usage. This only guards against an external `box-sizing` override corrupting the overflow-detection height budget, the same class of bug previously fixed for `border`/`padding-block`.
