### PR TITLE
Fix integration test result label updates

### DIFF
--- a/.github/workflows/check-for-integration-result-comment.yml
+++ b/.github/workflows/check-for-integration-result-comment.yml
@@ -43,23 +43,25 @@ jobs:
                 (comment.body.includes('<!-- test-result') || comment.body.includes('<!-- statuses:'))
             );
             if (integrationComments.length === 0) {
-              console.log('Integration result comment not found');
+              console.log('Integration comment with test-result not found');
               return; // CI should pass if there's nothing to do
             }
 
             const latestComment = integrationComments.pop();
             console.log(latestComment.body);
 
-            const isGithubUiResult = latestComment.body.includes('<!-- statuses:');
-            const pass = latestComment.body.includes('🟢') || latestComment.body.includes('All checks passed!');
-            const fail = latestComment.body.includes('fail.svg');
+            // based on comment message in github/github: https://github.com/github/github/blob/fe7fe9072fd913ec04255ce7403ae764e6c33d5f/.github/workflows/github-ci.yml#L664-L692
+            const pass = latestComment.body.includes('🟢');
+            console.log({ pass });
 
-            if (isGithubUiResult && !pass && !fail) {
+            const githubUiPass = latestComment.body.includes('All checks passed!');
+            const githubUiFail = latestComment.body.includes('fail.svg');
+            if (latestComment.body.includes('<!-- statuses:') && !githubUiPass && !githubUiFail) {
               console.log('Integration checks are still running');
               return;
             }
 
-            const newIntegrationLabel = pass ? INTEGRATION_LABEL_NAMES.passing : INTEGRATION_LABEL_NAMES.failing;
+            const newIntegrationLabel = pass || githubUiPass ? INTEGRATION_LABEL_NAMES.passing : INTEGRATION_LABEL_NAMES.failing;
             console.log({existingIntegrationLabels, newIntegrationLabel})
 
             Object.values(INTEGRATION_LABEL_NAMES).map(async (name) => {

--- a/.github/workflows/check-for-integration-result-comment.yml
+++ b/.github/workflows/check-for-integration-result-comment.yml
@@ -36,49 +36,38 @@ jobs:
 
             if (existingIntegrationLabels.includes(INTEGRATION_LABEL_NAMES.skipped)) return;
 
-            const comment = context.payload.comment;
-            if (comment.user.login !== 'primer-integration[bot]') return;
-
-            let newIntegrationLabel;
-            if (comment.body.includes('<!-- statuses:')) {
-              const statusMatch = comment.body.match(/<!-- statuses: (.+?) -->/);
-              if (!statusMatch) {
-                core.setFailed('Could not parse integration statuses');
-                return;
-              }
-
-              const workflowStatuses = JSON.parse(statusMatch[1]);
-              const hasFailure = Object.values(workflowStatuses).some(
-                status => status.conclusion && status.conclusion !== 'success'
-              );
-              const allChecksPassed = comment.body.includes('All checks passed!');
-
-              if (!allChecksPassed && !hasFailure) {
-                console.log('Integration checks are still running');
-                return;
-              }
-
-              newIntegrationLabel = allChecksPassed
-                ? INTEGRATION_LABEL_NAMES.passing
-                : INTEGRATION_LABEL_NAMES.failing;
-            } else if (comment.body.includes('<!-- test-result')) {
-              // Preserve support for integration results reported by github/github.
-              newIntegrationLabel = comment.body.includes('🟢')
-                ? INTEGRATION_LABEL_NAMES.passing
-                : INTEGRATION_LABEL_NAMES.failing;
-            } else {
+            const result = await github.rest.issues.listComments(issue);
+            const integrationComments = result.data.filter(
+              comment =>
+                comment.user.login == 'primer-integration[bot]' &&
+                (comment.body.includes('<!-- test-result') || comment.body.includes('<!-- statuses:'))
+            );
+            if (integrationComments.length === 0) {
               console.log('Integration result comment not found');
+              return; // CI should pass if there's nothing to do
+            }
+
+            const latestComment = integrationComments.pop();
+            console.log(latestComment.body);
+
+            const isGithubUiResult = latestComment.body.includes('<!-- statuses:');
+            const pass = latestComment.body.includes('🟢') || latestComment.body.includes('All checks passed!');
+            const fail = latestComment.body.includes('fail.svg');
+
+            if (isGithubUiResult && !pass && !fail) {
+              console.log('Integration checks are still running');
               return;
             }
 
+            const newIntegrationLabel = pass ? INTEGRATION_LABEL_NAMES.passing : INTEGRATION_LABEL_NAMES.failing;
             console.log({existingIntegrationLabels, newIntegrationLabel})
 
-            await Promise.all(Object.values(INTEGRATION_LABEL_NAMES).map(async (name) => {
+            Object.values(INTEGRATION_LABEL_NAMES).map(async (name) => {
               if (name === newIntegrationLabel) {
-                if (!existingIntegrationLabels.includes(name)) {
-                  await github.rest.issues.addLabels({...issue, labels: [newIntegrationLabel]});
-                }
+                if (existingIntegrationLabels.includes(name)); // already added, nothing to do here
+                else await github.rest.issues.addLabels({...issue, labels: [newIntegrationLabel]});
               } else if (existingIntegrationLabels.includes(name)) {
+                // remove outdated labels
                 await github.rest.issues.removeLabel({ ...issue, name });
               }
-            }));
+            });

--- a/.github/workflows/check-for-integration-result-comment.yml
+++ b/.github/workflows/check-for-integration-result-comment.yml
@@ -36,33 +36,49 @@ jobs:
 
             if (existingIntegrationLabels.includes(INTEGRATION_LABEL_NAMES.skipped)) return;
 
-            const result = await github.rest.issues.listComments(issue);
-            const integrationComments = result.data.filter(
-              comment =>
-                comment.user.login == 'primer-integration[bot]' &&
-                comment.body.includes('<!-- test-result')
-            );
-            if (integrationComments.length === 0) {
-              console.log('Integration comment with test-result not found');
-              return; // CI should pass if there's nothing to do
+            const comment = context.payload.comment;
+            if (comment.user.login !== 'primer-integration[bot]') return;
+
+            let newIntegrationLabel;
+            if (comment.body.includes('<!-- statuses:')) {
+              const statusMatch = comment.body.match(/<!-- statuses: (.+?) -->/);
+              if (!statusMatch) {
+                core.setFailed('Could not parse integration statuses');
+                return;
+              }
+
+              const workflowStatuses = JSON.parse(statusMatch[1]);
+              const hasFailure = Object.values(workflowStatuses).some(
+                status => status.conclusion && status.conclusion !== 'success'
+              );
+              const allChecksPassed = comment.body.includes('All checks passed!');
+
+              if (!allChecksPassed && !hasFailure) {
+                console.log('Integration checks are still running');
+                return;
+              }
+
+              newIntegrationLabel = allChecksPassed
+                ? INTEGRATION_LABEL_NAMES.passing
+                : INTEGRATION_LABEL_NAMES.failing;
+            } else if (comment.body.includes('<!-- test-result')) {
+              // Preserve support for integration results reported by github/github.
+              newIntegrationLabel = comment.body.includes('🟢')
+                ? INTEGRATION_LABEL_NAMES.passing
+                : INTEGRATION_LABEL_NAMES.failing;
+            } else {
+              console.log('Integration result comment not found');
+              return;
             }
 
-            const latestComment = integrationComments.pop();
-            console.log(latestComment.body);
-
-            // based on comment message in github/github: https://github.com/github/github/blob/fe7fe9072fd913ec04255ce7403ae764e6c33d5f/.github/workflows/github-ci.yml#L664-L692
-            const pass = latestComment.body.includes('🟢');
-            console.log({ pass });
-
-            const newIntegrationLabel = pass ? INTEGRATION_LABEL_NAMES.passing : INTEGRATION_LABEL_NAMES.failing;
             console.log({existingIntegrationLabels, newIntegrationLabel})
 
-            Object.values(INTEGRATION_LABEL_NAMES).map(async (name) => {
+            await Promise.all(Object.values(INTEGRATION_LABEL_NAMES).map(async (name) => {
               if (name === newIntegrationLabel) {
-                if (existingIntegrationLabels.includes(name)); // already added, nothing to do here
-                else await github.rest.issues.addLabels({...issue, labels: [newIntegrationLabel]});
+                if (!existingIntegrationLabels.includes(name)) {
+                  await github.rest.issues.addLabels({...issue, labels: [newIntegrationLabel]});
+                }
               } else if (existingIntegrationLabels.includes(name)) {
-                // remove outdated labels
                 await github.rest.issues.removeLabel({ ...issue, name });
               }
-            });
+            }));


### PR DESCRIPTION
Update the integration result workflow to recognize the result comments emitted by `github/github-ui`. Successful runs now replace `integration-tests: recommended` with `integration-tests: passing`, failed runs apply `integration-tests: failing`, and in-progress runs leave labels unchanged.

Existing `github/github` integration result handling is unchanged.

### Changelog

#### Changed

- Recognize passing, failing, and in-progress `github-ui` integration result comments.

#### Removed

None.

### Rollout strategy

- [ ] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [x] None; CI-only workflow change with no published package impact.

### Testing & Reviewing

Validated the result markers used by `github-ui`: `All checks passed!` applies the passing label, `fail.svg` applies the failing label, and a status comment with neither marker leaves labels unchanged. After merge, re-running a completed `Primer Report CI` workflow will exercise the updated default-branch `issue_comment` workflow end to end.