### PR TITLE
Add missing MCP scenario patterns

### DIFF
--- a/.changeset/update-mcp-scenario-patterns.md
+++ b/.changeset/update-mcp-scenario-patterns.md
@@ -2,4 +2,4 @@
 '@primer/mcp': minor
 ---
 
-MCP server: Add Create, Delegate, Edit and View scenario patterns to the `list_patterns` and `get_pattern` tools.
+MCP server: Add Create, Customize, Delegate, Edit and View scenario patterns to the `list_patterns` and `get_pattern` tools.

--- a/.changeset/update-mcp-scenario-patterns.md
+++ b/.changeset/update-mcp-scenario-patterns.md
@@ -1,0 +1,5 @@
+---
+'@primer/mcp': minor
+---
+
+MCP server: Add Create, Delegate, Edit and View scenario patterns to the `list_patterns` and `get_pattern` tools.

--- a/packages/mcp/src/primer.ts
+++ b/packages/mcp/src/primer.ts
@@ -57,6 +57,11 @@ const patterns: Array<Pattern> = [
     category: 'scenario',
   },
   {
+    id: 'customize',
+    name: 'Customize',
+    category: 'scenario',
+  },
+  {
     id: 'delegate',
     name: 'Delegate',
     category: 'scenario',

--- a/packages/mcp/src/primer.ts
+++ b/packages/mcp/src/primer.ts
@@ -52,8 +52,23 @@ const patterns: Array<Pattern> = [
     category: 'scenario',
   },
   {
+    id: 'create',
+    name: 'Create',
+    category: 'scenario',
+  },
+  {
+    id: 'delegate',
+    name: 'Delegate',
+    category: 'scenario',
+  },
+  {
     id: 'delete',
     name: 'Delete',
+    category: 'scenario',
+  },
+  {
+    id: 'edit',
+    name: 'Edit',
     category: 'scenario',
   },
   {
@@ -64,6 +79,11 @@ const patterns: Array<Pattern> = [
   {
     id: 'search',
     name: 'Search',
+    category: 'scenario',
+  },
+  {
+    id: 'view',
+    name: 'View',
     category: 'scenario',
   },
   {

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -72,6 +72,43 @@ describe('MCP server', () => {
     )
   })
 
+  it('lists every published scenario pattern', async () => {
+    const result = await client.callTool({name: 'list_patterns'})
+    const scenarioPatterns = ['Copy', 'Create', 'Delegate', 'Delete', 'Edit', 'Filter', 'Search', 'View']
+
+    expect(result.content).toContainEqual(
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining(
+          `## Scenario patterns\n\n${scenarioPatterns.map(name => `- ${name}`).join('\n')}`,
+        ),
+      }),
+    )
+  })
+
+  it.each([
+    {name: 'Create', id: 'create'},
+    {name: 'Delegate', id: 'delegate'},
+    {name: 'Edit', id: 'edit'},
+    {name: 'View', id: 'view'},
+  ])('retrieves the $name scenario pattern from its published URL', async ({name, id}) => {
+    vi.mocked(fetch).mockResolvedValue(new Response(`<main><h1>${name}</h1></main>`))
+
+    const result = await client.callTool({
+      name: 'get_pattern',
+      arguments: {name},
+    })
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(fetch).mock.calls[0]?.[0].toString()).toBe(`https://primer.style/product/scenario-patterns/${id}`)
+    expect(result.content).toContainEqual(
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining(`Here are the guidelines for the \`${name}\` pattern for Primer:`),
+      }),
+    )
+  })
+
   it('requires between 2 and 10 names', async () => {
     const tooFew = await callBatch(['Button'])
     const tooMany = await callBatch(Array.from({length: 11}, (_, index) => `Component${index}`))

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -74,7 +74,7 @@ describe('MCP server', () => {
 
   it('lists every published scenario pattern', async () => {
     const result = await client.callTool({name: 'list_patterns'})
-    const scenarioPatterns = ['Copy', 'Create', 'Delegate', 'Delete', 'Edit', 'Filter', 'Search', 'View']
+    const scenarioPatterns = ['Copy', 'Create', 'Customize', 'Delegate', 'Delete', 'Edit', 'Filter', 'Search', 'View']
 
     expect(result.content).toContainEqual(
       expect.objectContaining({
@@ -88,6 +88,7 @@ describe('MCP server', () => {
 
   it.each([
     {name: 'Create', id: 'create'},
+    {name: 'Customize', id: 'customize'},
     {name: 'Delegate', id: 'delegate'},
     {name: 'Edit', id: 'edit'},
     {name: 'View', id: 'view'},

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -441,7 +441,7 @@ ${text}`,
     'list_patterns',
     {
       description:
-        'List all of the patterns available from Primer React. Scenario patterns describe specific user tasks (copy, delete, filter, search). Prefer a scenario pattern when one fits the task, and fall back to the more generic UI patterns otherwise.',
+        'List all of the patterns available from Primer React. Scenario patterns describe specific user tasks. Prefer a scenario pattern when one fits the task, and fall back to the more generic UI patterns otherwise.',
       annotations: {readOnlyHint: true},
     },
     async () => {
@@ -471,7 +471,7 @@ ${ui.join('\n')}`,
     'get_pattern',
     {
       description:
-        'Get a specific pattern by name. Scenario patterns describe specific user tasks (copy, delete, filter, search). Prefer a scenario pattern when one fits the task, and fall back to the more generic UI patterns otherwise.',
+        'Get a specific pattern by name. Scenario patterns describe specific user tasks. Prefer a scenario pattern when one fits the task, and fall back to the more generic UI patterns otherwise.',
       inputSchema: z.object({
         name: z.string().describe('The name of the pattern to retrieve'),
       }),


### PR DESCRIPTION
This brings the MCP pattern catalogue back in line with primer.style. The catalogue is manually maintained and had fallen behind the docs that have now been published as part of https://github.com/github/core-ux/issues/2845.

It adds Create, Customize, Delegate, Edit and View to `list_patterns` and `get_pattern`. I’ve also removed the duplicated pattern list from the tool descriptions, so there’s one less place for the catalogue to drift.

Closes github/core-ux#3479

### Changelog

#### New

- Add Create, Customize, Delegate, Edit and View scenario patterns.

#### Changed

- Describe scenario patterns without repeating the full catalogue in tool metadata.

#### Removed

- Nothing.

### Rollout strategy

- [ ] Patch release
- [x] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

No special rollout is needed.

### Testing & Reviewing

- `npm test -w @primer/mcp`
- `npm run type-check -w @primer/mcp`
- `npm run build -w @primer/mcp`
- Prettier and ESLint checks for the touched files
- Confirmed all five primer.style scenario pattern URLs return `200`