### PR TITLE
Fix Autocomplete dropping the last typed character

### DIFF
--- a/.changeset/autocomplete-completed-suggestion.md
+++ b/.changeset/autocomplete-completed-suggestion.md
@@ -1,0 +1,5 @@
+---
+'@primer/react': patch
+---
+
+Autocomplete: Preserve the final typed character when completing an inline suggestion.

--- a/packages/react/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/react/src/Autocomplete/Autocomplete.test.tsx
@@ -1,11 +1,13 @@
-import {render, fireEvent, screen, waitFor} from '@testing-library/react'
+import {act, render, fireEvent, screen, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {createRef} from 'react'
+import {userEvent as browserUserEvent} from 'vitest/browser'
+import {createRef, useState} from 'react'
 import {describe, expect, it, vi} from 'vitest'
 import type {AutocompleteInputProps} from '../Autocomplete'
 import Autocomplete from '../Autocomplete'
 import type {AutocompleteMenuInternalProps, AutocompleteMenuItem} from '../Autocomplete/AutocompleteMenu'
 import BaseStyles from '../BaseStyles'
+import TextInputWithTokens from '../TextInputWithTokens'
 import {implementsClassName} from '../utils/testing'
 import classes from './AutocompleteOverlay.module.css'
 import {AutocompleteContext} from './AutocompleteContext'
@@ -22,6 +24,13 @@ const mockItems = [
   {text: 'twenty', id: '20'},
   {text: 'twentyone', id: '21'},
 ]
+
+// Use native keyboard events so React's input value tracking behaves as it does for real typing.
+async function typeWithNativeKeyboard(text: string) {
+  for (const character of text) {
+    await act(() => browserUserEvent.keyboard(character))
+  }
+}
 
 const AUTOCOMPLETE_LABEL = 'Autocomplete field'
 const LabelledAutocomplete = <T extends AutocompleteMenuItem>({
@@ -254,6 +263,97 @@ describe('Autocomplete', () => {
 
       // The input should retain the text the user typed rather than the full suggestion
       await waitFor(() => expect(inputNode.value).toBe('ze'))
+    })
+
+    it.each([
+      {prefix: 'zer', suffix: 'o', expected: 'zero'},
+      {prefix: 'ze', suffix: 'ro', expected: 'zero'},
+      {prefix: 'zer', suffix: 'x', expected: 'zerx'},
+      {prefix: 'zer', suffix: 'O', expected: 'zerO'},
+      {prefix: 'topi', suffix: 'c', expected: 'topic'},
+    ])(
+      'reports and retains $expected after typing $prefix + $suffix and blurring',
+      async ({prefix, suffix, expected}) => {
+        const onChange = vi.fn()
+        render(
+          <>
+            <LabelledAutocomplete
+              inputProps={{onChange: event => onChange(event.currentTarget.value)}}
+              menuProps={{items: mockItems, selectedItemIds: [], ['aria-labelledby']: 'autocompleteLabel'}}
+            />
+            <button type="button">outside</button>
+          </>,
+        )
+        const input = screen.getByRole('combobox') as HTMLInputElement
+
+        await act(() => browserUserEvent.click(input))
+        await typeWithNativeKeyboard(prefix)
+        if (prefix.startsWith('ze')) {
+          expect(input).toHaveValue('zero')
+          expect(input.selectionStart).toBe(prefix.length)
+          expect(input.selectionEnd).toBe(4)
+        }
+        onChange.mockClear()
+        await typeWithNativeKeyboard(suffix)
+        expect.soft(onChange).toHaveBeenLastCalledWith(expected)
+
+        await act(() => browserUserEvent.click(screen.getByRole('button', {name: 'outside'})))
+        await waitFor(() => expect(input).toHaveAttribute('aria-expanded', 'false'))
+        expect(input).toHaveValue(expected)
+      },
+    )
+
+    it('commits an exactly completed suggestion from controlled state on Space and clears the token input', async () => {
+      function TokenAutocomplete() {
+        const [value, setValue] = useState('')
+        const [tokens, setTokens] = useState<Array<{id: string; text: string}>>([])
+        return (
+          <BaseStyles>
+            <label id="topics-label" htmlFor="topics-input">
+              Topics
+            </label>
+            <Autocomplete>
+              <Autocomplete.Input
+                as={TextInputWithTokens}
+                id="topics-input"
+                value={value}
+                tokens={tokens}
+                onTokenRemove={id => setTokens(tokens.filter(token => token.id !== id))}
+                onChange={event => setValue(event.currentTarget.value)}
+                onKeyDown={event => {
+                  if (event.key === ' ' && value) {
+                    event.preventDefault()
+                    setTokens([...tokens, {id: value, text: value}])
+                    setValue('')
+                  }
+                }}
+              />
+              <Autocomplete.Overlay>
+                <Autocomplete.Menu
+                  items={[{id: 'nikon', text: 'nikon'}]}
+                  selectedItemIds={tokens.map(token => token.id)}
+                  selectionVariant="multiple"
+                  aria-labelledby="topics-label"
+                />
+              </Autocomplete.Overlay>
+            </Autocomplete>
+          </BaseStyles>
+        )
+      }
+      render(<TokenAutocomplete />)
+      const input = screen.getByRole('combobox') as HTMLInputElement
+
+      await act(() => browserUserEvent.click(input))
+      await typeWithNativeKeyboard('niko')
+      expect(input).toHaveValue('nikon')
+      expect(input.selectionStart).toBe(4)
+      expect(input.selectionEnd).toBe(5)
+      await typeWithNativeKeyboard('n ')
+
+      expect(
+        screen.getByText('nikon', {selector: '[data-component="TextInputWithTokens.Token"] *'}),
+      ).toBeInTheDocument()
+      expect(input).toHaveValue('')
     })
 
     it('allows the value to be 0', () => {

--- a/packages/react/src/Autocomplete/AutocompleteInput.tsx
+++ b/packages/react/src/Autocomplete/AutocompleteInput.tsx
@@ -163,7 +163,8 @@ const AutocompleteInput = React.forwardRef(
         autocompleteSuggestion &&
         (inputValue || isMenuDirectlyActivated)
       ) {
-        inputRef.current.value = autocompleteSuggestion
+        // Keep React's value tracking at the typed text so completing the suggestion still fires onChange.
+        inputRef.current.setRangeText(autocompleteSuggestion, 0, inputRef.current.value.length)
 
         if (autocompleteSuggestion.toLowerCase().indexOf(inputValue.toLowerCase()) === 0) {
           inputRef.current.setSelectionRange(inputValue.length, autocompleteSuggestion.length)


### PR DESCRIPTION
Closes #4289.

Fully typing a suggested value such as `css` can leave `onChange` at `cs`. Leaving the field then drops the final character. Use `setRangeText` to display suggestions so `onChange` receives the completed text.

Related: @timges's earlier fix attempt, #4290.

### Tests

Typing, blur, and Space-to-add regressions pass in Chromium and Firefox with React 18 and 19. Build and type checks pass.

The full suite has three PostCSS snapshot failures that also occur on the unchanged baseline.
