### PR TITLE
Update permissions in issue triage action to restore workflow

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -418,7 +418,22 @@ jobs:
     needs: activation
     if: needs.activation.outputs.daily_ai_credits_exceeded != 'true'
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions:
+      actions: read
+      attestations: read
+      checks: read
+      contents: read
+      copilot-requests: write
+      deployments: read
+      id-token: read
+      issues: read
+      discussions: read
+      packages: read
+      pages: read
+      pull-requests: read
+      repository-projects: read
+      security-events: read
+      statuses: read
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -77,6 +77,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      copilot-requests: write
       issues: write
     env:
       GH_AW_MAX_DAILY_AI_CREDITS: ${{ vars.GH_AW_DEFAULT_MAX_DAILY_AI_CREDITS || '5000' }}

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -11,7 +11,9 @@ on:
     types: [opened, reopened]
   reaction: eyes
 
-permissions: read-all
+permissions:
+  contents: read
+  copilot-requests: write
 
 network: defaults
 

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -12,8 +12,22 @@ on:
   reaction: eyes
 
 permissions:
-  contents: read
   copilot-requests: write
+  # Explicitly list all standard "read-all" scopes
+  actions: read
+  attestations: read
+  checks: read
+  contents: read
+  deployments: read
+  id-token: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 
 network: defaults
 


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes https://github.com/primer/react/issues/8374

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### Changed

<!-- List of things changed in this PR -->
Changed the permissions on the `issue-triage` workflow as instructed at https://github.github.com/gh-aw/reference/auth/#copilot-requests-write-permission in order to overcome the workflow failure detailed here: https://github.com/primer/react/actions/runs/33644600919. I had to change `permissions: read-all` to explicitly list all standard "read-all" scopes in order to maintain the same level of access as before while adding the `copilot-requests` line to resolve the failure.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why