### PR TITLE
Handle Fragment triggers safely in Tooltip

### DIFF
--- a/.changeset/strong-tooltips-anchor.md
+++ b/.changeset/strong-tooltips-anchor.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Tooltip: Prevent React Fragment triggers from crashing and provide a clear development warning

--- a/packages/react/src/TooltipV2/Tooltip.tsx
+++ b/packages/react/src/TooltipV2/Tooltip.tsx
@@ -127,6 +127,11 @@ export const Tooltip: ForwardRefExoticComponent<
   ) => {
     const tooltipId = useId(id)
     const child = Children.only(children)
+    const isFragmentTrigger = React.isValidElement(child) && child.type === React.Fragment
+    warning(
+      isFragmentTrigger,
+      'The `Tooltip` component does not support a React Fragment as its trigger. Pass a single interactive element instead.',
+    )
     const mergedRefEnabled = useFeatureFlag('primer_react_merged_forwarded_refs')
     const triggerRef = useRef<HTMLElement>(null)
     const mergedTriggerRef = useMergedRefs(triggerRef, forwardedRef)
@@ -149,7 +154,7 @@ export const Tooltip: ForwardRefExoticComponent<
       try {
         if (
           tooltipElRef.current &&
-          readTriggerRef.current &&
+          readTriggerRef.current instanceof HTMLElement &&
           tooltipElRef.current.hasAttribute('popover') &&
           !tooltipElRef.current.matches(':popover-open') &&
           !_privateDisableTooltip
@@ -227,12 +232,19 @@ export const Tooltip: ForwardRefExoticComponent<
 
     useEffect(() => {
       if (!tooltipElRef.current || !readTriggerRef.current) return
+      const trigger = readTriggerRef.current
+      const isInvalidTrigger = !(trigger instanceof HTMLElement)
+      warning(
+        isInvalidTrigger,
+        'The `Tooltip` component expects its trigger ref to resolve to an HTML element. Ensure the trigger forwards its ref to a single interactive element instead of a React Fragment.',
+      )
+      if (isInvalidTrigger) return
       /*
        * ACCESSIBILITY CHECKS
        */
       // Has trigger element or any of its children interactive elements?
-      const isTriggerInteractive = isInteractive(readTriggerRef.current)
-      const triggerChildren = readTriggerRef.current.childNodes
+      const isTriggerInteractive = isInteractive(trigger)
+      const triggerChildren = trigger.childNodes
       // two levels deep
       const hasInteractiveDescendant = Array.from(triggerChildren).some(child => {
         return (
@@ -249,8 +261,8 @@ export const Tooltip: ForwardRefExoticComponent<
       // If the tooltip is used for labelling the interactive element, the trigger element or any of its children should not have aria-label
       // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (type === 'label') {
-        const hasAriaLabel = readTriggerRef.current.hasAttribute('aria-label')
-        const hasAriaLabelInChildren = Array.from(readTriggerRef.current.childNodes).some(
+        const hasAriaLabel = trigger.hasAttribute('aria-label')
+        const hasAriaLabelInChildren = Array.from(trigger.childNodes).some(
           child => child instanceof HTMLElement && child.hasAttribute('aria-label'),
         )
         warning(
@@ -286,6 +298,8 @@ export const Tooltip: ForwardRefExoticComponent<
 
     // Normalize keybindingHint to an array for uniform rendering
     const keybindingHints = Array.isArray(keybindingHint) ? keybindingHint : [keybindingHint]
+
+    if (isFragmentTrigger) return child
 
     return (
       <TooltipContext.Provider value={value}>

--- a/packages/react/src/TooltipV2/__tests__/Tooltip.test.tsx
+++ b/packages/react/src/TooltipV2/__tests__/Tooltip.test.tsx
@@ -2,7 +2,7 @@ import type React from 'react'
 import {describe, expect, it, vi} from 'vitest'
 import type {TooltipProps} from '../Tooltip'
 import {Tooltip} from '../Tooltip'
-import {render as HTMLRender} from '@testing-library/react'
+import {fireEvent, render as HTMLRender} from '@testing-library/react'
 import BaseStyles from '../../BaseStyles'
 import {Button, IconButton} from '../../Button'
 import {ActionMenu} from '../../ActionMenu'
@@ -12,9 +12,9 @@ import {XIcon} from '@primer/octicons-react'
 import classes from '../Tooltip.module.css'
 
 import type {JSX} from 'react'
-import {createRef} from 'react'
+import {createRef, forwardRef, useImperativeHandle} from 'react'
 import {FeatureFlags} from '../../FeatureFlags'
-import {implementsClassName, withExpectedConsoleError} from '../../utils/testing'
+import {implementsClassName, withExpectedConsoleError, withExpectedConsoleWarning} from '../../utils/testing'
 
 const TooltipComponent = (props: Omit<TooltipProps, 'text'> & {text?: string}) => (
   <Tooltip text="Tooltip text" {...props}>
@@ -29,6 +29,17 @@ const TooltipComponentWithExistingDescription = (props: Omit<TooltipProps, 'text
       <Button aria-describedby="external-description">Button Text</Button>
     </Tooltip>
   </>
+)
+
+const InvalidRefTrigger = forwardRef<HTMLElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+  ({children, ...props}, forwardedRef) => {
+    useImperativeHandle(forwardedRef, () => ({}) as HTMLElement, [])
+    return (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    )
+  },
 )
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -146,6 +157,20 @@ describe('Tooltip', () => {
       )
     })
   })
+  it('should warn and render the trigger unchanged if it is a React Fragment', () => {
+    withExpectedConsoleWarning(() => {
+      const {getByRole, queryByText} = HTMLRender(
+        <Tooltip text="Tooltip text">
+          <>
+            <Button>Button Text</Button>
+          </>
+        </Tooltip>,
+      )
+
+      expect(getByRole('button', {name: 'Button Text'})).toBeInTheDocument()
+      expect(queryByText('Tooltip text')).not.toBeInTheDocument()
+    })
+  })
   it('should not throw an error when the trigger element is a button in a fieldset', () => {
     const {getByRole} = HTMLRender(
       <fieldset>
@@ -255,6 +280,20 @@ describe('Tooltip forwarded ref (primer_react_merged_forwarded_refs)', () => {
         )
         expect(refCallback).toHaveBeenCalled()
         expect(refCallback.mock.calls.some(([el]) => el instanceof HTMLButtonElement)).toBe(true)
+      })
+
+      it('warns without crashing when a custom trigger ref does not resolve to an HTML element', () => {
+        withExpectedConsoleWarning(() => {
+          const {getByRole} = HTMLRender(
+            <FeatureFlags flags={{primer_react_merged_forwarded_refs: enabled}}>
+              <Tooltip text="Tooltip text">
+                <InvalidRefTrigger>Button Text</InvalidRefTrigger>
+              </Tooltip>
+            </FeatureFlags>,
+          )
+
+          expect(() => fireEvent.focus(getByRole('button', {name: 'Button Text'}))).not.toThrow()
+        })
       })
     })
   }


### PR DESCRIPTION
<!-- Provide the GitHub issue that this issue closes. Start typing the number or name of the issue after the # below. -->

Closes #

<!-- Provide an overview of the changes, including before/after screenshots, videos, or graphs when helpful -->

Prevent `Tooltip` from crashing when React 19.3 supplies a `FragmentInstance` as the trigger ref. Direct Fragment triggers now warn and render unchanged without Tooltip enhancement, while custom triggers with non-HTML refs skip DOM positioning safely.

### Changelog

<!-- Under the headings below, list out relevant API changes that this Pull Request introduces -->

#### New

None.

#### Changed

- Preserve Fragment trigger content and provide a development warning.
- Guard Tooltip validation and positioning from non-`HTMLElement` trigger refs.
- Cover direct Fragments, invalid custom refs, and both merged-ref feature flag paths.

#### Removed

None.

### Rollout strategy

<!-- How do you recommend this change to be rolled out? Refer to [contributor docs on Versioning](https://github.com/primer/react/blob/main/contributor-docs/versioning.md) for details. -->

- [x] Patch release
- [ ] Minor release
- [ ] Major release; if selected, include a written rollout or migration plan
- [ ] None; if selected, include a brief description as to why

### Testing & Reviewing

<!-- Describe any specific details to help reviewers test or review this Pull Request -->
<!-- To test these changes with github/github-ui, use the [integration workflow](https://github.com/github/github-ui/actions/workflows/primer-npm-packages-integration.yml) -->

- `npx vitest --run packages/react/src/TooltipV2/__tests__/Tooltip.test.tsx` (30 passed)
- `npx turbo run lint:react-compiler` (827 migrated files passed)
- `npm run type-check -- --filter=@primer/react`
- Prettier and ESLint on changed files

<!-- Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs. -->