### PR TITLE
ci: update cache keys to improve cache behavior

### DIFF
--- a/.github/workflows/aat-reports.yml
+++ b/.github/workflows/aat-reports.yml
@@ -31,7 +31,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-${{ github.job }}-shard-${{ matrix.shard }}-
             ${{ runner.os }}-turbo-${{ github.job }}-
-            ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
       - name: Build storybook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,6 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-
-            ${{ runner.os }}-turbo-${{ github.job }}-
-            ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
       - if: ${{ matrix.react-version == 'react-19' }}
@@ -111,8 +109,6 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-
-            ${{ runner.os }}-turbo-${{ github.job }}-
-            ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
       - if: ${{ matrix.react-version == 'react-19' }}
@@ -145,8 +141,6 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.react-version }}-
-            ${{ runner.os }}-turbo-${{ github.job }}-
-            ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
       - if: ${{ matrix.react-version == 'react-19' }}
@@ -172,8 +166,6 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ github.job }}-default-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ${{ runner.os }}-turbo-${{ github.job }}-default-
-            ${{ runner.os }}-turbo-${{ github.job }}-
-            ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
       - name: Build storybook to generate story IDs
@@ -202,8 +194,6 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ github.job }}-default-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ${{ runner.os }}-turbo-${{ github.job }}-default-
-            ${{ runner.os }}-turbo-${{ github.job }}-
-            ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-
+            ${{ runner.os }}-turbo-${{ github.job }}-
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -25,8 +25,6 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ github.job }}-default-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ${{ runner.os }}-turbo-${{ github.job }}-default-
-            ${{ runner.os }}-turbo-${{ github.job }}-
-            ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/vrt-reports.yml
+++ b/.github/workflows/vrt-reports.yml
@@ -31,7 +31,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-${{ github.job }}-shard-${{ matrix.shard }}-
             ${{ runner.os }}-turbo-${{ github.job }}-
-            ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
       - name: Build storybook

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -47,7 +47,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-${{ github.job }}-shard-${{ matrix.shard }}-
             ${{ runner.os }}-turbo-${{ github.job }}-
-            ${{ runner.os }}-turbo-
       - name: Install dependencies
         run: npm ci
       - name: Build storybook


### PR DESCRIPTION
Noticed that some of our jobs were not restoring caches successfully and I think it's related to this generic fallback, potentially 🤔 Trying this out to see if it helps to improve our cache hits for turbo tasks