### PR TITLE
Implement accessibility fix for sortable DataTable headers

### DIFF
--- a/.changeset/friendly-tables-sort.md
+++ b/.changeset/friendly-tables-sort.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+DataTable: Keep sortable column names concise and convey the next sort action as an accessible description

--- a/packages/react/src/DataTable/Table.tsx
+++ b/packages/react/src/DataTable/Table.tsx
@@ -136,15 +136,41 @@ type TableSortHeaderProps = TableHeaderProps & {
   onToggleSort: () => void
 }
 
-function TableSortHeader({align, children, direction, onToggleSort, ...rest}: TableSortHeaderProps) {
+function getTextContent(node: React.ReactNode): string {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return ''
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+  if (Array.isArray(node)) {
+    return node.map(getTextContent).join('')
+  }
+  if (React.isValidElement(node)) {
+    return getTextContent((node.props as {children?: React.ReactNode}).children)
+  }
+  return ''
+}
+
+function TableSortHeader({
+  align,
+  'aria-label': ariaLabel,
+  children,
+  direction,
+  onToggleSort,
+  ...rest
+}: TableSortHeaderProps) {
   const ariaSort = direction === 'DESC' ? 'descending' : direction === 'ASC' ? 'ascending' : undefined
+  const columnName = ariaLabel ?? (getTextContent(children).trim() || undefined)
+  const sortAction = direction === SortDirection.ASC ? 'Sort descending' : 'Sort ascending'
 
   return (
-    <TableHeader {...rest} aria-sort={ariaSort} align={align} data-component="Table.SortHeader">
+    <TableHeader {...rest} aria-label={columnName} aria-sort={ariaSort} align={align} data-component="Table.SortHeader">
       <Button
         type="button"
         className={clsx('TableSortButton', classes.TableSortButton)}
         data-component="Table.SortHeader.Button"
+        aria-description={sortAction}
         onClick={() => {
           onToggleSort()
         }}
@@ -160,7 +186,6 @@ function TableSortHeader({align, children, direction, onToggleSort, ...rest}: Ta
                 classes['TableSortIcon--ascending'],
               )}
             />
-            {direction === SortDirection.NONE ? <VisuallyHidden>sort ascending</VisuallyHidden> : null}
           </>
         ) : null}
         {direction === SortDirection.DESC ? (

--- a/packages/react/src/DataTable/Table.tsx
+++ b/packages/react/src/DataTable/Table.tsx
@@ -136,51 +136,16 @@ type TableSortHeaderProps = TableHeaderProps & {
   onToggleSort: () => void
 }
 
-function getTextContent(node: React.ReactNode): string {
-  if (node === null || node === undefined || typeof node === 'boolean') {
-    return ''
-  }
-  if (typeof node === 'string' || typeof node === 'number') {
-    return String(node)
-  }
-  if (Array.isArray(node)) {
-    return node.map(getTextContent).join('')
-  }
-  if (React.isValidElement(node)) {
-    return getTextContent((node.props as {children?: React.ReactNode}).children)
-  }
-  return ''
-}
-
-function TableSortHeader({
-  align,
-  'aria-label': ariaLabel,
-  'aria-labelledby': ariaLabelledBy,
-  children,
-  direction,
-  onToggleSort,
-  ...rest
-}: TableSortHeaderProps) {
+function TableSortHeader({align, children, direction, onToggleSort, ...rest}: TableSortHeaderProps) {
   const ariaSort = direction === 'DESC' ? 'descending' : direction === 'ASC' ? 'ascending' : undefined
-  const childText = getTextContent(children).trim()
-  const columnName = ariaLabel ?? (ariaLabelledBy ? undefined : childText || undefined)
-  const sortButtonLabel = childText ? undefined : ariaLabel
   const sortAction = direction === SortDirection.ASC ? 'Sort descending' : 'Sort ascending'
 
   return (
-    <TableHeader
-      {...rest}
-      aria-label={columnName}
-      aria-labelledby={ariaLabelledBy}
-      aria-sort={ariaSort}
-      align={align}
-      data-component="Table.SortHeader"
-    >
+    <TableHeader {...rest} aria-sort={ariaSort} align={align} data-component="Table.SortHeader">
       <Button
         type="button"
         className={clsx('TableSortButton', classes.TableSortButton)}
         data-component="Table.SortHeader.Button"
-        aria-label={sortButtonLabel}
         aria-description={sortAction}
         onClick={() => {
           onToggleSort()

--- a/packages/react/src/DataTable/Table.tsx
+++ b/packages/react/src/DataTable/Table.tsx
@@ -155,21 +155,32 @@ function getTextContent(node: React.ReactNode): string {
 function TableSortHeader({
   align,
   'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
   children,
   direction,
   onToggleSort,
   ...rest
 }: TableSortHeaderProps) {
   const ariaSort = direction === 'DESC' ? 'descending' : direction === 'ASC' ? 'ascending' : undefined
-  const columnName = ariaLabel ?? (getTextContent(children).trim() || undefined)
+  const childText = getTextContent(children).trim()
+  const columnName = ariaLabel ?? (ariaLabelledBy ? undefined : childText || undefined)
+  const sortButtonLabel = childText ? undefined : ariaLabel
   const sortAction = direction === SortDirection.ASC ? 'Sort descending' : 'Sort ascending'
 
   return (
-    <TableHeader {...rest} aria-label={columnName} aria-sort={ariaSort} align={align} data-component="Table.SortHeader">
+    <TableHeader
+      {...rest}
+      aria-label={columnName}
+      aria-labelledby={ariaLabelledBy}
+      aria-sort={ariaSort}
+      align={align}
+      data-component="Table.SortHeader"
+    >
       <Button
         type="button"
         className={clsx('TableSortButton', classes.TableSortButton)}
         data-component="Table.SortHeader.Button"
+        aria-label={sortButtonLabel}
         aria-description={sortAction}
         onClick={() => {
           onToggleSort()

--- a/packages/react/src/DataTable/__tests__/DataTable.test.tsx
+++ b/packages/react/src/DataTable/__tests__/DataTable.test.tsx
@@ -732,6 +732,49 @@ describe('DataTable', () => {
       expect(getRowOrder()).toEqual(['1', '2', '3'])
     })
 
+    it('should keep the sort action in the button description', async () => {
+      const user = userEvent.setup()
+      render(
+        <DataTable
+          data={[
+            {
+              id: 1,
+              value: 1,
+            },
+          ]}
+          columns={[
+            {
+              header: 'Value',
+              field: 'value',
+              sortBy: true,
+            },
+          ]}
+        />,
+      )
+
+      const header = screen.getByRole('columnheader', {name: 'Value'})
+      const sortButton = screen.getByRole('button', {name: 'Value'})
+
+      expect(header).toHaveAccessibleName('Value')
+      expect(header).not.toHaveAttribute('aria-sort')
+      expect(sortButton).toHaveAccessibleName('Value')
+      expect(sortButton).toHaveAccessibleDescription('Sort ascending')
+
+      await user.click(sortButton)
+
+      expect(header).toHaveAccessibleName('Value')
+      expect(header).toHaveAttribute('aria-sort', 'ascending')
+      expect(sortButton).toHaveAccessibleName('Value')
+      expect(sortButton).toHaveAccessibleDescription('Sort descending')
+
+      await user.click(sortButton)
+
+      expect(header).toHaveAccessibleName('Value')
+      expect(header).toHaveAttribute('aria-sort', 'descending')
+      expect(sortButton).toHaveAccessibleName('Value')
+      expect(sortButton).toHaveAccessibleDescription('Sort ascending')
+    })
+
     it('should change the sort direction on keyboard Enter or Space', async () => {
       const user = userEvent.setup()
       render(
@@ -878,7 +921,7 @@ describe('DataTable', () => {
 
       // When interacting with Column B, sort order should reset to ASC
       await user.click(screen.getByText('Column B'))
-      expect(getSortHeader('Column A sort ascending')).not.toHaveAttribute('aria-sort')
+      expect(getSortHeader('Column A')).not.toHaveAttribute('aria-sort')
       expect(getSortHeader('Column B')).toHaveAttribute('aria-sort', 'ascending')
       expect(getRowOrder()).toEqual([
         [3, 1],

--- a/packages/react/src/DataTable/__tests__/Table.test.tsx
+++ b/packages/react/src/DataTable/__tests__/Table.test.tsx
@@ -240,7 +240,7 @@ describe('Table', () => {
       expect(sortButton).toHaveAccessibleDescription('Sort descending')
     })
 
-    it('should preserve a consumer-provided aria-labelledby without adding aria-label', () => {
+    it('should preserve a consumer-provided aria-labelledby', () => {
       render(
         <>
           <span id="custom-column-name">Custom column name</span>
@@ -263,25 +263,7 @@ describe('Table', () => {
       const header = screen.getByRole('columnheader', {name: 'Custom column name'})
 
       expect(header).toHaveAttribute('aria-labelledby', 'custom-column-name')
-      expect(header).not.toHaveAttribute('aria-label')
       expect(screen.getByRole('button', {name: 'Visible column name'})).toHaveAccessibleDescription('Sort descending')
-    })
-
-    it('should use a consumer-provided aria-label for an icon-only sort button', () => {
-      render(
-        <Table>
-          <Table.Head>
-            <Table.Row>
-              <TableSortHeader aria-label="Custom column name" direction={SortDirection.ASC} onToggleSort={() => {}}>
-                <span aria-hidden="true" />
-              </TableSortHeader>
-            </Table.Row>
-          </Table.Head>
-        </Table>,
-      )
-
-      expect(screen.getByRole('columnheader', {name: 'Custom column name'})).toBeInTheDocument()
-      expect(screen.getByRole('button', {name: 'Custom column name'})).toHaveAccessibleDescription('Sort descending')
     })
   })
 

--- a/packages/react/src/DataTable/__tests__/Table.test.tsx
+++ b/packages/react/src/DataTable/__tests__/Table.test.tsx
@@ -2,7 +2,8 @@ import {describe, expect, it} from 'vitest'
 import {render, screen} from '@testing-library/react'
 import {DataTable, Table} from '../../DataTable'
 import {createColumnHelper} from '../column'
-import type {TableProps} from '../Table'
+import {TableSortHeader, type TableProps} from '../Table'
+import {SortDirection} from '../sorting'
 import {implementsClassName} from '../../utils/testing'
 import classes from '../Table.module.css'
 
@@ -215,6 +216,28 @@ describe('Table', () => {
 
       expect(screen.getByRole('columnheader', {name: 'Column'})).toBeInTheDocument()
       expect(screen.getByRole('columnheader', {name: 'Column'})).toHaveAttribute('scope', 'col')
+    })
+  })
+
+  describe('Table.SortHeader', () => {
+    it('should preserve a consumer-provided aria-label', () => {
+      render(
+        <Table>
+          <Table.Head>
+            <Table.Row>
+              <TableSortHeader aria-label="Custom column name" direction={SortDirection.ASC} onToggleSort={() => {}}>
+                Visible column name
+              </TableSortHeader>
+            </Table.Row>
+          </Table.Head>
+        </Table>,
+      )
+
+      const header = screen.getByRole('columnheader', {name: 'Custom column name'})
+      const sortButton = screen.getByRole('button', {name: 'Visible column name'})
+
+      expect(header).toHaveAttribute('aria-sort', 'ascending')
+      expect(sortButton).toHaveAccessibleDescription('Sort descending')
     })
   })
 

--- a/packages/react/src/DataTable/__tests__/Table.test.tsx
+++ b/packages/react/src/DataTable/__tests__/Table.test.tsx
@@ -239,6 +239,50 @@ describe('Table', () => {
       expect(header).toHaveAttribute('aria-sort', 'ascending')
       expect(sortButton).toHaveAccessibleDescription('Sort descending')
     })
+
+    it('should preserve a consumer-provided aria-labelledby without adding aria-label', () => {
+      render(
+        <>
+          <span id="custom-column-name">Custom column name</span>
+          <Table>
+            <Table.Head>
+              <Table.Row>
+                <TableSortHeader
+                  aria-labelledby="custom-column-name"
+                  direction={SortDirection.ASC}
+                  onToggleSort={() => {}}
+                >
+                  Visible column name
+                </TableSortHeader>
+              </Table.Row>
+            </Table.Head>
+          </Table>
+        </>,
+      )
+
+      const header = screen.getByRole('columnheader', {name: 'Custom column name'})
+
+      expect(header).toHaveAttribute('aria-labelledby', 'custom-column-name')
+      expect(header).not.toHaveAttribute('aria-label')
+      expect(screen.getByRole('button', {name: 'Visible column name'})).toHaveAccessibleDescription('Sort descending')
+    })
+
+    it('should use a consumer-provided aria-label for an icon-only sort button', () => {
+      render(
+        <Table>
+          <Table.Head>
+            <Table.Row>
+              <TableSortHeader aria-label="Custom column name" direction={SortDirection.ASC} onToggleSort={() => {}}>
+                <span aria-hidden="true" />
+              </TableSortHeader>
+            </Table.Row>
+          </Table.Head>
+        </Table>,
+      )
+
+      expect(screen.getByRole('columnheader', {name: 'Custom column name'})).toBeInTheDocument()
+      expect(screen.getByRole('button', {name: 'Custom column name'})).toHaveAccessibleDescription('Sort descending')
+    })
   })
 
   describe('Table.Cell', () => {


### PR DESCRIPTION
Related to github/accessibility#10272 and github/accessibility#10807

This pull request fixes the accessible names and descriptions of sortable DataTable column headers. The column header and sort button retain the concise rendered column name, while the button conveys the next sort action separately through an accessible description. The current sort state remains exposed through `aria-sort` on the column header, and consumer-provided ARIA attributes continue to pass through unchanged.

Keyboard sorting behavior is unchanged, and this focused fix does not introduce DataTable grouping behavior.

#### Before

https://github.com/user-attachments/assets/088a8f13-437f-4e01-aa37-fa9262b6ff9e

#### After

https://github.com/user-attachments/assets/0bac6c03-3ef2-42f5-b0c9-68b07060f450

### Changelog

#### New

None.

#### Changed

- DataTable sortable column headers now keep the column name separate from the next sort action.
- Sort buttons expose the next action as an accessible description while column headers continue to expose the current state through `aria-sort`.
- Consumer-provided `aria-label` and `aria-labelledby` attributes are preserved.

#### Removed

None.

### Rollout strategy

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

Automated validation:

- `npm test -- packages/react/src/DataTable/__tests__/DataTable.test.tsx packages/react/src/DataTable/__tests__/Table.test.tsx` — 69 tests passed
- `npm run type-check -w @primer/react`
- `npm run build -w @primer/react`
- ESLint and Prettier checks for the changed source and test files
- `git diff --check`

The focused tests verify:

- Concise column header and sort button accessible names
- Next-action accessible descriptions for unsorted, ascending, and descending states
- `aria-sort` state transitions on the column header
- Keyboard operation of the sort button
- Preservation of consumer-provided `aria-label` and `aria-labelledby` attributes

There is no visual styling change. Reviewers can compare the before/after recordings above or inspect the `Experimental/Components/DataTable/Features / WithSorting` story in the browser accessibility tree.
