### PR TITLE
Fix ScrollableRegion focusability based on overflow state

### DIFF
--- a/.changeset/fresh-regions-scroll.md
+++ b/.changeset/fresh-regions-scroll.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+ScrollableRegion: Remove focusability when content no longer overflows

--- a/packages/react/src/ScrollableRegion/ScrollableRegion.test.tsx
+++ b/packages/react/src/ScrollableRegion/ScrollableRegion.test.tsx
@@ -7,10 +7,52 @@ import classes from './ScrollableRegion.module.css'
 
 const originalResizeObserver = window.ResizeObserver
 
+interface ElementDimensions {
+  scrollHeight: number
+  clientHeight: number
+  scrollWidth: number
+  clientWidth: number
+}
+
 describe('ScrollableRegion', () => {
   implementsClassName(ScrollableRegion, classes.ScrollableRegion)
 
   let mockResizeCallback: (entries: Array<ResizeObserverEntry>) => void
+
+  function triggerResize(target: HTMLElement, dimensions: Partial<ElementDimensions> = {}) {
+    const {scrollHeight = 100, clientHeight = 100, scrollWidth = 100, clientWidth = 100} = dimensions
+
+    Object.defineProperties(target, {
+      scrollHeight: {configurable: true, value: scrollHeight},
+      clientHeight: {configurable: true, value: clientHeight},
+      scrollWidth: {configurable: true, value: scrollWidth},
+      clientWidth: {configurable: true, value: clientWidth},
+    })
+
+    act(() => {
+      mockResizeCallback([
+        {
+          target,
+          borderBoxSize: [],
+          contentBoxSize: [],
+          contentRect: {
+            width: 0,
+            height: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+            x: 0,
+            y: 0,
+            toJSON() {
+              return {}
+            },
+          },
+          devicePixelContentBoxSize: [],
+        },
+      ])
+    })
+  }
 
   beforeEach(() => {
     window.ResizeObserver = class ResizeObserver {
@@ -40,64 +82,59 @@ describe('ScrollableRegion', () => {
     expect(screen.getByTestId('container')).toHaveAttribute('data-component', 'ScrollableRegion')
   })
 
-  test('does not render with region props by default', () => {
+  test('does not render with region props when overflow is absent', () => {
     render(
       <ScrollableRegion aria-label="Example label" data-testid="container">
         Example content
       </ScrollableRegion>,
     )
 
-    expect(screen.getByTestId('container')).not.toHaveAttribute('role')
-    expect(screen.getByTestId('container')).not.toHaveAttribute('tabindex')
-    expect(screen.getByTestId('container')).not.toHaveAttribute('aria-labelledby')
-    expect(screen.getByTestId('container')).not.toHaveAttribute('aria-label')
+    const container = screen.getByTestId('container')
+    triggerResize(container)
 
-    expect(screen.getByTestId('container')).toHaveStyle('overflow: auto')
-    expect(screen.getByTestId('container')).toHaveStyle('position: relative')
+    expect(container).not.toHaveAttribute('role')
+    expect(container).not.toHaveAttribute('tabindex')
+    expect(container).not.toHaveAttribute('aria-labelledby')
+    expect(container).not.toHaveAttribute('aria-label')
+
+    expect(container).toHaveStyle('overflow: auto')
+    expect(container).toHaveStyle('position: relative')
   })
 
-  test('does render with region props when overflow is present', () => {
+  test.each([
+    {direction: 'vertical', dimensions: {scrollHeight: 500}},
+    {direction: 'horizontal', dimensions: {scrollWidth: 500}},
+  ])('renders with region props when $direction overflow appears', ({dimensions}) => {
     render(
       <ScrollableRegion aria-label="Example label" data-testid="container">
         Example content
       </ScrollableRegion>,
     )
 
-    act(() => {
-      // Mock a resize occurring when the scroll height is greater than the
-      // client height
-      const target = document.createElement('div')
-      mockResizeCallback([
-        {
-          target: {
-            ...target,
-            scrollHeight: 500,
-            clientHeight: 100,
-          },
-          borderBoxSize: [],
-          contentBoxSize: [],
-          contentRect: {
-            width: 0,
-            height: 0,
-            top: 0,
-            right: 0,
-            bottom: 0,
-            left: 0,
-            x: 0,
-            y: 0,
-            toJSON() {
-              return {}
-            },
-          },
-          devicePixelContentBoxSize: [],
-        },
-      ])
-    })
+    const container = screen.getByTestId('container')
+    triggerResize(container, dimensions)
 
-    expect(screen.getByLabelText('Example label')).toBeVisible()
+    expect(container).toBeVisible()
+    expect(container).toHaveAttribute('role', 'region')
+    expect(container).toHaveAttribute('tabindex', '0')
+    expect(container).toHaveAttribute('aria-label', 'Example label')
+  })
 
-    expect(screen.getByLabelText('Example label')).toHaveAttribute('role', 'region')
-    expect(screen.getByLabelText('Example label')).toHaveAttribute('tabindex', '0')
-    expect(screen.getByLabelText('Example label')).toHaveAttribute('aria-label')
+  test('removes region props when overflow disappears', () => {
+    render(
+      <ScrollableRegion aria-label="Example label" data-testid="container">
+        Example content
+      </ScrollableRegion>,
+    )
+
+    const container = screen.getByTestId('container')
+    triggerResize(container, {scrollWidth: 500})
+    expect(container).toHaveAttribute('role', 'region')
+    expect(container).toHaveAttribute('tabindex', '0')
+
+    triggerResize(container)
+    expect(container).not.toHaveAttribute('role')
+    expect(container).not.toHaveAttribute('tabindex')
+    expect(container).not.toHaveAttribute('aria-label')
   })
 })

--- a/packages/react/src/hooks/useOverflow.ts
+++ b/packages/react/src/hooks/useOverflow.ts
@@ -9,15 +9,13 @@ export function useOverflow<T extends HTMLElement>(ref: React.RefObject<T>) {
     }
 
     const observer = new ResizeObserver(entries => {
-      for (const entry of entries) {
-        if (
-          entry.target.scrollHeight > entry.target.clientHeight ||
-          entry.target.scrollWidth > entry.target.clientWidth
-        ) {
-          setHasOverflow(true)
-          break
-        }
-      }
+      setHasOverflow(
+        entries.some(
+          entry =>
+            entry.target.scrollHeight > entry.target.clientHeight ||
+            entry.target.scrollWidth > entry.target.clientWidth,
+        ),
+      )
     })
 
     observer.observe(ref.current)


### PR DESCRIPTION
Addresses follow-up feedback from github/accessibility#10807, originally reported in github/accessibility#10269.

`ScrollableRegion` should only enter the tab order while its content can scroll. Previously, `useOverflow` set its state to `true` when overflow appeared but did not reset it to `false`. After resizing from a narrow viewport to a wider one, the wrapper could therefore retain its `region` role and remain focusable after horizontal overflow disappeared.

This change recalculates overflow for every `ResizeObserver` notification. It preserves horizontal and vertical overflow detection and the existing `ScrollableRegion` API.

#### Before

https://github.com/user-attachments/assets/e8b8d9f1-9ca1-45f9-83b6-7e41184f3c0a

#### After

https://github.com/user-attachments/assets/3296e3d8-09c0-4d7f-8660-2eb7f3b2de9b

### Changelog

#### New

- Focused test coverage for absent overflow, horizontal and vertical overflow appearing, and overflow disappearing after resize.

#### Changed

- `ScrollableRegion` now removes its region semantics and focusability when its content no longer overflows.

#### Removed

- None.

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Automated coverage verifies:

- No region semantics or focusability when content does not overflow.
- Region semantics and focusability when horizontal or vertical overflow appears.
- Removal of region semantics and focusability when horizontal overflow disappears after resizing from a narrow viewport to a wide viewport.

Validation completed with the focused `ScrollableRegion` tests, full unit test suite, build, type checking, linting, CSS linting, and formatting checks.

To review manually, open the `ScrollableRegion` Storybook story, narrow the viewport until horizontal scrolling appears, and confirm the wrapper enters the tab order. Widen the viewport without refreshing and confirm the wrapper no longer receives focus through keyboard navigation.
